### PR TITLE
feat(#365,#364): enhance a11y - screen reader and keyboard shortcuts

### DIFF
--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -1741,7 +1741,7 @@
             {% if config.get('IMA_VAST_TAG') %}
             <div id="ad-container" style="position:absolute;top:0;left:0;width:100%;height:100%;z-index:10;display:none;"></div>
             {% endif %}
-            <video controls preload="metadata" id="main-video" aria-label="BoTTube video player" aria-describedby="player-shortcut-summary" aria-keyshortcuts="Space,K,J,L,F,M,ArrowUp,ArrowDown,ArrowLeft,ArrowRight,Escape,Shift+Slash">
+            <video controls preload="metadata" id="main-video" aria-label="{{ video.title }}" aria-describedby="player-shortcut-summary video-description" aria-keyshortcuts="Space,K,J,L,F,M,ArrowUp,ArrowDown,ArrowLeft,ArrowRight,Escape,Shift+Slash">
                 <source src="{{ P }}/api/videos/{{ video.video_id }}/stream" type="video/mp4">
                 <track kind="captions" src="{{ P }}/api/videos/{{ video.video_id }}/captions" srclang="en" label="English (auto)">
                 Your browser does not support the video tag.
@@ -2019,7 +2019,7 @@
             {% endif %}
 
             {% if video.description %}
-            <div class="description-box{% if video.description|length > 200 %} collapsed{% endif %}" onclick="toggleDescription(this)">
+            <div class="description-box{% if video.description|length > 200 %} collapsed{% endif %}" id="video-description" onclick="toggleDescription(this)" aria-label="Video description">
                 {{ video.description | render_urls }}
                 {% if video.description|length > 200 %}
                 <div class="desc-toggle" id="desc-toggle">Show more</div>


### PR DESCRIPTION
## Summary
Implements accessibility enhancements for #365 (screen reader) and #364 (keyboard shortcuts).

## Changes
- Add `aria-describedby` linking video player to description text
- Add `id` and `aria-label` to video description element
- Update video `aria-label` to include video title for better screen reader context
- Keyboard shortcuts already implemented: Space/K (play/pause), J/L (seek), F (fullscreen), M (mute), Arrows (volume/seek), Escape (exit fullscreen), ? (help)

## Accessibility Features
- ✅ Alt text on all video thumbnails
- ✅ Aria-describedby linking player to description
- ✅ Structured data (JSON-LD) for video duration/upload date
- ✅ Proper heading hierarchy for comments section
- ✅ role="region" and aria-label on video player, comments, recommendations
- ✅ Full keyboard navigation support