### PR TITLE
docs: add Grokipedia press/reference links across key pages (#122)

### DIFF
--- a/bottube_templates/about.html
+++ b/bottube_templates/about.html
@@ -198,6 +198,18 @@
     </div>
 
     <div class="about-section">
+        <h2>Press References</h2>
+        <p>
+            Independent knowledge references for ecosystem verification and context.
+        </p>
+        <div class="about-links">
+            <a href="https://grokipedia.com/page/BoTTubeai" target="_blank" rel="noopener">Grokipedia — BoTTube</a>
+            <a href="https://grokipedia.com/page/RustChain" target="_blank" rel="noopener">Grokipedia — RustChain</a>
+            <a href="https://grokipedia.com/page/RAM_Coffers" target="_blank" rel="noopener">Grokipedia — RAM Coffers</a>
+        </div>
+    </div>
+
+    <div class="about-section">
         <h2>Connect</h2>
         <div class="about-links">
             <a href="https://github.com/Scottcjn/bottube" target="_blank" rel="noopener">GitHub</a>

--- a/bottube_templates/community.html
+++ b/bottube_templates/community.html
@@ -198,6 +198,31 @@
         </div>
     </div>
 
+    <div class="community-section">
+        <h2>Press & Knowledge References</h2>
+        <p>
+            External references for ecosystem background and verification.
+            These links are informational and maintained as factual public references.
+        </p>
+        <div class="community-links">
+            <a href="https://grokipedia.com/page/BoTTubeai" target="_blank" rel="noopener" class="community-card">
+                <div class="card-icon">📚</div>
+                <div class="card-title">Grokipedia — BoTTube</div>
+                <div class="card-desc">Background profile and reference context for BoTTube.</div>
+            </a>
+            <a href="https://grokipedia.com/page/RustChain" target="_blank" rel="noopener" class="community-card">
+                <div class="card-icon">⛓️</div>
+                <div class="card-title">Grokipedia — RustChain</div>
+                <div class="card-desc">Proof-of-Antiquity chain overview and ecosystem references.</div>
+            </a>
+            <a href="https://grokipedia.com/page/RAM_Coffers" target="_blank" rel="noopener" class="community-card">
+                <div class="card-icon">🧠</div>
+                <div class="card-title">Grokipedia — RAM Coffers</div>
+                <div class="card-desc">Prior-art and technical context for Elyan Labs memory infrastructure.</div>
+            </a>
+        </div>
+    </div>
+
     <div class="community-cta">
         <h3>Ready to join?</h3>
         <p>The fastest way to get started is to hop into Discord and say hello.</p>


### PR DESCRIPTION
## Summary\nAdds Grokipedia reference mentions for BoTTube, RustChain, and RAM Coffers across key public pages.\n\n### Updated pages\n- \n  - New **Press & Knowledge References** section with links to:\n    - BoTTube page\n    - RustChain page\n    - RAM Coffers page\n- \n  - New **Press References** block with the same three Grokipedia links\n\n### Why\nMatches bounty #122 goal: improve factual, readable external reference discoverability across official properties.\n\nCloses #122