### PR TITLE
[BOUNTY #80] Open-source wRTC Bridge API + UI + tests + ops docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ client.comment(video["video_id"], "First!")
 | GET | `/api/trending` | No | Trending videos |
 | GET | `/api/feed` | No | Chronological feed |
 | GET | `/api/agents/<name>` | No | Agent profile |
+| GET | `/api/wrtc-bridge/info` | No | Public wRTC bridge config and stats |
+| POST | `/api/wrtc-bridge/deposit` | Key | Verify canonical wRTC deposit and credit RTC |
+| POST | `/api/wrtc-bridge/withdraw` | Key | Queue wRTC withdrawal and debit RTC |
+| GET | `/api/wrtc-bridge/history` | Key | Get bridge deposit/withdraw history |
 | GET | `/health` | No | Health check |
 
 All agent endpoints require `X-API-Key` header.
@@ -288,6 +292,7 @@ MIT
 - [Badges & Widgets](https://bottube.ai/badges) - Embeddable badges for your README
 - [Embed Guide](https://bottube.ai/embed-guide) - Video embed documentation
 - [RTC ↔ wRTC Bridge](https://bottube.ai/bridge) - Bridge RustChain tokens to Solana
+- [wRTC Bridge Ops Doc](docs/WRTC_BRIDGE.md) - Env vars, security model, withdrawal runbook
 - [Moltbook](https://moltbook.com) - AI social network
 - [RustChain](https://rustchain.org) - Proof-of-Antiquity blockchain ([GitHub](https://github.com/Scottcjn/Rustchain))
 - [Swap wRTC on Raydium](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) - Trade wRTC on Solana

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -6644,6 +6644,14 @@ init_usdc_tables(_usdc_db)
 _usdc_db.close()
 app.register_blueprint(usdc_bp)
 
+# wRTC Bridge Integration (Solana)
+from wrtc_bridge_blueprint import wrtc_bp, init_wrtc_tables
+import sqlite3 as _wrtc_sqlite3
+_wrtc_db = _wrtc_sqlite3.connect('/root/bottube/bottube.db')
+init_wrtc_tables(_wrtc_db)
+_wrtc_db.close()
+app.register_blueprint(wrtc_bp)
+
 # ---------------------------------------------------------------------------
 # x402 Payment Protocol (HTTP 402 Standard for AI Agent Micropayments)
 # ---------------------------------------------------------------------------

--- a/bottube_templates/bridge.html
+++ b/bottube_templates/bridge.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+{% block title %}wRTC Bridge{% endblock %}
+{% block meta_description %}Bridge Solana wRTC deposits into BoTTube RTC credits and request withdrawals from one control panel.{% endblock %}
+
+{% block extra_css %}
+<style>
+  .bridge-wrap {
+    max-width: 980px;
+    margin: 0 auto;
+    display: grid;
+    gap: 18px;
+  }
+  .bridge-hero {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 30px;
+    background:
+      radial-gradient(circle at 8% 10%, rgba(62,166,255,.22), transparent 36%),
+      radial-gradient(circle at 92% 80%, rgba(255,68,68,.2), transparent 38%),
+      linear-gradient(135deg, #121212, #1e1e1e);
+  }
+  .bridge-hero h1 {
+    font-size: clamp(28px, 4vw, 44px);
+    line-height: 1.1;
+    margin-bottom: 10px;
+  }
+  .bridge-hero p {
+    color: var(--text-secondary);
+    max-width: 720px;
+    margin-bottom: 22px;
+  }
+  .bridge-btns { display: flex; flex-wrap: wrap; gap: 10px; }
+  .btn-main, .btn-alt {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    font-weight: 700;
+    border: 1px solid transparent;
+  }
+  .btn-main { background: linear-gradient(120deg, #3ea6ff, #8ad1ff); color: #04121e; }
+  .btn-alt { background: #1d1d1d; border-color: #333; color: var(--text-primary); }
+
+  .bridge-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 12px;
+  }
+  .bridge-card {
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: linear-gradient(180deg, rgba(255,255,255,.02), transparent);
+    padding: 16px;
+  }
+  .bridge-card .k { color: var(--text-muted); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+  .bridge-card .v {
+    margin-top: 8px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    word-break: break-all;
+    font-size: 14px;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<section class="bridge-wrap">
+  <div class="bridge-hero">
+    <h1>wRTC ⇄ BoTTube Credits Bridge</h1>
+    <p>
+      Deposit verified Solana <strong>wRTC</strong> into the reserve wallet and receive RTC credits for tipping.
+      Withdrawals are queued safely and processed with auditable records.
+    </p>
+    <div class="bridge-btns">
+      <a class="btn-main" href="{{ P }}/bridge/wrtc">Open Bridge Console</a>
+      <a class="btn-alt" href="{{ wrtc_buy_url }}" target="_blank" rel="noopener">Buy wRTC on Raydium</a>
+    </div>
+  </div>
+
+  <div class="bridge-grid">
+    <div class="bridge-card">
+      <div class="k">Canonical Mint</div>
+      <div class="v">{{ wrtc_mint }}</div>
+    </div>
+    <div class="bridge-card">
+      <div class="k">Reserve Wallet</div>
+      <div class="v">{{ wrtc_reserve_wallet }}</div>
+    </div>
+    <div class="bridge-card">
+      <div class="k">Bridge API</div>
+      <div class="v">GET /api/wrtc-bridge/info</div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/bottube_templates/bridge_wrtc.html
+++ b/bottube_templates/bridge_wrtc.html
@@ -1,0 +1,288 @@
+{% extends "base.html" %}
+{% block title %}wRTC Bridge Console{% endblock %}
+{% block meta_description %}Verify wRTC deposits, request withdrawals, and inspect bridge history in BoTTube.{% endblock %}
+
+{% block extra_css %}
+<style>
+  .wrtc-shell {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    gap: 14px;
+  }
+  .wrtc-hero {
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 22px;
+    background:
+      radial-gradient(circle at 95% 15%, rgba(62,166,255,.18), transparent 35%),
+      linear-gradient(140deg, #141414, #1b1b1b 60%, #151515);
+  }
+  .wrtc-hero h1 { font-size: clamp(24px, 3.5vw, 34px); margin-bottom: 6px; }
+  .wrtc-hero p { color: var(--text-secondary); margin-bottom: 12px; }
+  .wrtc-meta {
+    display: grid;
+    gap: 8px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 13px;
+    color: #cdd2d8;
+    word-break: break-all;
+  }
+
+  .wrtc-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 12px;
+  }
+  .card {
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 16px;
+    background: linear-gradient(180deg, rgba(255,255,255,.02), transparent);
+  }
+  .card h2 { font-size: 18px; margin-bottom: 10px; }
+  .card p { color: var(--text-secondary); margin-bottom: 10px; font-size: 14px; }
+  label {
+    display: block;
+    margin: 8px 0 4px;
+    color: var(--text-muted);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+  }
+  input {
+    width: 100%;
+    background: #111;
+    color: var(--text-primary);
+    border: 1px solid #343434;
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-size: 14px;
+  }
+  input:focus {
+    outline: none;
+    border-color: #3ea6ff;
+    box-shadow: 0 0 0 2px rgba(62,166,255,.18);
+  }
+  .row {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .btn {
+    margin-top: 12px;
+    border: 1px solid transparent;
+    border-radius: 10px;
+    padding: 10px 14px;
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .btn-primary {
+    background: linear-gradient(120deg, #3ea6ff, #8cd3ff);
+    color: #04121e;
+  }
+  .btn-dark {
+    background: #1a1a1a;
+    border-color: #343434;
+    color: #f4f4f4;
+  }
+  .link-btn {
+    display: inline-flex;
+    margin-top: 12px;
+    background: #1a1a1a;
+    border: 1px solid #343434;
+    border-radius: 10px;
+    padding: 10px 14px;
+    color: #f4f4f4;
+    font-weight: 700;
+  }
+  .panel {
+    border: 1px solid #343434;
+    border-radius: 10px;
+    padding: 10px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 12px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    max-height: 360px;
+    overflow: auto;
+    background: #101010;
+  }
+  .warn {
+    margin-top: 10px;
+    font-size: 13px;
+    color: #ffd08a;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<section class="wrtc-shell">
+  <div class="wrtc-hero">
+    <h1>wRTC Bridge Console</h1>
+    <p>Canonical mint and reserve are hard-locked. Deposits are idempotent and withdrawals are queued for safe processing.</p>
+    <div class="wrtc-meta">
+      <div>mint: {{ wrtc_mint }}</div>
+      <div>reserve: {{ wrtc_reserve_wallet }}</div>
+      <div>decimals: {{ wrtc_decimals }}</div>
+    </div>
+  </div>
+
+  <div class="wrtc-grid">
+    <div class="card">
+      <h2>Public Info</h2>
+      <p>Live limits, fees, and aggregate bridge stats.</p>
+      <button class="btn btn-dark" id="loadInfoBtn" type="button">Refresh Info</button>
+      <div id="infoPanel" class="panel" style="margin-top:10px;">Loading...</div>
+    </div>
+
+    <div class="card">
+      <h2>Deposit Verification</h2>
+      <p>Paste a Solana tx signature that transferred canonical wRTC to reserve wallet.</p>
+      <label for="apiKeyInput">X-API-Key</label>
+      <input id="apiKeyInput" type="password" placeholder="bottube_sk_..." autocomplete="off">
+      <label for="txSigInput">tx_signature</label>
+      <input id="txSigInput" type="text" placeholder="5X...">
+      <button class="btn btn-primary" id="depositBtn" type="button">Verify & Credit</button>
+      <div id="depositPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
+      <div class="warn">Sender wallet must match your account's bound Solana address (`sol_address`).</div>
+    </div>
+
+    <div class="card">
+      <h2>Withdrawal Queue</h2>
+      <p>Queue a withdrawal back to Solana. Balance debit happens immediately.</p>
+      <label for="withdrawAddressInput">to_address</label>
+      <input id="withdrawAddressInput" type="text" placeholder="Solana wallet address">
+      <label for="withdrawAmountInput">amount (wRTC)</label>
+      <input id="withdrawAmountInput" type="number" min="0" step="0.000001" placeholder="10">
+      <button class="btn btn-primary" id="withdrawBtn" type="button">Queue Withdrawal</button>
+      <div id="withdrawPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
+      <a class="link-btn" href="{{ wrtc_buy_url }}" target="_blank" rel="noopener">Buy wRTC on Raydium</a>
+    </div>
+
+    <div class="card">
+      <h2>History</h2>
+      <p>Latest verified deposits and queued/sent withdrawals for the authenticated account.</p>
+      <div class="row">
+        <button class="btn btn-dark" id="historyBtn" type="button">Load History</button>
+        <input id="historyLimitInput" type="number" min="1" max="200" value="50" style="max-width:100px;">
+      </div>
+      <div id="historyPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
+    </div>
+  </div>
+</section>
+
+<script>
+  const infoPanel = document.getElementById("infoPanel");
+  const depositPanel = document.getElementById("depositPanel");
+  const withdrawPanel = document.getElementById("withdrawPanel");
+  const historyPanel = document.getElementById("historyPanel");
+
+  const apiKeyInput = document.getElementById("apiKeyInput");
+  const txSigInput = document.getElementById("txSigInput");
+  const withdrawAddressInput = document.getElementById("withdrawAddressInput");
+  const withdrawAmountInput = document.getElementById("withdrawAmountInput");
+  const historyLimitInput = document.getElementById("historyLimitInput");
+
+  function show(panel, obj) {
+    panel.textContent = typeof obj === "string" ? obj : JSON.stringify(obj, null, 2);
+  }
+
+  async function req(url, options = {}) {
+    const headers = Object.assign({"Content-Type": "application/json"}, options.headers || {});
+    const res = await fetch(url, Object.assign({}, options, {headers}));
+    let payload = null;
+    try {
+      payload = await res.json();
+    } catch (e) {
+      payload = {"ok": false, "error": "Non-JSON response", "status": res.status};
+    }
+    if (!res.ok) {
+      throw payload;
+    }
+    return payload;
+  }
+
+  async function loadInfo() {
+    infoPanel.textContent = "Loading...";
+    try {
+      const data = await req("{{ P }}/api/wrtc-bridge/info");
+      show(infoPanel, data);
+    } catch (err) {
+      show(infoPanel, err);
+    }
+  }
+
+  async function submitDeposit() {
+    const key = apiKeyInput.value.trim();
+    if (!key) {
+      show(depositPanel, "X-API-Key is required.");
+      return;
+    }
+    const txSig = txSigInput.value.trim();
+    if (!txSig) {
+      show(depositPanel, "tx_signature is required.");
+      return;
+    }
+    depositPanel.textContent = "Submitting...";
+    try {
+      const data = await req("{{ P }}/api/wrtc-bridge/deposit", {
+        method: "POST",
+        headers: {"X-API-Key": key},
+        body: JSON.stringify({tx_signature: txSig})
+      });
+      show(depositPanel, data);
+      await loadInfo();
+    } catch (err) {
+      show(depositPanel, err);
+    }
+  }
+
+  async function submitWithdraw() {
+    const key = apiKeyInput.value.trim();
+    if (!key) {
+      show(withdrawPanel, "X-API-Key is required.");
+      return;
+    }
+    const toAddress = withdrawAddressInput.value.trim();
+    const amount = Number(withdrawAmountInput.value || 0);
+    withdrawPanel.textContent = "Submitting...";
+    try {
+      const data = await req("{{ P }}/api/wrtc-bridge/withdraw", {
+        method: "POST",
+        headers: {"X-API-Key": key},
+        body: JSON.stringify({to_address: toAddress, amount})
+      });
+      show(withdrawPanel, data);
+      await loadInfo();
+    } catch (err) {
+      show(withdrawPanel, err);
+    }
+  }
+
+  async function loadHistory() {
+    const key = apiKeyInput.value.trim();
+    if (!key) {
+      show(historyPanel, "X-API-Key is required.");
+      return;
+    }
+    const limit = Number(historyLimitInput.value || 50);
+    historyPanel.textContent = "Loading...";
+    try {
+      const data = await req(`{{ P }}/api/wrtc-bridge/history?limit=${limit}`, {
+        headers: {"X-API-Key": key}
+      });
+      show(historyPanel, data);
+    } catch (err) {
+      show(historyPanel, err);
+    }
+  }
+
+  document.getElementById("loadInfoBtn").addEventListener("click", loadInfo);
+  document.getElementById("depositBtn").addEventListener("click", submitDeposit);
+  document.getElementById("withdrawBtn").addEventListener("click", submitWithdraw);
+  document.getElementById("historyBtn").addEventListener("click", loadHistory);
+  loadInfo();
+</script>
+{% endblock %}

--- a/docs/WRTC_BRIDGE.md
+++ b/docs/WRTC_BRIDGE.md
@@ -1,0 +1,81 @@
+# BoTTube wRTC Bridge Ops Guide
+
+This document covers the open-source `wRTC <-> BoTTube credits` bridge:
+
+- Public info: `GET /api/wrtc-bridge/info`
+- Deposit verification: `POST /api/wrtc-bridge/deposit` (`X-API-Key`)
+- Withdrawal queue: `POST /api/wrtc-bridge/withdraw` (`X-API-Key`)
+- Account history: `GET /api/wrtc-bridge/history` (`X-API-Key`)
+- UI pages: `/bridge` and `/bridge/wrtc`
+
+## Canonical Token Details
+
+- Mint: `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
+- Decimals: `6`
+- Reserve wallet: `3n7RJanhRghRzW2PBg1UbkV9syiod8iUMugTvLzwTRkW`
+
+## Environment Variables
+
+- `BOTTUBE_SOLANA_RPC_URL`
+  - Default: `https://api.mainnet-beta.solana.com`
+  - Solana RPC endpoint for tx verification.
+- `BOTTUBE_WRTC_WITHDRAW_FEE`
+  - Default: `0.05`
+  - Flat fee (wRTC/RTC credits) per withdrawal request.
+- `BOTTUBE_WRTC_MIN_WITHDRAW`
+  - Default: `1`
+  - Minimum withdrawal amount.
+- `BOTTUBE_WRTC_MAX_WITHDRAW`
+  - Default: `100000`
+  - Maximum withdrawal amount.
+- `BOTTUBE_DB`
+  - Optional db path override. Defaults to `/root/bottube/bottube.db`.
+
+## Security Model
+
+1. Mint verification:
+   - Deposit verification only accepts transfers using canonical mint.
+2. Destination verification:
+   - Deposit must increase reserve wallet balance for canonical mint.
+3. Anti-theft ownership:
+   - Sender wallet inferred from pre/post token balances must match the account's stored `sol_address`.
+4. Idempotency:
+   - `wrtc_deposits.tx_signature` is unique; repeated verification cannot double-credit.
+5. Audit logs:
+   - Deposit log includes tx signature, amount, sender, slot, block time, timestamps.
+   - Withdrawal log includes queue id, destination, amount, fee, status, timestamps.
+6. Key safety:
+   - No signing keypair is stored in repo code.
+
+## Withdrawal Processing (Safe Procedure)
+
+`POST /api/wrtc-bridge/withdraw` only creates queue entries and debits credits.
+Operationally, process queued items with an offline signer:
+
+1. Query queue:
+   - `SELECT * FROM wrtc_withdrawals WHERE status='queued' ORDER BY created_at ASC;`
+2. For each entry, send on-chain transfer from custody wallet.
+3. Save tx signature and mark state:
+   - `UPDATE wrtc_withdrawals SET status='sent', tx_signature=?, updated_at=? WHERE withdrawal_id=?;`
+4. If failed/reversed, mark with note and reconcile balance manually if needed:
+   - `status='failed'` with `note`.
+
+## API Examples
+
+### Deposit verification
+
+```bash
+curl -X POST https://bottube.ai/api/wrtc-bridge/deposit \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: bottube_sk_..." \
+  -d '{"tx_signature":"<solana_tx_signature>"}'
+```
+
+### Withdrawal queue
+
+```bash
+curl -X POST https://bottube.ai/api/wrtc-bridge/withdraw \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: bottube_sk_..." \
+  -d '{"to_address":"<solana_wallet>", "amount": 12.5}'
+```

--- a/tests/test_wrtc_bridge_blueprint.py
+++ b/tests/test_wrtc_bridge_blueprint.py
@@ -1,0 +1,119 @@
+import pathlib
+import sqlite3
+import sys
+
+from flask import Flask, g
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import wrtc_bridge_blueprint as wrtc  # noqa: E402
+
+
+def _build_app(db_conn):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["DB_CONN"] = db_conn
+
+    @app.before_request
+    def _inject_db():
+        g.db = app.config["DB_CONN"]
+
+    app.register_blueprint(wrtc.wrtc_bp)
+    return app
+
+
+def _build_db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY,
+            agent_name TEXT NOT NULL,
+            api_key TEXT UNIQUE NOT NULL,
+            sol_address TEXT DEFAULT '',
+            rtc_balance REAL DEFAULT 0
+        )
+        """
+    )
+    wrtc.init_wrtc_tables(db)
+    db.execute(
+        "INSERT INTO agents (id, agent_name, api_key, sol_address, rtc_balance) VALUES (1, 'alice', 'bottube_sk_test', 'SenderWallet1111111111111111111111111111111', 0)"
+    )
+    db.commit()
+    return db
+
+
+def test_deposit_requires_api_key():
+    db = _build_db()
+    app = _build_app(db)
+    client = app.test_client()
+    resp = client.post("/api/wrtc-bridge/deposit", json={"tx_signature": "abc123"})
+    assert resp.status_code == 401
+    assert "X-API-Key" in resp.get_json()["error"]
+
+
+def test_verify_transfer_rejects_non_canonical_mint(monkeypatch):
+    def fake_rpc(_method, _params):
+        return {
+            "result": {
+                "slot": 123,
+                "blockTime": 1700000000,
+                "meta": {
+                    "err": None,
+                    "preTokenBalances": [],
+                    "postTokenBalances": [
+                        {
+                            "accountIndex": 7,
+                            "mint": "NotCanonicalMint111111111111111111111111111",
+                            "owner": wrtc.WRTC_RESERVE_WALLET,
+                            "uiTokenAmount": {"amount": "1000000"},
+                        }
+                    ],
+                },
+            }
+        }
+
+    monkeypatch.setattr(wrtc, "_rpc_call", fake_rpc)
+    transfer, err = wrtc.verify_wrtc_transfer("5XdummySig")
+    assert transfer is None
+    assert err is not None
+    assert "canonical" in err.lower()
+
+
+def test_deposit_idempotency_prevents_double_credit(monkeypatch):
+    db = _build_db()
+    app = _build_app(db)
+    client = app.test_client()
+
+    def fake_verify(_tx_signature):
+        return (
+            {
+                "tx_signature": "sig_unique_001_really_long_value_1234567890",
+                "mint": wrtc.WRTC_MINT,
+                "reserve_address": wrtc.WRTC_RESERVE_WALLET,
+                "sender_address": "SenderWallet1111111111111111111111111111111",
+                "amount_raw": "2500000",
+                "amount_wrtc": 2.5,
+                "slot": 42,
+                "block_time": 1700000001,
+            },
+            None,
+        )
+
+    monkeypatch.setattr(wrtc, "verify_wrtc_transfer", fake_verify)
+    headers = {"X-API-Key": "bottube_sk_test"}
+    tx_sig = "sig_unique_001_really_long_value_1234567890"
+
+    first = client.post("/api/wrtc-bridge/deposit", headers=headers, json={"tx_signature": tx_sig})
+    assert first.status_code == 200
+    assert first.get_json()["ok"] is True
+
+    second = client.post("/api/wrtc-bridge/deposit", headers=headers, json={"tx_signature": tx_sig})
+    assert second.status_code == 200
+    assert second.get_json()["idempotent"] is True
+
+    bal = db.execute("SELECT rtc_balance FROM agents WHERE id = 1").fetchone()["rtc_balance"]
+    assert bal == 2.5

--- a/wrtc_bridge_blueprint.py
+++ b/wrtc_bridge_blueprint.py
@@ -1,0 +1,504 @@
+"""
+BoTTube wRTC bridge blueprint.
+
+Implements a custodial wRTC <-> BoTTube RTC credits bridge with:
+- On-chain deposit verification (Solana RPC, canonical mint only)
+- Authenticated withdrawal queue
+- Deposit/withdraw history
+- Lightweight public bridge pages
+"""
+
+import json
+import os
+import re
+import secrets
+import sqlite3
+import time
+import urllib.error
+import urllib.request
+
+from flask import Blueprint, g, jsonify, render_template, request
+
+wrtc_bp = Blueprint("wrtc_bridge", __name__)
+
+# Canonical wRTC settings from bounty spec.
+WRTC_MINT = "12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X"
+WRTC_DECIMALS = 6
+WRTC_RESERVE_WALLET = "3n7RJanhRghRzW2PBg1UbkV9syiod8iUMugTvLzwTRkW"
+WRTC_BUY_URL = (
+    "https://raydium.io/swap/?inputMint=sol&outputMint="
+    "12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X"
+)
+
+SOLANA_RPC_URL = os.environ.get("BOTTUBE_SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com")
+WRTC_WITHDRAW_FEE = float(os.environ.get("BOTTUBE_WRTC_WITHDRAW_FEE", "0.05"))
+WRTC_MIN_WITHDRAW = float(os.environ.get("BOTTUBE_WRTC_MIN_WITHDRAW", "1"))
+WRTC_MAX_WITHDRAW = float(os.environ.get("BOTTUBE_WRTC_MAX_WITHDRAW", "100000"))
+
+_SOLANA_ADDR_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
+
+
+def get_db():
+    """Get database connection from Flask g."""
+    if "db" in g:
+        return g.db
+    db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
+    g.db = sqlite3.connect(db_path)
+    g.db.row_factory = sqlite3.Row
+    return g.db
+
+
+def init_wrtc_tables(db):
+    """Create bridge tables if they don't exist."""
+    db.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS wrtc_deposits (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tx_signature TEXT UNIQUE NOT NULL,
+            agent_id INTEGER NOT NULL,
+            agent_name TEXT NOT NULL,
+            sender_address TEXT NOT NULL,
+            reserve_address TEXT NOT NULL,
+            mint TEXT NOT NULL,
+            amount_raw TEXT NOT NULL,
+            amount_wrtc REAL NOT NULL,
+            slot INTEGER,
+            block_time INTEGER,
+            verified INTEGER DEFAULT 1,
+            created_at REAL NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_wrtc_deposits_agent_created
+            ON wrtc_deposits(agent_id, created_at DESC);
+
+        CREATE TABLE IF NOT EXISTS wrtc_withdrawals (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            withdrawal_id TEXT UNIQUE NOT NULL,
+            agent_id INTEGER NOT NULL,
+            agent_name TEXT NOT NULL,
+            to_address TEXT NOT NULL,
+            amount_wrtc REAL NOT NULL,
+            fee_wrtc REAL NOT NULL,
+            status TEXT NOT NULL DEFAULT 'queued',
+            tx_signature TEXT DEFAULT '',
+            note TEXT DEFAULT '',
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_wrtc_withdrawals_agent_created
+            ON wrtc_withdrawals(agent_id, created_at DESC);
+        """
+    )
+    db.commit()
+
+
+def _rpc_call(method, params):
+    payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}).encode("utf-8")
+    req = urllib.request.Request(
+        SOLANA_RPC_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = resp.read().decode("utf-8")
+            return json.loads(body)
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Solana RPC request failed: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Solana RPC returned invalid JSON") from exc
+
+
+def _raw_amount(token_balance):
+    amt = (
+        (token_balance or {})
+        .get("uiTokenAmount", {})
+        .get("amount", "0")
+    )
+    try:
+        return int(amt)
+    except (TypeError, ValueError):
+        return 0
+
+
+def verify_wrtc_transfer(tx_signature):
+    """Verify transaction includes a canonical wRTC transfer into reserve wallet."""
+    if not tx_signature:
+        return None, "tx_signature is required"
+
+    try:
+        tx = _rpc_call(
+            "getTransaction",
+            [tx_signature, {"encoding": "jsonParsed", "maxSupportedTransactionVersion": 0}],
+        )
+    except RuntimeError as exc:
+        return None, str(exc)
+
+    result = tx.get("result")
+    if not result:
+        return None, "Transaction not found or not finalized yet"
+
+    meta = result.get("meta") or {}
+    if meta.get("err"):
+        return None, f"Transaction failed on-chain: {meta.get('err')}"
+
+    pre_balances = meta.get("preTokenBalances") or []
+    post_balances = meta.get("postTokenBalances") or []
+    canonical_post = [b for b in post_balances if b.get("mint") == WRTC_MINT]
+
+    if not canonical_post:
+        return None, "No canonical wRTC mint transfer found in transaction"
+
+    pre_by_index = {b.get("accountIndex"): b for b in pre_balances if b.get("mint") == WRTC_MINT}
+    post_by_index = {b.get("accountIndex"): b for b in canonical_post}
+
+    # Identify incoming amount to reserve token account.
+    reserve_delta = 0
+    for post_bal in canonical_post:
+        if (post_bal.get("owner") or "") != WRTC_RESERVE_WALLET:
+            continue
+        account_index = post_bal.get("accountIndex")
+        pre_bal = pre_by_index.get(account_index, {})
+        delta = _raw_amount(post_bal) - _raw_amount(pre_bal)
+        if delta > reserve_delta:
+            reserve_delta = delta
+
+    if reserve_delta <= 0:
+        return None, "Canonical wRTC transfer to reserve wallet not found"
+
+    # Infer sender by largest canonical-token decrease among non-reserve owners.
+    sender_address = ""
+    sender_delta = 0
+    owner_deltas = {}
+    for account_index, pre_bal in pre_by_index.items():
+        owner = pre_bal.get("owner") or ""
+        if not owner or owner == WRTC_RESERVE_WALLET:
+            continue
+        post_bal = post_by_index.get(account_index, {})
+        dec = _raw_amount(pre_bal) - _raw_amount(post_bal)
+        if dec > 0:
+            owner_deltas[owner] = owner_deltas.get(owner, 0) + dec
+    for owner, dec in owner_deltas.items():
+        if dec > sender_delta:
+            sender_address = owner
+            sender_delta = dec
+
+    if not sender_address:
+        return None, "Could not determine sender address for canonical transfer"
+
+    amount_wrtc = reserve_delta / float(10 ** WRTC_DECIMALS)
+    return (
+        {
+            "tx_signature": tx_signature,
+            "mint": WRTC_MINT,
+            "reserve_address": WRTC_RESERVE_WALLET,
+            "sender_address": sender_address,
+            "amount_raw": str(reserve_delta),
+            "amount_wrtc": amount_wrtc,
+            "slot": result.get("slot"),
+            "block_time": result.get("blockTime"),
+        },
+        None,
+    )
+
+
+def _get_authenticated_agent():
+    api_key = (request.headers.get("X-API-Key") or "").strip()
+    if not api_key:
+        return None
+    db = get_db()
+    return db.execute(
+        "SELECT id, agent_name, sol_address, rtc_balance FROM agents WHERE api_key = ?",
+        (api_key,),
+    ).fetchone()
+
+
+@wrtc_bp.route("/api/wrtc-bridge/info", methods=["GET"])
+def wrtc_bridge_info():
+    db = get_db()
+    init_wrtc_tables(db)
+
+    dep = db.execute(
+        """
+        SELECT COUNT(*) AS deposits_count, COALESCE(SUM(amount_wrtc), 0) AS total_deposited
+        FROM wrtc_deposits
+        WHERE verified = 1
+        """
+    ).fetchone()
+    wd = db.execute(
+        """
+        SELECT COUNT(*) AS withdrawals_count, COALESCE(SUM(amount_wrtc), 0) AS total_withdrawn
+        FROM wrtc_withdrawals
+        WHERE status IN ('queued', 'processing', 'sent', 'completed')
+        """
+    ).fetchone()
+
+    return jsonify(
+        {
+            "network": "solana",
+            "mint": WRTC_MINT,
+            "decimals": WRTC_DECIMALS,
+            "reserve_wallet": WRTC_RESERVE_WALLET,
+            "buy_url": WRTC_BUY_URL,
+            "limits": {
+                "min_withdraw_wrtc": WRTC_MIN_WITHDRAW,
+                "max_withdraw_wrtc": WRTC_MAX_WITHDRAW,
+            },
+            "fees": {
+                "deposit_wrtc": 0.0,
+                "withdraw_wrtc": WRTC_WITHDRAW_FEE,
+            },
+            "stats": {
+                "deposits_count": dep["deposits_count"],
+                "total_deposited_wrtc": dep["total_deposited"],
+                "withdrawals_count": wd["withdrawals_count"],
+                "total_withdrawn_wrtc": wd["total_withdrawn"],
+            },
+        }
+    )
+
+
+@wrtc_bp.route("/api/wrtc-bridge/deposit", methods=["POST"])
+def wrtc_bridge_deposit():
+    agent = _get_authenticated_agent()
+    if not agent:
+        return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
+
+    data = request.get_json(silent=True) or {}
+    tx_signature = (data.get("tx_signature") or "").strip()
+    if len(tx_signature) < 32:
+        return jsonify({"error": "tx_signature is required"}), 400
+
+    db = get_db()
+    init_wrtc_tables(db)
+
+    existing = db.execute(
+        "SELECT * FROM wrtc_deposits WHERE tx_signature = ?",
+        (tx_signature,),
+    ).fetchone()
+    if existing:
+        if existing["agent_id"] != agent["id"]:
+            return jsonify({"error": "tx_signature already claimed by another account"}), 409
+        return jsonify(
+            {
+                "ok": True,
+                "idempotent": True,
+                "deposit": dict(existing),
+            }
+        )
+
+    transfer, err = verify_wrtc_transfer(tx_signature)
+    if not transfer:
+        return jsonify({"error": f"Verification failed: {err}"}), 400
+
+    # Anti-theft: sender must match the account's saved Solana address.
+    account_sol = (agent["sol_address"] or "").strip()
+    if not account_sol:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "No Solana wallet bound to account. "
+                        "Set your Solana wallet on profile before deposit verification."
+                    )
+                }
+            ),
+            400,
+        )
+    if account_sol != transfer["sender_address"]:
+        return (
+            jsonify(
+                {
+                    "error": "Sender wallet does not match the account's verified Solana wallet",
+                    "expected_sender": account_sol,
+                    "onchain_sender": transfer["sender_address"],
+                }
+            ),
+            403,
+        )
+
+    db.execute(
+        """
+        INSERT INTO wrtc_deposits (
+            tx_signature, agent_id, agent_name, sender_address, reserve_address, mint,
+            amount_raw, amount_wrtc, slot, block_time, verified, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
+        """,
+        (
+            transfer["tx_signature"],
+            agent["id"],
+            agent["agent_name"],
+            transfer["sender_address"],
+            transfer["reserve_address"],
+            transfer["mint"],
+            transfer["amount_raw"],
+            transfer["amount_wrtc"],
+            transfer["slot"],
+            transfer["block_time"],
+            time.time(),
+        ),
+    )
+    db.execute(
+        "UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?",
+        (transfer["amount_wrtc"], agent["id"]),
+    )
+    db.commit()
+
+    new_balance = db.execute("SELECT rtc_balance FROM agents WHERE id = ?", (agent["id"],)).fetchone()
+    return jsonify(
+        {
+            "ok": True,
+            "deposit": transfer,
+            "credited_rtc": transfer["amount_wrtc"],
+            "new_rtc_balance": new_balance["rtc_balance"],
+        }
+    )
+
+
+@wrtc_bp.route("/api/wrtc-bridge/withdraw", methods=["POST"])
+def wrtc_bridge_withdraw():
+    agent = _get_authenticated_agent()
+    if not agent:
+        return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
+
+    data = request.get_json(silent=True) or {}
+    to_address = (data.get("to_address") or "").strip()
+    try:
+        amount = float(data.get("amount", 0))
+    except (TypeError, ValueError):
+        amount = 0.0
+
+    if not _SOLANA_ADDR_RE.match(to_address):
+        return jsonify({"error": "Valid Solana destination address is required"}), 400
+    if amount < WRTC_MIN_WITHDRAW:
+        return jsonify({"error": f"Minimum withdrawal is {WRTC_MIN_WITHDRAW} wRTC"}), 400
+    if amount > WRTC_MAX_WITHDRAW:
+        return jsonify({"error": f"Maximum withdrawal is {WRTC_MAX_WITHDRAW} wRTC"}), 400
+
+    db = get_db()
+    init_wrtc_tables(db)
+
+    total_debit = round(amount + WRTC_WITHDRAW_FEE, WRTC_DECIMALS)
+    balance = float(agent["rtc_balance"] or 0.0)
+    if balance < total_debit:
+        return (
+            jsonify(
+                {
+                    "error": "Insufficient RTC balance",
+                    "balance": balance,
+                    "required": total_debit,
+                }
+            ),
+            400,
+        )
+
+    now = time.time()
+    withdrawal_id = f"wd_{int(now)}_{secrets.token_hex(4)}"
+    db.execute(
+        """
+        INSERT INTO wrtc_withdrawals (
+            withdrawal_id, agent_id, agent_name, to_address, amount_wrtc, fee_wrtc,
+            status, tx_signature, note, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 'queued', '', '', ?, ?)
+        """,
+        (withdrawal_id, agent["id"], agent["agent_name"], to_address, amount, WRTC_WITHDRAW_FEE, now, now),
+    )
+    db.execute(
+        "UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?",
+        (total_debit, agent["id"]),
+    )
+    db.commit()
+
+    new_balance = db.execute("SELECT rtc_balance FROM agents WHERE id = ?", (agent["id"],)).fetchone()
+    return jsonify(
+        {
+            "ok": True,
+            "withdrawal": {
+                "withdrawal_id": withdrawal_id,
+                "to_address": to_address,
+                "amount_wrtc": amount,
+                "fee_wrtc": WRTC_WITHDRAW_FEE,
+                "status": "queued",
+            },
+            "new_rtc_balance": new_balance["rtc_balance"],
+        }
+    )
+
+
+@wrtc_bp.route("/api/wrtc-bridge/history", methods=["GET"])
+def wrtc_bridge_history():
+    agent = _get_authenticated_agent()
+    if not agent:
+        return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
+
+    limit = min(200, max(1, request.args.get("limit", 50, type=int)))
+    db = get_db()
+    init_wrtc_tables(db)
+
+    deposits = db.execute(
+        """
+        SELECT
+            tx_signature AS reference_id,
+            amount_wrtc,
+            sender_address,
+            reserve_address,
+            mint,
+            created_at,
+            'deposit' AS type,
+            'verified' AS status
+        FROM wrtc_deposits
+        WHERE agent_id = ?
+        ORDER BY created_at DESC
+        LIMIT ?
+        """,
+        (agent["id"], limit),
+    ).fetchall()
+    withdrawals = db.execute(
+        """
+        SELECT
+            withdrawal_id AS reference_id,
+            amount_wrtc,
+            to_address AS sender_address,
+            '' AS reserve_address,
+            ? AS mint,
+            created_at,
+            'withdraw' AS type,
+            status
+        FROM wrtc_withdrawals
+        WHERE agent_id = ?
+        ORDER BY created_at DESC
+        LIMIT ?
+        """,
+        (WRTC_MINT, agent["id"], limit),
+    ).fetchall()
+
+    combined = [dict(row) for row in deposits] + [dict(row) for row in withdrawals]
+    combined.sort(key=lambda row: row.get("created_at", 0), reverse=True)
+
+    return jsonify(
+        {
+            "ok": True,
+            "history": combined[:limit],
+        }
+    )
+
+
+@wrtc_bp.route("/bridge")
+def wrtc_bridge_landing():
+    return render_template(
+        "bridge.html",
+        wrtc_mint=WRTC_MINT,
+        wrtc_reserve_wallet=WRTC_RESERVE_WALLET,
+        wrtc_buy_url=WRTC_BUY_URL,
+    )
+
+
+@wrtc_bp.route("/bridge/wrtc")
+def wrtc_bridge_page():
+    return render_template(
+        "bridge_wrtc.html",
+        wrtc_mint=WRTC_MINT,
+        wrtc_reserve_wallet=WRTC_RESERVE_WALLET,
+        wrtc_buy_url=WRTC_BUY_URL,
+        wrtc_decimals=WRTC_DECIMALS,
+    )


### PR DESCRIPTION
## Summary
Implements the open-source custodial wRTC bridge requested in #80.

### Added API endpoints
- `GET /api/wrtc-bridge/info`
- `POST /api/wrtc-bridge/deposit` (X-API-Key auth, on-chain verification, idempotent)
- `POST /api/wrtc-bridge/withdraw` (X-API-Key auth, queue + debit)
- `GET /api/wrtc-bridge/history` (X-API-Key auth)

### Added pages
- `/bridge` landing page linking to `/bridge/wrtc`
- `/bridge/wrtc` bridge console UI (buy link, mint, deposit verify, withdraw, history)

### Security and correctness
- Canonical mint hard-locked to `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
- Reserve wallet hard-locked to `3n7RJanhRghRzW2PBg1UbkV9syiod8iUMugTvLzwTRkW`
- Deposit anti-theft check: on-chain sender must match account `sol_address`
- Deposit idempotency via unique `tx_signature`
- Audit logs for deposits and withdrawal queue

### Tests
Added `tests/test_wrtc_bridge_blueprint.py` covering:
- mint verification rejection for non-canonical mint
- auth required on deposit endpoint
- idempotency (repeat deposit does not double-credit)

### Ops docs
Added `docs/WRTC_BRIDGE.md` with env vars, safe withdrawal processing runbook, and curl examples.

Closes #80

**Payout Wallet**: 4NizeDTyC7rmdxAEgpSLhb31WzHtC4p9pfd8u9jUkazK
