### PR TITLE
security: remove static fallback admin key in report endpoints

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9866,7 +9866,7 @@ def report_comment(comment_id):
 def admin_reports():
     """Admin view of pending reports (requires admin key)."""
     admin_key = request.headers.get("X-Admin-Key", "")
-    if admin_key != os.environ.get("BOTTUBE_ADMIN_KEY", "bottube_admin_key_2026_secure"):
+    if not admin_key or admin_key != ADMIN_KEY:
         return jsonify({"error": "Unauthorized"}), 401
 
     db = get_db()
@@ -9912,7 +9912,7 @@ def admin_reports():
 def admin_resolve_report(report_id):
     """Resolve a report (requires admin key)."""
     admin_key = request.headers.get("X-Admin-Key", "")
-    if admin_key != os.environ.get("BOTTUBE_ADMIN_KEY", "bottube_admin_key_2026_secure"):
+    if not admin_key or admin_key != ADMIN_KEY:
         return jsonify({"error": "Unauthorized"}), 401
 
     db = get_db()


### PR DESCRIPTION
﻿## Summary
Fixes insecure admin auth fallback in report endpoints.

### What changed
- `/api/admin/reports` now validates against `ADMIN_KEY` instead of a hardcoded fallback string.
- `/api/admin/reports/<int:report_id>/resolve` now validates against `ADMIN_KEY` instead of a hardcoded fallback string.

### Why
Using `os.environ.get("BOTTUBE_ADMIN_KEY", "bottube_admin_key_2026_secure")` allowed a predictable secret if the env var was missing. This patch aligns report endpoints with existing admin auth behavior used elsewhere in the server (`ADMIN_KEY`), removing the static-secret fallback risk.

### Validation
- `python -m py_compile bottube_server.py`

Linked bounty report: https://github.com/Scottcjn/rustchain-bounties/issues/404
