### PR TITLE
ui: add buy/bridge CTAs for wRTC with anti-scam notes

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -595,6 +595,8 @@
             <a href="{{ P }}/trending">{{ _('nav.trending') }}</a>
             <a href="{{ P }}/categories">{{ _('nav.categories') }}</a>
             <a href="{{ P }}/challenges">{{ _('nav.challenges') }}</a>
+            <a href="https://bottube.ai/bridge/wrtc" target="_blank" rel="noopener">Bridge Credits</a>
+            <a href="https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X" target="_blank" rel="noopener">Buy Credits</a>
             <a href="{{ P }}/giveaway" style="color:#ffd700;font-weight:600;">{{ _('nav.giveaway') }}</a>
             <a href="{{ P }}/agents">{{ _('nav.agents') }}</a>
             <a href="{{ P }}/blog">{{ _('nav.blog') }}</a>
@@ -647,6 +649,14 @@
                 <a href="https://bowora.com/bottube.ai" target="_blank" rel="noopener">Bowora</a>
                 <a href="https://grokipedia.com/page/BoTTubeai" target="_blank" rel="noopener">Grokipedia</a>
             </div>
+        </div>
+
+        <div style="margin:14px auto 8px auto;max-width:760px;background:rgba(62,166,255,0.08);border:1px solid rgba(62,166,255,0.35);border-radius:8px;padding:10px 12px;font-size:13px;line-height:1.45;color:var(--text-secondary);">
+            <strong style="color:var(--text-primary);">Need wRTC for tipping?</strong>
+            <a href="https://bottube.ai/bridge/wrtc" target="_blank" rel="noopener">Bridge to BoTTube credits</a>
+            or
+            <a href="https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X" target="_blank" rel="noopener">buy on Raydium</a>.
+            Anti-scam: verify mint <code>12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X</code> and decimals <code>6</code>.
         </div>
 
         <div class="footer-lang" style="margin:8px 0;">

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -1708,6 +1708,14 @@
                     Send RTC Tip
                 </button>
 
+                <div style="margin-top:10px;font-size:12.5px;line-height:1.45;color:var(--text-secondary);background:rgba(62,166,255,0.08);border:1px solid rgba(62,166,255,0.28);border-radius:8px;padding:8px 10px;">
+                    Need more credits?
+                    <a href="https://bottube.ai/bridge/wrtc" target="_blank" rel="noopener">Bridge wRTC</a>
+                    or
+                    <a href="https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X" target="_blank" rel="noopener">buy wRTC</a>.
+                    Anti-scam: verify mint <code>12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X</code> and decimals <code>6</code>.
+                </div>
+
                 <div class="tip-panel" id="tip-panel">
                     <div class="tip-amounts">
                         <button class="tip-amount-btn" onclick="selectTipAmount(0.01)">0.01</button>


### PR DESCRIPTION
Implements bounty #79 by adding 4 CTA entry points to buy/bridge flow: 2 in top nav, 1 in footer callout, 1 in watch-page tipping section.\n\nAll wRTC mentions include anti-scam guidance with canonical mint + decimals verification.

**Payout Wallet**: 4NizeDTyC7rmdxAEgpSLhb31WzHtC4p9pfd8u9jUkazK
