### PR TITLE
fix(embed): switch guide snippets to /embed + hardened iframe attrs

### DIFF
--- a/bottube_templates/embed_guide.html
+++ b/bottube_templates/embed_guide.html
@@ -259,10 +259,13 @@
         <p>Copy and paste this HTML to embed a video. Replace <code>VIDEO_ID</code> with any BoTTube video ID.</p>
 
         <div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;iframe
-  src="https://bottube.ai/watch/VIDEO_ID"
+  src="https://bottube.ai/embed/VIDEO_ID"
   width="560"
   height="315"
   frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  loading="lazy"
+  referrerpolicy="strict-origin-when-cross-origin"
   allowfullscreen
 &gt;&lt;/iframe&gt;</div>
 
@@ -293,7 +296,7 @@
 
         <div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;"&gt;
   &lt;iframe
-    src="https://bottube.ai/watch/VIDEO_ID"
+    src="https://bottube.ai/embed/VIDEO_ID"
     style="position:absolute;top:0;left:0;width:100%;height:100%;"
     frameborder="0"
     allowfullscreen
@@ -354,10 +357,10 @@ function setVideo(videoId, btn) {
     btn.classList.add("active");
 
     var iframe = document.getElementById("embed-iframe");
-    iframe.src = "https://bottube.ai/watch/" + videoId;
+    iframe.src = "https://bottube.ai/embed/" + videoId;
     document.getElementById("embed-demo").style.display = "block";
 
-    var codeText = '&lt;iframe src="https://bottube.ai/watch/' + videoId + '" width="560" height="315" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;';
+    var codeText = '&lt;iframe src="https://bottube.ai/embed/' + videoId + '" width="560" height="315" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen&gt;&lt;/iframe&gt;';
     document.getElementById("embed-code-text").innerHTML = codeText;
     document.getElementById("embed-code-output").style.display = "block";
 }

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2309,7 +2309,7 @@ function updateEmbedCode() {
     var parts = size.split("x");
     var w = parts[0], h = parts[1];
     var style = w === "100%" ? ' style="width:100%;max-width:853px;"' : '';
-    var code = '<iframe src="https://bottube.ai/embed/' + videoId + '" width="' + w + '" height="' + h + '" frameborder="0" allowfullscreen' + style + '></iframe>';
+    var code = '<iframe src="https://bottube.ai/embed/' + videoId + '" width="' + w + '" height="' + h + '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen' + style + '></iframe>';
     document.getElementById("embed-code").value = code;
 }
 


### PR DESCRIPTION
## What\n- Replace incorrect iframe examples from `/watch/VIDEO_ID` to `/embed/VIDEO_ID` in `embed_guide.html`\n- Align dynamic generated embed code with `/embed` endpoint\n- Add safer/default iframe attributes to generated snippets:\n  - `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"`\n  - `loading="lazy"`\n  - `referrerpolicy="strict-origin-when-cross-origin"`\n\n## Why\nIssue #121 asks for an embeddable player experience. Existing guide snippets pointed to watch pages in some places, which is inconsistent with the actual embed route and can confuse integrators. This PR makes copy-paste embeds work reliably and improves default privacy/perf posture.\n\nCloses #121