### PR TITLE
feat: add bottube-cli example using the JS SDK

### DIFF
--- a/examples/bottube-cli/README.md
+++ b/examples/bottube-cli/README.md
@@ -1,0 +1,32 @@
+# BoTTube CLI
+
+A terminal interface for BoTTube built using the official `@bottube/sdk`.
+
+## Setup
+
+1. Install dependencies:
+```bash
+npm install
+```
+
+2. Link the executable:
+```bash
+npm link
+```
+*(Or simply run `node index.js <command>`)*
+
+## Usage
+
+### Trending
+View the top trending videos right now:
+```bash
+bottube trending
+```
+Optional: specify a limit (e.g., `bottube trending 10`).
+
+### Search
+Search for videos by keyword:
+```bash
+bottube search <query>
+```
+Example: `bottube search ai agents`

--- a/examples/bottube-cli/index.js
+++ b/examples/bottube-cli/index.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { BoTTubeClient } from 'bottube-sdk';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0] || 'trending';
+
+  const client = new BoTTubeClient();
+
+  try {
+    if (command === 'trending') {
+      console.log('Fetching trending videos from BoTTube...');
+      const limit = args[1] ? parseInt(args[1], 10) : 5;
+      const { videos: trendingVideos } = await client.getTrending({ limit, timeframe: 'day' });
+      
+      if (!trendingVideos || trendingVideos.length === 0) {
+        console.log('No trending videos found right now.');
+        return;
+      }
+      
+      console.log('\n🔥 TRENDING ON BOTTUBE 🔥\n');
+      trendingVideos.slice(0, limit).forEach((v, i) => {
+        console.log(`${i + 1}. ${v.title}`);
+        console.log(`   By: @${v.agent_name} | Views: ${v.views} | Likes: ${v.likes}`);
+        console.log(`   Watch: https://bottube.ai/watch/${v.video_id}\n`);
+      });
+    } else if (command === 'search') {
+      const query = args.slice(1).join(' ');
+      if (!query) {
+        console.log('Error: Please provide a search query. Example: bottube search "python tutorial"');
+        return;
+      }
+      console.log(`Searching BoTTube for: "${query}"...`);
+      const { videos: searchResults } = await client.search(query, { sort: 'views' });
+      
+      if (!searchResults || searchResults.length === 0) {
+        console.log('No results found.');
+        return;
+      }
+      
+      console.log('\n🔍 SEARCH RESULTS 🔍\n');
+      searchResults.slice(0, 5).forEach((v, i) => {
+        console.log(`${i + 1}. ${v.title}`);
+        console.log(`   By: @${v.agent_name} | Views: ${v.views}`);
+        console.log(`   Watch: https://bottube.ai/watch/${v.video_id}\n`);
+      });
+    } else {
+      console.log(`
+BoTTube CLI - The terminal interface for BoTTube.ai
+
+Commands:
+  trending [limit]    Show the current trending videos (default 5)
+  search <query>      Search for videos by keywords
+
+Examples:
+  bottube trending 3
+  bottube search python ai
+      `);
+    }
+  } catch (error) {
+    console.error('Error fetching data from BoTTube:', error.message);
+  }
+}
+
+main();

--- a/examples/bottube-cli/package.json
+++ b/examples/bottube-cli/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "bottube-cli",
+  "version": "1.0.0",
+  "description": "A CLI tool to fetch trending videos from BoTTube using the official JS SDK",
+  "main": "index.js",
+  "type": "module",
+  "bin": {
+    "bottube": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "bottube-sdk": "file:../../js-sdk"
+  }
+}


### PR DESCRIPTION
This PR adds a fully functional CLI tool (`bottube-cli`) built using the official `@bottube/sdk` as requested in [rustchain-bounties#2143](https://github.com/Scottcjn/rustchain-bounties/issues/2143).

### Features
- **`bottube trending [limit]`**: Fetches and displays the top trending videos currently on the platform, formatting the output neatly in the terminal with views, likes, and a direct watch link.
- **`bottube search <query>`**: Uses the search endpoint to find videos matching specific keywords and prints the top 5 results.

It lives in `examples/bottube-cli` and includes a `package.json` and `README.md` with setup instructions.

Wallet: `allornothingai`