### PR TITLE
feat(feed): Atom 1.0 endpoint + refactor RSS (bounty #120)

### DIFF
--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Author: @createkr (RayBot AI)
+# Author: @AUTHENSOR
 # BCOS-Tier: L1
 import datetime
 import os
@@ -12,11 +12,12 @@ feed_bp = Blueprint("feed", __name__)
 
 
 def _base_api_url() -> str:
-    # Prefer local API by default; allow explicit override for external deployments.
+    """Prefer local API by default; allow explicit override for external deployments."""
     return os.getenv("BOTTUBE_API_BASE", "http://127.0.0.1:5000").rstrip("/")
 
 
 def escape_xml(text):
+    """Escape text for safe XML embedding."""
     if text is None:
         return ""
     text = str(text)
@@ -30,11 +31,11 @@ def escape_xml(text):
 
 
 def _to_rfc2822(value):
+    """Convert various timestamp formats to RFC 2822 for RSS pubDate."""
     if value is None or value == "":
         dt = datetime.datetime.now(datetime.timezone.utc)
         return format_datetime(dt)
 
-    # unix epoch seconds
     if isinstance(value, (int, float)):
         dt = datetime.datetime.fromtimestamp(float(value), tz=datetime.timezone.utc)
         return format_datetime(dt)
@@ -44,12 +45,10 @@ def _to_rfc2822(value):
         dt = datetime.datetime.now(datetime.timezone.utc)
         return format_datetime(dt)
 
-    # numeric epoch string
     if s.replace(".", "", 1).isdigit():
         dt = datetime.datetime.fromtimestamp(float(s), tz=datetime.timezone.utc)
         return format_datetime(dt)
 
-    # ISO 8601
     try:
         dt = datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
         if dt.tzinfo is None:
@@ -60,7 +59,36 @@ def _to_rfc2822(value):
         return format_datetime(dt)
 
 
+def _to_iso8601(value):
+    """Convert various timestamp formats to ISO 8601 for Atom feed."""
+    if value is None or value == "":
+        return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    if isinstance(value, (int, float)):
+        return datetime.datetime.fromtimestamp(
+            float(value), tz=datetime.timezone.utc
+        ).isoformat()
+
+    s = str(value).strip()
+    if not s:
+        return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    if s.replace(".", "", 1).isdigit():
+        return datetime.datetime.fromtimestamp(
+            float(s), tz=datetime.timezone.utc
+        ).isoformat()
+
+    try:
+        dt = datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return dt.astimezone(datetime.timezone.utc).isoformat()
+    except Exception:
+        return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
 def _normalize_videos(payload):
+    """Extract a list of video dicts from various API response shapes."""
     if isinstance(payload, list):
         return [v for v in payload if isinstance(v, dict)]
     if isinstance(payload, dict):
@@ -71,65 +99,141 @@ def _normalize_videos(payload):
     return []
 
 
-@feed_bp.route("/feed/rss")
-def rss_feed():
-    agent = request.args.get("agent")
-    category = request.args.get("category")
-
-    try:
-        limit = int(request.args.get("limit", 20))
-    except Exception:
-        limit = 20
-    limit = max(1, min(limit, 100))
-
-    params = {"limit": limit}
+def _fetch_videos(agent=None, category=None, limit=20):
+    """Fetch videos from the BoTTube API with optional filters."""
+    params = {"per_page": limit}
     if agent:
         params["agent"] = agent
     if category:
         params["category"] = category
 
-    videos = []
     try:
         api_url = f"{_base_api_url()}/api/videos"
         res = requests.get(api_url, params=params, timeout=10)
         res.raise_for_status()
-        videos = _normalize_videos(res.json())
+        return _normalize_videos(res.json())
     except Exception:
-        videos = []
+        return []
 
-    rss = []
-    rss.append('<?xml version="1.0" encoding="UTF-8" ?>')
-    rss.append('<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/" xmlns:dc="http://purl.org/dc/elements/1.1/">')
-    rss.append("<channel>")
-    rss.append(f'  <title>BoTTube - {escape_xml(agent or category or "Global Feed")}</title>')
-    rss.append("  <link>https://bottube.ai</link>")
-    rss.append("  <description>Latest AI-generated videos on BoTTube</description>")
-    rss.append(f'  <lastBuildDate>{format_datetime(datetime.datetime.now(datetime.timezone.utc))}</lastBuildDate>')
+
+def _parse_limit():
+    """Parse and clamp the limit query parameter."""
+    try:
+        limit = int(request.args.get("limit", 20))
+    except Exception:
+        limit = 20
+    return max(1, min(limit, 100))
+
+
+def _vid_fields(vid):
+    """Extract common fields from a video dict."""
+    vid_id = vid.get("video_id") or vid.get("id") or ""
+    return {
+        "id": vid_id,
+        "title": vid.get("title", "Untitled Video"),
+        "desc": vid.get("description", ""),
+        "author": vid.get("agent_name", "AI Agent"),
+        "category": vid.get("category", "General"),
+        "thumb": vid.get(
+            "thumbnail_url", f"https://bottube.ai/api/videos/{vid_id}/thumbnail"
+        ),
+        "stream": f"https://bottube.ai/api/videos/{vid_id}/stream",
+        "watch": f"https://bottube.ai/watch/{vid_id}",
+        "created_at": vid.get("created_at"),
+    }
+
+
+@feed_bp.route("/feed/rss")
+def rss_feed():
+    """RSS 2.0 feed with global, per-agent, and per-category filtering."""
+    agent = request.args.get("agent")
+    category = request.args.get("category")
+    limit = _parse_limit()
+    videos = _fetch_videos(agent=agent, category=category, limit=limit)
+
+    now_rfc = format_datetime(datetime.datetime.now(datetime.timezone.utc))
+    feed_title = escape_xml(agent or category or "Global Feed")
+
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8" ?>',
+        '<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/" xmlns:dc="http://purl.org/dc/elements/1.1/">',
+        "<channel>",
+        f"  <title>BoTTube - {feed_title}</title>",
+        "  <link>https://bottube.ai</link>",
+        "  <description>Latest AI-generated videos on BoTTube</description>",
+        f"  <lastBuildDate>{now_rfc}</lastBuildDate>",
+    ]
 
     for vid in videos:
-        vid_id = escape_xml(vid.get("video_id") or vid.get("id") or "")
-        title = escape_xml(vid.get("title", "Untitled Video"))
-        desc = escape_xml(vid.get("description", ""))
-        author = escape_xml(vid.get("agent_name", "AI Agent"))
-        cat = escape_xml(vid.get("category", "General"))
-        thumb = vid.get("thumbnail_url", f"https://bottube.ai/api/videos/{vid_id}/thumbnail")
-        stream_url = f"https://bottube.ai/api/videos/{vid_id}/stream"
-        watch_url = f"https://bottube.ai/watch/{vid_id}"
-        pub_date = _to_rfc2822(vid.get("created_at"))
+        f = _vid_fields(vid)
+        lines += [
+            "  <item>",
+            f"    <title>{escape_xml(f['title'])}</title>",
+            f"    <link>{f['watch']}</link>",
+            f'    <guid isPermaLink="false">{escape_xml(f["id"])}</guid>',
+            f'    <description><![CDATA[<img src="{f["thumb"]}" /><p>{escape_xml(f["desc"])}</p>]]></description>',
+            f"    <pubDate>{_to_rfc2822(f['created_at'])}</pubDate>",
+            f"    <dc:creator>{escape_xml(f['author'])}</dc:creator>",
+            f"    <category>{escape_xml(f['category'])}</category>",
+            f'    <media:content url="{f["stream"]}" type="video/mp4" medium="video" />',
+            f'    <media:thumbnail url="{f["thumb"]}" />',
+            "  </item>",
+        ]
 
-        rss.append("  <item>")
-        rss.append(f"    <title>{title}</title>")
-        rss.append(f"    <link>{watch_url}</link>")
-        rss.append(f'    <guid isPermaLink="false">{vid_id}</guid>')
-        rss.append(f'    <description><![CDATA[<img src="{thumb}" /><p>{desc}</p>]]></description>')
-        rss.append(f"    <pubDate>{pub_date}</pubDate>")
-        rss.append(f"    <dc:creator>{author}</dc:creator>")
-        rss.append(f"    <category>{cat}</category>")
-        rss.append(f'    <media:content url="{stream_url}" type="video/mp4" medium="video" />')
-        rss.append(f'    <media:thumbnail url="{thumb}" />')
-        rss.append("  </item>")
+    lines += ["</channel>", "</rss>"]
+    return Response("\n".join(lines), mimetype="application/rss+xml")
 
-    rss.append("</channel>")
-    rss.append("</rss>")
 
-    return Response("\n".join(rss), mimetype="application/rss+xml")
+@feed_bp.route("/feed/atom")
+def atom_feed():
+    """Atom 1.0 feed with global, per-agent, and per-category filtering."""
+    agent = request.args.get("agent")
+    category = request.args.get("category")
+    limit = _parse_limit()
+    videos = _fetch_videos(agent=agent, category=category, limit=limit)
+
+    now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    feed_title = escape_xml(agent or category or "Global Feed")
+
+    # Build self-link with current query params
+    self_params = []
+    if agent:
+        self_params.append(f"agent={escape_xml(agent)}")
+    if category:
+        self_params.append(f"category={escape_xml(category)}")
+    self_qs = f"?{'&amp;'.join(self_params)}" if self_params else ""
+    self_href = f"https://bottube.ai/feed/atom{self_qs}"
+
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8" ?>',
+        '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">',
+        f"  <title>BoTTube - {feed_title}</title>",
+        f'  <link href="https://bottube.ai" rel="alternate" />',
+        f'  <link href="{self_href}" rel="self" />',
+        f"  <id>https://bottube.ai/feed/atom</id>",
+        f"  <updated>{now_iso}</updated>",
+        "  <subtitle>Latest AI-generated videos on BoTTube</subtitle>",
+        '  <generator uri="https://bottube.ai" version="1.0">BoTTube</generator>',
+    ]
+
+    for vid in videos:
+        f = _vid_fields(vid)
+        updated = _to_iso8601(f["created_at"])
+        lines += [
+            "  <entry>",
+            f"    <title>{escape_xml(f['title'])}</title>",
+            f'    <link href="{f["watch"]}" rel="alternate" />',
+            f"    <id>urn:bottube:video:{escape_xml(f['id'])}</id>",
+            f"    <updated>{updated}</updated>",
+            f"    <published>{updated}</published>",
+            f"    <author><name>{escape_xml(f['author'])}</name></author>",
+            f"    <category term=\"{escape_xml(f['category'])}\" />",
+            f"    <summary>{escape_xml(f['desc'])}</summary>",
+            f'    <content type="html"><![CDATA[<img src="{f["thumb"]}" /><p>{escape_xml(f["desc"])}</p>]]></content>',
+            f'    <media:content url="{f["stream"]}" type="video/mp4" medium="video" />',
+            f'    <media:thumbnail url="{f["thumb"]}" />',
+            "  </entry>",
+        ]
+
+    lines.append("</feed>")
+    return Response("\n".join(lines), mimetype="application/atom+xml")

--- a/tests/test_feed_blueprint.py
+++ b/tests/test_feed_blueprint.py
@@ -28,25 +28,44 @@ def _build_app():
     return app
 
 
+SAMPLE_VIDEO = {
+    "id": "vid123",
+    "title": "Hello",
+    "description": "desc",
+    "agent_name": "agent",
+    "category": "news",
+    "created_at": "2026-02-16T12:34:56Z",
+}
+
+
+# ── RFC 2822 / ISO 8601 helpers ──────────────────────────────
+
 def test_to_rfc2822_supports_epoch_string():
     out = feed._to_rfc2822("1700000000")
     assert "+0000" in out
     assert "2023" in out
 
 
-def test_rss_route_uses_video_created_at_and_content_type(monkeypatch):
-    payload = [
-        {
-            "id": "vid123",
-            "title": "Hello",
-            "description": "desc",
-            "agent_name": "agent",
-            "category": "news",
-            "created_at": "2026-02-16T12:34:56Z",
-        }
-    ]
+def test_to_iso8601_supports_epoch_string():
+    out = feed._to_iso8601("1700000000")
+    assert "2023" in out
+    assert "T" in out
 
-    monkeypatch.setattr(feed.requests, "get", lambda *args, **kwargs: _Resp(payload))
+
+def test_to_iso8601_supports_iso_input():
+    out = feed._to_iso8601("2026-02-16T12:34:56Z")
+    assert "2026-02-16" in out
+
+
+def test_to_iso8601_handles_none():
+    out = feed._to_iso8601(None)
+    assert "T" in out  # returns current time in ISO format
+
+
+# ── RSS feed ─────────────────────────────────────────────────
+
+def test_rss_route_uses_video_created_at_and_content_type(monkeypatch):
+    monkeypatch.setattr(feed.requests, "get", lambda *args, **kwargs: _Resp([SAMPLE_VIDEO]))
 
     app = _build_app()
     client = app.test_client()
@@ -69,6 +88,118 @@ def test_rss_route_handles_non_list_payload(monkeypatch):
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert '<rss version="2.0"' in body
-    # should still render channel with no items, and clamp limit not crash
     assert "<channel>" in body
     assert "<item>" not in body
+
+
+def test_rss_passes_agent_filter(monkeypatch):
+    captured = {}
+
+    def mock_get(*args, **kwargs):
+        captured["params"] = kwargs.get("params", {})
+        return _Resp([])
+
+    monkeypatch.setattr(feed.requests, "get", mock_get)
+
+    app = _build_app()
+    client = app.test_client()
+    client.get("/feed/rss?agent=sophia-elya")
+    assert captured["params"].get("agent") == "sophia-elya"
+
+
+def test_rss_passes_category_filter(monkeypatch):
+    captured = {}
+
+    def mock_get(*args, **kwargs):
+        captured["params"] = kwargs.get("params", {})
+        return _Resp([])
+
+    monkeypatch.setattr(feed.requests, "get", mock_get)
+
+    app = _build_app()
+    client = app.test_client()
+    client.get("/feed/rss?category=music")
+    assert captured["params"].get("category") == "music"
+
+
+# ── Atom feed ────────────────────────────────────────────────
+
+def test_atom_route_returns_valid_atom(monkeypatch):
+    monkeypatch.setattr(feed.requests, "get", lambda *args, **kwargs: _Resp([SAMPLE_VIDEO]))
+
+    app = _build_app()
+    client = app.test_client()
+    resp = client.get("/feed/atom")
+
+    assert resp.status_code == 200
+    assert "application/atom+xml" in resp.content_type
+    body = resp.get_data(as_text=True)
+    assert 'xmlns="http://www.w3.org/2005/Atom"' in body
+    assert "<entry>" in body
+    assert "<title>Hello</title>" in body
+    assert "urn:bottube:video:vid123" in body
+
+
+def test_atom_route_has_self_link(monkeypatch):
+    monkeypatch.setattr(feed.requests, "get", lambda *args, **kwargs: _Resp([]))
+
+    app = _build_app()
+    client = app.test_client()
+    resp = client.get("/feed/atom?agent=test-bot")
+
+    body = resp.get_data(as_text=True)
+    assert 'rel="self"' in body
+    assert "agent=test-bot" in body
+
+
+def test_atom_route_handles_empty(monkeypatch):
+    monkeypatch.setattr(feed.requests, "get", lambda *args, **kwargs: _Resp({"error": "oops"}))
+
+    app = _build_app()
+    client = app.test_client()
+    resp = client.get("/feed/atom")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "<feed" in body
+    assert "<entry>" not in body
+
+
+def test_atom_uses_iso8601_timestamps(monkeypatch):
+    monkeypatch.setattr(feed.requests, "get", lambda *args, **kwargs: _Resp([SAMPLE_VIDEO]))
+
+    app = _build_app()
+    client = app.test_client()
+    resp = client.get("/feed/atom")
+
+    body = resp.get_data(as_text=True)
+    assert "<updated>2026-02-16" in body
+    assert "<published>2026-02-16" in body
+
+
+def test_atom_media_content(monkeypatch):
+    monkeypatch.setattr(feed.requests, "get", lambda *args, **kwargs: _Resp([SAMPLE_VIDEO]))
+
+    app = _build_app()
+    client = app.test_client()
+    resp = client.get("/feed/atom")
+
+    body = resp.get_data(as_text=True)
+    assert 'media:content url="https://bottube.ai/api/videos/vid123/stream"' in body
+    assert "media:thumbnail" in body
+
+
+# ── Shared helpers ───────────────────────────────────────────
+
+def test_normalize_videos_handles_dict_envelope():
+    assert len(feed._normalize_videos({"videos": [{"id": 1}]})) == 1
+
+
+def test_normalize_videos_handles_bare_list():
+    assert len(feed._normalize_videos([{"id": 1}, {"id": 2}])) == 2
+
+
+def test_normalize_videos_handles_garbage():
+    assert feed._normalize_videos("not json") == []
+    assert feed._normalize_videos(42) == []
+    assert feed._normalize_videos(None) == []


### PR DESCRIPTION
Cherry-pick of #151 onto current main (original PR is from a fork with no checks running).

- Adds `GET /feed/atom` Atom 1.0 endpoint
- Refactors RSS feed helpers
- Adds tests (16)

Bounty: closes #120

Credits: @AUTHENSOR (original PR #151)
