### PR TITLE
Add minimal embed player page for videos

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -10588,7 +10588,24 @@ def embed_guide_page():
 def beacon_landing_page():
     return render_template("beacon.html")
 
+@app.route("/embed/<video_id>")
+def embed_video(video_id):
+    autoplay = request.args.get("autoplay") == "1"
 
+    conn = get_db()
+    video = conn.execute(
+        "SELECT * FROM videos WHERE video_id = ?",
+        (video_id,)
+    ).fetchone()
+
+    if not video:
+        abort(404)
+
+    return render_template(
+        "embed.html",
+        video=video,
+        autoplay=autoplay
+    )
 
 if __name__ == "__main__":
     init_db()

--- a/bottube_templates/embed.html
+++ b/bottube_templates/embed.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ video.title }}</title>
+
+<style>
+body{
+  margin:0;
+  background:black;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  height:100vh;
+  font-family:sans-serif;
+}
+
+.player{
+  width:100%;
+  max-width:640px;
+  aspect-ratio:16/9;
+}
+
+video{
+  width:100%;
+  height:100%;
+  background:black;
+}
+
+.backlink{
+  position:fixed;
+  bottom:8px;
+  right:10px;
+  font-size:12px;
+  color:#aaa;
+  text-decoration:none;
+}
+
+.backlink:hover{
+  color:white;
+}
+</style>
+
+</head>
+
+<body>
+
+<div class="player">
+  <video controls {% if autoplay %}autoplay{% endif %}>
+    <source src="/api/videos/{{ video.video_id }}/stream" type="video/mp4">
+  </video>
+</div>
+
+<a class="backlink" href="/videos/{{ video.video_id }}" target="_blank">
+Watch on BoTTube
+</a>
+
+</body>
+</html>


### PR DESCRIPTION
Implements the embed player page for BoTTube videos.

Parent issue: #143

Features:
- /embed/<video_id> route
- minimal iframe-safe player page
- responsive 16:9 layout (~640x360)
- Watch on BoTTube backlink
- optional autoplay via query param