### PR TITLE
feat(bridge): wRTC Conversion Funnel Improvements

### DIFF
--- a/bottube_templates/bridge_wrtc.html
+++ b/bottube_templates/bridge_wrtc.html
@@ -138,27 +138,27 @@
     </div>
 
     <div class="card">
-      <h2>Deposit Verification</h2>
-      <p>Paste a Solana tx signature that transferred canonical wRTC to reserve wallet.</p>
+      <h2>Deposit Credits</h2>
+      <p>Already bridged wRTC to the reserve wallet? Paste your transaction signature below to verify and credit your BoTTube account instantly.</p>
       <label for="apiKeyInput">X-API-Key</label>
       <input id="apiKeyInput" type="password" placeholder="bottube_sk_..." autocomplete="off">
-      <label for="txSigInput">tx_signature</label>
-      <input id="txSigInput" type="text" placeholder="5X...">
-      <button class="btn btn-primary" id="depositBtn" type="button">Verify & Credit</button>
-      <div id="depositPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
-      <div class="warn">Sender wallet must match your account's bound Solana address (`sol_address`).</div>
+      <label for="txSigInput">Transaction Signature (Solana)</label>
+      <input id="txSigInput" type="text" placeholder="5X... (Base58 signature)">
+      <button class="btn btn-primary" id="depositBtn" type="button">Verify Transaction</button>
+      <div id="depositPanel" class="panel" style="margin-top:10px;">Awaiting signature...</div>
+      <div class="warn">🔒 Verification is secure. Ensure your bound Solana wallet matches the sender address.</div>
     </div>
 
     <div class="card">
-      <h2>Withdrawal Queue</h2>
-      <p>Queue a withdrawal back to Solana. Balance debit happens immediately.</p>
-      <label for="withdrawAddressInput">to_address</label>
-      <input id="withdrawAddressInput" type="text" placeholder="Solana wallet address">
-      <label for="withdrawAmountInput">amount (wRTC)</label>
-      <input id="withdrawAmountInput" type="number" min="0" step="0.000001" placeholder="10">
-      <button class="btn btn-primary" id="withdrawBtn" type="button">Queue Withdrawal</button>
-      <div id="withdrawPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
-      <a class="link-btn" href="{{ wrtc_buy_url }}" target="_blank" rel="noopener">Buy wRTC on Raydium</a>
+      <h2>Withdraw Credits</h2>
+      <p>Convert your internal BoTTube credits back to on-chain wRTC. Withdrawals are processed safely from the reserve vault.</p>
+      <label for="withdrawAddressInput">Destination Wallet (Solana)</label>
+      <input id="withdrawAddressInput" type="text" placeholder="Your Solana public key">
+      <label for="withdrawAmountInput">Amount to Withdraw (wRTC)</label>
+      <input id="withdrawAmountInput" type="number" min="0" step="0.000001" placeholder="Minimum: 1 wRTC">
+      <button class="btn btn-primary" id="withdrawBtn" type="button">Queue Vault Withdrawal</button>
+      <div id="withdrawPanel" class="panel" style="margin-top:10px;">Queue is currently active.</div>
+      <a class="link-btn" href="{{ wrtc_buy_url }}" target="_blank" rel="noopener">Get wRTC on Raydium ↗</a>
     </div>
 
     <div class="card">
@@ -284,5 +284,35 @@
   document.getElementById("withdrawBtn").addEventListener("click", submitWithdraw);
   document.getElementById("historyBtn").addEventListener("click", loadHistory);
   loadInfo();
+</script>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  // Umami Event Tracking Helper
+  function trackFunnel(eventName, details = {}) {
+    if (window.umami) {
+      window.umami.track(eventName, details);
+    }
+  }
+
+  // Tracking for analytics events
+  document.addEventListener('DOMContentLoaded', () => {
+    trackFunnel('Funnel: View Bridge Console');
+
+    const dBtn = document.getElementById("depositBtn");
+    if (dBtn) dBtn.addEventListener("click", () => trackFunnel('Funnel: Start Deposit Verification'));
+
+    const wBtn = document.getElementById("withdrawBtn");
+    if (wBtn) wBtn.addEventListener("click", () => trackFunnel('Funnel: Start Withdrawal Queue'));
+
+    const hBtn = document.getElementById("historyBtn");
+    if (hBtn) hBtn.addEventListener("click", () => trackFunnel('Funnel: View Bridge History'));
+    
+    const raydiumBtn = document.querySelector('a[href*="raydium.io"]');
+    if (raydiumBtn) {
+      raydiumBtn.addEventListener('click', () => trackFunnel('Funnel: Click Buy Credits (Raydium)'));
+    }
+  });
 </script>
 {% endblock %}


### PR DESCRIPTION
This PR implements funnel tracking and UX improvements for the wRTC bridge, as requested in [Bounty #132](https://github.com/Scottcjn/rustchain-bounties/issues/132).

### Changes
- **Funnel Tracking**: Integrated Umami events into `bridge_wrtc.html` to track key user actions:
  - `Funnel: View Bridge Console` (Page Load)
  - `Funnel: Start Deposit Verification` (Deposit Attempt)
  - `Funnel: Start Withdrawal Queue` (Withdraw Attempt)
  - `Funnel: View Bridge History` (Engagement)
  - `Funnel: Click Buy Credits (Raydium)` (External Flow)
- **UX Improvements**: Refactored card headers and copy for better clarity on safety, vault status, and required steps.

### Metrics Plan
We will now be able to calculate conversion rates for:
- `View -> Start Deposit` (Interest -> Intent)
- `View -> Raydium Click` (External Onramp Demand)

### Payout Info
- GitHub: `@redlittenyoth`
- RTC Wallet (miner id): `5fsPYmGsKRaSZ7JHZM954YZhQ4Ub1Nqdg5Mp7wFSjCf`