### PR TITLE
fix: replace invalid ffmpeg transcode args in media prep pipeline (#359)

### DIFF
--- a/media_prep.py
+++ b/media_prep.py
@@ -369,23 +369,13 @@ class MediaPrepPipeline:
     def _transcode(self, input_path: str, video_id: str) -> Path:
         """Transcode video to web-optimized format."""
         output_path = self.video_dir / f"{video_id}.mp4"
-        
-        # FFmpeg transcoding command
-        cmd = [
-            "ffmpeg",
-            "-i", input_path,
-            "-c:v", "libx264",
-            "-preset", "medium",
-            "-crf", "23",
-            "-max_width", str(self.target_width),
-            "-max_height", str(self.target_height),
-            "-c:a", "aac",
-            "-b:a", "128k",
-            "-movflags", "+faststart",
-            "-y",
-            str(output_path),
-        ]
-        
+
+        # FFmpeg transcoding command with valid scale filter
+        # Uses aspect-ratio-safe scaling: scales down if larger than target,
+        # preserves aspect ratio, never upscales
+        scale_filter = f"scale='min({self.target_width},iw)':'min({self.target_height},ih)':force_original_aspect_ratio=decrease"
+        cmd = self._build_transcode_command(input_path, video_id)
+
         try:
             subprocess.run(cmd, capture_output=True, timeout=600, check=True)
         except subprocess.CalledProcessError as e:
@@ -393,8 +383,27 @@ class MediaPrepPipeline:
             raise RuntimeError(f"Transcoding failed: {e}")
         except subprocess.TimeoutExpired:
             raise RuntimeError("Transcoding timed out")
-        
+
         return output_path
+
+    def _build_transcode_command(self, input_path: str, video_id: str) -> List[str]:
+        """Build ffmpeg transcode command (exposed for testing)."""
+        output_path = self.video_dir / f"{video_id}.mp4"
+
+        scale_filter = f"scale='min({self.target_width},iw)':'min({self.target_height},ih)':force_original_aspect_ratio=decrease"
+        return [
+            "ffmpeg",
+            "-i", input_path,
+            "-c:v", "libx264",
+            "-preset", "medium",
+            "-crf", "23",
+            "-vf", scale_filter,
+            "-c:a", "aac",
+            "-b:a", "128k",
+            "-movflags", "+faststart",
+            "-y",
+            str(output_path),
+        ]
     
     def _get_video_info(self, video_path: str) -> Tuple[float, int, int]:
         """Get video duration, width, height."""

--- a/tests/test_media_prep.py
+++ b/tests/test_media_prep.py
@@ -417,9 +417,82 @@ class TestVideoAttributionColumns:
         assert json.loads(row[1]) == [{"video_id": "parent123"}]
 
 
+class TestTranscodeCommand:
+    """Tests for ffmpeg transcode command generation."""
+
+    def test_transcode_uses_valid_scale_filter(self, temp_db, temp_dirs):
+        """Test that transcode uses -vf scale instead of invalid -max_width/-max_height."""
+        video_dir, thumb_dir = temp_dirs
+        pipeline = MediaPrepPipeline(
+            db=temp_db,
+            video_dir=video_dir,
+            thumb_dir=thumb_dir,
+            target_width=1280,
+            target_height=720,
+        )
+
+        # Create a fake input file for validation
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+            tmp.write(b"fake video content")
+            input_path = tmp.name
+
+        try:
+            # Mock _get_duration to bypass validation
+            with patch.object(pipeline, '_get_duration', return_value=10.0):
+                cmd = pipeline._build_transcode_command(input_path, "test123")
+
+            # Assert no invalid arguments
+            assert "-max_width" not in cmd
+            assert "-max_height" not in cmd
+
+            # Assert valid scale filter is present
+            assert "-vf" in cmd
+            vf_index = cmd.index("-vf")
+            scale_filter = cmd[vf_index + 1]
+            assert "scale" in scale_filter
+            assert "min(1280,iw)" in scale_filter
+            assert "min(720,ih)" in scale_filter
+            assert "force_original_aspect_ratio=decrease" in scale_filter
+
+            # Assert output format remains MP4/H264
+            assert "-c:v" in cmd
+            assert "libx264" in cmd
+            assert "-c:a" in cmd
+            assert "aac" in cmd
+            assert str(cmd[-1]).endswith(".mp4")
+        finally:
+            os.unlink(input_path)
+
+    def test_transcode_custom_dimensions(self, temp_db, temp_dirs):
+        """Test scale filter uses custom target dimensions."""
+        video_dir, thumb_dir = temp_dirs
+        pipeline = MediaPrepPipeline(
+            db=temp_db,
+            video_dir=video_dir,
+            thumb_dir=thumb_dir,
+            target_width=1920,
+            target_height=1080,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+            tmp.write(b"fake video content")
+            input_path = tmp.name
+
+        try:
+            with patch.object(pipeline, '_get_duration', return_value=10.0):
+                cmd = pipeline._build_transcode_command(input_path, "test456")
+
+            vf_index = cmd.index("-vf")
+            scale_filter = cmd[vf_index + 1]
+            assert "min(1920,iw)" in scale_filter
+            assert "min(1080,ih)" in scale_filter
+        finally:
+            os.unlink(input_path)
+
+
 class TestPrepResult:
     """Tests for PrepResult dataclass."""
-    
+
     def test_result_to_dict(self):
         """Test PrepResult serialization."""
         result = PrepResult(


### PR DESCRIPTION
Fixes issue #359 by replacing invalid ffmpeg arguments (-max_width/-max_height) with a valid scale filter path in media prep transcoding.\n\nAlso adds regression coverage to assert valid command construction and prevent reintroduction of invalid ffmpeg options.\n\nValidation:\n- pytest tests/test_media_prep.py (21 passed)\n\nCloses #359