### PR TITLE
feat: add wRTC buy/bridge CTAs across homepage, upload, and embed guide

### DIFF
--- a/bottube_templates/embed_guide.html
+++ b/bottube_templates/embed_guide.html
@@ -182,6 +182,32 @@
         font-size: 13px;
     }
 
+
+    .wrtc-embed-cta {
+        margin-bottom: 28px;
+        padding: 14px 16px;
+        border-radius: var(--radius);
+        border: 1px solid rgba(62,166,255,0.35);
+        background: rgba(62,166,255,0.08);
+        font-size: 13px;
+        line-height: 1.6;
+        color: var(--text-secondary);
+    }
+
+    .wrtc-embed-cta a {
+        color: var(--accent);
+        font-weight: 600;
+        text-decoration: none;
+    }
+
+    .wrtc-embed-cta code {
+        background: var(--bg-primary);
+        border-radius: 4px;
+        padding: 2px 5px;
+        color: var(--text-primary);
+        font-size: 12px;
+    }
+
     @media (max-width: 600px) {
         .feature-grid {
             grid-template-columns: 1fr;
@@ -197,6 +223,12 @@
         Share AI-generated videos anywhere on the web. BoTTube supports iframe embeds,
         oEmbed auto-discovery, and responsive layouts out of the box.
     </p>
+
+    <div class="wrtc-embed-cta">
+        Monetizing embeds with tips? Route users to <a href="{{ P }}/bridge/wrtc">wRTC Bridge</a> and
+        <a href="https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X" target="_blank" rel="noopener">Raydium buy link</a>.
+        Anti-scam: verify mint <code>12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X</code> and decimals <code>6</code> before deposit.
+    </div>
 
     <!-- Features -->
     <div class="embed-section">

--- a/bottube_templates/index.html
+++ b/bottube_templates/index.html
@@ -117,6 +117,28 @@
         transform: translateY(-1px);
     }
 
+    .wrtc-hero-note {
+        margin: 12px auto 0;
+        max-width: 760px;
+        font-size: 13px;
+        color: var(--text-secondary);
+        line-height: 1.5;
+    }
+
+    .wrtc-hero-note a {
+        color: var(--accent);
+        font-weight: 600;
+        text-decoration: none;
+    }
+
+    .wrtc-hero-note code {
+        background: rgba(255,255,255,0.08);
+        color: var(--text-primary);
+        border-radius: 4px;
+        padding: 2px 6px;
+        font-size: 12px;
+    }
+
     /* ── Pip install banner ── */
     .pip-banner {
         display: inline-block;
@@ -557,8 +579,15 @@
 	    <div class="hero-actions">
 	        <a href="{{ P }}/join" class="btn-hero btn-primary">Join now</a>
 	        <a href="{{ P }}/trending" class="btn-hero btn-secondary">Watch Now</a>
+	        <a href="{{ P }}/bridge/wrtc" class="btn-hero btn-secondary">Bridge wRTC</a>
 	        <a href="https://github.com/Scottcjn/bottube" class="btn-hero btn-secondary">GitHub</a>
 	    </div>
+
+    <div class="wrtc-hero-note">
+        Need BoTTube tipping credits? <a href="{{ P }}/bridge/wrtc">Deposit wRTC</a> or
+        <a href="https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X" target="_blank" rel="noopener">buy on Raydium</a>.
+        Anti-scam: verify mint <code>12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X</code> and decimals <code>6</code>.
+    </div>
 
     <div class="stats-ribbon">
         <div class="stat-pill">

--- a/bottube_templates/upload.html
+++ b/bottube_templates/upload.html
@@ -149,12 +149,44 @@
         color: var(--red);
         border: 1px solid var(--red);
     }
+
+    .wrtc-upload-cta {
+        margin-top: 18px;
+        background: rgba(20, 241, 149, 0.08);
+        border: 1px solid rgba(20, 241, 149, 0.35);
+        border-radius: var(--radius);
+        padding: 14px;
+        font-size: 13px;
+        color: var(--text-secondary);
+        line-height: 1.5;
+    }
+
+    .wrtc-upload-cta a {
+        color: var(--accent);
+        font-weight: 600;
+        text-decoration: none;
+    }
+
+    .wrtc-upload-cta code {
+        background: var(--bg-primary);
+        border-radius: 4px;
+        padding: 2px 5px;
+        color: var(--text-primary);
+        font-size: 12px;
+    }
 </style>
 {% endblock %}
 
 {% block content %}
 <div class="upload-container">
     <h1>Upload a Video</h1>
+
+
+    <div class="wrtc-upload-cta">
+        Need more tipping credits after upload? <a href="{{ P }}/bridge/wrtc">Bridge wRTC</a> or
+        <a href="https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X" target="_blank" rel="noopener">buy wRTC</a>.
+        Anti-scam: verify mint <code>12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X</code> and decimals <code>6</code>.
+    </div>
 
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}


### PR DESCRIPTION
## Summary
Adds three visible entry points for wRTC buy/bridge flow, each including anti-scam mint/decimals guidance:

1. Homepage hero (`index.html`)
   - New **Bridge wRTC** CTA button
   - New helper note with bridge + Raydium link and mint/decimals verification

2. Upload page (`upload.html`)
   - New tipping-credit CTA panel above upload form
   - Includes bridge + buy links and anti-scam verification text

3. Embed guide (`embed_guide.html`)
   - New monetization CTA panel for embed users
   - Includes bridge + buy links and anti-scam verification text

## Why
This targets issue #79 requirements to add multiple buy/bridge CTAs across UI and include anti-scam safety details (mint + decimals).

Closes #79
