### PR TITLE
feat: social graph API + real Flask integration tests

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -4802,6 +4802,146 @@ def unsubscribe_agent(agent_name):
     return jsonify({"ok": True, "following": False, "agent": agent_name})
 
 
+def _social_graph_limit(default=50, min_v=1, max_v=200):
+    """Parse and clamp social graph limit query parameter."""
+    try:
+        raw = int(request.args.get("limit", default))
+    except (TypeError, ValueError):
+        raw = default
+    return max(min_v, min(max_v, raw))
+
+
+@app.route("/api/social/graph")
+def social_graph():
+    """Return social graph network edges and connection summaries."""
+    db = get_db()
+    limit = _social_graph_limit()
+
+    network_rows = db.execute(
+        """SELECT f.agent_name AS follower, t.agent_name AS following, s.created_at
+           FROM subscriptions s
+           JOIN agents f ON s.follower_id = f.id
+           JOIN agents t ON s.following_id = t.id
+           ORDER BY s.created_at DESC
+           LIMIT ?""",
+        (limit,),
+    ).fetchall()
+
+    top_pairs_rows = db.execute(
+        """SELECT f.agent_name AS follower, t.agent_name AS following, COUNT(*) AS count
+           FROM subscriptions s
+           JOIN agents f ON s.follower_id = f.id
+           JOIN agents t ON s.following_id = t.id
+           GROUP BY s.follower_id, s.following_id
+           ORDER BY count DESC, s.created_at DESC
+           LIMIT ?""",
+        (limit,),
+    ).fetchall()
+
+    most_connected_rows = db.execute(
+        """SELECT a.agent_name, a.display_name,
+                  COUNT(DISTINCT s1.follower_id) AS followers,
+                  COUNT(DISTINCT s2.following_id) AS following,
+                  (COUNT(DISTINCT s1.follower_id) + COUNT(DISTINCT s2.following_id)) AS connections
+           FROM agents a
+           LEFT JOIN subscriptions s1 ON s1.following_id = a.id
+           LEFT JOIN subscriptions s2 ON s2.follower_id = a.id
+           GROUP BY a.id
+           ORDER BY connections DESC, followers DESC, a.agent_name ASC
+           LIMIT ?""",
+        (limit,),
+    ).fetchall()
+
+    return jsonify({
+        "network": [
+            {
+                "follower": r["follower"],
+                "following": r["following"],
+                "created_at": r["created_at"],
+            }
+            for r in network_rows
+        ],
+        "top_pairs": [
+            {
+                "follower": r["follower"],
+                "following": r["following"],
+                "count": int(r["count"] or 0),
+            }
+            for r in top_pairs_rows
+        ],
+        "most_connected": [
+            {
+                "agent_name": r["agent_name"],
+                "display_name": r["display_name"],
+                "followers": int(r["followers"] or 0),
+                "following": int(r["following"] or 0),
+                "connections": int(r["connections"] or 0),
+            }
+            for r in most_connected_rows
+        ],
+    })
+
+
+@app.route("/api/agents/<agent_name>/interactions")
+def get_agent_interactions(agent_name):
+    """Return incoming/outgoing subscription interactions for one agent."""
+    db = get_db()
+    limit = _social_graph_limit()
+
+    agent = db.execute(
+        "SELECT id, agent_name, display_name FROM agents WHERE agent_name = ?",
+        (agent_name,),
+    ).fetchone()
+    if not agent:
+        return jsonify({"error": "Agent not found"}), 404
+
+    incoming_rows = db.execute(
+        """SELECT a.agent_name, a.display_name, a.is_human, a.avatar_url, s.created_at AS followed_at
+           FROM subscriptions s
+           JOIN agents a ON s.follower_id = a.id
+           WHERE s.following_id = ?
+           ORDER BY s.created_at DESC
+           LIMIT ?""",
+        (agent["id"], limit),
+    ).fetchall()
+
+    outgoing_rows = db.execute(
+        """SELECT a.agent_name, a.display_name, a.is_human, a.avatar_url, s.created_at AS followed_at
+           FROM subscriptions s
+           JOIN agents a ON s.following_id = a.id
+           WHERE s.follower_id = ?
+           ORDER BY s.created_at DESC
+           LIMIT ?""",
+        (agent["id"], limit),
+    ).fetchall()
+
+    return jsonify({
+        "agent_name": agent["agent_name"],
+        "incoming": [
+            {
+                "agent_name": r["agent_name"],
+                "display_name": r["display_name"],
+                "is_human": bool(r["is_human"]),
+                "avatar_url": r["avatar_url"],
+                "followed_at": r["followed_at"],
+            }
+            for r in incoming_rows
+        ],
+        "outgoing": [
+            {
+                "agent_name": r["agent_name"],
+                "display_name": r["display_name"],
+                "is_human": bool(r["is_human"]),
+                "avatar_url": r["avatar_url"],
+                "followed_at": r["followed_at"],
+            }
+            for r in outgoing_rows
+        ],
+        "incoming_count": len(incoming_rows),
+        "outgoing_count": len(outgoing_rows),
+    })
+
+
 @app.route("/api/agents/<agent_name>/analytics")
 def get_agent_analytics(agent_name):
     """Get analytics for an agent."""

--- a/tests/test_social_graph.py
+++ b/tests/test_social_graph.py
@@ -1,52 +1,198 @@
-import pytest
-from unittest.mock import MagicMock
+# SPDX-License-Identifier: MIT
 
-def test_social_graph_returns_correct_structure(client):
-    """
-    Test /api/social/graph returns network, top_pairs, most_connected
-    (Bounty #205 Requirement)
-    """
-    response = client.get('/api/social/graph')
-    assert response.status_code == 200
-    data = response.get_json()
-    assert 'network' in data
-    assert 'top_pairs' in data
-    assert 'most_connected' in data
+import os
+import sqlite3
+import importlib
+import tempfile
+from pathlib import Path
 
-def test_agent_interactions_returns_correct_structure(client):
-    """
-    Test /api/agents/<name>/interactions returns incoming and outgoing
-    (Bounty #205 Requirement)
-    """
-    # Mocking an agent named 'vector'
-    response = client.get('/api/agents/vector/interactions')
-    if response.status_code == 200:
-        data = response.get_json()
-        assert 'incoming' in data
-        assert 'outgoing' in data
 
-def test_agent_interactions_404_nonexistent(client):
-    """
-    Test 404 for nonexistent agent
-    (Bounty #205 Requirement)
-    """
-    response = client.get('/api/agents/nonexistent_agent_xyz/interactions')
-    assert response.status_code == 404
+_original_connect = sqlite3.connect
 
-def test_social_graph_limit_parameter(client):
-    """
-    Test limit parameter works
-    (Bounty #205 Requirement)
-    """
-    response = client.get('/api/social/graph?limit=5')
-    assert response.status_code == 200
 
-def test_mock_data_interactions(client):
-    """
-    Test with mocked DB data of at least 3 interacting agents
-    (Bounty #205 Requirement)
-    """
-    # In a real environment, we would use a fixture to seed the DB
-    # For this PR, we assume the test client handles the internal mocking
-    response = client.get('/api/social/graph')
-    assert response.status_code == 200
+def _safe_import_connect(path, *args, **kwargs):
+    # Prevent hardcoded production DB access during import
+    if isinstance(path, str) and "/root/bottube/" in path:
+        return _original_connect(":memory:")
+    return _original_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _safe_import_connect
+
+if "bottube_server" in globals():
+    import sys
+    if "bottube_server" in sys.modules:
+        del sys.modules["bottube_server"]
+
+bs = importlib.import_module("bottube_server")
+sqlite3.connect = _original_connect
+
+
+def _build_app(db_path):
+    bs.DB_PATH = Path(db_path)
+    bs.app.config["TESTING"] = True
+    with bs.app.app_context():
+        bs.init_db()
+    return bs.app
+
+
+def _create_agent(db, name, is_human=0):
+    api_key = f"key_{name}"
+    db.execute(
+        """
+        INSERT INTO agents (agent_name, display_name, api_key, is_human, created_at)
+        VALUES (?, ?, ?, ?, strftime('%s','now'))
+        """,
+        (name, name.title(), api_key, is_human),
+    )
+    db.commit()
+    return db.execute("SELECT id FROM agents WHERE agent_name = ?", (name,)).fetchone()["id"]
+
+
+def _seed_social_graph(db):
+    alice = _create_agent(db, "alice", is_human=1)
+    bob = _create_agent(db, "bob", is_human=1)
+    charlie = _create_agent(db, "charlie", is_human=0)
+    diana = _create_agent(db, "diana", is_human=1)
+
+    edges = [
+        (alice, bob, 1700000001),
+        (alice, charlie, 1700000002),
+        (bob, alice, 1700000003),
+        (charlie, alice, 1700000004),
+        (charlie, bob, 1700000005),
+        (diana, alice, 1700000006),
+        (diana, bob, 1700000007),
+    ]
+    db.executemany(
+        "INSERT INTO subscriptions (follower_id, following_id, created_at) VALUES (?, ?, ?)",
+        edges,
+    )
+    db.commit()
+
+
+def _cleanup(app, db_path):
+    with app.app_context():
+        try:
+            bs.get_db().close()
+        except Exception:
+            pass
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+def test_social_graph_structure_and_counts():
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    try:
+        app = _build_app(tmp.name)
+        client = app.test_client()
+        with app.app_context():
+            db = bs.get_db()
+            _seed_social_graph(db)
+
+        resp = client.get("/api/social/graph")
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert "network" in data and "top_pairs" in data and "most_connected" in data
+        assert len(data["network"]) == 7
+        assert len(data["top_pairs"]) == 7
+        assert any(x["agent_name"] == "alice" for x in data["most_connected"])
+
+    finally:
+        _cleanup(app, tmp.name)
+
+
+def test_social_graph_limit_bounds_checking():
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    try:
+        app = _build_app(tmp.name)
+        client = app.test_client()
+        with app.app_context():
+            db = bs.get_db()
+            _seed_social_graph(db)
+
+        # limit=2 should cap list sizes to 2
+        resp = client.get("/api/social/graph?limit=2")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data["network"]) == 2
+        assert len(data["top_pairs"]) == 2
+        assert len(data["most_connected"]) == 2
+
+        # non-integer -> default path, still returns success
+        resp2 = client.get("/api/social/graph?limit=abc")
+        assert resp2.status_code == 200
+
+        # negative -> clamped to min=1
+        resp3 = client.get("/api/social/graph?limit=-5")
+        assert resp3.status_code == 200
+        assert len(resp3.get_json()["network"]) == 1
+
+    finally:
+        _cleanup(app, tmp.name)
+
+
+def test_agent_interactions_happy_path():
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    try:
+        app = _build_app(tmp.name)
+        client = app.test_client()
+        with app.app_context():
+            db = bs.get_db()
+            _seed_social_graph(db)
+
+        resp = client.get("/api/agents/alice/interactions")
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert data["agent_name"] == "alice"
+        assert "incoming" in data and "outgoing" in data
+        assert data["incoming_count"] == len(data["incoming"])
+        assert data["outgoing_count"] == len(data["outgoing"])
+        assert data["incoming_count"] == 3  # bob,charlie,diana follow alice
+        assert data["outgoing_count"] == 2  # alice follows bob,charlie
+
+    finally:
+        _cleanup(app, tmp.name)
+
+
+def test_agent_interactions_404_nonexistent():
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    try:
+        app = _build_app(tmp.name)
+        client = app.test_client()
+        with app.app_context():
+            db = bs.get_db()
+            _seed_social_graph(db)
+
+        resp = client.get("/api/agents/ghost/interactions")
+        assert resp.status_code == 404
+        assert "error" in resp.get_json()
+
+    finally:
+        _cleanup(app, tmp.name)
+
+
+def test_agent_interactions_limit_param_applies():
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    try:
+        app = _build_app(tmp.name)
+        client = app.test_client()
+        with app.app_context():
+            db = bs.get_db()
+            _seed_social_graph(db)
+
+        resp = client.get("/api/agents/alice/interactions?limit=1")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data["incoming"]) == 1
+        assert len(data["outgoing"]) == 1
+
+    finally:
+        _cleanup(app, tmp.name)


### PR DESCRIPTION
This PR implements the Social Graph API bounty scope with SQL JOIN-backed endpoints and real Flask integration tests.

### Implemented endpoints
- `GET /api/social/graph`
  - returns `network` (follower/following edges)
  - returns `top_pairs`
  - returns `most_connected`
- `GET /api/agents/<agent_name>/interactions`
  - returns `incoming` and `outgoing`
  - returns `incoming_count` and `outgoing_count`

### Requirements coverage
- SQL JOINs on existing `subscriptions` table: ✅
- `limit` parameter with bounds checking: ✅
- Flask `test_client()` integration tests (non-mock): ✅
- Test style aligned with `tests/test_tipping.py`: ✅

### Notes
- Added `_social_graph_limit()` helper for robust `limit` parsing/clamping.
- Replaced previous mock-based social graph tests with DB-backed integration tests.

Payout wallet: RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35
