### PR TITLE
ci(bcos): accept existing tier labels (micro/standard/major/critical)

### DIFF
--- a/.github/workflows/bcos.yml
+++ b/.github/workflows/bcos.yml
@@ -22,7 +22,12 @@ jobs:
             const pr = context.payload.pull_request;
             const prNumber = pr.number;
 
-            const allowedLabels = new Set(["BCOS-L1", "BCOS-L2", "bcos:l1", "bcos:l2"]);
+            // Accept either explicit BCOS tiers, or the repo's existing tier labels.
+            // (Some repos only have micro/standard/major/critical and no BCOS-* labels.)
+            const allowedLabels = new Set([
+              "BCOS-L1", "BCOS-L2", "bcos:l1", "bcos:l2",
+              "micro", "standard", "major", "critical"
+            ]);
 
             const labels = (pr.labels || []).map(l => l.name);
             const hasTier = labels.some(l => allowedLabels.has(l));
@@ -53,7 +58,7 @@ jobs:
 
             if (!hasTier) {
               core.setFailed(
-                "BCOS label required for non-doc changes. Add one of: BCOS-L1, BCOS-L2 (or bcos:l1, bcos:l2)."
+                "Tier label required for non-doc changes. Add one of: BCOS-L1/BCOS-L2 (or bcos:l1/bcos:l2), or the repo tier labels: micro/standard/major/critical."
               );
             } else {
               core.info(`Tier label present: ${labels.join(", ")}`);
@@ -111,9 +116,10 @@ jobs:
             const pr = context.payload.pull_request || null;
             const prNumber = pr ? pr.number : null;
             const labels = pr ? (pr.labels || []).map(l => l.name) : [];
+            // Map either BCOS-* labels or repo tier labels → attested tier.
             const tier =
-              labels.includes('BCOS-L2') || labels.includes('bcos:l2') ? 'L2' :
-              labels.includes('BCOS-L1') || labels.includes('bcos:l1') ? 'L1' :
+              labels.includes('BCOS-L2') || labels.includes('bcos:l2') || labels.includes('critical') || labels.includes('major') ? 'L2' :
+              labels.includes('BCOS-L1') || labels.includes('bcos:l1') || labels.includes('standard') || labels.includes('micro') ? 'L1' :
               null;
 
             const att = {

--- a/.github/workflows/bcos.yml
+++ b/.github/workflows/bcos.yml
@@ -94,7 +94,8 @@ jobs:
         run: |
           . .venv-bcos/bin/activate
           mkdir -p artifacts
-          python -m cyclonedx_py environment --format json -o artifacts/sbom_environment.json
+          # cyclonedx_py CLI uses --of/--output-format (JSON|XML)
+          python -m cyclonedx_py environment --of JSON -o artifacts/sbom_environment.json
 
       - name: Generate dependency license report
         run: |


### PR DESCRIPTION
The BCOS label gate currently requires BCOS-L1/BCOS-L2 labels, but this repo only has tier labels like micro/standard/major/critical. That makes every non-doc PR fail CI.

This PR updates .github/workflows/bcos.yml to accept either BCOS-* labels OR the existing tier labels, and maps the repo tier labels into the attested BCOS tier (major/critical→L2, standard/micro→L1).