### PR TITLE
feat: creator analytics dashboard with trends, retention proxy, tips revenue, CSV export

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7020,6 +7020,190 @@ def dashboard_page():
     )
 
 
+@app.route("/api/dashboard/analytics")
+def dashboard_analytics_api():
+    """Time-series analytics for the logged-in creator dashboard."""
+    if not g.user:
+        return jsonify({"error": "Unauthorized"}), 401
+
+    db = get_db()
+    uid = g.user["id"]
+
+    try:
+        days = int(request.args.get("days", 30))
+    except Exception:
+        days = 30
+    days = max(7, min(days, 90))
+
+    now = time.time()
+    day_sec = 86400
+    # include one extra day for repeat-viewer baseline
+    since = now - (days + 14) * day_sec
+
+    def _all_days(n):
+        out = []
+        base = int(now // day_sec) * day_sec
+        for i in range(n - 1, -1, -1):
+            ts = base - i * day_sec
+            out.append(datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d"))
+        return out
+
+    labels = _all_days(days)
+
+    # Daily views (event-level from views table)
+    views_rows = db.execute(
+        """SELECT strftime('%Y-%m-%d', datetime(vw.created_at, 'unixepoch')) AS day,
+                  COUNT(*) AS c
+           FROM views vw
+           JOIN videos v ON v.video_id = vw.video_id
+           WHERE v.agent_id = ? AND vw.created_at >= ?
+           GROUP BY day""",
+        (uid, now - days * day_sec),
+    ).fetchall()
+    views_map = {r["day"]: int(r["c"] or 0) for r in views_rows}
+
+    # Daily new subscribers
+    subs_rows = db.execute(
+        """SELECT strftime('%Y-%m-%d', datetime(created_at, 'unixepoch')) AS day,
+                  COUNT(*) AS c
+           FROM subscriptions
+           WHERE following_id = ? AND created_at >= ?
+           GROUP BY day""",
+        (uid, now - days * day_sec),
+    ).fetchall()
+    subs_map = {r["day"]: int(r["c"] or 0) for r in subs_rows}
+
+    # Daily RTC tips received (confirmed only)
+    tips_rows = db.execute(
+        """SELECT strftime('%Y-%m-%d', datetime(created_at, 'unixepoch')) AS day,
+                  COALESCE(SUM(amount),0) AS amt
+           FROM tips
+           WHERE to_agent_id = ?
+             AND created_at >= ?
+             AND COALESCE(status, 'confirmed') = 'confirmed'
+           GROUP BY day""",
+        (uid, now - days * day_sec),
+    ).fetchall()
+    tips_map = {r["day"]: float(r["amt"] or 0.0) for r in tips_rows}
+
+    # Repeat viewer rate (% of unique viewers on a day who were seen before)
+    rv_rows = db.execute(
+        """SELECT vw.created_at, vw.ip_address
+           FROM views vw
+           JOIN videos v ON v.video_id = vw.video_id
+           WHERE v.agent_id = ?
+             AND vw.created_at >= ?
+             AND vw.ip_address IS NOT NULL
+             AND vw.ip_address != ''
+           ORDER BY vw.created_at ASC""",
+        (uid, since),
+    ).fetchall()
+
+    seen_before = set()
+    day_ips = {}
+    for r in rv_rows:
+        day = datetime.utcfromtimestamp(float(r["created_at"])) .strftime("%Y-%m-%d")
+        ip = r["ip_address"]
+        day_ips.setdefault(day, set()).add(ip)
+
+    repeat_rate = {}
+    for day in sorted(day_ips.keys()):
+        ips = day_ips[day]
+        if not ips:
+            repeat_rate[day] = 0.0
+        else:
+            repeat = len(ips & seen_before)
+            repeat_rate[day] = round((repeat / len(ips)) * 100.0, 2)
+        seen_before.update(ips)
+
+    # Top performing videos by weighted score
+    top_rows = db.execute(
+        """SELECT v.video_id, v.title, v.views, v.likes,
+                  COALESCE((SELECT SUM(t.amount)
+                            FROM tips t
+                            WHERE t.video_id = v.video_id
+                              AND t.to_agent_id = ?
+                              AND COALESCE(t.status, 'confirmed') = 'confirmed'), 0) AS rtc_tips
+           FROM videos v
+           WHERE v.agent_id = ?
+           ORDER BY (v.views * 1.0 + v.likes * 3.0 + COALESCE((SELECT SUM(t2.amount)
+                            FROM tips t2
+                            WHERE t2.video_id = v.video_id
+                              AND t2.to_agent_id = ?
+                              AND COALESCE(t2.status, 'confirmed') = 'confirmed'), 0) * 40.0) DESC,
+                    v.created_at DESC
+           LIMIT 10""",
+        (uid, uid, uid),
+    ).fetchall()
+
+    payload = {
+        "labels": labels,
+        "series": {
+            "views": [views_map.get(d, 0) for d in labels],
+            "new_subscribers": [subs_map.get(d, 0) for d in labels],
+            "tips_rtc": [round(tips_map.get(d, 0.0), 6) for d in labels],
+            "repeat_viewer_rate": [repeat_rate.get(d, 0.0) for d in labels],
+        },
+        "top_videos": [
+            {
+                "video_id": r["video_id"],
+                "title": r["title"],
+                "views": int(r["views"] or 0),
+                "likes": int(r["likes"] or 0),
+                "tips_rtc": round(float(r["rtc_tips"] or 0.0), 6),
+            }
+            for r in top_rows
+        ],
+    }
+    return jsonify(payload)
+
+
+@app.route("/dashboard/export.csv")
+def dashboard_export_csv():
+    """Export creator analytics summary as CSV."""
+    if not g.user:
+        return jsonify({"error": "Unauthorized"}), 401
+
+    db = get_db()
+    uid = g.user["id"]
+
+    rows = db.execute(
+        """SELECT v.video_id, v.title, v.category, v.created_at, v.views, v.likes, v.dislikes,
+                  COALESCE((SELECT SUM(t.amount)
+                            FROM tips t
+                            WHERE t.video_id = v.video_id
+                              AND t.to_agent_id = ?
+                              AND COALESCE(t.status, 'confirmed') = 'confirmed'), 0) AS rtc_tips
+           FROM videos v
+           WHERE v.agent_id = ?
+           ORDER BY v.created_at DESC""",
+        (uid, uid),
+    ).fetchall()
+
+    import csv
+    import io
+
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(["video_id", "title", "category", "created_at", "views", "likes", "dislikes", "rtc_tips"])
+    for r in rows:
+        w.writerow([
+            r["video_id"],
+            r["title"],
+            r["category"],
+            datetime.utcfromtimestamp(float(r["created_at"])).isoformat() + "Z" if r["created_at"] else "",
+            int(r["views"] or 0),
+            int(r["likes"] or 0),
+            int(r["dislikes"] or 0),
+            round(float(r["rtc_tips"] or 0.0), 6),
+        ])
+
+    data = buf.getvalue()
+    resp = app.response_class(data, mimetype="text/csv")
+    resp.headers["Content-Disposition"] = "attachment; filename=creator-analytics.csv"
+    return resp
+
+
 @app.route("/join")
 def join_page():
     """Instructions for agents and humans to join BoTTube."""

--- a/bottube_templates/dashboard.html
+++ b/bottube_templates/dashboard.html
@@ -274,6 +274,73 @@
         color: var(--text-muted);
     }
 
+
+
+    .analytics-section {
+        margin-bottom: 28px;
+    }
+
+    .analytics-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+    }
+
+    .chart-card {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 12px;
+    }
+
+    .chart-title {
+        font-size: 13px;
+        color: var(--text-muted);
+        margin-bottom: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.4px;
+    }
+
+    .chart-wrap {
+        width: 100%;
+        height: 220px;
+    }
+
+    .chart-wrap canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+    }
+
+    .top-videos-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .top-videos-list li {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 10px;
+        border-bottom: 1px solid var(--border);
+        padding: 9px 0;
+        font-size: 13px;
+    }
+
+    .top-videos-list li:last-child {
+        border-bottom: 0;
+    }
+
+    .top-videos-title {
+        color: var(--text-primary);
+        font-weight: 500;
+    }
+
+    .top-videos-meta {
+        color: var(--text-muted);
+        font-size: 12px;
+    }
+
     /* Two-column layout for bottom sections */
     .dash-two-col {
         display: grid;
@@ -284,6 +351,7 @@
     @media (max-width: 768px) {
         .stats-row { grid-template-columns: repeat(2, 1fr); }
         .dash-two-col { grid-template-columns: 1fr; }
+        .analytics-grid { grid-template-columns: 1fr; }
         .vid-table .vid-thumb { width: 60px; }
         .dash-header { flex-direction: column; gap: 12px; align-items: flex-start; }
     }
@@ -296,6 +364,7 @@
     <div class="dash-header-actions">
         <a href="{{ P }}/agent/{{ current_user.agent_name }}">My Channel</a>
         <a href="{{ P }}/playlists/new">New Playlist</a>
+        <a href="{{ P }}/dashboard/export.csv">Export CSV</a>
         <a href="{{ P }}/upload" class="btn-upload">Upload</a>
     </div>
 </div>
@@ -360,6 +429,38 @@
     <div class="stat-card green">
         <div class="stat-value">{{ "%.4f"|format(rtc_balance) }}</div>
         <div class="stat-label">RTC Balance</div>
+    </div>
+</div>
+
+<!-- Analytics -->
+<div class="dash-section analytics-section">
+    <div class="dash-section-header">
+        <h2>Creator Analytics</h2>
+        <div style="font-size:12px;color:var(--text-muted)">Last 30 days</div>
+    </div>
+    <div class="analytics-grid">
+        <div class="chart-card">
+            <div class="chart-title">Views over time</div>
+            <div class="chart-wrap"><canvas id="viewsChart" width="640" height="220"></canvas></div>
+        </div>
+        <div class="chart-card">
+            <div class="chart-title">Subscribers over time</div>
+            <div class="chart-wrap"><canvas id="subsChart" width="640" height="220"></canvas></div>
+        </div>
+        <div class="chart-card">
+            <div class="chart-title">Audience retention (repeat viewers %)</div>
+            <div class="chart-wrap"><canvas id="retentionChart" width="640" height="220"></canvas></div>
+        </div>
+        <div class="chart-card">
+            <div class="chart-title">Revenue tracking (RTC tips)</div>
+            <div class="chart-wrap"><canvas id="tipsChart" width="640" height="220"></canvas></div>
+        </div>
+        <div class="chart-card" style="grid-column:1 / -1;">
+            <div class="chart-title">Top performing videos</div>
+            <ul id="topVideos" class="top-videos-list">
+                <li><span class="top-videos-meta">Loading analytics…</span></li>
+            </ul>
+        </div>
     </div>
 </div>
 
@@ -497,23 +598,117 @@
 (() => {
   const btn = document.getElementById('copyRefBtn');
   const el = document.getElementById('refUrl');
-  if (!btn || !el) return;
-  btn.addEventListener('click', async () => {
-    const text = el.textContent.trim();
-    try {
-      await navigator.clipboard.writeText(text);
-      const prev = btn.textContent;
-      btn.textContent = 'Copied';
-      setTimeout(() => (btn.textContent = prev), 900);
-    } catch {
-      // Fallback: select text for manual copy
-      const r = document.createRange();
-      r.selectNodeContents(el);
-      const sel = window.getSelection();
-      sel.removeAllRanges();
-      sel.addRange(r);
+  if (btn && el) {
+    btn.addEventListener('click', async () => {
+      const text = el.textContent.trim();
+      try {
+        await navigator.clipboard.writeText(text);
+        const prev = btn.textContent;
+        btn.textContent = 'Copied';
+        setTimeout(() => (btn.textContent = prev), 900);
+      } catch {
+        const r = document.createRange();
+        r.selectNodeContents(el);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(r);
+      }
+    });
+  }
+
+  function drawLineChart(canvasId, labels, values, color, ySuffix = '') {
+    const c = document.getElementById(canvasId);
+    if (!c) return;
+    const ctx = c.getContext('2d');
+    const w = c.width, h = c.height;
+    ctx.clearRect(0, 0, w, h);
+
+    const pad = { l: 42, r: 12, t: 10, b: 24 };
+    const min = 0;
+    const max = Math.max(...values, 1);
+    const xStep = (w - pad.l - pad.r) / Math.max(values.length - 1, 1);
+    const yScale = (h - pad.t - pad.b) / (max - min || 1);
+
+    // grid
+    ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+    ctx.lineWidth = 1;
+    for (let i = 0; i <= 4; i++) {
+      const y = pad.t + ((h - pad.t - pad.b) * i / 4);
+      ctx.beginPath(); ctx.moveTo(pad.l, y); ctx.lineTo(w - pad.r, y); ctx.stroke();
+      const v = (max - (max * i / 4)).toFixed(max > 10 ? 0 : 2);
+      ctx.fillStyle = 'rgba(255,255,255,0.55)';
+      ctx.font = '11px sans-serif';
+      ctx.fillText(v + ySuffix, 4, y + 4);
     }
-  });
+
+    // line
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    values.forEach((v, i) => {
+      const x = pad.l + i * xStep;
+      const y = h - pad.b - (v - min) * yScale;
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+
+    // fill
+    ctx.lineTo(pad.l + (values.length - 1) * xStep, h - pad.b);
+    ctx.lineTo(pad.l, h - pad.b);
+    ctx.closePath();
+    const g = ctx.createLinearGradient(0, pad.t, 0, h - pad.b);
+    g.addColorStop(0, color.replace('1)', '0.22)'));
+    g.addColorStop(1, color.replace('1)', '0.03)'));
+    ctx.fillStyle = g;
+    ctx.fill();
+
+    // x labels (sparse)
+    ctx.fillStyle = 'rgba(255,255,255,0.5)';
+    ctx.font = '11px sans-serif';
+    const ticks = 5;
+    for (let i = 0; i < ticks; i++) {
+      const idx = Math.floor((labels.length - 1) * (i / (ticks - 1)));
+      const x = pad.l + idx * xStep;
+      const lbl = labels[idx] ? labels[idx].slice(5) : '';
+      ctx.fillText(lbl, x - 12, h - 6);
+    }
+  }
+
+  async function loadAnalytics() {
+    try {
+      const r = await fetch('{{ P }}/api/dashboard/analytics?days=30');
+      if (!r.ok) return;
+      const data = await r.json();
+      const labels = data.labels || [];
+      const s = data.series || {};
+      drawLineChart('viewsChart', labels, s.views || [], 'rgba(62,166,255,1)');
+      drawLineChart('subsChart', labels, s.new_subscribers || [], 'rgba(114,137,218,1)');
+      drawLineChart('retentionChart', labels, s.repeat_viewer_rate || [], 'rgba(46,204,113,1)', '%');
+      drawLineChart('tipsChart', labels, s.tips_rtc || [], 'rgba(241,196,15,1)');
+
+      const top = document.getElementById('topVideos');
+      if (top) {
+        const rows = data.top_videos || [];
+        if (!rows.length) {
+          top.innerHTML = '<li><span class="top-videos-meta">No videos yet.</span></li>';
+        } else {
+          top.innerHTML = rows.map(v => `
+            <li>
+              <div>
+                <div class="top-videos-title"><a href="{{ P }}/watch/${v.video_id}" style="color:inherit">${(v.title||'').replace(/</g,'&lt;')}</a></div>
+                <div class="top-videos-meta">${v.views} views · ${v.likes} likes · ${Number(v.tips_rtc||0).toFixed(4)} RTC tips</div>
+              </div>
+              <div class="top-videos-meta">Score ${(v.views + v.likes*3 + Number(v.tips_rtc||0)*40).toFixed(1)}</div>
+            </li>
+          `).join('');
+        }
+      }
+    } catch (e) {
+      // swallow
+    }
+  }
+
+  loadAnalytics();
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
Implements bounty #35 (Creator Analytics Dashboard).

## Delivered
### 1) Analytics API for creator dashboard
- `GET /api/dashboard/analytics?days=30`
- Returns:
  - `views` over time (daily)
  - `new_subscribers` over time (daily)
  - `tips_rtc` over time (confirmed tips)
  - `repeat_viewer_rate` over time (audience retention proxy)
  - `top_videos` ranked by weighted performance score

### 2) Audience retention graph
- Added repeat-viewer rate (%): unique viewers on a day who had viewed this creator before.
- Exposed as `series.repeat_viewer_rate` and rendered in dashboard.

### 3) Revenue tracking (RTC tips)
- Daily confirmed tips trend added to analytics series.
- Top videos include per-video confirmed RTC tips.

### 4) Top performing videos
- Added top-performers panel in dashboard
- Weighted score includes views + likes + RTC tips

### 5) Export to CSV
- `GET /dashboard/export.csv`
- Exports per-video metrics: views, likes, dislikes, category, created_at, rtc_tips.
- Added “Export CSV” button in dashboard header.

### 6) Dashboard UI
- Added four analytics charts:
  - Views over time
  - Subscribers over time
  - Audience retention (repeat viewers %)
  - RTC tips revenue trend
- Added top-performing videos list.

## Files changed
- `bottube_server.py`
- `bottube_templates/dashboard.html`

Miner ID: createker02140054RTC

Closes #35
