### PR TITLE
dashboard: show zero-video onboarding card above stats

### DIFF
--- a/bottube_templates/dashboard.html
+++ b/bottube_templates/dashboard.html
@@ -387,6 +387,32 @@
     </div>
 </div>
 
+{% if totals.video_count == 0 %}
+<!-- Creator onboarding card (Scottcjn/bottube#297) -->
+<div style="background:linear-gradient(135deg,rgba(62,166,255,0.10) 0%,rgba(35,112,255,0.06) 100%);border:1px solid rgba(62,166,255,0.32);border-radius:14px;padding:18px 18px 16px;margin-bottom:18px;">
+    <div style="display:flex;justify-content:space-between;gap:16px;flex-wrap:wrap;align-items:flex-start;">
+        <div style="flex:1;min-width:260px;">
+            <h2 style="font-size:18px;font-weight:700;color:var(--text-primary);margin:0 0 8px;">Start your first upload</h2>
+            <p style="font-size:13px;color:var(--text-secondary);margin:0 0 12px;max-width:760px;">
+                Publish your first BoTTube video from this dashboard. Constraints: <strong>500MB max upload</strong>,
+                <strong>8s max duration</strong>, <strong>720×720 max output bounds</strong>,
+                <strong>H.264 MP4 final transcode</strong>, and <strong>~2MB final size target after transcoding</strong>.
+            </p>
+            <ul style="margin:0 0 14px 18px;padding:0;color:var(--text-secondary);font-size:13px;line-height:1.5;">
+                <li>Set up profile identity (name/avatar/bio)</li>
+                <li>Upload first video from the web uploader</li>
+                <li>Optional: automate uploads via the developer/API path</li>
+            </ul>
+            <div style="display:flex;gap:10px;flex-wrap:wrap;">
+                <a href="{{ P }}/upload" style="background:var(--accent);color:#000;border:1px solid var(--accent);padding:8px 14px;border-radius:9px;font-size:13px;font-weight:700;">Upload first video</a>
+                <a href="{{ P }}/developers" style="border:1px solid var(--border);color:var(--text-secondary);padding:8px 14px;border-radius:9px;font-size:13px;font-weight:600;">Developer/API path</a>
+                <a href="https://github.com/Scottcjn/bottube#readme" target="_blank" rel="noopener" style="border:1px solid var(--border);color:var(--text-secondary);padding:8px 14px;border-radius:9px;font-size:13px;font-weight:600;">Working quickstart reference</a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- Stats -->
 <div class="stats-row">
     <div class="stat-card">
@@ -477,97 +503,7 @@
     </table>
     </div>
     {% else %}
-    <!-- Creator Onboarding Empty-State -->
-    <!-- References: Scottcjn/bottube#297 -->
-    <div class="onboarding-empty-state" style="background:linear-gradient(135deg,rgba(62,166,255,0.08) 0%,rgba(114,137,218,0.06) 100%);border:2px dashed var(--accent);border-radius:16px;padding:32px 24px;margin-bottom:32px;text-align:center;">
-        <div style="font-size:48px;margin-bottom:16px;">🎬</div>
-        <h2 style="font-size:22px;font-weight:700;color:var(--text-primary);margin:0 0 8px 0;">Welcome to BoTTube, {{ current_user.display_name or current_user.agent_name }}!</h2>
-        <p style="font-size:14px;color:var(--text-secondary);margin:0 0 24px 0;max-width:520px;margin-left:auto;margin-right:auto;">
-            You're all set up! Now let's get your first video uploaded. BoTTube is where AI agents create, share, and interact with short-form video content.
-        </p>
-        
-        <!-- Upload Constraints Card -->
-        <div style="background:rgba(0,0,0,0.25);border:1px solid var(--border);border-radius:12px;padding:16px;margin-bottom:24px;max-width:600px;margin-left:auto;margin-right:auto;">
-            <h3 style="font-size:14px;font-weight:600;color:var(--text-primary);margin:0 0 12px 0;text-transform:uppercase;letter-spacing:0.5px;">📋 Video Requirements</h3>
-            <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:12px;text-align:left;">
-                <div style="background:rgba(0,0,0,0.2);border-radius:8px;padding:12px;">
-                    <div style="font-size:20px;margin-bottom:4px;">⏱️</div>
-                    <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;">Max Duration</div>
-                    <div style="font-size:14px;font-weight:600;color:var(--text-primary);">8 seconds</div>
-                </div>
-                <div style="background:rgba(0,0,0,0.2);border-radius:8px;padding:12px;">
-                    <div style="font-size:20px;margin-bottom:4px;">📐</div>
-                    <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;">Resolution</div>
-                    <div style="font-size:14px;font-weight:600;color:var(--text-primary);">720×720 max</div>
-                </div>
-                <div style="background:rgba(0,0,0,0.2);border-radius:8px;padding:12px;">
-                    <div style="font-size:20px;margin-bottom:4px;">📦</div>
-                    <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;">File Size</div>
-                    <div style="font-size:14px;font-weight:600;color:var(--text-primary);">2 MB max</div>
-                </div>
-                <div style="background:rgba(0,0,0,0.2);border-radius:8px;padding:12px;">
-                    <div style="font-size:20px;margin-bottom:4px;">🎞️</div>
-                    <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;">Format</div>
-                    <div style="font-size:14px;font-weight:600;color:var(--text-primary);">H.264 MP4</div>
-                </div>
-            </div>
-        </div>
-        
-        <!-- First Upload Checklist -->
-        <div style="background:rgba(0,0,0,0.25);border:1px solid var(--border);border-radius:12px;padding:20px;margin-bottom:24px;max-width:600px;margin-left:auto;margin-right:auto;text-align:left;">
-            <h3 style="font-size:14px;font-weight:600;color:var(--text-primary);margin:0 0 16px 0;text-transform:uppercase;letter-spacing:0.5px;">✅ Your First Upload Checklist</h3>
-            <ul style="list-style:none;padding:0;margin:0;">
-                <li style="display:flex;align-items:flex-start;gap:10px;padding:8px 0;border-bottom:1px solid rgba(255,255,255,0.06);">
-                    <span style="flex-shrink:0;width:20px;height:20px;border-radius:50%;background:rgba(240,185,11,0.2);border:2px solid var(--accent);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;color:var(--accent);">1</span>
-                    <div>
-                        <div style="font-size:13px;font-weight:500;color:var(--text-primary);">Prepare your video</div>
-                        <div style="font-size:12px;color:var(--text-muted);margin-top:2px;">Resize to 720×720, keep it under 8 seconds and 2MB</div>
-                    </div>
-                </li>
-                <li style="display:flex;align-items:flex-start;gap:10px;padding:8px 0;border-bottom:1px solid rgba(255,255,255,0.06);">
-                    <span style="flex-shrink:0;width:20px;height:20px;border-radius:50%;background:rgba(240,185,11,0.2);border:2px solid var(--accent);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;color:var(--accent);">2</span>
-                    <div>
-                        <div style="font-size:13px;font-weight:500;color:var(--text-primary);">Click Upload below</div>
-                        <div style="font-size:12px;color:var(--text-muted);margin-top:2px;">Choose your file, add title, description, and tags</div>
-                    </div>
-                </li>
-                <li style="display:flex;align-items:flex-start;gap:10px;padding:8px 0;">
-                    <span style="flex-shrink:0;width:20px;height:20px;border-radius:50%;background:rgba(240,185,11,0.2);border:2px solid var(--accent);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;color:var(--accent);">3</span>
-                    <div>
-                        <div style="font-size:13px;font-weight:500;color:var(--text-primary);">Share &amp; engage</div>
-                        <div style="font-size:12px;color:var(--text-muted);margin-top:2px;">Your video goes live instantly. Start earning RTC from views!</div>
-                    </div>
-                </li>
-            </ul>
-        </div>
-        
-        <!-- Action Buttons -->
-        <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">
-            <a href="{{ P }}/upload" style="display:inline-flex;align-items:center;gap:8px;background:var(--accent);color:#000;padding:14px 28px;border-radius:10px;font-size:15px;font-weight:700;text-decoration:none;transition:all 0.15s;box-shadow:0 4px 14px rgba(240,185,11,0.3);">
-                <span style="font-size:18px;">📤</span>
-                Upload Your First Video
-            </a>
-            <a href="{{ P }}/api/docs" style="display:inline-flex;align-items:center;gap:6px;background:rgba(0,0,0,0.25);color:var(--text-secondary);border:1px solid var(--border);padding:14px 20px;border-radius:10px;font-size:13px;font-weight:600;text-decoration:none;transition:all 0.15s;">
-                <span style="font-size:16px;">📖</span>
-                API Docs
-            </a>
-            <a href="https://github.com/Scottcjn/bottube#readme" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;background:rgba(0,0,0,0.25);color:var(--text-secondary);border:1px solid var(--border);padding:14px 20px;border-radius:10px;font-size:13px;font-weight:600;text-decoration:none;transition:all 0.15s;">
-                <span style="font-size:16px;">🚀</span>
-                Quickstart Guide
-            </a>
-        </div>
-        
-        <!-- Pro Tip -->
-        <div style="margin-top:24px;padding:14px 18px;background:rgba(62,166,255,0.08);border:1px solid rgba(62,166,255,0.25);border-radius:10px;max-width:600px;margin-left:auto;margin-right:auto;">
-            <div style="display:flex;gap:10px;align-items:flex-start;">
-                <span style="font-size:18px;flex-shrink:0;">💡</span>
-                <div style="font-size:13px;color:var(--text-secondary);">
-                    <strong style="color:var(--text-primary);">Pro tip:</strong> Use the API for automated uploads! Perfect for AI agents. Check the 
-                    <a href="{{ P }}/api/docs" style="color:var(--accent);font-weight:600;">API documentation</a> for examples.
-                </div>
-            </div>
-        </div>
-    </div>
+    <p style="color:var(--text-muted);font-size:13px;">No videos yet. Start with your first upload from <a href="{{ P }}/upload" style="color:var(--accent);">/upload</a>.</p>
     {% endif %}
 </div>
 


### PR DESCRIPTION
## Summary
Implements the onboarding placement and visibility behavior requested in `Scottcjn/bottube#297` (and bounty routing in `Scottcjn/rustchain-bounties#1492`).

## What changed
- Render zero-video onboarding card **on `/dashboard` below header area and above stats row**.
- Card is gated by `totals.video_count == 0` so it auto-hides after first successful upload.
- CTA links:
  - primary: `/upload`
  - secondary: `/developers`
  - reference: working quickstart link in repository README
- Constraint copy aligned with current limits:
  - 500MB max upload
  - 8s max duration
  - 720x720 max output bounds
  - H.264 mp4 final transcode path
  - ~2MB final size target after transcoding
- Simplified empty state in the “Your Videos” section to avoid duplicate onboarding surfaces.

## Validation checklist
- [x] zero-video account sees onboarding card before stats
- [x] `/upload` CTA is one click
- [x] `/developers` CTA is one click
- [x] onboarding hidden when creator has >=1 videos (conditioned on `totals.video_count == 0`)

## Notes
Draft PR for early maintainer feedback before final polish/screenshots.
