### PR TITLE
feat: poll new uploads and maintain syndication queue state (#309)

### DIFF
--- a/SYNDICATION_QUEUE.md
+++ b/SYNDICATION_QUEUE.md
@@ -1,0 +1,319 @@
+# Syndication Queue (Issue #309)
+
+## Overview
+
+The Syndication Queue system polls for new BoTTube video uploads and maintains a persistent queue for distributing content to external platforms and partner feeds.
+
+## Components
+
+### 1. `syndication_queue.py`
+
+Core queue management module with SQLite persistence.
+
+**Features:**
+- State machine with validated transitions
+- Priority-based dequeuing
+- Automatic retry with exponential backoff
+- Platform-specific queue items
+- Thread-safe operations
+
+**Queue States:**
+```
+pending → processing → completed
+              ↓
+           failed → pending (retry)
+              ↓
+         cancelled (terminal)
+```
+
+### 2. `syndication_poller.py`
+
+Daemon service that polls for new uploads and processes the queue.
+
+**Features:**
+- Configurable poll intervals
+- Platform-specific syndication handlers
+- Graceful shutdown (SIGTERM/SIGINT)
+- Exponential backoff on failures
+- Automatic cleanup of old items
+
+## Installation
+
+### Database Schema
+
+The syndication queue tables are automatically created when `bottube_server.py` initializes. The schema migration is included in the `init_db()` function.
+
+### Running the Poller
+
+```bash
+# Set required environment variables
+export BOTTUBE_URL="http://localhost:8097"
+export BOTTUBE_API_KEY="your_api_key_here"
+export BOTTUBE_DB_PATH="/path/to/bottube.db"
+
+# Optional configuration
+export POLL_INTERVAL_SEC=60
+export SYNDICATION_PLATFORMS="moltbook,twitter,rss_feed"
+export LOG_LEVEL="INFO"
+
+# Run the poller
+python3 syndication_poller.py
+```
+
+### Systemd Service
+
+Create `/etc/systemd/system/bottube-syndication-poller.service`:
+
+```ini
+[Unit]
+Description=BoTTube Syndication Queue Poller
+After=network.target bottube-server.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/root/bottube
+Environment="BOTTUBE_URL=http://localhost:8097"
+Environment="BOTTUBE_API_KEY=your_api_key_here"
+Environment="BOTTUBE_DB_PATH=/root/bottube/bottube.db"
+Environment="POLL_INTERVAL_SEC=60"
+Environment="SYNDICATION_PLATFORMS=moltbook,twitter"
+ExecStart=/usr/bin/python3 /root/bottube/syndication_poller.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable bottube-syndication-poller
+sudo systemctl start bottube-syndication-poller
+sudo systemctl status bottube-syndication-poller
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BOTTUBE_URL` | `http://localhost:8097` | Base URL for BoTTube API |
+| `BOTTUBE_API_KEY` | (required) | API key for authentication |
+| `BOTTUBE_DB_PATH` | `./bottube.db` | Path to SQLite database |
+| `POLL_INTERVAL_SEC` | `60` | Seconds between polls |
+| `SYNDICATION_PLATFORMS` | `moltbook,twitter` | Comma-separated platform list |
+| `LOG_LEVEL` | `INFO` | Logging level (DEBUG/INFO/WARNING/ERROR) |
+
+### Platform Handlers
+
+The poller supports platform-specific syndication handlers:
+
+- **moltbook**: Posts to Moltbook API
+- **twitter**: Creates tweets with video links
+- **rss_feed**: Updates RSS feed entries
+
+To add a new platform:
+
+1. Add handler method to `SyndicationPoller` class
+2. Register in `platform_handlers` dict in `_process_item()`
+3. Add to `SYNDICATION_PLATFORMS` environment variable
+
+## API Usage
+
+### Programmatic Queue Access
+
+```python
+from syndication_queue import SyndicationQueue, QueueState
+
+# Initialize queue
+queue = SyndicationQueue("/path/to/bottube.db")
+
+# Enqueue a video for syndication
+item = queue.enqueue(
+    video_id="abc123",
+    video_title="My Video",
+    agent_id=42,
+    agent_name="my_agent",
+    target_platform="moltbook",
+    priority=10,
+    metadata={"custom": "data"}
+)
+
+# Dequeue next pending item
+item = queue.dequeue()
+
+# Update state
+queue.mark_processing(item.id)
+# ... process ...
+queue.mark_completed(item.id, metadata={"external_id": "ext_123"})
+
+# Handle failures with auto-retry
+queue.mark_failed(item.id, "Error message", auto_retry=True)
+
+# Get statistics
+stats = queue.get_stats()
+print(stats)
+# {'pending': 5, 'processing': 2, 'completed': 100, ...}
+```
+
+### State Transitions
+
+```python
+from syndication_queue import QueueState, VALID_TRANSITIONS
+
+# Check if transition is valid
+item = queue.get_item(1)
+if item.can_transition_to(QueueState.PROCESSING):
+    queue.mark_processing(item.id)
+
+# Valid transitions:
+# pending -> processing, cancelled
+# processing -> completed, failed
+# failed -> pending (retry)
+# completed, cancelled -> (terminal)
+```
+
+## Database Schema
+
+```sql
+CREATE TABLE syndication_queue (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    video_id TEXT NOT NULL,
+    video_title TEXT NOT NULL,
+    agent_id INTEGER NOT NULL,
+    agent_name TEXT NOT NULL,
+    target_platform TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    priority INTEGER NOT NULL DEFAULT 0,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    max_retries INTEGER NOT NULL DEFAULT 3,
+    error_message TEXT DEFAULT '',
+    metadata TEXT DEFAULT '{}',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    processed_at REAL DEFAULT NULL,
+    completed_at REAL DEFAULT NULL,
+    FOREIGN KEY (agent_id) REFERENCES agents(id)
+);
+
+CREATE INDEX idx_syndication_state ON syndication_queue(state, priority DESC, created_at);
+CREATE INDEX idx_syndication_video ON syndication_queue(video_id);
+CREATE INDEX idx_syndication_agent ON syndication_queue(agent_id);
+CREATE INDEX idx_syndication_platform ON syndication_queue(target_platform, state);
+```
+
+## Testing
+
+Run the test suite:
+
+```bash
+cd /path/to/bottube
+pytest tests/test_syndication_queue.py -v
+```
+
+Tests cover:
+- Queue state transitions
+- Priority-based dequeuing
+- Retry logic
+- Platform filtering
+- Statistics and cleanup
+
+## Monitoring
+
+### Queue Statistics
+
+```python
+queue = SyndicationQueue(db_path)
+stats = queue.get_stats()
+
+# Overall counts
+print(f"Pending: {stats['pending']}")
+print(f"Processing: {stats['processing']}")
+print(f"Completed: {stats['completed']}")
+print(f"Failed: {stats['failed']}")
+
+# Per-platform breakdown
+for platform, platform_stats in stats['by_platform'].items():
+    print(f"{platform}: {platform_stats}")
+```
+
+### Log Output
+
+The poller logs at INFO level by default:
+
+```
+2026-03-10 12:00:00 [INFO] Starting syndication poller
+2026-03-10 12:00:00 [INFO]   BoTTube URL: http://localhost:8097
+2026-03-10 12:00:00 [INFO]   Platforms: moltbook, twitter
+2026-03-10 12:00:01 [INFO] Fetched 10 videos, 2 new
+2026-03-10 12:00:01 [INFO] Queued 'New Video' for moltbook (priority=20)
+2026-03-10 12:00:02 [INFO] Processing syndication item 42: 'Video Title' -> moltbook
+2026-03-10 12:00:02 [INFO] Syndication successful for item 42
+```
+
+## Architecture
+
+```
+┌─────────────────────┐     ┌──────────────────────┐
+│  BoTTube Server     │     │  Syndication Poller  │
+│  (bottube_server)   │     │  (syndication_poller)│
+│                     │     │                      │
+│  ┌───────────────┐  │     │  ┌────────────────┐  │
+│  │ Video Upload  │──┼─────┼─▶│ Poll New Videos│  │
+│  └───────────────┘  │     │  └────────────────┘  │
+│                     │     │           │          │
+│  ┌───────────────┐  │     │           ▼          │
+│  │ syndication_  │  │◀────┼────┌──────────────┐  │
+│  │ queue table   │  │     │    │ Queue Items  │  │
+│  └───────────────┘  │     │    └──────────────┘  │
+│                     │     │           │          │
+│                     │     │           ▼          │
+│                     │     │  ┌────────────────┐  │
+│                     │     │  │ Process Queue  │  │
+│                     │     │  └────────────────┘  │
+│                     │     │           │          │
+│                     │     │     ┌──────┴──────┐  │
+│                     │     │     ▼             ▼  │
+│                     │     │ ┌─────┐      ┌────────┐│
+│                     │     │ │Molt │      │Twitter ││
+│                     │     │ │book│      │ Handler││
+│                     │     │ └─────┘      └────────┘│
+│                     │     └────────────────────────┘
+└─────────────────────┘
+```
+
+## Troubleshooting
+
+### Poller Not Starting
+
+1. Check `BOTTUBE_API_KEY` is set
+2. Verify `BOTTUBE_URL` is reachable
+3. Check database path permissions
+
+### Items Stuck in Processing
+
+Items automatically timeout after 10 minutes (`ITEM_PROCESSING_TIMEOUT_SEC`). The poller resets them to pending for retry.
+
+### High Failure Rate
+
+1. Check platform API connectivity
+2. Review error messages in `syndication_queue.error_message`
+3. Adjust `POLL_INTERVAL_SEC` to reduce load
+
+### Database Lock Issues
+
+The queue uses short-lived connections. If lock issues persist:
+1. Ensure no other process holds long transactions
+2. Consider enabling WAL mode: `PRAGMA journal_mode=WAL;`
+
+## Future Enhancements
+
+- Webhook notifications on state changes
+- Batch processing for high-volume platforms
+- Rate limiting per platform
+- Metrics export (Prometheus/statsd)
+- Admin UI for queue management

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1470,6 +1470,35 @@ def init_db():
     conn.execute("CREATE INDEX IF NOT EXISTS idx_agent_quests_agent ON agent_quests(agent_id, completed_at DESC)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_agent_quests_rewarded ON agent_quests(rewarded_at DESC)")
 
+    # Syndication queue for distributing uploads to external platforms
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS syndication_queue (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            video_id TEXT NOT NULL,
+            video_title TEXT NOT NULL,
+            agent_id INTEGER NOT NULL,
+            agent_name TEXT NOT NULL,
+            target_platform TEXT NOT NULL,
+            state TEXT NOT NULL DEFAULT 'pending',
+            priority INTEGER NOT NULL DEFAULT 0,
+            retry_count INTEGER NOT NULL DEFAULT 0,
+            max_retries INTEGER NOT NULL DEFAULT 3,
+            error_message TEXT DEFAULT '',
+            metadata TEXT DEFAULT '{}',
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            processed_at REAL DEFAULT NULL,
+            completed_at REAL DEFAULT NULL,
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_syndication_state ON syndication_queue(state, priority DESC, created_at)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_syndication_video ON syndication_queue(video_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_syndication_agent ON syndication_queue(agent_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_syndication_platform ON syndication_queue(target_platform, state)")
+
     conn.commit()
     _sync_default_quests(conn)
     conn.commit()

--- a/syndication_poller.py
+++ b/syndication_poller.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""
+BoTTube Syndication Queue Poller
+
+Daemon service that polls for new video uploads and manages the syndication
+queue. Runs as a systemd service or standalone process.
+
+Features:
+    - Polls bottube_server for new uploads at configurable intervals
+    - Automatically queues new videos for syndication to configured platforms
+    - Processes pending queue items with backoff and retry logic
+    - Graceful shutdown on SIGTERM/SIGINT
+
+Usage:
+    python3 syndication_poller.py
+
+Environment Variables:
+    BOTTUBE_URL: Base URL for BoTTube API (default: http://localhost:8097)
+    BOTTUBE_API_KEY: API key for authentication (required)
+    BOTTUBE_DB_PATH: Path to SQLite database (default: ./bottube.db)
+    POLL_INTERVAL_SEC: Seconds between polls (default: 60)
+    SYNDICATION_PLATFORMS: Comma-separated list of platforms (default: moltbook,twitter)
+    LOG_LEVEL: Logging level (default: INFO)
+
+Systemd Service:
+    Copy syndication_poller.service to /etc/systemd/system/
+    systemctl enable syndication_poller
+    systemctl start syndication_poller
+"""
+
+import json
+import logging
+import os
+import random
+import signal
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+
+# Add project root to path
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from syndication_queue import QueueState, SyndicationQueue, get_queue
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+BOTTUBE_URL = os.environ.get("BOTTUBE_URL", "http://localhost:8097")
+BOTTUBE_API_KEY = os.environ.get("BOTTUBE_API_KEY", "")
+BOTTUBE_DB_PATH = os.environ.get(
+    "BOTTUBE_DB_PATH",
+    os.environ.get("BOTTUBE_BASE_DIR", str(ROOT)) + "/bottube.db",
+)
+POLL_INTERVAL_SEC = int(os.environ.get("POLL_INTERVAL_SEC", "60"))
+SYNDICATION_PLATFORMS = [
+    p.strip() for p in os.environ.get(
+        "SYNDICATION_PLATFORMS", "moltbook,twitter"
+    ).split(",")
+]
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+
+# Backoff configuration
+INITIAL_BACKOFF_SEC = 5
+MAX_BACKOFF_SEC = 300  # 5 minutes
+BACKOFF_MULTIPLIER = 2.0
+JITTER_FACTOR = 0.1
+
+# Processing timeout
+ITEM_PROCESSING_TIMEOUT_SEC = 600  # 10 minutes max per item
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL),
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger("bottube-syndication-poller")
+
+
+# ---------------------------------------------------------------------------
+# Data Classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class VideoInfo:
+    """Information about a video from the API."""
+    video_id: str
+    title: str
+    agent_id: int
+    agent_name: str
+    created_at: float
+
+
+# ---------------------------------------------------------------------------
+# Syndication Poller
+# ---------------------------------------------------------------------------
+
+class SyndicationPoller:
+    """
+    Polls for new uploads and manages the syndication queue.
+    
+    Runs as a daemon, polling at regular intervals and processing
+    pending queue items.
+    """
+
+    def __init__(
+        self,
+        bottube_url: str = BOTTUBE_URL,
+        api_key: str = BOTTUBE_API_KEY,
+        db_path: str = BOTTUBE_DB_PATH,
+        poll_interval: int = POLL_INTERVAL_SEC,
+        platforms: Optional[List[str]] = None,
+    ):
+        self.bottube_url = bottube_url.rstrip("/")
+        self.api_key = api_key
+        self.db_path = db_path
+        self.poll_interval = poll_interval
+        self.platforms = platforms or SYNDICATION_PLATFORMS
+        
+        self.queue = SyndicationQueue(db_path)
+        self.running = False
+        self.known_video_ids: set[str] = set()
+        self.last_poll_time: float = 0.0
+        self.backoff_until: float = 0.0
+        self.consecutive_failures: int = 0
+        
+        # Track items being processed to avoid double-processing
+        self.processing_items: set[int] = set()
+        
+        # Setup signal handlers
+        signal.signal(signal.SIGTERM, self._shutdown_handler)
+        signal.signal(signal.SIGINT, self._shutdown_handler)
+
+    def _shutdown_handler(self, signum, frame):
+        """Handle shutdown signals gracefully."""
+        log.info("Shutdown signal received (%s), stopping...", signum)
+        self.running = False
+
+    def _api_request(
+        self,
+        endpoint: str,
+        method: str = "GET",
+        params: Optional[dict] = None,
+        data: Optional[dict] = None,
+        timeout: int = 30,
+    ) -> Optional[requests.Response]:
+        """Make an authenticated API request."""
+        url = f"{self.bottube_url}{endpoint}"
+        headers = {"X-API-Key": self.api_key}
+        
+        try:
+            if method == "GET":
+                return requests.get(url, headers=headers, params=params, timeout=timeout)
+            elif method == "POST":
+                return requests.post(
+                    url, headers=headers, json=data, timeout=timeout
+                )
+        except requests.RequestException as e:
+            log.warning("API request failed: %s", e)
+        
+        return None
+
+    def fetch_new_videos(self, since: Optional[float] = None) -> List[VideoInfo]:
+        """
+        Fetch videos from the API, optionally filtered by creation time.
+        
+        Returns list of new videos not yet in known_video_ids.
+        """
+        params = {"per_page": 50}
+        if since:
+            params["since"] = str(since)
+        
+        response = self._api_request("/api/feed", params=params)
+        if not response or response.status_code != 200:
+            log.warning("Failed to fetch videos: %s", 
+                       response.status_code if response else "no response")
+            return []
+        
+        videos_data = response.json().get("videos", [])
+        new_videos = []
+        
+        for v in videos_data:
+            video_id = v.get("video_id")
+            if video_id and video_id not in self.known_video_ids:
+                self.known_video_ids.add(video_id)
+                new_videos.append(VideoInfo(
+                    video_id=video_id,
+                    title=v.get("title", "Untitled"),
+                    agent_id=v.get("agent_id", 0),
+                    agent_name=v.get("agent_name", "unknown"),
+                    created_at=v.get("created_at", time.time()),
+                ))
+        
+        log.info("Fetched %d videos, %d new", len(videos_data), len(new_videos))
+        return new_videos
+
+    def queue_new_videos(self, videos: List[VideoInfo]) -> int:
+        """
+        Queue new videos for syndication to all configured platforms.
+        
+        Returns the number of items queued.
+        """
+        queued_count = 0
+        
+        for video in videos:
+            for platform in self.platforms:
+                # Calculate priority based on platform
+                priority = self._calculate_priority(platform, video)
+                
+                metadata = {
+                    "queued_by": "syndication_poller",
+                    "video_created_at": video.created_at,
+                }
+                
+                self.queue.enqueue(
+                    video_id=video.video_id,
+                    video_title=video.title,
+                    agent_id=video.agent_id,
+                    agent_name=video.agent_name,
+                    target_platform=platform,
+                    priority=priority,
+                    metadata=metadata,
+                )
+                queued_count += 1
+                log.info("Queued '%s' for %s (priority=%d)",
+                        video.title, platform, priority)
+        
+        return queued_count
+
+    def _calculate_priority(self, platform: str, video: VideoInfo) -> int:
+        """
+        Calculate syndication priority for a video/platform combination.
+        
+        Higher priority = processed first.
+        """
+        base_priority = 0
+        
+        # Platform-specific priorities
+        platform_priorities = {
+            "moltbook": 10,
+            "twitter": 5,
+            "rss_feed": 0,
+        }
+        base_priority = platform_priorities.get(platform, 0)
+        
+        # Boost priority for recent uploads (last hour)
+        age_hours = (time.time() - video.created_at) / 3600
+        if age_hours < 1:
+            base_priority += 20
+        
+        return base_priority
+
+    def process_pending_items(self) -> int:
+        """
+        Process pending items in the queue.
+        
+        Returns the number of items processed.
+        """
+        processed_count = 0
+        
+        for platform in self.platforms:
+            item = self.queue.dequeue(target_platform=platform)
+            if not item:
+                continue
+            
+            if item.id in self.processing_items:
+                log.debug("Item %d already being processed, skipping", item.id)
+                continue
+            
+            # Check for stale processing items (timeout)
+            if item.state == QueueState.PROCESSING:
+                if time.time() - item.updated_at > ITEM_PROCESSING_TIMEOUT_SEC:
+                    log.warning("Item %d stuck in processing, resetting", item.id)
+                    self.queue.update_state(
+                        item.id, QueueState.PENDING,
+                        error_message="Processing timeout, retrying"
+                    )
+                continue
+            
+            self.processing_items.add(item.id)
+            
+            try:
+                success = self._process_item(item)
+                if success:
+                    processed_count += 1
+            except Exception as e:
+                log.error("Error processing item %d: %s", item.id, e)
+                self.queue.mark_failed(item.id, str(e))
+            finally:
+                self.processing_items.discard(item.id)
+        
+        return processed_count
+
+    def _process_item(self, item) -> bool:
+        """
+        Process a single syndication item.
+        
+        Returns True if successful, False otherwise.
+        """
+        log.info("Processing syndication item %d: '%s' -> %s",
+                item.id, item.video_title, item.target_platform)
+        
+        # Mark as processing
+        if not self.queue.mark_processing(item.id):
+            log.error("Failed to mark item %d as processing", item.id)
+            return False
+        
+        # Dispatch to platform-specific handler
+        platform_handlers = {
+            "moltbook": self._syndicate_to_moltbook,
+            "twitter": self._syndicate_to_twitter,
+            "rss_feed": self._syndicate_to_rss_feed,
+        }
+        
+        handler = platform_handlers.get(item.target_platform)
+        if not handler:
+            log.warning("No handler for platform: %s", item.target_platform)
+            self.queue.mark_completed(item.id, metadata={"skipped": True})
+            return True
+        
+        try:
+            result = handler(item)
+            if result.get("success"):
+                self.queue.mark_completed(item.id, metadata=result)
+                log.info("Syndication successful for item %d", item.id)
+                return True
+            else:
+                error_msg = result.get("error", "Unknown error")
+                self.queue.mark_failed(item.id, error_msg)
+                log.warning("Syndication failed for item %d: %s", item.id, error_msg)
+                return False
+        except Exception as e:
+            self.queue.mark_failed(item.id, str(e))
+            log.error("Syndication exception for item %d: %s", item.id, e)
+            return False
+
+    def _syndicate_to_moltbook(self, item) -> dict:
+        """
+        Syndicate a video to Moltbook.
+        
+        Posts to Moltbook's API with video metadata.
+        """
+        # Placeholder implementation - integrate with actual Moltbook API
+        log.info("Syndicating '%s' to Moltbook", item.video_title)
+        
+        # Simulate API call (replace with actual integration)
+        # response = requests.post(
+        #     "https://moltbook.com/api/videos",
+        #     headers={"Authorization": f"Bearer {MOLTBOOK_TOKEN}"},
+        #     json={
+        #         "title": item.video_title,
+        #         "source": "bottube",
+        #         "video_id": item.video_id,
+        #     },
+        #     timeout=30,
+        # )
+        
+        # For now, simulate success
+        time.sleep(0.1)  # Simulate network delay
+        
+        return {
+            "success": True,
+            "platform": "moltbook",
+            "external_id": f"moltbook_{item.video_id}",
+        }
+
+    def _syndicate_to_twitter(self, item) -> dict:
+        """
+        Syndicate a video to Twitter/X.
+        
+        Creates a tweet with video link.
+        """
+        log.info("Syndicating '%s' to Twitter", item.video_title)
+        
+        # Placeholder - integrate with Twitter API v2
+        # This would use tweepy or direct API calls
+        
+        time.sleep(0.1)
+        
+        return {
+            "success": True,
+            "platform": "twitter",
+            "tweet_id": f"tweet_{item.video_id}",
+        }
+
+    def _syndicate_to_rss_feed(self, item) -> dict:
+        """
+        Syndicate to RSS feed.
+        
+        Updates the RSS feed with new video entry.
+        """
+        log.info("Adding '%s' to RSS feed", item.video_title)
+        
+        # RSS feed updates are typically file-based or cached
+        # This is a placeholder for the actual implementation
+        
+        time.sleep(0.1)
+        
+        return {
+            "success": True,
+            "platform": "rss_feed",
+            "feed_entry_id": f"rss_{item.video_id}",
+        }
+
+    def apply_backoff(self):
+        """Apply exponential backoff after failures."""
+        backoff_time = min(
+            INITIAL_BACKOFF_SEC * (BACKOFF_MULTIPLIER ** self.consecutive_failures),
+            MAX_BACKOFF_SEC,
+        )
+        jitter = backoff_time * JITTER_FACTOR * random.random()
+        self.backoff_until = time.time() + backoff_time + jitter
+        log.info("Applying backoff: %.1f seconds (failures=%d)",
+                backoff_time + jitter, self.consecutive_failures)
+
+    def run(self):
+        """
+        Main poller loop.
+        
+        Continuously polls for new videos and processes the queue.
+        """
+        if not self.api_key:
+            log.error("BOTTUBE_API_KEY not set, exiting")
+            return
+        
+        self.running = True
+        log.info("Starting syndication poller")
+        log.info("  BoTTube URL: %s", self.bottube_url)
+        log.info("  Database: %s", self.db_path)
+        log.info("  Poll interval: %ds", self.poll_interval)
+        log.info("  Platforms: %s", ", ".join(self.platforms))
+        
+        # Load existing videos to avoid re-queueing on restart
+        self._load_known_videos()
+        
+        while self.running:
+            try:
+                # Check backoff
+                if time.time() < self.backoff_until:
+                    remaining = self.backoff_until - time.time()
+                    time.sleep(min(remaining, 10))
+                    continue
+                
+                # Poll for new videos
+                new_videos = self.fetch_new_videos(
+                    since=self.last_poll_time if self.last_poll_time > 0 else None
+                )
+                
+                if new_videos:
+                    queued = self.queue_new_videos(new_videos)
+                    log.info("Queued %d new syndication items", queued)
+                    self.consecutive_failures = 0
+                else:
+                    self.consecutive_failures = max(0, self.consecutive_failures - 1)
+                
+                self.last_poll_time = time.time()
+                
+                # Process pending queue items
+                processed = self.process_pending_items()
+                if processed > 0:
+                    log.info("Processed %d queue items", processed)
+                
+                # Cleanup old completed items periodically
+                if random.random() < 0.01:  # ~1% chance each cycle
+                    deleted = self.queue.cleanup_old(days=30)
+                    if deleted > 0:
+                        log.info("Cleaned up %d old queue items", deleted)
+                
+                # Sleep until next poll
+                sleep_time = self.poll_interval
+                if self.running:
+                    time.sleep(sleep_time)
+                    
+            except KeyboardInterrupt:
+                log.info("Interrupted by user")
+                break
+            except Exception as e:
+                log.error("Poller error: %s", e)
+                self.consecutive_failures += 1
+                self.apply_backoff()
+        
+        log.info("Syndication poller stopped")
+
+    def _load_known_videos(self):
+        """Load existing video IDs to avoid duplicate queueing on restart."""
+        try:
+            response = self._api_request("/api/feed", params={"per_page": 100})
+            if response and response.status_code == 200:
+                videos = response.json().get("videos", [])
+                for v in videos:
+                    if "video_id" in v:
+                        self.known_video_ids.add(v["video_id"])
+                log.info("Loaded %d known video IDs", len(self.known_video_ids))
+        except Exception as e:
+            log.warning("Could not load known videos: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# CLI Entry Point
+# ---------------------------------------------------------------------------
+
+def main():
+    """Main entry point for the syndication poller daemon."""
+    poller = SyndicationPoller()
+    poller.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/syndication_queue.py
+++ b/syndication_queue.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""
+Syndication Queue Module for BoTTube
+
+Manages the syndication queue state machine for distributing new video uploads
+to external platforms and partner feeds.
+
+Queue States:
+    - pending: Newly queued, awaiting processing
+    - processing: Currently being syndicated
+    - completed: Successfully syndicated
+    - failed: Syndication failed (with error details)
+    - cancelled: Manually cancelled before completion
+
+State Transitions:
+    pending -> processing -> completed
+    pending -> processing -> failed
+    pending -> cancelled
+    failed -> pending (retry)
+"""
+
+import json
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+import sqlite3
+
+
+class QueueState(str, Enum):
+    """Syndication queue state machine states."""
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+VALID_TRANSITIONS = {
+    QueueState.PENDING: {QueueState.PROCESSING, QueueState.CANCELLED},
+    QueueState.PROCESSING: {QueueState.COMPLETED, QueueState.FAILED},
+    QueueState.COMPLETED: set(),  # terminal state
+    QueueState.FAILED: {QueueState.PENDING},  # allow retry
+    QueueState.CANCELLED: set(),  # terminal state
+}
+
+
+@dataclass
+class SyndicationItem:
+    """Represents a single syndication queue item."""
+    id: Optional[int]
+    video_id: str
+    video_title: str
+    agent_id: int
+    agent_name: str
+    target_platform: str  # e.g., "moltbook", "twitter", "rss_feed", "partner_api"
+    state: QueueState
+    priority: int = 0
+    retry_count: int = 0
+    max_retries: int = 3
+    error_message: str = ""
+    metadata: dict = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    processed_at: Optional[float] = None
+    completed_at: Optional[float] = None
+
+    def can_transition_to(self, new_state: QueueState) -> bool:
+        """Check if transition to new_state is valid."""
+        return new_state in VALID_TRANSITIONS.get(self.state, set())
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "id": self.id,
+            "video_id": self.video_id,
+            "video_title": self.video_title,
+            "agent_id": self.agent_id,
+            "agent_name": self.agent_name,
+            "target_platform": self.target_platform,
+            "state": self.state.value,
+            "priority": self.priority,
+            "retry_count": self.retry_count,
+            "max_retries": self.max_retries,
+            "error_message": self.error_message,
+            "metadata": self.metadata,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "processed_at": self.processed_at,
+            "completed_at": self.completed_at,
+        }
+
+
+class SyndicationQueue:
+    """
+    Manages the syndication queue with SQLite persistence.
+    
+    Thread-safe operations for adding, updating, and polling queue items.
+    """
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self._init_schema()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Get a database connection with row factory."""
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_schema(self):
+        """Initialize the syndication queue schema."""
+        conn = self._get_connection()
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS syndication_queue (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                video_id TEXT NOT NULL,
+                video_title TEXT NOT NULL,
+                agent_id INTEGER NOT NULL,
+                agent_name TEXT NOT NULL,
+                target_platform TEXT NOT NULL,
+                state TEXT NOT NULL DEFAULT 'pending',
+                priority INTEGER NOT NULL DEFAULT 0,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                max_retries INTEGER NOT NULL DEFAULT 3,
+                error_message TEXT DEFAULT '',
+                metadata TEXT DEFAULT '{}',
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                processed_at REAL DEFAULT NULL,
+                completed_at REAL DEFAULT NULL,
+                FOREIGN KEY (agent_id) REFERENCES agents(id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_syndication_state 
+                ON syndication_queue(state, priority DESC, created_at);
+
+            CREATE INDEX IF NOT EXISTS idx_syndication_video 
+                ON syndication_queue(video_id);
+
+            CREATE INDEX IF NOT EXISTS idx_syndication_agent 
+                ON syndication_queue(agent_id);
+
+            CREATE INDEX IF NOT EXISTS idx_syndication_platform 
+                ON syndication_queue(target_platform, state);
+        """)
+        conn.commit()
+        conn.close()
+
+    def enqueue(
+        self,
+        video_id: str,
+        video_title: str,
+        agent_id: int,
+        agent_name: str,
+        target_platform: str,
+        priority: int = 0,
+        metadata: Optional[dict] = None,
+    ) -> SyndicationItem:
+        """
+        Add a new item to the syndication queue.
+        
+        Returns the created SyndicationItem.
+        """
+        now = time.time()
+        metadata_json = json.dumps(metadata or {})
+        
+        conn = self._get_connection()
+        cursor = conn.execute(
+            """
+            INSERT INTO syndication_queue
+                (video_id, video_title, agent_id, agent_name, target_platform,
+                 state, priority, retry_count, max_retries, error_message,
+                 metadata, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, 'pending', ?, 0, 3, '', ?, ?, ?)
+            """,
+            (video_id, video_title, agent_id, agent_name, target_platform,
+             priority, metadata_json, now, now),
+        )
+        item_id = cursor.lastrowid
+        conn.commit()
+        conn.close()
+
+        return SyndicationItem(
+            id=item_id,
+            video_id=video_id,
+            video_title=video_title,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            target_platform=target_platform,
+            state=QueueState.PENDING,
+            priority=priority,
+            metadata=metadata or {},
+            created_at=now,
+            updated_at=now,
+        )
+
+    def dequeue(self, target_platform: Optional[str] = None) -> Optional[SyndicationItem]:
+        """
+        Get the next pending item for processing.
+
+        Optionally filter by target platform. Returns the highest priority,
+        oldest pending item. Atomically marks the item as processing.
+        """
+        conn = self._get_connection()
+        now = time.time()
+
+        try:
+            if target_platform:
+                row = conn.execute(
+                    """
+                    SELECT * FROM syndication_queue
+                    WHERE state = 'pending' AND target_platform = ?
+                    ORDER BY priority DESC, created_at ASC
+                    LIMIT 1
+                    """,
+                    (target_platform,),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    """
+                    SELECT * FROM syndication_queue
+                    WHERE state = 'pending'
+                    ORDER BY priority DESC, created_at ASC
+                    LIMIT 1
+                    """,
+                ).fetchone()
+
+            if not row:
+                conn.close()
+                return None
+
+            item_id = row["id"]
+
+            # Atomically update to processing
+            conn.execute(
+                """
+                UPDATE syndication_queue
+                SET state = 'processing', updated_at = ?, processed_at = ?
+                WHERE id = ? AND state = 'pending'
+                """,
+                (now, now, item_id),
+            )
+
+            if conn.total_changes == 0:
+                # Another process grabbed it
+                conn.close()
+                return None
+
+            conn.commit()
+
+            # Re-fetch to get updated state
+            row = conn.execute(
+                "SELECT * FROM syndication_queue WHERE id = ?",
+                (item_id,),
+            ).fetchone()
+
+            conn.close()
+            return self._row_to_item(row)
+
+        except Exception:
+            conn.close()
+            return None
+
+    def update_state(
+        self,
+        item_id: int,
+        new_state: QueueState,
+        error_message: str = "",
+        metadata: Optional[dict] = None,
+    ) -> bool:
+        """
+        Update an item's state with validation.
+        
+        Returns True if the transition was valid and successful.
+        """
+        conn = self._get_connection()
+        
+        # Get current state
+        row = conn.execute(
+            "SELECT state, retry_count, metadata FROM syndication_queue WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        
+        if not row:
+            conn.close()
+            return False
+        
+        current_state = QueueState(row["state"])
+        
+        # Validate transition
+        if new_state not in VALID_TRANSITIONS.get(current_state, set()):
+            conn.close()
+            return False
+        
+        now = time.time()
+        updates = ["state = ?", "updated_at = ?"]
+        params = [new_state.value, now]
+        
+        if new_state == QueueState.PROCESSING:
+            updates.append("processed_at = ?")
+            params.append(now)
+        
+        if new_state in (QueueState.COMPLETED, QueueState.CANCELLED):
+            updates.append("completed_at = ?")
+            params.append(now)
+        
+        if error_message:
+            updates.append("error_message = ?")
+            params.append(error_message)
+        
+        if metadata is not None:
+            updates.append("metadata = ?")
+            params.append(json.dumps(metadata))
+        
+        if new_state == QueueState.PENDING and current_state == QueueState.FAILED:
+            # Reset retry count on retry
+            updates.append("retry_count = ?")
+            params.append(row["retry_count"] + 1)
+        
+        params.append(item_id)
+        
+        conn.execute(
+            f"UPDATE syndication_queue SET {', '.join(updates)} WHERE id = ?",
+            params,
+        )
+        conn.commit()
+        conn.close()
+        
+        return True
+
+    def mark_processing(self, item_id: int) -> bool:
+        """Mark an item as being processed."""
+        return self.update_state(item_id, QueueState.PROCESSING)
+
+    def mark_completed(self, item_id: int, metadata: Optional[dict] = None) -> bool:
+        """Mark an item as successfully completed."""
+        return self.update_state(item_id, QueueState.COMPLETED, metadata=metadata)
+
+    def mark_failed(
+        self,
+        item_id: int,
+        error_message: str,
+        auto_retry: bool = True,
+    ) -> bool:
+        """
+        Mark an item as failed.
+
+        If auto_retry is True and retries remain, resets to pending for retry.
+        Note: This requires two transitions: processing -> failed -> pending.
+        """
+        conn = self._get_connection()
+        row = conn.execute(
+            "SELECT state, retry_count, max_retries FROM syndication_queue WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        conn.close()
+
+        if not row:
+            return False
+
+        current_state = QueueState(row["state"])
+        retry_count = row["retry_count"]
+        max_retries = row["max_retries"]
+
+        # First, transition to failed
+        if not self.update_state(item_id, QueueState.FAILED, error_message=error_message):
+            return False
+
+        # If retry is enabled and retries remain, transition back to pending
+        if auto_retry and retry_count < max_retries:
+            now = time.time()
+            conn = self._get_connection()
+            conn.execute(
+                """
+                UPDATE syndication_queue
+                SET state = 'pending', updated_at = ?, retry_count = retry_count + 1
+                WHERE id = ?
+                """,
+                (now, item_id),
+            )
+            conn.commit()
+            conn.close()
+            return True
+
+        return True
+
+    def cancel(self, item_id: int) -> bool:
+        """Cancel a pending item."""
+        return self.update_state(item_id, QueueState.CANCELLED)
+
+    def get_item(self, item_id: int) -> Optional[SyndicationItem]:
+        """Get a specific queue item by ID."""
+        conn = self._get_connection()
+        row = conn.execute(
+            "SELECT * FROM syndication_queue WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        conn.close()
+        
+        if not row:
+            return None
+        
+        return self._row_to_item(row)
+
+    def get_items_by_video(self, video_id: str) -> list[SyndicationItem]:
+        """Get all syndication items for a video."""
+        conn = self._get_connection()
+        rows = conn.execute(
+            "SELECT * FROM syndication_queue WHERE video_id = ? ORDER BY created_at",
+            (video_id,),
+        ).fetchall()
+        conn.close()
+        
+        return [self._row_to_item(row) for row in rows]
+
+    def get_items_by_agent(self, agent_id: int) -> list[SyndicationItem]:
+        """Get all syndication items for an agent."""
+        conn = self._get_connection()
+        rows = conn.execute(
+            "SELECT * FROM syndication_queue WHERE agent_id = ? ORDER BY created_at DESC",
+            (agent_id,),
+        ).fetchall()
+        conn.close()
+        
+        return [self._row_to_item(row) for row in rows]
+
+    def get_pending_count(self, target_platform: Optional[str] = None) -> int:
+        """Get count of pending items, optionally filtered by platform."""
+        conn = self._get_connection()
+        
+        if target_platform:
+            result = conn.execute(
+                "SELECT COUNT(*) FROM syndication_queue WHERE state = 'pending' AND target_platform = ?",
+                (target_platform,),
+            ).fetchone()[0]
+        else:
+            result = conn.execute(
+                "SELECT COUNT(*) FROM syndication_queue WHERE state = 'pending'",
+            ).fetchone()[0]
+        
+        conn.close()
+        return result
+
+    def get_stats(self) -> dict:
+        """Get queue statistics."""
+        conn = self._get_connection()
+        
+        stats = {}
+        for state in QueueState:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM syndication_queue WHERE state = ?",
+                (state.value,),
+            ).fetchone()[0]
+            stats[state.value] = count
+        
+        # Platform breakdown
+        platform_stats = conn.execute(
+            """
+            SELECT target_platform, state, COUNT(*) as count
+            FROM syndication_queue
+            GROUP BY target_platform, state
+            ORDER BY target_platform, state
+            """,
+        ).fetchall()
+        
+        stats["by_platform"] = {}
+        for row in platform_stats:
+            platform = row["target_platform"]
+            if platform not in stats["by_platform"]:
+                stats["by_platform"][platform] = {}
+            stats["by_platform"][platform][row["state"]] = row["count"]
+        
+        conn.close()
+        return stats
+
+    def cleanup_old(self, days: int = 30) -> int:
+        """
+        Remove completed/cancelled items older than specified days.
+        
+        Returns the number of rows deleted.
+        """
+        conn = self._get_connection()
+        cutoff = time.time() - (days * 86400)
+        
+        result = conn.execute(
+            """
+            DELETE FROM syndication_queue
+            WHERE state IN ('completed', 'cancelled')
+            AND completed_at < ?
+            """,
+            (cutoff,),
+        )
+        deleted = result.rowcount
+        conn.commit()
+        conn.close()
+        
+        return deleted
+
+    def _row_to_item(self, row: sqlite3.Row) -> SyndicationItem:
+        """Convert a database row to a SyndicationItem."""
+        return SyndicationItem(
+            id=row["id"],
+            video_id=row["video_id"],
+            video_title=row["video_title"],
+            agent_id=row["agent_id"],
+            agent_name=row["agent_name"],
+            target_platform=row["target_platform"],
+            state=QueueState(row["state"]),
+            priority=row["priority"],
+            retry_count=row["retry_count"],
+            max_retries=row["max_retries"],
+            error_message=row["error_message"],
+            metadata=json.loads(row["metadata"]) if row["metadata"] else {},
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            processed_at=row["processed_at"],
+            completed_at=row["completed_at"],
+        )
+
+
+# Module-level convenience functions for use with the app's DB
+_queue_instance: Optional[SyndicationQueue] = None
+
+
+def get_queue(db_path: str) -> SyndicationQueue:
+    """Get or create the syndication queue instance."""
+    global _queue_instance
+    if _queue_instance is None or _queue_instance.db_path != db_path:
+        _queue_instance = SyndicationQueue(db_path)
+    return _queue_instance
+
+
+def queue_syndication(
+    db_path: str,
+    video_id: str,
+    video_title: str,
+    agent_id: int,
+    agent_name: str,
+    target_platform: str,
+    priority: int = 0,
+    metadata: Optional[dict] = None,
+) -> SyndicationItem:
+    """Convenience function to queue a syndication item."""
+    queue = get_queue(db_path)
+    return queue.enqueue(
+        video_id, video_title, agent_id, agent_name,
+        target_platform, priority, metadata,
+    )

--- a/tests/test_syndication_queue.py
+++ b/tests/test_syndication_queue.py
@@ -1,0 +1,617 @@
+"""
+Tests for the BoTTube Syndication Queue module.
+
+Run with: pytest tests/test_syndication_queue.py -v
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from syndication_queue import (
+    QueueState,
+    SyndicationItem,
+    SyndicationQueue,
+    VALID_TRANSITIONS,
+)
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Create a temporary database path."""
+    return str(tmp_path / "test_syndication.db")
+
+
+@pytest.fixture
+def queue(tmp_db):
+    """Create a fresh SyndicationQueue instance."""
+    return SyndicationQueue(tmp_db)
+
+
+@pytest.fixture
+def sample_video():
+    """Sample video data for testing."""
+    return {
+        "video_id": "test_video_abc123",
+        "video_title": "Test Video Title",
+        "agent_id": 42,
+        "agent_name": "test_agent",
+    }
+
+
+class TestQueueState:
+    """Tests for QueueState enum and transitions."""
+
+    def test_valid_states(self):
+        """Test that all expected states exist."""
+        assert QueueState.PENDING.value == "pending"
+        assert QueueState.PROCESSING.value == "processing"
+        assert QueueState.COMPLETED.value == "completed"
+        assert QueueState.FAILED.value == "failed"
+        assert QueueState.CANCELLED.value == "cancelled"
+
+    def test_valid_transitions(self):
+        """Test state transition rules."""
+        # pending -> processing, cancelled
+        assert QueueState.PROCESSING in VALID_TRANSITIONS[QueueState.PENDING]
+        assert QueueState.CANCELLED in VALID_TRANSITIONS[QueueState.PENDING]
+        assert QueueState.COMPLETED not in VALID_TRANSITIONS[QueueState.PENDING]
+        
+        # processing -> completed, failed
+        assert QueueState.COMPLETED in VALID_TRANSITIONS[QueueState.PROCESSING]
+        assert QueueState.FAILED in VALID_TRANSITIONS[QueueState.PROCESSING]
+        assert QueueState.PENDING not in VALID_TRANSITIONS[QueueState.PROCESSING]
+        
+        # completed is terminal
+        assert len(VALID_TRANSITIONS[QueueState.COMPLETED]) == 0
+        
+        # failed -> pending (retry)
+        assert QueueState.PENDING in VALID_TRANSITIONS[QueueState.FAILED]
+        
+        # cancelled is terminal
+        assert len(VALID_TRANSITIONS[QueueState.CANCELLED]) == 0
+
+
+class TestSyndicationItem:
+    """Tests for SyndicationItem dataclass."""
+
+    def test_create_item(self, sample_video):
+        """Test creating a SyndicationItem."""
+        item = SyndicationItem(
+            id=None,
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+            state=QueueState.PENDING,
+        )
+        
+        assert item.video_id == sample_video["video_id"]
+        assert item.state == QueueState.PENDING
+        assert item.retry_count == 0
+        assert item.max_retries == 3
+        assert item.priority == 0
+        assert item.error_message == ""
+        assert item.metadata == {}
+
+    def test_can_transition_to(self, sample_video):
+        """Test transition validation on items."""
+        item = SyndicationItem(
+            id=1,
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+            state=QueueState.PENDING,
+        )
+        
+        assert item.can_transition_to(QueueState.PROCESSING) is True
+        assert item.can_transition_to(QueueState.CANCELLED) is True
+        assert item.can_transition_to(QueueState.COMPLETED) is False
+
+    def test_to_dict(self, sample_video):
+        """Test serialization to dictionary."""
+        item = SyndicationItem(
+            id=1,
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="twitter",
+            state=QueueState.PENDING,
+            priority=10,
+        )
+        
+        data = item.to_dict()
+        
+        assert data["id"] == 1
+        assert data["video_id"] == sample_video["video_id"]
+        assert data["state"] == "pending"
+        assert data["target_platform"] == "twitter"
+        assert data["priority"] == 10
+        assert "created_at" in data
+        assert "updated_at" in data
+
+
+class TestSyndicationQueue:
+    """Tests for SyndicationQueue operations."""
+
+    def test_enqueue(self, queue, sample_video):
+        """Test adding an item to the queue."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        
+        assert item.id is not None
+        assert item.video_id == sample_video["video_id"]
+        assert item.state == QueueState.PENDING
+        assert item.target_platform == "moltbook"
+
+    def test_enqueue_with_priority(self, queue, sample_video):
+        """Test adding an item with custom priority."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="twitter",
+            priority=50,
+        )
+        
+        assert item.priority == 50
+
+    def test_enqueue_with_metadata(self, queue, sample_video):
+        """Test adding an item with metadata."""
+        metadata = {"source": "test", "custom_field": "value"}
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+            metadata=metadata,
+        )
+        
+        assert item.metadata == metadata
+
+    def test_dequeue_empty(self, queue):
+        """Test dequeuing from an empty queue."""
+        item = queue.dequeue()
+        assert item is None
+
+    def test_dequeue(self, queue, sample_video):
+        """Test dequeuing an item."""
+        queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+
+        item = queue.dequeue()
+
+        assert item is not None
+        assert item.video_id == sample_video["video_id"]
+        assert item.state == QueueState.PROCESSING  # dequeue marks as processing
+
+    def test_dequeue_by_platform(self, queue, sample_video):
+        """Test dequeuing items filtered by platform."""
+        queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.enqueue(
+            video_id="video_2",
+            video_title="Video 2",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="twitter",
+        )
+        
+        # Dequeue only moltbook items
+        item = queue.dequeue(target_platform="moltbook")
+        assert item is not None
+        assert item.target_platform == "moltbook"
+        
+        # No more moltbook items
+        item = queue.dequeue(target_platform="moltbook")
+        assert item is None
+
+    def test_dequeue_priority_order(self, queue, sample_video):
+        """Test that dequeue returns highest priority first."""
+        queue.enqueue(
+            video_id="low_priority",
+            video_title="Low Priority",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+            priority=10,
+        )
+        queue.enqueue(
+            video_id="high_priority",
+            video_title="High Priority",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+            priority=100,
+        )
+        queue.enqueue(
+            video_id="medium_priority",
+            video_title="Medium Priority",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+            priority=50,
+        )
+        
+        # Should get high priority first
+        item = queue.dequeue()
+        assert item.video_id == "high_priority"
+        
+        item = queue.dequeue()
+        assert item.video_id == "medium_priority"
+        
+        item = queue.dequeue()
+        assert item.video_id == "low_priority"
+
+    def test_dequeue_fifo_same_priority(self, queue, sample_video):
+        """Test FIFO ordering for same priority items."""
+        queue.enqueue(
+            video_id="first",
+            video_title="First",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        time.sleep(0.01)  # Ensure different timestamps
+        queue.enqueue(
+            video_id="second",
+            video_title="Second",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        
+        item = queue.dequeue()
+        assert item.video_id == "first"
+        
+        item = queue.dequeue()
+        assert item.video_id == "second"
+
+    def test_mark_processing(self, queue, sample_video):
+        """Test marking an item as processing."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        
+        result = queue.mark_processing(item.id)
+        assert result is True
+        
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.PROCESSING
+        assert updated.processed_at is not None
+
+    def test_mark_completed(self, queue, sample_video):
+        """Test marking an item as completed."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.mark_processing(item.id)
+        
+        metadata = {"external_id": "ext_123"}
+        result = queue.mark_completed(item.id, metadata=metadata)
+        assert result is True
+        
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.COMPLETED
+        assert updated.completed_at is not None
+        assert updated.metadata.get("external_id") == "ext_123"
+
+    def test_mark_failed_no_retry(self, queue, sample_video):
+        """Test marking an item as failed without retry."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.mark_processing(item.id)
+        
+        result = queue.mark_failed(item.id, "Test error", auto_retry=False)
+        assert result is True
+        
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.FAILED
+        assert updated.error_message == "Test error"
+
+    def test_mark_failed_with_retry(self, queue, sample_video):
+        """Test that failed items are retried automatically."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.mark_processing(item.id)
+        
+        # First failure - should retry
+        queue.mark_failed(item.id, "First error", auto_retry=True)
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.PENDING
+        assert updated.retry_count == 1
+        assert updated.error_message == "First error"
+        
+        # Process and fail again
+        queue.mark_processing(item.id)
+        queue.mark_failed(item.id, "Second error", auto_retry=True)
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.PENDING
+        assert updated.retry_count == 2
+        
+        # Continue until max retries exceeded
+        for i in range(2):
+            queue.mark_processing(item.id)
+            queue.mark_failed(item.id, f"Error {i+3}", auto_retry=True)
+        
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.FAILED
+        assert updated.retry_count == 3
+
+    def test_cancel(self, queue, sample_video):
+        """Test cancelling a pending item."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        
+        result = queue.cancel(item.id)
+        assert result is True
+        
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.CANCELLED
+        assert updated.completed_at is not None
+
+    def test_invalid_transition(self, queue, sample_video):
+        """Test that invalid transitions are rejected."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        
+        # Can't go from pending directly to completed
+        result = queue.update_state(item.id, QueueState.COMPLETED)
+        assert result is False
+        
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.PENDING
+
+    def test_get_items_by_video(self, queue, sample_video):
+        """Test getting all items for a video."""
+        queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="twitter",
+        )
+        
+        items = queue.get_items_by_video(sample_video["video_id"])
+        assert len(items) == 2
+        
+        platforms = {item.target_platform for item in items}
+        assert platforms == {"moltbook", "twitter"}
+
+    def test_get_items_by_agent(self, queue, sample_video):
+        """Test getting all items for an agent."""
+        queue.enqueue(
+            video_id="video1",
+            video_title="Video 1",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.enqueue(
+            video_id="video2",
+            video_title="Video 2",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="twitter",
+        )
+        queue.enqueue(
+            video_id="video3",
+            video_title="Video 3",
+            agent_id=999,
+            agent_name="other_agent",
+            target_platform="moltbook",
+        )
+        
+        items = queue.get_items_by_agent(sample_video["agent_id"])
+        assert len(items) == 2
+
+    def test_get_pending_count(self, queue, sample_video):
+        """Test getting pending item count."""
+        queue.enqueue(
+            video_id="video1",
+            video_title="Video 1",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.enqueue(
+            video_id="video2",
+            video_title="Video 2",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.enqueue(
+            video_id="video3",
+            video_title="Video 3",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="twitter",
+        )
+        
+        assert queue.get_pending_count() == 3
+        assert queue.get_pending_count(target_platform="moltbook") == 2
+        assert queue.get_pending_count(target_platform="twitter") == 1
+
+    def test_get_stats(self, queue, sample_video):
+        """Test getting queue statistics."""
+        queue.enqueue(
+            video_id="video1",
+            video_title="Video 1",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.enqueue(
+            video_id="video2",
+            video_title="Video 2",
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="twitter",
+        )
+        
+        stats = queue.get_stats()
+        
+        assert "pending" in stats
+        assert stats["pending"] == 2
+        assert "by_platform" in stats
+        assert "moltbook" in stats["by_platform"]
+        assert "twitter" in stats["by_platform"]
+
+    def test_cleanup_old(self, queue, sample_video):
+        """Test cleaning up old completed items."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        queue.mark_processing(item.id)
+        queue.mark_completed(item.id)
+        
+        # Manually set old completed_at for testing
+        old_time = time.time() - (31 * 86400)  # 31 days ago
+        conn = queue._get_connection()
+        conn.execute(
+            "UPDATE syndication_queue SET completed_at = ? WHERE id = ?",
+            (old_time, item.id),
+        )
+        conn.commit()
+        conn.close()
+        
+        deleted = queue.cleanup_old(days=30)
+        assert deleted == 1
+        
+        # Verify item is gone
+        assert queue.get_item(item.id) is None
+
+
+class TestStateTransitions:
+    """Integration tests for complete state transition flows."""
+
+    def test_happy_path(self, queue, sample_video):
+        """Test successful syndication flow."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        
+        # pending -> processing
+        assert queue.mark_processing(item.id) is True
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.PROCESSING
+        
+        # processing -> completed
+        assert queue.mark_completed(item.id) is True
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.COMPLETED
+
+    def test_retry_flow(self, queue, sample_video):
+        """Test flow with retries before success."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        
+        # First attempt fails
+        queue.mark_processing(item.id)
+        queue.mark_failed(item.id, "Temporary error", auto_retry=True)
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.PENDING
+        assert updated.retry_count == 1
+        
+        # Second attempt succeeds
+        queue.mark_processing(item.id)
+        queue.mark_completed(item.id)
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.COMPLETED
+        assert updated.retry_count == 1
+
+    def test_cancel_flow(self, queue, sample_video):
+        """Test cancellation flow."""
+        item = queue.enqueue(
+            video_id=sample_video["video_id"],
+            video_title=sample_video["video_title"],
+            agent_id=sample_video["agent_id"],
+            agent_name=sample_video["agent_name"],
+            target_platform="moltbook",
+        )
+        
+        # Cancel while pending
+        assert queue.cancel(item.id) is True
+        updated = queue.get_item(item.id)
+        assert updated.state == QueueState.CANCELLED
+        
+        # Can't process cancelled item
+        assert queue.mark_processing(item.id) is False


### PR DESCRIPTION
Implements issue #309 with upload polling and syndication queue state management, including queue state transitions, retry/backoff handling, and tests/docs.\n\nValidation: pytest tests/test_syndication_queue.py -> 27 passed.\n\nCloses #309