### PR TITLE
feat(cli): add login/config, videos list, upload --dry-run, and JSON output (bounty #119)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ avatars/
 dist/
 build/
 venv/
+.venv/
 visitor_log.jsonl
 *.bak
 *.bak.*

--- a/bottube/client.py
+++ b/bottube/client.py
@@ -214,12 +214,28 @@ class BoTTubeClient:
         return self._request("POST", f"/api/videos/{video_id}/view", auth=True,
                              headers={"X-API-Key": self.api_key} if self.api_key else {})
 
-    def list_videos(self, page: int = 1, per_page: int = 20, sort: str = "newest",
-                    agent: str = "") -> dict:
-        """List videos with pagination."""
+    def list_videos(
+        self,
+        page: int = 1,
+        per_page: int = 20,
+        sort: str = "newest",
+        agent: str = "",
+        category: str = "",
+    ) -> dict:
+        """List videos with pagination.
+
+        Args:
+            page: 1-indexed page number
+            per_page: page size
+            sort: sort mode (server-defined)
+            agent: optional agent filter
+            category: optional category slug filter
+        """
         params = {"page": page, "per_page": per_page, "sort": sort}
         if agent:
             params["agent"] = agent
+        if category:
+            params["category"] = category
         return self._request("GET", "/api/videos", params=params)
 
     def trending(self) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dependencies = [
 
 [project.optional-dependencies]
 screenshot = ["playwright>=1.30.0"]
+dev = [
+    "pytest>=7.0.0",
+    "flask>=2.0.0",
+]
 
 [project.urls]
 Homepage = "https://bottube.ai"
@@ -44,6 +48,11 @@ bottube = "bottube:_cli_main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["bottube"]
+
+[tool.pytest.ini_options]
+markers = [
+  "integration: live API tests (opt-in)",
+]
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,73 @@
+import json
+import sys
+
+import pytest
+
+
+def run_cli(monkeypatch, capsys, args, fake_client=None):
+    from bottube import cli as bottube_cli
+
+    if fake_client is not None:
+        monkeypatch.setattr(bottube_cli, "BoTTubeClient", lambda **kwargs: fake_client)
+
+    monkeypatch.setattr(sys, "argv", ["bottube"] + args)
+    bottube_cli.main()
+    captured = capsys.readouterr()
+    return captured.out.strip()
+
+
+class FakeClient:
+    def __init__(self):
+        self._health = {"ok": True}
+
+    def health(self):
+        return self._health
+
+    def list_videos(self, **kwargs):
+        return {
+            "total": 1,
+            "videos": [
+                {
+                    "video_id": "v1",
+                    "title": "Hello",
+                    "agent_name": "alice",
+                    "views": 1,
+                    "likes": 2,
+                }
+            ],
+        }
+
+    def upload(self, *a, **k):
+        return {"uploaded": True}
+
+
+def test_health_json(monkeypatch, capsys):
+    fake = FakeClient()
+    s = run_cli(monkeypatch, capsys, ["--json", "health"], fake_client=fake)
+    obj = json.loads(s)
+    assert obj["ok"] is True
+
+
+def test_videos_human(monkeypatch, capsys):
+    fake = FakeClient()
+    s = run_cli(monkeypatch, capsys, ["videos"], fake_client=fake)
+    assert "[v1]" in s
+    assert "@alice" in s
+
+
+@pytest.mark.integration
+def test_live_api_health():
+    """Optional live integration test against bottube.ai.
+
+    Enable by setting BOTTUBE_RUN_LIVE_TESTS=1.
+    """
+    import os
+
+    if os.environ.get("BOTTUBE_RUN_LIVE_TESTS") != "1":
+        pytest.skip("set BOTTUBE_RUN_LIVE_TESTS=1 to run")
+
+    from bottube.client import BoTTubeClient
+
+    c = BoTTubeClient(base_url="https://bottube.ai", api_key="", verify_ssl=True)
+    r = c.health()
+    assert r.get("ok") is True


### PR DESCRIPTION
Implements core requirements for bottube CLI bounty #119.\n\n## What’s included\n-  saves API key + base URL to \n-  command with , , paging, and optional \n-  preview (no network call)\n- Global  output mode + command-level  for videos/upload (so  works)\n- Client supports  filter for list_videos()\n- Pytest CLI coverage + optional live API integration test (opt-in via )\n\nWallet (miner_id): createker02140054RTC\n\nCloses #119