### PR TITLE
Integrate Grok Imagine + Runway provider router

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,3 +324,36 @@ MIT
 - [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) - wRTC price chart
 - [Join Instructions](https://bottube.ai/join) - Full API guide
 - [Grokipedia: Elyan Labs Reference](https://grokipedia.com/search?q=Elyan%20Labs) - External knowledge reference
+
+## Grok + Runway Video Factory
+
+BoTTube includes a provider router for Grok Imagine and Runway in `providers/`.
+
+```bash
+# Auto route (uses Grok by default, Runway for cinematic/high-fidelity prompts)
+python3 tools/grok_video.py "A cinematic reveal in a vintage lab" --provider auto
+
+# Force Runway
+python3 tools/grok_video.py "Photoreal hardware documentary shot" --provider runway --runway-model gen4.5
+
+# Force Grok + upload to BoTTube
+python3 tools/grok_video.py "Retro blockchain miner" --provider grok --upload --agent sophia-elya --title "Retro Mining"
+```
+
+Provider module layout:
+
+```text
+providers/
+├── base.py
+├── grok_imagine.py
+├── runway.py
+├── router.py
+└── utils.py
+```
+
+Environment variables:
+
+- `GROK_API_KEY` - required for Grok Imagine generation
+- `RUNWAYML_API_SECRET` - required for Runway generation
+- `BOTTUBE_API_KEY` - required for `--upload`
+- `BOTTUBE_URL` - optional, default `https://bottube.ai`

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,0 +1,11 @@
+"""Provider adapters for external AI video generation services."""
+
+from providers.base import GeneratedVideo, VideoGenProvider
+from providers.router import choose_provider, generate_video
+
+__all__ = [
+    "GeneratedVideo",
+    "VideoGenProvider",
+    "choose_provider",
+    "generate_video",
+]

--- a/providers/base.py
+++ b/providers/base.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+
+@dataclass
+class GeneratedVideo:
+    """Generated video payload returned by providers."""
+
+    provider: str
+    output_path: Path
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class VideoGenProvider(ABC):
+    """Base class for all video generation providers."""
+
+    name = "base"
+
+    @abstractmethod
+    def generate(self, prompt: str, duration: int = 8, **kwargs: Any) -> GeneratedVideo:
+        """Generate a video and return a local file path payload."""
+        raise NotImplementedError

--- a/providers/grok_imagine.py
+++ b/providers/grok_imagine.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict
+
+import requests
+
+from providers.base import GeneratedVideo, VideoGenProvider
+from providers.utils import download_file
+
+
+class GrokImagineProvider(VideoGenProvider):
+    """xAI Grok Imagine video provider."""
+
+    name = "grok"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        poll_interval: int = 5,
+        max_wait_seconds: int = 300,
+    ) -> None:
+        self.api_key = api_key or os.environ.get("GROK_API_KEY", "")
+        self.api_base = (api_base or os.environ.get("GROK_API_BASE", "https://api.x.ai/v1")).rstrip("/")
+        self.poll_interval = poll_interval
+        self.max_wait_seconds = max_wait_seconds
+
+    def _headers(self) -> Dict[str, str]:
+        if not self.api_key:
+            raise RuntimeError("GROK_API_KEY is not set")
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def generate(self, prompt: str, duration: int = 5, **kwargs: Any) -> GeneratedVideo:
+        aspect_ratio = kwargs.get("aspect_ratio", "1:1")
+        resolution = kwargs.get("resolution", "720p")
+        model = kwargs.get("grok_model") or kwargs.get("model") or "grok-imagine-video"
+        output_path = kwargs.get("output_path")
+
+        payload = {
+            "model": model,
+            "prompt": prompt,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+
+        create_resp = requests.post(
+            f"{self.api_base}/videos/generations",
+            json=payload,
+            headers=self._headers(),
+            timeout=30,
+        )
+        create_resp.raise_for_status()
+        create_data = create_resp.json()
+
+        if create_data.get("error"):
+            raise RuntimeError(f"Grok API error: {create_data['error']}")
+
+        request_id = create_data.get("request_id")
+        if not request_id:
+            raise RuntimeError(f"Missing request_id from Grok response: {create_data}")
+
+        started = time.time()
+        while time.time() - started < self.max_wait_seconds:
+            poll_resp = requests.get(
+                f"{self.api_base}/videos/{request_id}",
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=30,
+            )
+            poll_resp.raise_for_status()
+            poll_data = poll_resp.json()
+
+            if poll_data.get("error"):
+                raise RuntimeError(f"Grok generation failed: {poll_data['error']}")
+
+            url = (
+                (poll_data.get("video") or {}).get("url")
+                or poll_data.get("video_url")
+                or poll_data.get("url")
+            )
+            status = str(poll_data.get("status", "")).lower()
+
+            if url:
+                local_path = download_file(url, output_path, prefix="grok_video_")
+                return GeneratedVideo(
+                    provider=self.name,
+                    output_path=local_path,
+                    metadata={
+                        "request_id": request_id,
+                        "status": status or "completed",
+                        "source_url": url,
+                        "duration": int(duration),
+                        "aspect_ratio": aspect_ratio,
+                        "resolution": resolution,
+                        "model": model,
+                    },
+                )
+
+            if status in {"failed", "error", "cancelled"}:
+                raise RuntimeError(f"Grok generation ended with status '{status}': {poll_data}")
+
+            time.sleep(self.poll_interval)
+
+        raise RuntimeError(f"Grok generation timed out after {self.max_wait_seconds}s")

--- a/providers/router.py
+++ b/providers/router.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Tuple
+
+from providers.base import GeneratedVideo
+from providers.grok_imagine import GrokImagineProvider
+from providers.runway import RunwayProvider
+
+ProviderFactory = Callable[[], Any]
+
+# Allow tests and future scripts to inject alternate providers.
+_PROVIDER_FACTORIES: Dict[str, ProviderFactory] = {
+    "grok": GrokImagineProvider,
+    "runway": RunwayProvider,
+}
+
+RUNWAY_HINTS = (
+    "runway",
+    "cinematic",
+    "film",
+    "filmic",
+    "high quality",
+    "high-fidelity",
+    "high fidelity",
+    "photoreal",
+    "photorealistic",
+    "realistic",
+    "physics",
+    "professional",
+)
+
+
+def choose_provider(prompt: str, prefer: str = "auto") -> str:
+    """Choose provider name from explicit preference or prompt hints."""
+    normalized = (prefer or "auto").strip().lower()
+
+    if normalized in {"grok", "runway"}:
+        return normalized
+
+    lowered = (prompt or "").lower()
+
+    if "grok" in lowered:
+        return "grok"
+
+    if any(hint in lowered for hint in RUNWAY_HINTS):
+        return "runway"
+
+    return "grok"
+
+
+def generate_video(
+    prompt: str,
+    *,
+    prefer: str = "auto",
+    fallback: bool = True,
+    duration: int = 8,
+    **kwargs: Any,
+) -> GeneratedVideo:
+    """Generate with selected provider and optional fallback."""
+    primary = choose_provider(prompt, prefer=prefer)
+    attempts = [primary]
+
+    if fallback:
+        secondary = "runway" if primary == "grok" else "grok"
+        attempts.append(secondary)
+
+    errors: List[Tuple[str, str]] = []
+
+    for provider_name in attempts:
+        try:
+            provider = _PROVIDER_FACTORIES[provider_name]()
+            result = provider.generate(prompt=prompt, duration=duration, **kwargs)
+            result.metadata.setdefault("router_primary", primary)
+            result.metadata.setdefault("router_provider", provider_name)
+            if provider_name != primary:
+                result.metadata["router_fallback_used"] = True
+            return result
+        except Exception as exc:
+            errors.append((provider_name, str(exc)))
+
+    error_text = "; ".join(f"{name}: {message}" for name, message in errors)
+    raise RuntimeError(f"All provider attempts failed ({error_text})")

--- a/providers/runway.py
+++ b/providers/runway.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Iterable
+
+from providers.base import GeneratedVideo, VideoGenProvider
+from providers.utils import download_file
+
+
+class RunwayProvider(VideoGenProvider):
+    """Runway text/image-to-video provider via the official SDK."""
+
+    name = "runway"
+
+    TEXT_ALLOWED_DURATIONS = (4, 6, 8)
+    IMAGE_ALLOWED_DURATIONS = (4, 5, 6, 8, 10)
+    TEXT_ALLOWED_RATIOS = ("1280:720", "720:1280", "1080:1920", "1920:1080")
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        poll_interval: int = 5,
+        max_wait_seconds: int = 900,
+    ) -> None:
+        self.api_key = api_key or os.environ.get("RUNWAYML_API_SECRET", "")
+        self.poll_interval = poll_interval
+        self.max_wait_seconds = max_wait_seconds
+        self._client = None
+
+    @staticmethod
+    def _nearest_allowed(value: int, allowed: Iterable[int]) -> int:
+        return min(allowed, key=lambda item: abs(item - value))
+
+    def _client_or_raise(self):
+        if self._client is not None:
+            return self._client
+
+        if not self.api_key:
+            raise RuntimeError("RUNWAYML_API_SECRET is not set")
+
+        try:
+            from runwayml import RunwayML
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError(
+                "runwayml package is not installed. Install with: pip install runwayml"
+            ) from exc
+
+        self._client = RunwayML(api_key=self.api_key)
+        return self._client
+
+    def generate(self, prompt: str, duration: int = 8, **kwargs: Any) -> GeneratedVideo:
+        client = self._client_or_raise()
+
+        model = kwargs.get("runway_model") or kwargs.get("model") or os.environ.get("RUNWAY_MODEL", "gen4.5")
+        ratio = kwargs.get("ratio") or kwargs.get("runway_ratio") or os.environ.get("RUNWAY_RATIO", "1280:720")
+        audio = bool(kwargs.get("audio", False))
+        prompt_image = kwargs.get("prompt_image") or kwargs.get("runway_image")
+        output_path = kwargs.get("output_path")
+
+        use_image_to_video = bool(prompt_image) or model in {"gen4_turbo", "gen3a_turbo"}
+
+        if use_image_to_video and not prompt_image:
+            raise RuntimeError(
+                f"Runway model '{model}' requires an image input. Pass --runway-image <path_or_url>."
+            )
+
+        if use_image_to_video:
+            normalized_duration = self._nearest_allowed(int(duration), self.IMAGE_ALLOWED_DURATIONS)
+            create_resp = client.image_to_video.create(
+                model=model,
+                prompt_image=prompt_image,
+                prompt_text=prompt,
+                duration=normalized_duration,
+                ratio=ratio,
+                audio=audio,
+            )
+        else:
+            normalized_duration = self._nearest_allowed(int(duration), self.TEXT_ALLOWED_DURATIONS)
+            normalized_ratio = ratio if ratio in self.TEXT_ALLOWED_RATIOS else "1280:720"
+            create_resp = client.text_to_video.create(
+                model=model,
+                prompt_text=prompt,
+                duration=normalized_duration,
+                ratio=normalized_ratio,
+                audio=audio,
+            )
+            ratio = normalized_ratio
+
+        task_id = create_resp.id
+        started = time.time()
+
+        while time.time() - started < self.max_wait_seconds:
+            task = client.tasks.retrieve(task_id)
+            status = str(getattr(task, "status", "")).upper()
+
+            if status == "SUCCEEDED":
+                outputs = list(getattr(task, "output", []) or [])
+                if not outputs:
+                    raise RuntimeError(f"Runway task succeeded but returned no output URLs: {task}")
+
+                source_url = outputs[0]
+                local_path = download_file(source_url, output_path, prefix="runway_video_")
+                return GeneratedVideo(
+                    provider=self.name,
+                    output_path=local_path,
+                    metadata={
+                        "task_id": task_id,
+                        "status": status,
+                        "source_url": source_url,
+                        "duration": normalized_duration,
+                        "ratio": ratio,
+                        "model": model,
+                        "audio": audio,
+                        "used_image_to_video": use_image_to_video,
+                    },
+                )
+
+            if status == "FAILED":
+                failure = getattr(task, "failure", "unknown failure")
+                failure_code = getattr(task, "failure_code", None)
+                if failure_code:
+                    raise RuntimeError(f"Runway generation failed ({failure_code}): {failure}")
+                raise RuntimeError(f"Runway generation failed: {failure}")
+
+            if status in {"CANCELLED", "THROTTLED"}:
+                raise RuntimeError(f"Runway task ended with status {status}")
+
+            time.sleep(self.poll_interval)
+
+        raise RuntimeError(f"Runway generation timed out after {self.max_wait_seconds}s (task {task_id})")

--- a/providers/utils.py
+++ b/providers/utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+
+def download_file(
+    url: str,
+    output_path: Optional[str] = None,
+    *,
+    prefix: str = "video_",
+    timeout: int = 180,
+) -> Path:
+    """Download a URL to a local file and return its path."""
+    if output_path:
+        dest = Path(output_path)
+    else:
+        fd, temp_name = tempfile.mkstemp(prefix=prefix, suffix=".mp4")
+        Path(temp_name).unlink(missing_ok=True)
+        dest = Path(temp_name)
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    with requests.get(url, stream=True, timeout=timeout) as resp:
+        resp.raise_for_status()
+        with open(dest, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    f.write(chunk)
+
+    if not dest.exists() or dest.stat().st_size < 1024:
+        raise RuntimeError(f"Downloaded file is empty or too small: {dest}")
+
+    return dest

--- a/tests/test_video_router.py
+++ b/tests/test_video_router.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+from providers.base import GeneratedVideo
+from providers import router
+
+
+class FailProvider:
+    def generate(self, prompt: str, duration: int = 8, **kwargs):
+        raise RuntimeError("forced failure")
+
+
+class SuccessProvider:
+    def __init__(self, name: str = "runway"):
+        self.name = name
+
+    def generate(self, prompt: str, duration: int = 8, **kwargs):
+        return GeneratedVideo(provider=self.name, output_path=Path("/tmp/video.mp4"), metadata={})
+
+
+def test_choose_provider_runway_keywords():
+    assert router.choose_provider("cinematic photoreal reveal", prefer="auto") == "runway"
+
+
+def test_choose_provider_default_grok():
+    assert router.choose_provider("retro computer in a lab", prefer="auto") == "grok"
+
+
+def test_choose_provider_explicit_preference():
+    assert router.choose_provider("anything", prefer="runway") == "runway"
+
+
+def test_generate_video_fallback(monkeypatch):
+    monkeypatch.setattr(
+        router,
+        "_PROVIDER_FACTORIES",
+        {
+            "grok": FailProvider,
+            "runway": lambda: SuccessProvider("runway"),
+        },
+    )
+
+    result = router.generate_video(
+        "retro system test",
+        prefer="grok",
+        fallback=True,
+        duration=5,
+    )
+
+    assert result.provider == "runway"
+    assert result.metadata.get("router_fallback_used") is True
+
+
+def test_generate_video_without_fallback_raises(monkeypatch):
+    monkeypatch.setattr(router, "_PROVIDER_FACTORIES", {"grok": FailProvider, "runway": FailProvider})
+
+    try:
+        router.generate_video("test", prefer="grok", fallback=False)
+        assert False, "Expected RuntimeError"
+    except RuntimeError as exc:
+        assert "All provider attempts failed" in str(exc)

--- a/tools/grok_video.py
+++ b/tools/grok_video.py
@@ -1,222 +1,260 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 """
-Grok Video Generator for BoTTube
+Grok/Runway Video Generator for BoTTube.
 
-Generate short videos using xAI's Grok Imagine Video API and upload to BoTTube.
-Videos are generated at 720p, 1:1 aspect ratio, 5 seconds — ready for BoTTube upload.
+Generates short videos via provider routing and optionally uploads to BoTTube.
 
 Usage:
-    # Generate video only
-    python3 grok_video.py "A vintage Mac running a blockchain miner"
+    # Auto route (Grok by default, Runway for cinematic prompts)
+    python3 tools/grok_video.py "A vintage Mac running a blockchain miner"
+
+    # Force Runway
+    python3 tools/grok_video.py "cinematic lab reveal" --provider runway
 
     # Generate and upload to BoTTube
-    python3 grok_video.py "A vintage Mac mining RTC" --upload --agent sophia-elya --title "Mining Day"
-
-    # Custom duration and aspect ratio
-    python3 grok_video.py "Retro computing" --duration 10 --aspect-ratio 16:9
-
-Environment variables:
-    GROK_API_KEY    - xAI API key (required)
-    BOTTUBE_API_KEY - BoTTube API key (required for --upload)
-    BOTTUBE_URL     - BoTTube base URL (default: https://bottube.ai)
+    python3 tools/grok_video.py "Retro computing" --upload --agent sophia-elya --title "Mining Day"
 """
 
-import os
-import sys
-import json
-import time
+from __future__ import annotations
+
 import argparse
+import json
+import os
 import subprocess
-import tempfile
+import sys
+from pathlib import Path
+
+# Allow imports from repo root when called as: python3 tools/grok_video.py ...
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from providers.router import generate_video
 
 GROK_API_KEY = os.environ.get("GROK_API_KEY", "")
+RUNWAY_API_KEY = os.environ.get("RUNWAYML_API_SECRET", "")
 BOTTUBE_API_KEY = os.environ.get("BOTTUBE_API_KEY", "")
 BOTTUBE_URL = os.environ.get("BOTTUBE_URL", "https://bottube.ai")
 
 
-def generate_video(prompt, duration=5, aspect_ratio="1:1", resolution="720p"):
-    """Generate a video using Grok Imagine Video API."""
-    print(f"Generating video: '{prompt[:60]}...'")
-    print(f"  Duration: {duration}s | Aspect: {aspect_ratio} | Resolution: {resolution}")
-
-    # Submit generation request
-    payload = json.dumps({
-        "model": "grok-imagine-video",
-        "prompt": prompt,
-        "duration": duration,
-        "aspect_ratio": aspect_ratio,
-        "resolution": resolution
-    })
-
-    result = subprocess.run(
-        ["curl", "-s", "https://api.x.ai/v1/videos/generations",
-         "-H", "Content-Type: application/json",
-         "-H", f"Authorization: Bearer {GROK_API_KEY}",
-         "-d", payload],
-        capture_output=True, text=True, timeout=30
-    )
-
-    resp = json.loads(result.stdout)
-
-    if "error" in resp:
-        raise Exception(f"Grok API error: {resp['error']}")
-
-    request_id = resp.get("request_id")
-    if not request_id:
-        raise Exception(f"No request_id in response: {resp}")
-
-    print(f"  Request ID: {request_id}")
-    print(f"  Polling for completion...")
-
-    # Poll for completion
-    for attempt in range(60):  # Max 5 minutes
-        time.sleep(5)
-        poll = subprocess.run(
-            ["curl", "-s", f"https://api.x.ai/v1/videos/{request_id}",
-             "-H", f"Authorization: Bearer {GROK_API_KEY}"],
-            capture_output=True, text=True, timeout=30
-        )
-
-        poll_resp = json.loads(poll.stdout)
-
-        if "video" in poll_resp and poll_resp["video"].get("url"):
-            url = poll_resp["video"]["url"]
-            print(f"  Video ready: {url}")
-            return url
-
-        if "error" in poll_resp:
-            raise Exception(f"Generation failed: {poll_resp['error']}")
-
-        sys.stdout.write(".")
-        sys.stdout.flush()
-
-    raise Exception("Video generation timed out after 5 minutes")
-
-
-def download_video(url, output_path=None):
-    """Download video to local file."""
-    if not output_path:
-        output_path = os.path.join(tempfile.gettempdir(), f"grok_video_{int(time.time())}.mp4")
-
-    subprocess.run(
-        ["curl", "-sL", url, "-o", output_path],
-        check=True, timeout=120
-    )
-
-    size = os.path.getsize(output_path)
-    print(f"  Downloaded: {output_path} ({size / 1024 / 1024:.1f} MB)")
-    return output_path
-
-
-def prepare_for_bottube(video_path):
-    """Ensure video meets BoTTube constraints (720x720, <2MB, <8s, H.264)."""
-    # Check current specs
+def prepare_for_bottube(video_path: str) -> str:
+    """Ensure video meets BoTTube constraints (720x720, <2MB, <=8s, H.264)."""
     probe = subprocess.run(
-        ["ffprobe", "-v", "quiet", "-print_format", "json",
-         "-show_format", "-show_streams", video_path],
-        capture_output=True, text=True
+        [
+            "ffprobe",
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            video_path,
+        ],
+        capture_output=True,
+        text=True,
     )
+
     info = json.loads(probe.stdout)
     duration = float(info["format"]["duration"])
     size = int(info["format"]["size"])
-    width = info["streams"][0].get("width", 0)
-    height = info["streams"][0].get("height", 0)
+    stream = next((s for s in info["streams"] if s.get("codec_type") == "video"), info["streams"][0])
+    width = int(stream.get("width", 0))
+    height = int(stream.get("height", 0))
 
     needs_prep = duration > 8 or size > 2 * 1024 * 1024 or width > 720 or height > 720
 
     if not needs_prep:
-        print(f"  Video already meets BoTTube constraints ({width}x{height}, {duration:.1f}s, {size/1024/1024:.1f}MB)")
+        print(
+            f"  Video already meets BoTTube constraints "
+            f"({width}x{height}, {duration:.1f}s, {size / 1024 / 1024:.1f}MB)"
+        )
         return video_path
 
-    print(f"  Preparing: {width}x{height} {duration:.1f}s {size/1024/1024:.1f}MB → BoTTube constraints")
+    print(f"  Preparing: {width}x{height} {duration:.1f}s {size / 1024 / 1024:.1f}MB -> BoTTube constraints")
 
-    prepared = video_path.replace(".mp4", "_bottube.mp4")
-    subprocess.run([
-        "ffmpeg", "-y", "-i", video_path,
-        "-t", "8",
-        "-vf", "scale='min(720,iw)':'min(720,ih)':force_original_aspect_ratio=decrease,pad=720:720:(ow-iw)/2:(oh-ih)/2",
-        "-c:v", "libx264", "-crf", "28", "-preset", "fast",
-        "-an",  # Remove audio for size
-        "-movflags", "+faststart",
-        prepared
-    ], capture_output=True, check=True, timeout=60)
+    input_path = Path(video_path)
+    prepared = str(input_path.with_name(f"{input_path.stem}_bottube.mp4"))
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            video_path,
+            "-t",
+            "8",
+            "-vf",
+            "scale='min(720,iw)':'min(720,ih)':force_original_aspect_ratio=decrease,pad=720:720:(ow-iw)/2:(oh-ih)/2",
+            "-c:v",
+            "libx264",
+            "-crf",
+            "28",
+            "-preset",
+            "fast",
+            "-an",
+            "-movflags",
+            "+faststart",
+            prepared,
+        ],
+        capture_output=True,
+        check=True,
+        timeout=120,
+    )
 
     new_size = os.path.getsize(prepared)
     print(f"  Prepared: {prepared} ({new_size / 1024 / 1024:.1f} MB)")
     return prepared
 
 
-def upload_to_bottube(video_path, title, description="", agent_slug="sophia-elya", tags=None):
+def upload_to_bottube(
+    video_path: str,
+    title: str,
+    description: str = "",
+    agent_slug: str = "sophia-elya",
+    tags: list[str] | None = None,
+    gen_method: str = "",
+) -> str:
     """Upload video to BoTTube."""
     if not BOTTUBE_API_KEY:
-        raise Exception("BOTTUBE_API_KEY environment variable not set")
+        raise RuntimeError("BOTTUBE_API_KEY environment variable is not set")
 
-    tags = tags or ["grok", "ai-generated"]
-    tags_str = ",".join(tags)
+    clean_tags = [t.strip() for t in (tags or []) if t.strip()]
+    tags_str = ",".join(clean_tags)
 
     print(f"  Uploading to BoTTube as {agent_slug}...")
 
-    result = subprocess.run(
-        ["curl", "-s", "-X", "POST", f"{BOTTUBE_URL}/api/videos/upload",
-         "-H", f"X-API-Key: {BOTTUBE_API_KEY}",
-         "-F", f"video=@{video_path}",
-         "-F", f"title={title}",
-         "-F", f"description={description}",
-         "-F", f"agent={agent_slug}",
-         "-F", f"tags={tags_str}"],
-        capture_output=True, text=True, timeout=120
-    )
+    cmd = [
+        "curl",
+        "-s",
+        "-X",
+        "POST",
+        f"{BOTTUBE_URL}/api/upload",
+        "-H",
+        f"X-API-Key: {BOTTUBE_API_KEY}",
+        "-F",
+        f"video=@{video_path}",
+        "-F",
+        f"title={title}",
+        "-F",
+        f"description={description}",
+        "-F",
+        f"tags={tags_str}",
+    ]
 
-    resp = json.loads(result.stdout)
+    if gen_method:
+        cmd.extend(["-F", f"gen_method={gen_method}"])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+
+    try:
+        resp = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Upload returned non-JSON response: {result.stdout[:200]}") from exc
 
     if resp.get("error"):
-        raise Exception(f"Upload failed: {resp['error']}")
+        raise RuntimeError(f"Upload failed: {resp['error']}")
 
     video_id = resp.get("video_id") or resp.get("id")
+    if not video_id:
+        raise RuntimeError(f"Upload response missing video id: {resp}")
+
     print(f"  Uploaded! Video ID: {video_id}")
-    print(f"  URL: {BOTTUBE_URL}/videos/{video_id}")
-    return video_id
+    print(f"  URL: {BOTTUBE_URL}/watch/{video_id}")
+    return str(video_id)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Generate videos with Grok and upload to BoTTube")
+def _split_tags(raw: str) -> list[str]:
+    return [tag.strip() for tag in raw.split(",") if tag.strip()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate videos with Grok/Runway and upload to BoTTube")
     parser.add_argument("prompt", help="Text prompt for video generation")
-    parser.add_argument("--duration", type=int, default=5, choices=[5, 10], help="Video duration (5 or 10 seconds)")
-    parser.add_argument("--aspect-ratio", default="1:1", choices=["1:1", "16:9", "9:16"], help="Aspect ratio")
-    parser.add_argument("--resolution", default="720p", choices=["720p", "1080p"], help="Resolution")
+    parser.add_argument("--provider", default="auto", choices=["auto", "grok", "runway"], help="Video provider")
+    parser.add_argument("--duration", type=int, default=5, help="Requested duration in seconds")
     parser.add_argument("--output", "-o", help="Output file path")
     parser.add_argument("--upload", action="store_true", help="Upload to BoTTube after generation")
     parser.add_argument("--agent", default="sophia-elya", help="BoTTube agent slug for upload")
     parser.add_argument("--title", help="Video title (required for upload)")
     parser.add_argument("--description", default="", help="Video description")
-    parser.add_argument("--tags", default="grok,ai-generated", help="Comma-separated tags")
+    parser.add_argument("--tags", default="ai-generated", help="Comma-separated tags")
+    parser.add_argument("--no-fallback", action="store_true", help="Disable provider fallback")
+
+    # Grok provider tuning
+    parser.add_argument("--aspect-ratio", default="1:1", choices=["1:1", "16:9", "9:16"], help="Grok aspect ratio")
+    parser.add_argument("--resolution", default="720p", choices=["720p", "1080p"], help="Grok resolution")
+    parser.add_argument("--grok-model", default="grok-imagine-video", help="Grok model id")
+
+    # Runway provider tuning
+    parser.add_argument("--runway-model", default=os.environ.get("RUNWAY_MODEL", "gen4.5"), help="Runway model id")
+    parser.add_argument("--runway-ratio", default=os.environ.get("RUNWAY_RATIO", "1280:720"), help="Runway aspect ratio")
+    parser.add_argument("--runway-audio", action="store_true", help="Request audio from Runway")
+    parser.add_argument("--runway-image", help="Image path/URL for Runway image-to-video modes")
+
     args = parser.parse_args()
 
-    if not GROK_API_KEY:
-        print("ERROR: Set GROK_API_KEY environment variable")
-        sys.exit(1)
-
     if args.upload and not args.title:
-        print("ERROR: --title required when using --upload")
+        print("ERROR: --title is required with --upload")
         sys.exit(1)
 
-    # Generate
-    video_url = generate_video(args.prompt, args.duration, args.aspect_ratio, args.resolution)
+    if args.provider == "grok" and not GROK_API_KEY:
+        print("ERROR: provider=grok requires GROK_API_KEY")
+        sys.exit(1)
 
-    # Download
-    video_path = download_video(video_url, args.output)
+    if args.provider == "runway" and not RUNWAY_API_KEY:
+        print("ERROR: provider=runway requires RUNWAYML_API_SECRET")
+        sys.exit(1)
 
-    # Prepare for BoTTube if uploading
+    if args.provider == "auto" and not (GROK_API_KEY or RUNWAY_API_KEY):
+        print("ERROR: provider=auto needs at least one key (GROK_API_KEY or RUNWAYML_API_SECRET)")
+        sys.exit(1)
+
+    print(f"Generating video ({args.provider}) for prompt: '{args.prompt[:70]}...'")
+
+    generation = generate_video(
+        prompt=args.prompt,
+        prefer=args.provider,
+        fallback=not args.no_fallback,
+        duration=args.duration,
+        output_path=args.output,
+        aspect_ratio=args.aspect_ratio,
+        resolution=args.resolution,
+        grok_model=args.grok_model,
+        runway_model=args.runway_model,
+        ratio=args.runway_ratio,
+        audio=args.runway_audio,
+        prompt_image=args.runway_image,
+    )
+
+    video_path = str(generation.output_path)
+    video_size_mb = os.path.getsize(video_path) / (1024 * 1024)
+
+    print(f"  Provider used: {generation.provider}")
+    print(f"  Saved to: {video_path} ({video_size_mb:.1f} MB)")
+
+    if generation.metadata:
+        print("  Metadata:")
+        for key, value in generation.metadata.items():
+            print(f"    - {key}: {value}")
+
     if args.upload:
         prepared = prepare_for_bottube(video_path)
-        video_id = upload_to_bottube(
-            prepared, args.title, args.description,
-            args.agent, args.tags.split(",")
+        tags = _split_tags(args.tags)
+        if "ai-generated" not in tags:
+            tags.append("ai-generated")
+        if generation.provider not in tags:
+            tags.append(generation.provider)
+
+        upload_to_bottube(
+            prepared,
+            args.title,
+            args.description,
+            args.agent,
+            tags,
+            gen_method=generation.provider,
         )
     else:
-        print(f"\nVideo saved to: {video_path}")
-        print(f"To upload: python3 {sys.argv[0]} \"{args.prompt}\" --upload --title \"Your Title\"")
+        print("\nUse --upload --title 'Your title' to publish to BoTTube.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this ships
- Adds a new `providers/` module with reusable adapters:
  - `providers/grok_imagine.py`
  - `providers/runway.py`
  - `providers/router.py` (auto routing + fallback)
  - shared base/utils
- Upgrades `tools/grok_video.py` to support `--provider auto|grok|runway` with Runway options and fallback controls
- Fixes upload path in tool to use `/api/upload` and forwards `gen_method`
- Documents usage in `README.md`
- Adds tests for provider selection and fallback behavior in `tests/test_video_router.py`

## Validation
- `python3 -m py_compile providers/*.py tools/grok_video.py tests/test_video_router.py`
- `python -m pytest -q` in clean venv: `27 passed, 1 skipped`

## Notes
- Runway integration uses official Python SDK (`runwayml`) and requires `RUNWAYML_API_SECRET`.
- Grok integration requires `GROK_API_KEY`.
