### PR TITLE
Provider router hardening: retries, error categories, metrics, observability

### DIFF
--- a/docs/ROUTER_HARDENING.md
+++ b/docs/ROUTER_HARDENING.md
@@ -1,0 +1,55 @@
+# Provider Router Hardening
+
+This document describes reliability and observability updates for `providers/router.py`.
+
+## Scope
+
+- Retry and backoff for transient/throttled failures.
+- Structured error categorization.
+- Per-provider attempt timing and aggregate metadata.
+- Repeated-failure warning signal for operator visibility.
+
+## Error Categories
+
+`classify_error()` maps provider failures to:
+
+- `auth`: unauthorized/forbidden/API key issues.
+- `throttled`: rate limit or quota errors.
+- `transient`: timeout/network/5xx temporary failures.
+- `permanent`: invalid request/unsupported/4xx non-retryable.
+- `unknown`: fallback category.
+
+## Retry Strategy
+
+`generate_video(..., max_retries, retry_backoff_s)` behavior:
+
+- Retries only for `transient` and `throttled` categories.
+- Backoff is exponential per retry index:
+  - `retry_backoff_s * (2 ** retry_index)` (capped to 10s).
+- No retries for `auth` or `permanent` errors.
+
+## Runtime Metadata
+
+Returned `GeneratedVideo.metadata` now includes:
+
+- `router_primary`
+- `router_provider`
+- `router_fallback_used`
+- `router_attempts` (attempt-level timeline with status/category/duration)
+- `router_provider_time_ms` (accumulated provider timing)
+- `router_error_categories` (category counters)
+
+## Alerting / Observability
+
+- Router tracks consecutive failures per provider.
+- When a provider reaches 3 consecutive failed runs, a warning is logged:
+  - `Provider '<name>' has failed <N> consecutive router runs`
+
+## CLI Compatibility
+
+`tools/grok_video.py` remains compatible and adds optional knobs:
+
+- `--router-max-retries`
+- `--router-retry-backoff`
+
+Defaults preserve current behavior while adding better resilience.

--- a/providers/router.py
+++ b/providers/router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+import time
 from typing import Any, Callable, Dict, List, Tuple
 
 from providers.base import GeneratedVideo
@@ -13,6 +15,9 @@ _PROVIDER_FACTORIES: Dict[str, ProviderFactory] = {
     "grok": GrokImagineProvider,
     "runway": RunwayProvider,
 }
+_PROVIDER_FAILURE_STREAK: Dict[str, int] = {"grok": 0, "runway": 0}
+_FAILURE_ALERT_THRESHOLD = 3
+_LOGGER = logging.getLogger(__name__)
 
 RUNWAY_HINTS = (
     "runway",
@@ -48,12 +53,64 @@ def choose_provider(prompt: str, prefer: str = "auto") -> str:
     return "grok"
 
 
+def classify_error(exc: Exception) -> str:
+    msg = str(exc).lower()
+    if any(x in msg for x in ("401", "403", "unauthorized", "forbidden", "api key", "invalid token", "auth")):
+        return "auth"
+    if any(x in msg for x in ("429", "rate limit", "throttle", "quota")):
+        return "throttled"
+    if any(
+        x in msg
+        for x in (
+            "timeout",
+            "timed out",
+            "temporarily unavailable",
+            "connection",
+            "network",
+            "503",
+            "502",
+            "500",
+            "504",
+        )
+    ):
+        return "transient"
+    if any(x in msg for x in ("400", "404", "invalid", "bad request", "unsupported", "requires an image")):
+        return "permanent"
+    return "unknown"
+
+
+def _should_retry(category: str) -> bool:
+    return category in {"transient", "throttled"}
+
+
+def _backoff_seconds(retry_idx: int, base_seconds: float, cap_seconds: float = 10.0) -> float:
+    return min(float(cap_seconds), float(base_seconds) * (2 ** retry_idx))
+
+
+def _record_provider_failure(provider_name: str) -> None:
+    current = int(_PROVIDER_FAILURE_STREAK.get(provider_name, 0)) + 1
+    _PROVIDER_FAILURE_STREAK[provider_name] = current
+    if current >= _FAILURE_ALERT_THRESHOLD:
+        _LOGGER.warning(
+            "Provider '%s' has failed %d consecutive router runs",
+            provider_name,
+            current,
+        )
+
+
+def _record_provider_success(provider_name: str) -> None:
+    _PROVIDER_FAILURE_STREAK[provider_name] = 0
+
+
 def generate_video(
     prompt: str,
     *,
     prefer: str = "auto",
     fallback: bool = True,
     duration: int = 8,
+    max_retries: int = 2,
+    retry_backoff_s: float = 1.0,
+    sleep_fn: Callable[[float], None] = time.sleep,
     **kwargs: Any,
 ) -> GeneratedVideo:
     """Generate with selected provider and optional fallback."""
@@ -64,19 +121,66 @@ def generate_video(
         secondary = "runway" if primary == "grok" else "grok"
         attempts.append(secondary)
 
-    errors: List[Tuple[str, str]] = []
+    errors: List[Tuple[str, str, str]] = []
+    attempt_metrics: List[Dict[str, Any]] = []
+    category_totals: Dict[str, int] = {}
+    provider_time_ms: Dict[str, int] = {}
+    retries_per_provider = max(0, int(max_retries))
+    base_backoff = max(0.0, float(retry_backoff_s))
 
     for provider_name in attempts:
-        try:
-            provider = _PROVIDER_FACTORIES[provider_name]()
-            result = provider.generate(prompt=prompt, duration=duration, **kwargs)
-            result.metadata.setdefault("router_primary", primary)
-            result.metadata.setdefault("router_provider", provider_name)
-            if provider_name != primary:
-                result.metadata["router_fallback_used"] = True
-            return result
-        except Exception as exc:
-            errors.append((provider_name, str(exc)))
+        provider = _PROVIDER_FACTORIES[provider_name]()
+        final_failure_for_provider = False
+        for retry_idx in range(retries_per_provider + 1):
+            started = time.perf_counter()
+            try:
+                result = provider.generate(prompt=prompt, duration=duration, **kwargs)
+                elapsed_ms = int((time.perf_counter() - started) * 1000)
+                provider_time_ms[provider_name] = provider_time_ms.get(provider_name, 0) + elapsed_ms
+                _record_provider_success(provider_name)
 
-    error_text = "; ".join(f"{name}: {message}" for name, message in errors)
+                attempt_metrics.append(
+                    {
+                        "provider": provider_name,
+                        "status": "ok",
+                        "retry_index": retry_idx,
+                        "duration_ms": elapsed_ms,
+                    }
+                )
+
+                result.metadata.setdefault("router_primary", primary)
+                result.metadata.setdefault("router_provider", provider_name)
+                result.metadata.setdefault("router_attempts", attempt_metrics)
+                result.metadata.setdefault("router_provider_time_ms", provider_time_ms)
+                result.metadata.setdefault("router_error_categories", category_totals)
+                result.metadata.setdefault("router_fallback_used", provider_name != primary)
+                return result
+            except Exception as exc:
+                elapsed_ms = int((time.perf_counter() - started) * 1000)
+                provider_time_ms[provider_name] = provider_time_ms.get(provider_name, 0) + elapsed_ms
+                category = classify_error(exc)
+                category_totals[category] = int(category_totals.get(category, 0)) + 1
+                errors.append((provider_name, category, str(exc)))
+                attempt_metrics.append(
+                    {
+                        "provider": provider_name,
+                        "status": "error",
+                        "retry_index": retry_idx,
+                        "duration_ms": elapsed_ms,
+                        "category": category,
+                        "error": str(exc),
+                    }
+                )
+                should_retry = _should_retry(category) and retry_idx < retries_per_provider
+                if should_retry:
+                    delay = _backoff_seconds(retry_idx, base_backoff)
+                    if delay > 0:
+                        sleep_fn(delay)
+                    continue
+                final_failure_for_provider = True
+                break
+        if final_failure_for_provider:
+            _record_provider_failure(provider_name)
+
+    error_text = "; ".join(f"{name}/{category}: {message}" for name, category, message in errors)
     raise RuntimeError(f"All provider attempts failed ({error_text})")

--- a/tests/test_video_router.py
+++ b/tests/test_video_router.py
@@ -6,8 +6,11 @@ from providers import router
 
 
 class FailProvider:
+    def __init__(self, message: str = "forced failure"):
+        self.message = message
+
     def generate(self, prompt: str, duration: int = 8, **kwargs):
-        raise RuntimeError("forced failure")
+        raise RuntimeError(self.message)
 
 
 class SuccessProvider:
@@ -16,6 +19,19 @@ class SuccessProvider:
 
     def generate(self, prompt: str, duration: int = 8, **kwargs):
         return GeneratedVideo(provider=self.name, output_path=Path("/tmp/video.mp4"), metadata={})
+
+
+class FailThenSuccessProvider:
+    def __init__(self, failures: int = 1, message: str = "timeout"):
+        self.failures = failures
+        self.calls = 0
+        self.message = message
+
+    def generate(self, prompt: str, duration: int = 8, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise RuntimeError(self.message)
+        return GeneratedVideo(provider="grok", output_path=Path("/tmp/video.mp4"), metadata={})
 
 
 def test_choose_provider_runway_keywords():
@@ -30,12 +46,19 @@ def test_choose_provider_explicit_preference():
     assert router.choose_provider("anything", prefer="runway") == "runway"
 
 
+def test_classify_error_categories():
+    assert router.classify_error(RuntimeError("401 unauthorized")) == "auth"
+    assert router.classify_error(RuntimeError("429 rate limit")) == "throttled"
+    assert router.classify_error(RuntimeError("request timeout")) == "transient"
+    assert router.classify_error(RuntimeError("400 bad request")) == "permanent"
+
+
 def test_generate_video_fallback(monkeypatch):
     monkeypatch.setattr(
         router,
         "_PROVIDER_FACTORIES",
         {
-            "grok": FailProvider,
+            "grok": lambda: FailProvider("timeout"),
             "runway": lambda: SuccessProvider("runway"),
         },
     )
@@ -49,13 +72,93 @@ def test_generate_video_fallback(monkeypatch):
 
     assert result.provider == "runway"
     assert result.metadata.get("router_fallback_used") is True
+    assert result.metadata.get("router_primary") == "grok"
+    assert result.metadata.get("router_provider") == "runway"
+
+
+def test_generate_video_retries_transient(monkeypatch):
+    provider = FailThenSuccessProvider(failures=1, message="timeout while connecting")
+    delays = []
+    monkeypatch.setattr(
+        router,
+        "_PROVIDER_FACTORIES",
+        {
+            "grok": lambda: provider,
+            "runway": lambda: SuccessProvider("runway"),
+        },
+    )
+
+    result = router.generate_video(
+        "retry test",
+        prefer="grok",
+        fallback=False,
+        max_retries=2,
+        retry_backoff_s=1.0,
+        sleep_fn=delays.append,
+    )
+
+    assert result.provider == "grok"
+    assert provider.calls == 2
+    assert delays == [1.0]
+    attempts = result.metadata.get("router_attempts") or []
+    assert len(attempts) == 2
+    assert attempts[0]["status"] == "error"
+    assert attempts[1]["status"] == "ok"
+    assert result.metadata.get("router_error_categories", {}).get("transient") == 1
+
+
+def test_generate_video_auth_error_no_retry(monkeypatch):
+    delays = []
+    monkeypatch.setattr(
+        router,
+        "_PROVIDER_FACTORIES",
+        {"grok": lambda: FailProvider("401 unauthorized"), "runway": lambda: SuccessProvider("runway")},
+    )
+
+    try:
+        router.generate_video(
+            "auth failure",
+            prefer="grok",
+            fallback=False,
+            max_retries=3,
+            sleep_fn=delays.append,
+        )
+        assert False, "Expected RuntimeError"
+    except RuntimeError as exc:
+        assert "All provider attempts failed" in str(exc)
+        assert "auth" in str(exc)
+
+    assert delays == []
 
 
 def test_generate_video_without_fallback_raises(monkeypatch):
-    monkeypatch.setattr(router, "_PROVIDER_FACTORIES", {"grok": FailProvider, "runway": FailProvider})
+    monkeypatch.setattr(
+        router,
+        "_PROVIDER_FACTORIES",
+        {"grok": lambda: FailProvider("forced failure"), "runway": lambda: FailProvider("forced failure")},
+    )
 
     try:
         router.generate_video("test", prefer="grok", fallback=False)
         assert False, "Expected RuntimeError"
     except RuntimeError as exc:
         assert "All provider attempts failed" in str(exc)
+
+
+def test_repeated_failures_emit_warning(monkeypatch):
+    warnings = []
+    monkeypatch.setattr(router, "_PROVIDER_FAILURE_STREAK", {"grok": 0, "runway": 0})
+    monkeypatch.setattr(router._LOGGER, "warning", lambda *args, **kwargs: warnings.append(args))
+    monkeypatch.setattr(
+        router,
+        "_PROVIDER_FACTORIES",
+        {"grok": lambda: FailProvider("network timeout"), "runway": lambda: SuccessProvider("runway")},
+    )
+
+    for _ in range(3):
+        try:
+            router.generate_video("warn test", prefer="grok", fallback=False, max_retries=0)
+        except RuntimeError:
+            pass
+
+    assert len(warnings) == 1

--- a/tools/grok_video.py
+++ b/tools/grok_video.py
@@ -179,6 +179,8 @@ def main() -> None:
     parser.add_argument("--description", default="", help="Video description")
     parser.add_argument("--tags", default="ai-generated", help="Comma-separated tags")
     parser.add_argument("--no-fallback", action="store_true", help="Disable provider fallback")
+    parser.add_argument("--router-max-retries", type=int, default=2, help="Retries per provider on transient errors")
+    parser.add_argument("--router-retry-backoff", type=float, default=1.0, help="Base backoff seconds between retries")
 
     # Grok provider tuning
     parser.add_argument("--aspect-ratio", default="1:1", choices=["1:1", "16:9", "9:16"], help="Grok aspect ratio")
@@ -224,6 +226,8 @@ def main() -> None:
         ratio=args.runway_ratio,
         audio=args.runway_audio,
         prompt_image=args.runway_image,
+        max_retries=args.router_max_retries,
+        retry_backoff_s=args.router_retry_backoff,
     )
 
     video_path = str(generation.output_path)


### PR DESCRIPTION
## Summary
Implements hardening-only follow-up scope for provider routing (issue #307).

### What changed
- `providers/router.py`
  - Added structured error categorization: `auth`, `throttled`, `transient`, `permanent`, `unknown`.
  - Added retry+exponential backoff for `transient`/`throttled` categories.
  - Added per-attempt metrics and provider timing metadata.
  - Added fallback observability metadata (`router_attempts`, `router_provider_time_ms`, `router_error_categories`).
  - Added repeated-failure warning signal after consecutive provider failures.
- `tools/grok_video.py`
  - Added router tuning flags while preserving compatibility:
    - `--router-max-retries`
    - `--router-retry-backoff`
- Docs
  - Added `docs/ROUTER_HARDENING.md` with behavior, categories, retry strategy, and observability notes.
- Tests
  - Expanded `tests/test_video_router.py` with retry behavior, category classification, no-retry auth path, and repeated-failure warning coverage.

## Validation
- `python -m pytest tests/test_video_router.py -q` (9 passed)

## Notes
- Keeps existing `generate_video(...)` usage compatible in scripts.
- Fallback behavior remains deterministic (`primary` then `secondary`) and now reports richer metadata.
