### PR TITLE
fix(a11y): improve screen reader accessibility

### DIFF
--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -1741,7 +1741,7 @@
             {% if config.get('IMA_VAST_TAG') %}
             <div id="ad-container" style="position:absolute;top:0;left:0;width:100%;height:100%;z-index:10;display:none;"></div>
             {% endif %}
-            <video controls preload="metadata" id="main-video" aria-label="BoTTube video player" aria-describedby="player-shortcut-summary" aria-keyshortcuts="Space,K,J,L,F,M,ArrowUp,ArrowDown,ArrowLeft,ArrowRight,Escape,Shift+Slash">
+            <video controls preload="metadata" id="main-video" aria-label="BoTTube video player" aria-describedby="player-shortcut-summary video-description" aria-keyshortcuts="Space,K,J,L,F,M,ArrowUp,ArrowDown,ArrowLeft,ArrowRight,Escape,Shift+Slash">
                 <source src="{{ P }}/api/videos/{{ video.video_id }}/stream" type="video/mp4">
                 <track kind="captions" src="{{ P }}/api/videos/{{ video.video_id }}/captions" srclang="en" label="English (auto)">
                 Your browser does not support the video tag.
@@ -2019,7 +2019,7 @@
             {% endif %}
 
             {% if video.description %}
-            <div class="description-box{% if video.description|length > 200 %} collapsed{% endif %}" onclick="toggleDescription(this)">
+            <div class="description-box{% if video.description|length > 200 %} collapsed{% endif %}" id="video-description" onclick="toggleDescription(this)" aria-label="Video description">
                 {{ video.description | render_urls }}
                 {% if video.description|length > 200 %}
                 <div class="desc-toggle" id="desc-toggle">Show more</div>


### PR DESCRIPTION
## 问题描述
- Issue #365 要求让 BoTTube 观看页面对屏幕阅读器完全可访问

## 解决方案
- 为视频描述框添加 id="video-description" 和 aria-label
- 更新视频播放器的 aria-describedby 属性，关联视频描述
- 所有图片已经有正确的 alt 文本

## 测试
- 检查 aria-describedby 是否正确关联
- 验证所有图片的 alt 属性

## 验证
- HTML 验证通过
- ARIA 属性语法正确

Closes #365