### PR TITLE
fix: display live global stats in footer (Resolves #408)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13066,8 +13066,25 @@ def footer_counters():
     _refresh_github_repo_cache(_clawrtc_github_cache, "Scottcjn/Rustchain")
     _refresh_github_repo_cache(_grazer_github_cache, "Scottcjn/grazer-skill")
 
+    # Get stats from DB
+    video_count = 0
+    agent_count = 0
+    human_count = 0
+    try:
+        db = get_db()
+        video_count = db.execute("SELECT COUNT(*) FROM videos").fetchone()[0]
+        agent_count = db.execute("SELECT COUNT(*) FROM agents WHERE is_human = 0").fetchone()[0]
+        human_count = db.execute("SELECT COUNT(*) FROM agents WHERE is_human = 1").fetchone()[0]
+    except Exception as e:
+        app.logger.warning(f"Failed to fetch footer stats: {e}")
+
     data = {
         "ts": int(now),
+        "stats": {
+            "videos": video_count,
+            "agents": agent_count,
+            "humans": human_count
+        },
         "bottube": {
             "downloads": {
                 "clawhub": int(cache.get("clawhub", 0) or 0),

--- a/bottube_static/counters.js
+++ b/bottube_static/counters.js
@@ -32,11 +32,16 @@
     var b = d.bottube || {};
     var c = d.clawrtc || {};
     var g = d.grazer || {};
+    var s = d.stats || {};
 
     function setNum(id, n) {
       if (n === undefined || n === null) return;
       setText(id, fmt(n));
     }
+
+    setNum("ctr-global-videos", s.videos);
+    setNum("ctr-global-agents", s.agents);
+    setNum("ctr-global-humans", s.humans);
 
     setNum("ctr-clawhub", b.downloads && b.downloads.clawhub);
     setNum("ctr-npm", b.downloads && b.downloads.npm);

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -854,6 +854,22 @@
             <a href="https://grokipedia.com/page/BoTTubeai" target="_blank" rel="noopener">Grokipedia</a>
         </div>
 
+        <!-- Global Platform Stats -->
+        <div id="bottube-global-stats" style="margin:20px auto;max-width:700px;display:flex;flex-wrap:wrap;justify-content:center;gap:24px;padding:16px 12px;background:rgba(33,33,33,0.4);border:1px solid #333;border-radius:10px;">
+            <div style="text-align:center;min-width:100px;">
+                <div style="font-size:11px;color:#717171;text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">Videos</div>
+                <div id="ctr-global-videos" style="font-size:24px;font-weight:700;color:#65b8ff;">--</div>
+            </div>
+            <div style="text-align:center;min-width:100px;">
+                <div style="font-size:11px;color:#717171;text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">Agents</div>
+                <div id="ctr-global-agents" style="font-size:24px;font-weight:700;color:#f0c040;">--</div>
+            </div>
+            <div style="text-align:center;min-width:100px;">
+                <div style="font-size:11px;color:#717171;text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">Humans</div>
+                <div id="ctr-global-humans" style="font-size:24px;font-weight:700;color:#14F195;">--</div>
+            </div>
+        </div>
+
         <div class="footer-featured">
             <div class="footer-featured-label">{{ _('footer.featured_on') }}</div>
             <div class="footer-badges">


### PR DESCRIPTION
This PR fixes the issue where the footer statistics were permanently displaying `--` instead of real platform numbers.

### Implementation Details:
1. **`bottube_server.py`**: Modified the `/api/footer-counters` endpoint to also fetch and return the `videos`, `agents`, and `humans` counts directly from the SQLite database (mirroring the logic in the `/health` endpoint).
2. **`bottube_static/counters.js`**: Updated the client-side counter loading script to parse the new `stats` object from the JSON response and map it to the DOM elements.
3. **`bottube_templates/base.html`**: Added a new **Global Platform Stats** block in the footer using the `ctr-global-*` IDs so they get populated asynchronously when the footer comes into view.

Resolves #408 and satisfies the requirements for [Bounty #2138](https://github.com/Scottcjn/rustchain-bounties/issues/2138).

Wallet: `allornothingai`