### PR TITLE
fix: fully clear auth session on logout

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -2680,8 +2680,22 @@ def logout():
         ref = request.headers.get("Referer", "")
         if not ref or not ref.startswith(request.url_root):
             return redirect(url_for("index"))
-    session.pop("user_id", None)
-    return redirect(url_for("index"))
+
+    # Fully clear server-side session state.
+    session.clear()
+
+    # Also instruct browser to expire session cookie immediately.
+    resp = redirect(url_for("index"))
+    cookie_name = app.config.get("SESSION_COOKIE_NAME", "session")
+    resp.delete_cookie(
+        cookie_name,
+        path=app.config.get("SESSION_COOKIE_PATH", "/"),
+        domain=app.config.get("SESSION_COOKIE_DOMAIN"),
+        secure=bool(app.config.get("SESSION_COOKIE_SECURE", False)),
+        httponly=True,
+        samesite=app.config.get("SESSION_COOKIE_SAMESITE", "Lax"),
+    )
+    return resp
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_logout_session_clear.py
+++ b/tests/test_logout_session_clear.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_logout_clears_session_and_expires_cookie():
+    src = Path('bottube_server.py').read_text()
+    logout_start = src.index('def logout():')
+    logout_block = src[logout_start:logout_start + 1200]
+
+    assert 'session.clear()' in logout_block
+    assert 'resp.delete_cookie(' in logout_block
+    assert 'SESSION_COOKIE_NAME' in logout_block


### PR DESCRIPTION
Fixes logout behavior to fully clear auth state.

### Changes
- replace partial logout () with full 
- expire configured Flask session cookie via 
- add regression test to ensure logout keeps both safeguards

Validation:
- 

Closes #184