### PR TITLE
feat: add global wRTC funnel CTA tracking + metrics notes (#132)

### DIFF
--- a/bottube_static/base.js
+++ b/bottube_static/base.js
@@ -160,6 +160,35 @@
     });
   }
 
+  function initFunnelCtaTracking() {
+    function getLocation(el) {
+      if (!el) return "unknown";
+      if (el.closest(".header")) return "header";
+      if (el.closest(".footer")) return "footer";
+      if (el.closest(".hero")) return "hero";
+      if (el.closest(".wrtc-upload-cta")) return "upload-cta";
+      if (el.closest(".wrtc-embed-cta")) return "embed-cta";
+      if (el.closest(".wrtc-hero-note")) return "hero-note";
+      return "content";
+    }
+
+    document.addEventListener("click", function (evt) {
+      var link = evt.target && evt.target.closest ? evt.target.closest("a[href]") : null;
+      if (!link) return;
+      var href = String(link.getAttribute("href") || "");
+      var source = String(link.getAttribute("data-track-source") || link.textContent || "link").trim().slice(0, 64);
+      var location = getLocation(link);
+
+      if (href.indexOf("/bridge/wrtc") !== -1) {
+        window.btTrack("funnel-bridge-cta-click", { source: source, location: location });
+        return;
+      }
+      if (href.indexOf("raydium.io/swap") !== -1) {
+        window.btTrack("funnel-swap-cta-click", { source: source, location: location });
+      }
+    }, true);
+  }
+
   function sendBotProofPing() {
     try {
       var x = new XMLHttpRequest();
@@ -194,6 +223,7 @@
   initMobileMenu();
   initNotifications();
   initPipBannerCopy();
+  initFunnelCtaTracking();
   sendBotProofPing();
   initGa4();
   registerServiceWorker();

--- a/docs/WRTC_FUNNEL_METRICS_132.md
+++ b/docs/WRTC_FUNNEL_METRICS_132.md
@@ -1,0 +1,45 @@
+# wRTC Conversion Funnel Improvements — #132
+
+## Baseline
+Before this patch, wRTC bridge pages had partial funnel events, but global CTA clicks (header/footer/home hero/upload/embed) were not consistently tracked under a unified schema.
+
+## Changes
+- Added delegated global CTA tracking in `bottube_static/base.js` for:
+  - `funnel-bridge-cta-click`
+  - `funnel-swap-cta-click`
+- Event metadata now includes:
+  - `source` (link text or explicit `data-track-source`)
+  - `location` (`header`, `footer`, `hero`, `upload-cta`, `embed-cta`, `hero-note`, `content`)
+- Existing bridge-level funnel events remain active (view, deposit/withdraw start/success/fail, history view, chain switch).
+
+## Event Map
+1. Discovery / intent
+   - `funnel-bridge-cta-click`
+   - `funnel-swap-cta-click`
+2. Bridge entry
+   - `funnel-bridge-view`
+   - `funnel-bridge-switch-chain`
+3. Conversion actions
+   - `funnel-wrtc-buy-click`
+   - `funnel-wrtc-deposit-start`
+   - `funnel-wrtc-deposit-ok` / `funnel-wrtc-deposit-fail`
+   - `funnel-wrtc-withdraw-start`
+   - `funnel-wrtc-withdraw-ok` / `funnel-wrtc-withdraw-fail`
+
+## Privacy Notes
+- No private keys, seed phrases, or full wallet secrets are tracked.
+- Only high-level UX event names and non-sensitive context fields (`source`, `location`) are sent.
+- Existing analytics providers (`umami`, `gtag`) are used through `window.btTrack`.
+
+## Post-change measurement plan
+Track 7-day movement for:
+- CTR to bridge: `funnel-bridge-cta-click`
+- CTR to swap: `funnel-swap-cta-click`
+- Bridge view-to-deposit-start rate:
+  - `funnel-wrtc-deposit-start / funnel-bridge-view`
+- Deposit success rate:
+  - `funnel-wrtc-deposit-ok / funnel-wrtc-deposit-start`
+- Withdraw start rate:
+  - `funnel-wrtc-withdraw-start / funnel-bridge-view`
+
+Use the same date window as baseline to compare pre/post movement.


### PR DESCRIPTION
## Summary
Implements the measurement layer requested in bounty #132 for wRTC conversion funnel improvements.

### What changed
- Added delegated global CTA tracking in `bottube_static/base.js`:
  - `funnel-bridge-cta-click`
  - `funnel-swap-cta-click`
- Added metadata fields for each click event:
  - `source` (link text / explicit source)
  - `location` (header/footer/hero/upload-cta/embed-cta/hero-note/content)
- Added measurement/reporting doc:
  - `docs/WRTC_FUNNEL_METRICS_132.md`

### Why
Existing bridge-level events were present, but this closes the gap for top-of-funnel CTA attribution across site entry points.

Closes #132
