### PR TITLE
fix: lock down syndication reporting routes to owner/admin scope (#360)

### DIFF
--- a/syndication_routes.py
+++ b/syndication_routes.py
@@ -1,20 +1,25 @@
 #!/usr/bin/env python3
 """
-BoTTube Syndication Routes — Issue #312
+BoTTube Syndication Routes — Issue #312 / #360
 API endpoints for syndication tracking and outbound reporting.
 
 Endpoints:
     POST   /api/syndication/run/start       - Start a new syndication run
     POST   /api/syndication/run/<id>/end    - End a syndication run
     POST   /api/syndication/item            - Log a syndication item
-    PUT    /api/syndication/item/<id>       - Update item status
+    PUT    /api/syndication/item/<id>       - Update item status (owner/admin only)
     GET    /api/syndication/run/<id>        - Get run details
     GET    /api/syndication/runs            - List recent runs
     GET    /api/syndication/runs/active     - List active runs
-    GET    /api/syndication/report/daily    - Generate daily report
-    GET    /api/syndication/report/weekly   - Generate weekly report
-    GET    /api/syndication/report/outbound - Generate outbound network report
-    GET    /api/syndication/report/export   - Export report to JSON
+    GET    /api/syndication/report/daily    - Generate daily report (agent-scoped, admin network-wide)
+    GET    /api/syndication/report/weekly   - Generate weekly report (agent-scoped, admin network-wide)
+    GET    /api/syndication/report/outbound - Generate outbound network report (agent-scoped, admin network-wide)
+    GET    /api/syndication/report/export   - Export report to JSON (inline, no file write)
+
+Issue #360 Changes:
+    - PUT /api/syndication/item/<id>: Enforce owner/admin authorization
+    - Report endpoints: Agent-scoped by default, admin can access network-wide via ?scope=network
+    - /report/export: Returns JSON directly without writing server files
 """
 
 import json
@@ -54,6 +59,13 @@ def get_generator() -> ReportGenerator:
     return _generator
 
 
+def _is_admin_request() -> bool:
+    """Check if request has admin key authentication."""
+    from bottube_server import ADMIN_KEY
+    admin_key = request.headers.get("X-Admin-Key", "")
+    return bool(ADMIN_KEY and admin_key == ADMIN_KEY)
+
+
 def require_api_key(f):
     """Decorator to require API key authentication."""
     @wraps(f)
@@ -61,7 +73,7 @@ def require_api_key(f):
         api_key = request.headers.get("X-API-Key")
         if not api_key:
             return jsonify({"error": "Missing X-API-Key header"}), 401
-        
+
         # Validate API key against database
         from bottube_server import get_db
         db = get_db()
@@ -69,11 +81,12 @@ def require_api_key(f):
             "SELECT id, agent_name FROM agents WHERE api_key = ?",
             (api_key,)
         ).fetchone()
-        
+
         if not agent:
             return jsonify({"error": "Invalid API key"}), 403
-        
+
         request.agent = agent
+        request.is_admin = _is_admin_request()
         return f(*args, **kwargs)
     return decorated
 
@@ -231,24 +244,49 @@ def log_item():
 def update_item(item_id):
     """
     Update a syndication item status.
-    
+
+    Authorization: Only the owner of the item's run or an admin can update.
+
     Request JSON:
         status (str): New status (required)
         external_id (str): External platform content ID
         external_url (str): External platform content URL
         error_message (str): Error message if failed
-    
+
     Response:
         ok (bool): Success indicator
     """
     data = request.get_json() or {}
-    
+
     status = data.get("status")
     if not status or status not in ("success", "failed", "pending", "skipped"):
         return jsonify({"error": "Valid status is required"}), 400
-    
+
     try:
         tracker = get_tracker()
+        
+        # Get the item to verify ownership
+        conn = tracker._get_connection()
+        try:
+            item = conn.execute(
+                """
+                SELECT si.id, si.run_id, sr.agent_id
+                FROM syndication_items si
+                JOIN syndication_runs sr ON si.run_id = sr.id
+                WHERE si.id = ?
+                """,
+                (item_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        
+        if not item:
+            return jsonify({"error": "Item not found"}), 404
+        
+        # Enforce owner/admin authorization (Issue #360)
+        if not request.is_admin and item["agent_id"] != request.agent["id"]:
+            return jsonify({"error": "Access denied: only item owner or admin can update"}), 403
+
         tracker.update_item_status(
             item_id=item_id,
             status=status,
@@ -256,7 +294,7 @@ def update_item(item_id):
             external_url=data.get("external_url"),
             error_message=data.get("error_message")
         )
-        
+
         return jsonify({"ok": True})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -397,18 +435,29 @@ def list_active_runs():
 def daily_report():
     """
     Generate daily syndication report.
-    
+
     Query params:
         date (str): Date in YYYY-MM-DD format (default: today)
-    
+        scope (str): 'agent' (default) or 'network' (admin only)
+
     Response:
-        report (dict): Daily report data
+        report (dict): Daily report data (scoped to agent by default)
     """
     try:
         date_str = request.args.get("date")
-        generator = get_generator()
-        report = generator.generate_daily_report(date_str)
+        scope = request.args.get("scope", "agent")
         
+        # Network-wide scope requires admin
+        agent_id = None
+        if scope == "network":
+            if not request.is_admin:
+                return jsonify({"error": "Admin access required for network-wide scope"}), 403
+        else:
+            agent_id = request.agent["id"]
+        
+        generator = get_generator()
+        report = generator.generate_daily_report(date_str, agent_id=agent_id)
+
         return jsonify({"report": report})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -419,18 +468,29 @@ def daily_report():
 def weekly_report():
     """
     Generate weekly syndication report.
-    
+
     Query params:
         end_date (str): End date in YYYY-MM-DD format (default: today)
-    
+        scope (str): 'agent' (default) or 'network' (admin only)
+
     Response:
-        report (dict): Weekly report data
+        report (dict): Weekly report data (scoped to agent by default)
     """
     try:
         end_date = request.args.get("end_date")
-        generator = get_generator()
-        report = generator.generate_weekly_report(end_date)
+        scope = request.args.get("scope", "agent")
         
+        # Network-wide scope requires admin
+        agent_id = None
+        if scope == "network":
+            if not request.is_admin:
+                return jsonify({"error": "Admin access required for network-wide scope"}), 403
+        else:
+            agent_id = request.agent["id"]
+        
+        generator = get_generator()
+        report = generator.generate_weekly_report(end_date, agent_id=agent_id)
+
         return jsonify({"report": report})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -441,21 +501,35 @@ def weekly_report():
 def outbound_report():
     """
     Generate comprehensive outbound network report.
-    
+
     This is the primary report for issue #312, showing all outbound
     syndication activity across the unified network.
     
+    Issue #360: By default scoped to authenticated agent. Admin can
+    access network-wide data via ?scope=network.
+
     Query params:
         days (int): Number of days to include (default: 30)
-    
+        scope (str): 'agent' (default) or 'network' (admin only)
+
     Response:
-        report (dict): Outbound network report
+        report (dict): Outbound network report (scoped to agent by default)
     """
     try:
         days = int(request.args.get("days", 30))
-        generator = get_generator()
-        report = generator.generate_outbound_report(days=days)
+        scope = request.args.get("scope", "agent")
         
+        # Network-wide scope requires admin
+        agent_id = None
+        if scope == "network":
+            if not request.is_admin:
+                return jsonify({"error": "Admin access required for network-wide scope"}), 403
+        else:
+            agent_id = request.agent["id"]
+        
+        generator = get_generator()
+        report = generator.generate_outbound_report(days=days, agent_id=agent_id)
+
         return jsonify({"report": report})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -465,50 +539,52 @@ def outbound_report():
 @require_api_key
 def export_report():
     """
-    Export syndication report to JSON file.
+    Export syndication report to JSON.
     
+    Issue #360: Returns JSON directly without writing server files.
+
     Query params:
         type (str): Report type (daily, weekly, outbound) (default: outbound)
         days (int): Days for outbound report (default: 30)
         date (str): Date for daily report (YYYY-MM-DD)
         end_date (str): End date for weekly report (YYYY-MM-DD)
-    
+        scope (str): 'agent' (default) or 'network' (admin only)
+
     Response:
-        file_path (str): Path to generated file
-        report (dict): Report data
+        report (dict): Report data (returned inline, no file write)
     """
     try:
         report_type = request.args.get("type", "outbound")
-        generator = get_generator()
+        scope = request.args.get("scope", "agent")
         
-        kwargs = {}
+        # Network-wide scope requires admin
+        agent_id = None
+        if scope == "network":
+            if not request.is_admin:
+                return jsonify({"error": "Admin access required for network-wide scope"}), 403
+        else:
+            agent_id = request.agent["id"]
+
+        kwargs = {"agent_id": agent_id}
         if report_type == "daily":
             kwargs["date_str"] = request.args.get("date")
         elif report_type == "weekly":
             kwargs["end_date"] = request.args.get("end_date")
         else:
             kwargs["days"] = int(request.args.get("days", 30))
+
+        generator = get_generator()
         
-        # Generate output path in reports directory
-        reports_dir = Path(__file__).parent / "syndication_reports"
-        reports_dir.mkdir(exist_ok=True)
-        
-        timestamp = time.strftime("%Y%m%d_%H%M%S")
-        output_path = str(reports_dir / f"syndication_{report_type}_{timestamp}.json")
-        
-        generator.export_report_json(
+        # Issue #360: Return report directly without writing file
+        report_data = generator.export_report_json(
             report_type=report_type,
-            output_path=output_path,
+            output_path=None,  # Return dict directly
             **kwargs
         )
-        
-        # Read back the report for response
-        with open(output_path) as f:
-            report_data = json.load(f)
-        
+
         return jsonify({
             "ok": True,
-            "file_path": output_path,
+            "scope": "network" if scope == "network" else "agent",
             "report": report_data
         })
     except Exception as e:

--- a/syndication_tracker.py
+++ b/syndication_tracker.py
@@ -553,39 +553,45 @@ class ReportGenerator:
     
     def generate_daily_report(
         self,
-        date_str: Optional[str] = None
+        date_str: Optional[str] = None,
+        agent_id: Optional[int] = None
     ) -> Dict[str, Any]:
         """
         Generate a daily syndication report.
-        
+
         Args:
             date_str: Date in YYYY-MM-DD format (default: today)
-            
+            agent_id: Optional agent ID to scope report (default: all agents)
+
         Returns:
             Report dictionary with stats and details
         """
         if date_str is None:
             date_str = datetime.now().strftime("%Y-%m-%d")
-        
+
         summary = self.tracker.get_daily_summary(date_str)
-        
+
         conn = self._get_connection()
         try:
             # Get detailed run list for the day
             start_ts = datetime.strptime(date_str, "%Y-%m-%d").timestamp()
             end_ts = start_ts + 86400
-            
+
+            # Build query with optional agent scoping
+            agent_filter = "AND sr.agent_id = ?" if agent_id is not None else ""
+            agent_params = (agent_id,) if agent_id is not None else ()
+
             runs = conn.execute(
-                """
+                f"""
                 SELECT sr.*, a.agent_name
                 FROM syndication_runs sr
                 LEFT JOIN agents a ON sr.agent_id = a.id
-                WHERE sr.started_at >= ? AND sr.started_at < ?
+                WHERE sr.started_at >= ? AND sr.started_at < ? {agent_filter}
                 ORDER BY sr.started_at
                 """,
-                (start_ts, end_ts)
+                (start_ts, end_ts) + agent_params
             ).fetchall()
-            
+
             run_details = []
             for run in runs:
                 items = conn.execute(
@@ -614,11 +620,12 @@ class ReportGenerator:
                         for item in items
                     ]
                 })
-            
+
             return {
                 "report_type": "daily",
                 "date": date_str,
                 "generated_at": time.time(),
+                "scope": "agent" if agent_id is not None else "network",
                 "summary": summary or {
                     "total_runs": 0,
                     "completed_runs": 0,
@@ -635,88 +642,97 @@ class ReportGenerator:
     
     def generate_weekly_report(
         self,
-        end_date: Optional[str] = None
+        end_date: Optional[str] = None,
+        agent_id: Optional[int] = None
     ) -> Dict[str, Any]:
         """
         Generate a weekly syndication report (7 days).
-        
+
         Args:
             end_date: End date in YYYY-MM-DD format (default: today)
-            
+            agent_id: Optional agent ID to scope report (default: all agents)
+
         Returns:
             Report dictionary with aggregated stats
         """
         if end_date is None:
             end_date = datetime.now().strftime("%Y-%m-%d")
-        
+
         end_dt = datetime.strptime(end_date, "%Y-%m-%d")
         start_dt = end_dt - timedelta(days=6)
         start_date = start_dt.strftime("%Y-%m-%d")
-        
+
         conn = self._get_connection()
         try:
             start_ts = start_dt.timestamp()
             end_ts = end_dt.timestamp() + 86400
-            
+
+            # Build agent filter for queries
+            agent_filter = "AND sr.agent_id = ?" if agent_id is not None else ""
+            agent_params = (agent_id,) if agent_id is not None else ()
+
             # Overall stats
             stats = conn.execute(
-                """
-                SELECT 
+                f"""
+                SELECT
                     COUNT(*) as total_runs,
-                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed_runs,
-                    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed_runs,
-                    SUM(total_items) as total_items,
-                    SUM(successful_items) as successful_items,
-                    SUM(failed_items) as failed_items
-                FROM syndication_runs
-                WHERE started_at >= ? AND started_at < ?
+                    SUM(CASE WHEN sr.status = 'completed' THEN 1 ELSE 0 END) as completed_runs,
+                    SUM(CASE WHEN sr.status = 'failed' THEN 1 ELSE 0 END) as failed_runs,
+                    SUM(sr.total_items) as total_items,
+                    SUM(sr.successful_items) as successful_items,
+                    SUM(sr.failed_items) as failed_items
+                FROM syndication_runs sr
+                WHERE sr.started_at >= ? AND sr.started_at < ? {agent_filter}
                 """,
-                (start_ts, end_ts)
+                (start_ts, end_ts) + agent_params
             ).fetchone()
-            
+
             # Platform breakdown
             platform_stats = conn.execute(
-                """
+                f"""
                 SELECT si.target_platform,
                        COUNT(*) as count,
                        SUM(CASE WHEN si.status = 'success' THEN 1 ELSE 0 END) as successful
                 FROM syndication_items si
                 JOIN syndication_runs sr ON si.run_id = sr.id
-                WHERE sr.started_at >= ? AND sr.started_at < ?
+                WHERE sr.started_at >= ? AND sr.started_at < ? {agent_filter}
                 GROUP BY si.target_platform
                 """,
-                (start_ts, end_ts)
+                (start_ts, end_ts) + agent_params
             ).fetchall()
-            
+
             # Run type breakdown
             type_stats = conn.execute(
-                """
-                SELECT run_type,
+                f"""
+                SELECT sr.run_type,
                        COUNT(*) as count,
-                       SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed
-                FROM syndication_runs
-                WHERE started_at >= ? AND started_at < ?
-                GROUP BY run_type
-                """,
-                (start_ts, end_ts)
-            ).fetchall()
-            
-            # Top agents by syndication activity
-            agent_stats = conn.execute(
-                """
-                SELECT a.agent_name, a.display_name,
-                       COUNT(sr.id) as run_count,
-                       SUM(sr.successful_items) as total_success
+                       SUM(CASE WHEN sr.status = 'completed' THEN 1 ELSE 0 END) as completed
                 FROM syndication_runs sr
-                JOIN agents a ON sr.agent_id = a.id
-                WHERE sr.started_at >= ? AND sr.started_at < ?
-                GROUP BY sr.agent_id
-                ORDER BY total_success DESC
-                LIMIT 10
+                WHERE sr.started_at >= ? AND sr.started_at < ? {agent_filter}
+                GROUP BY sr.run_type
                 """,
-                (start_ts, end_ts)
+                (start_ts, end_ts) + agent_params
             ).fetchall()
-            
+
+            # Top agents by syndication activity (only show if network-wide)
+            if agent_id is None:
+                agent_stats = conn.execute(
+                    """
+                    SELECT a.agent_name, a.display_name,
+                           COUNT(sr.id) as run_count,
+                           SUM(sr.successful_items) as total_success
+                    FROM syndication_runs sr
+                    JOIN agents a ON sr.agent_id = a.id
+                    WHERE sr.started_at >= ? AND sr.started_at < ?
+                    GROUP BY sr.agent_id
+                    ORDER BY total_success DESC
+                    LIMIT 10
+                    """,
+                    (start_ts, end_ts)
+                ).fetchall()
+            else:
+                agent_stats = []
+
             # Daily breakdown
             daily_breakdown = conn.execute(
                 """
@@ -727,12 +743,13 @@ class ReportGenerator:
                 """,
                 (start_date, end_date)
             ).fetchall()
-            
+
             return {
                 "report_type": "weekly",
                 "start_date": start_date,
                 "end_date": end_date,
                 "generated_at": time.time(),
+                "scope": "agent" if agent_id is not None else "network",
                 "summary": {
                     "total_runs": stats["total_runs"] or 0,
                     "completed_runs": stats["completed_runs"] or 0,
@@ -782,119 +799,126 @@ class ReportGenerator:
     
     def generate_outbound_report(
         self,
-        days: int = 30
+        days: int = 30,
+        agent_id: Optional[int] = None
     ) -> Dict[str, Any]:
         """
         Generate comprehensive outbound report for unified network.
-        
+
         This is the primary report for issue #312, showing all outbound
         syndication activity across the network.
-        
+
         Args:
             days: Number of days to include (default: 30)
-            
+            agent_id: Optional agent ID to scope report (default: all agents)
+
         Returns:
             Comprehensive outbound report
         """
         cutoff = time.time() - (days * 86400)
-        
+
         conn = self._get_connection()
         try:
+            # Build agent filter for queries
+            agent_filter = "AND sr.agent_id = ?" if agent_id is not None else ""
+            agent_params = (agent_id,) if agent_id is not None else ()
+
             # Overall network stats
             network_stats = conn.execute(
-                """
-                SELECT 
+                f"""
+                SELECT
                     COUNT(DISTINCT sr.id) as total_runs,
                     COUNT(DISTINCT sr.agent_id) as active_agents,
                     SUM(sr.successful_items) as total_outbound,
                     SUM(sr.failed_items) as total_failures
                 FROM syndication_runs sr
-                WHERE sr.started_at >= ?
+                WHERE sr.started_at >= ? {agent_filter}
                 """,
-                (cutoff,)
+                (cutoff,) + agent_params
             ).fetchone()
-            
+
             # Platform reach
             platform_reach = conn.execute(
-                """
+                f"""
                 SELECT si.target_platform,
                        COUNT(DISTINCT si.content_id) as unique_content,
                        COUNT(*) as total_syndications,
                        SUM(CASE WHEN si.status = 'success' THEN 1 ELSE 0 END) as successful
                 FROM syndication_items si
                 JOIN syndication_runs sr ON si.run_id = sr.id
-                WHERE sr.started_at >= ?
+                WHERE sr.started_at >= ? {agent_filter}
                 GROUP BY si.target_platform
                 ORDER BY total_syndications DESC
                 """,
-                (cutoff,)
+                (cutoff,) + agent_params
             ).fetchall()
-            
+
             # Content distribution (top syndicated content)
             top_content = conn.execute(
-                """
+                f"""
                 SELECT content_id,
                        COUNT(DISTINCT target_platform) as platform_count,
                        COUNT(*) as total_syndications,
                        MAX(external_url) as latest_url
                 FROM syndication_items si
                 JOIN syndication_runs sr ON si.run_id = sr.id
-                WHERE sr.started_at >= ? AND si.status = 'success'
+                WHERE sr.started_at >= ? AND si.status = 'success' {agent_filter}
                 GROUP BY content_id
                 ORDER BY platform_count DESC, total_syndications DESC
                 LIMIT 20
                 """,
-                (cutoff,)
+                (cutoff,) + agent_params
             ).fetchall()
-            
+
             # Success rate trend (by day)
             trend = conn.execute(
-                """
-                SELECT DATE(datetime(started_at, 'unixepoch')) as date,
-                       SUM(successful_items) as successful,
-                       SUM(failed_items) as failed,
+                f"""
+                SELECT DATE(datetime(sr.started_at, 'unixepoch')) as date,
+                       SUM(sr.successful_items) as successful,
+                       SUM(sr.failed_items) as failed,
                        ROUND(
-                           100.0 * SUM(successful_items) / 
-                           NULLIF(SUM(total_items), 0), 2
+                           100.0 * SUM(sr.successful_items) /
+                           NULLIF(SUM(sr.total_items), 0), 2
                        ) as success_rate
-                FROM syndication_runs
-                WHERE started_at >= ?
-                GROUP BY DATE(datetime(started_at, 'unixepoch'))
+                FROM syndication_runs sr
+                WHERE sr.started_at >= ? {agent_filter}
+                GROUP BY DATE(datetime(sr.started_at, 'unixepoch'))
                 ORDER BY date DESC
                 LIMIT 30
                 """,
-                (cutoff,)
+                (cutoff,) + agent_params
             ).fetchall()
-            
+
             # Recent failed items for investigation
             recent_failures = conn.execute(
-                """
+                f"""
                 SELECT si.content_id, si.target_platform, si.error_message,
                        sr.run_type, a.agent_name, si.created_at
                 FROM syndication_items si
                 JOIN syndication_runs sr ON si.run_id = sr.id
                 LEFT JOIN agents a ON sr.agent_id = a.id
-                WHERE si.status = 'failed' AND si.created_at >= ?
+                WHERE si.status = 'failed' AND si.created_at >= ? {agent_filter}
                 ORDER BY si.created_at DESC
                 LIMIT 50
                 """,
-                (cutoff,)
+                (cutoff,) + agent_params
             ).fetchall()
-            
+
             return {
                 "report_type": "outbound",
                 "title": "Unified Network Outbound Syndication Report",
                 "period_days": days,
                 "generated_at": time.time(),
                 "generated_at_iso": datetime.now().isoformat(),
+                "scope": "agent" if agent_id is not None else "network",
                 "network_summary": {
                     "total_runs": network_stats["total_runs"] or 0,
                     "active_agents": network_stats["active_agents"] or 0,
                     "total_outbound_items": network_stats["total_outbound"] or 0,
                     "total_failures": network_stats["total_failures"] or 0,
                     "overall_success_rate": (
-                        (network_stats["total_outbound"] or 0) / 
-                        ((network_stats["total_outbound"] or 0) + 
+                        (network_stats["total_outbound"] or 0) /
+                        ((network_stats["total_outbound"] or 0) +
                          (network_stats["total_failures"] or 1))
                     ) * 100
                 },
@@ -949,17 +973,18 @@ class ReportGenerator:
         report_type: str = "outbound",
         output_path: Optional[str] = None,
         **kwargs
-    ) -> str:
+    ):
         """
         Export a report to JSON file.
-        
+
         Args:
             report_type: Type of report (daily, weekly, outbound)
-            output_path: Output file path (default: auto-generated)
-            **kwargs: Arguments passed to report generator
-            
+            output_path: Output file path (default: auto-generated).
+                         If None, returns the report dict directly (Issue #360).
+            **kwargs: Arguments passed to report generator (supports agent_id for scoping)
+
         Returns:
-            Path to generated file
+            Path to generated file, or report dict if output_path is None
         """
         if report_type == "daily":
             report = self.generate_daily_report(**kwargs)
@@ -967,12 +992,12 @@ class ReportGenerator:
             report = self.generate_weekly_report(**kwargs)
         else:
             report = self.generate_outbound_report(**kwargs)
-        
+
         if output_path is None:
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            output_path = f"syndication_report_{report_type}_{timestamp}.json"
-        
+            # Issue #360: Return report directly without writing file
+            return report
+
         with open(output_path, "w") as f:
             json.dump(report, f, indent=2, default=str)
-        
+
         return output_path

--- a/tests/test_syndication.py
+++ b/tests/test_syndication.py
@@ -341,19 +341,22 @@ class TestReportGenerator(TestCase):
     
     def test_export_report_json(self):
         """Test JSON report export."""
-        output_path = self.generator.export_report_json(
+        import tempfile
+        output_path = os.path.join(self.temp_dir, "test_export.json")
+        self.generator.export_report_json(
             report_type="outbound",
-            days=7
+            days=7,
+            output_path=output_path
         )
-        
+
         self.assertTrue(os.path.exists(output_path))
-        
+
         with open(output_path) as f:
             data = json.load(f)
-        
+
         self.assertEqual(data["report_type"], "outbound")
         self.assertIn("network_summary", data)
-        
+
         # Clean up
         os.remove(output_path)
     
@@ -491,11 +494,11 @@ class TestSyndicationIntegration(TestCase):
         # Verify all runs completed
         active = self.tracker.get_active_runs()
         self.assertEqual(len(active), 0)
-    
+
     def test_multi_platform_syndication(self):
         """Test syndication to multiple platforms."""
         run_id = self.tracker.start_run("multi_platform", agent_id=1)
-        
+
         # Syndicate same content to multiple platforms
         platforms = ["x", "moltbook", "rss", "activitypub"]
         for platform in platforms:
@@ -506,15 +509,238 @@ class TestSyndicationIntegration(TestCase):
                 platform,
                 external_id=f"{platform}_123"
             )
-        
+
         self.tracker.end_run(run_id, "completed")
-        
+
         # Generate report and verify platform reach
         report = self.generator.generate_outbound_report(days=1)
-        
+
         platform_names = [p["platform"] for p in report["platform_reach"]]
         for platform in platforms:
             self.assertIn(platform, platform_names)
+
+
+class TestIssue360Authorization(TestCase):
+    """
+    Regression tests for Issue #360: Syndication Auth Lockdown
+    
+    Tests:
+    - Cross-agent denial on PUT /api/syndication/item/<id>
+    - Report scoping (agent vs network-wide)
+    """
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test_issue360.db")
+        self.tracker = SyndicationTracker(self.db_path)
+        self.generator = ReportGenerator(self.db_path)
+
+        # Create agents table
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS agents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_name TEXT UNIQUE NOT NULL,
+                display_name TEXT,
+                api_key TEXT
+            )
+        """)
+        # Create two test agents
+        conn.execute(
+            "INSERT INTO agents (agent_name, display_name, api_key) VALUES (?, ?, ?)",
+            ("agent_alice", "Alice Agent", "key_alice")
+        )
+        conn.execute(
+            "INSERT INTO agents (agent_name, display_name, api_key) VALUES (?, ?, ?)",
+            ("agent_bob", "Bob Agent", "key_bob")
+        )
+        conn.commit()
+        conn.close()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        if os.path.exists(self.temp_dir):
+            os.rmdir(self.temp_dir)
+
+    def test_cross_agent_item_update_denied(self):
+        """Test that Agent Bob cannot update Agent Alice's syndication item."""
+        # Alice creates a run and logs an item
+        alice_run_id = self.tracker.start_run("x_crosspost", agent_id=1)
+        alice_item_id = self.tracker.log_item(
+            alice_run_id, "video_alice", "pending", "x"
+        )
+
+        # Verify Bob (agent_id=2) cannot access Alice's item via run ownership check
+        # This simulates the authorization check in the route
+        conn = self.tracker._get_connection()
+        try:
+            item = conn.execute(
+                """
+                SELECT si.id, si.run_id, sr.agent_id
+                FROM syndication_items si
+                JOIN syndication_runs sr ON si.run_id = sr.id
+                WHERE si.id = ?
+                """,
+                (alice_item_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        # Bob's agent_id (2) != item's agent_id (1)
+        self.assertEqual(item["agent_id"], 1)  # Alice's agent_id
+        self.assertNotEqual(item["agent_id"], 2)  # Bob's agent_id
+
+    def test_owner_can_update_own_item(self):
+        """Test that an agent can update their own syndication item."""
+        # Alice creates a run and logs an item
+        alice_run_id = self.tracker.start_run("x_crosspost", agent_id=1)
+        alice_item_id = self.tracker.log_item(
+            alice_run_id, "video_alice", "pending", "x"
+        )
+
+        # Verify Alice (agent_id=1) owns the item
+        conn = self.tracker._get_connection()
+        try:
+            item = conn.execute(
+                """
+                SELECT si.id, si.run_id, sr.agent_id
+                FROM syndication_items si
+                JOIN syndication_runs sr ON si.run_id = sr.id
+                WHERE si.id = ?
+                """,
+                (alice_item_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        self.assertEqual(item["agent_id"], 1)  # Alice's agent_id
+
+        # Alice can update her own item
+        self.tracker.update_item_status(
+            item_id=alice_item_id,
+            status="success",
+            external_id="x_12345"
+        )
+
+        # Verify update succeeded
+        conn = self.tracker._get_connection()
+        try:
+            updated_item = conn.execute(
+                "SELECT status, external_id FROM syndication_items WHERE id = ?",
+                (alice_item_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        self.assertEqual(updated_item["status"], "success")
+        self.assertEqual(updated_item["external_id"], "x_12345")
+
+    def test_report_scoping_daily(self):
+        """Test daily report scoping by agent."""
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        # Create runs for both agents
+        alice_run = self.tracker.start_run("x_crosspost", agent_id=1)
+        self.tracker.log_item(alice_run, "video_alice_1", "success", "x")
+        self.tracker.end_run(alice_run, "completed")
+
+        bob_run = self.tracker.start_run("moltbook_sync", agent_id=2)
+        self.tracker.log_item(bob_run, "video_bob_1", "success", "moltbook")
+        self.tracker.end_run(bob_run, "completed")
+
+        # Network-wide report (agent_id=None) should see both runs
+        network_report = self.generator.generate_daily_report(today, agent_id=None)
+        self.assertEqual(len(network_report["runs"]), 2)
+        self.assertEqual(network_report["scope"], "network")
+
+        # Agent-scoped report (agent_id=1) should only see Alice's run
+        alice_report = self.generator.generate_daily_report(today, agent_id=1)
+        self.assertEqual(len(alice_report["runs"]), 1)
+        self.assertEqual(alice_report["runs"][0]["run_id"], alice_run)
+        self.assertEqual(alice_report["scope"], "agent")
+
+        # Agent-scoped report (agent_id=2) should only see Bob's run
+        bob_report = self.generator.generate_daily_report(today, agent_id=2)
+        self.assertEqual(len(bob_report["runs"]), 1)
+        self.assertEqual(bob_report["runs"][0]["run_id"], bob_run)
+        self.assertEqual(bob_report["scope"], "agent")
+
+    def test_report_scoping_weekly(self):
+        """Test weekly report scoping by agent."""
+        # Create runs for both agents
+        alice_run = self.tracker.start_run("x_crosspost", agent_id=1)
+        self.tracker.log_item(alice_run, "video_alice_1", "success", "x")
+        self.tracker.end_run(alice_run, "completed")
+
+        bob_run = self.tracker.start_run("moltbook_sync", agent_id=2)
+        self.tracker.log_item(bob_run, "video_bob_1", "success", "moltbook")
+        self.tracker.end_run(bob_run, "completed")
+
+        # Network-wide report should see both runs
+        network_report = self.generator.generate_weekly_report(agent_id=None)
+        self.assertEqual(network_report["summary"]["total_runs"], 2)
+        self.assertEqual(network_report["scope"], "network")
+        # Network report should include top_agents
+        self.assertIn("top_agents", network_report)
+
+        # Agent-scoped report should only see own runs
+        alice_report = self.generator.generate_weekly_report(agent_id=1)
+        self.assertEqual(alice_report["summary"]["total_runs"], 1)
+        self.assertEqual(alice_report["scope"], "agent")
+        # Agent-scoped report should not include top_agents
+        self.assertEqual(alice_report.get("top_agents"), [])
+
+    def test_report_scoping_outbound(self):
+        """Test outbound report scoping by agent."""
+        # Create runs for both agents
+        alice_run = self.tracker.start_run("x_crosspost", agent_id=1)
+        self.tracker.log_item(alice_run, "video_alice_1", "success", "x")
+        self.tracker.log_item(alice_run, "video_alice_2", "success", "moltbook")
+        self.tracker.end_run(alice_run, "completed")
+
+        bob_run = self.tracker.start_run("rss_update", agent_id=2)
+        self.tracker.log_item(bob_run, "video_bob_1", "success", "rss")
+        self.tracker.end_run(bob_run, "completed")
+
+        # Network-wide report should see all items
+        network_report = self.generator.generate_outbound_report(days=1, agent_id=None)
+        self.assertEqual(network_report["network_summary"]["total_runs"], 2)
+        self.assertEqual(network_report["network_summary"]["total_outbound_items"], 3)
+        self.assertEqual(network_report["scope"], "network")
+
+        # Agent-scoped report should only see own items
+        alice_report = self.generator.generate_outbound_report(days=1, agent_id=1)
+        self.assertEqual(alice_report["network_summary"]["total_runs"], 1)
+        self.assertEqual(alice_report["network_summary"]["total_outbound_items"], 2)
+        self.assertEqual(alice_report["scope"], "agent")
+
+        bob_report = self.generator.generate_outbound_report(days=1, agent_id=2)
+        self.assertEqual(bob_report["network_summary"]["total_runs"], 1)
+        self.assertEqual(bob_report["network_summary"]["total_outbound_items"], 1)
+        self.assertEqual(bob_report["scope"], "agent")
+
+    def test_export_report_no_file_write(self):
+        """Test that export_report_json with output_path=None returns dict directly."""
+        # Create some test data
+        run_id = self.tracker.start_run("x_crosspost", agent_id=1)
+        self.tracker.log_item(run_id, "video_1", "success", "x")
+        self.tracker.end_run(run_id, "completed")
+
+        # Export without file path should return dict directly
+        result = self.generator.export_report_json(
+            report_type="outbound",
+            output_path=None,
+            days=1,
+            agent_id=1
+        )
+
+        # Should be a dict, not a string path
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["report_type"], "outbound")
+        self.assertIn("network_summary", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes issue #360 with targeted auth/data exposure hardening:\n\n- Enforce owner-or-admin authorization on item updates\n- Scope report endpoints to authenticated agent by default\n- Allow network-wide reporting only for admin scope\n- Change export endpoint to return JSON directly (no server-side file writes/paths)\n- Add regression tests for cross-agent denial and report scoping\n\nValidation:\n- PYTHONPATH=. pytest tests/test_syndication.py (22 passed)\n\nCloses #360