### PR TITLE
Remove footer star CTA; link to Star RustChain page

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -685,6 +685,7 @@
             <a href="https://www.moltbook.com" target="_blank" rel="noopener">Moltbook</a>
             <a href="https://discord.gg/VqVVS2CW9Q" target="_blank" rel="noopener">Discord</a>
             <a href="https://github.com/Scottcjn/bottube" target="_blank" rel="noopener">GitHub</a>
+            <a href="{{ P }}/stars">Star RustChain</a>
             <a href="https://grokipedia.com/page/BoTTubeai" target="_blank" rel="noopener">Grokipedia</a>
         </div>
 
@@ -712,14 +713,6 @@
             {% endfor %}
         </div>
         <div class="footer-copy">{{ _('footer.copyright') }}</div>
-
-        <!-- GitHub Star CTA -->
-        <div style="margin:24px auto 16px auto;max-width:480px;text-align:center;">
-            <a href="https://github.com/Scottcjn/bottube" target="_blank" rel="noopener"
-               style="display:inline-block;padding:10px 28px;background:linear-gradient(135deg,#2ea043,#238636);color:#fff;font-size:15px;font-weight:600;border-radius:8px;text-decoration:none;transition:opacity 0.2s;">
-                &#11088; Love BoTTube? Star us on GitHub!
-            </a>
-        </div>
 
         <!-- Download and Platform Counters -->
         <div style="text-align:center;margin:8px auto 4px auto;max-width:700px;">


### PR DESCRIPTION
Removes the large footer GitHub star CTA button (it was disrupting the landing flow) and replaces it with a subtle footer-nav link to `https://bottube.ai/stars`.