### PR TITLE
feat: add watch-page keyboard shortcuts including captions toggle (#2140)

### DIFF
--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -1782,7 +1782,7 @@
             {% if config.get('IMA_VAST_TAG') %}
             <div id="ad-container" style="position:absolute;top:0;left:0;width:100%;height:100%;z-index:10;display:none;" role="region" aria-label="Advertisement"></div>
             {% endif %}
-            <video controls preload="metadata" id="main-video" aria-label="{{ video.title }}, duration {{ ((video.duration_sec or 0)|int) // 60 }} minutes {{ ((video.duration_sec or 0)|int) % 60 }} seconds" aria-describedby="player-shortcut-summary player-state" aria-keyshortcuts="Space,K,J,L,F,M,ArrowUp,ArrowDown,ArrowLeft,ArrowRight,Escape,Shift+Slash">
+            <video controls preload="metadata" id="main-video" aria-label="{{ video.title }}, duration {{ ((video.duration_sec or 0)|int) // 60 }} minutes {{ ((video.duration_sec or 0)|int) % 60 }} seconds" aria-describedby="player-shortcut-summary player-state" aria-keyshortcuts="Space,K,J,L,F,M,C,ArrowUp,ArrowDown,ArrowLeft,ArrowRight,Escape,Shift+Slash">
                 <source src="{{ P }}/api/videos/{{ video.video_id }}/stream" type="video/mp4">
                 <track kind="captions" src="{{ P }}/api/videos/{{ video.video_id }}/captions" srclang="en" label="English (auto)">
                 Your browser does not support the video tag.
@@ -1793,7 +1793,7 @@
                 &#128264; Click to unmute
             </button>
             <p id="player-shortcut-summary" class="sr-only">
-                Keyboard shortcuts are available for play and pause, seeking, volume, mute, fullscreen, and the shortcut help overlay.
+                Keyboard shortcuts are available for play and pause, seeking, volume, mute, fullscreen, captions toggle, and the shortcut help overlay.
                 Shortcuts are disabled while typing in comment or reply fields.
             </p>
             <div class="video-endscreen" id="video-endscreen">
@@ -1822,6 +1822,7 @@
                     <li><kbd>Left / Right</kbd><span>Seek 5 seconds backward or forward</span></li>
                     <li><kbd>Up / Down</kbd><span>Increase or decrease volume by 5%</span></li>
                     <li><kbd>M</kbd><span>Mute or unmute</span></li>
+                    <li><kbd>C</kbd><span>Toggle captions (if available)</span></li>
                     <li><kbd>F / Escape</kbd><span>Enter or exit fullscreen</span></li>
                     <li><kbd>?</kbd><span>Open this help overlay</span></li>
                 </ul>
@@ -2309,6 +2310,17 @@ function toggleMute(video) {
     video.muted = !video.muted;
 }
 
+function toggleCaptions(video) {
+    if (!video) return;
+    var tracks = video.textTracks;
+    if (!tracks || tracks.length === 0) return;
+    for (var i = 0; i < tracks.length; i++) {
+        if (tracks[i].kind === 'captions' || tracks[i].kind === 'subtitles') {
+            tracks[i].mode = tracks[i].mode === 'showing' ? 'hidden' : 'showing';
+        }
+    }
+}
+
 function toggleFullscreen() {
     var player = document.getElementById('video-player-region');
     if (!player) return;
@@ -2371,6 +2383,10 @@ document.addEventListener('keydown', function(event) {
         case 'm':
             event.preventDefault();
             toggleMute(video);
+            return;
+        case 'c':
+            event.preventDefault();
+            toggleCaptions(video);
             return;
         case 'arrowup':
             event.preventDefault();
@@ -3109,99 +3125,6 @@ function reportVideo() {
             }
         );
     };
-})();
-
-// --- Video Player Keyboard Shortcuts (Bounty #2140) ---
-(function() {
-    const video = document.getElementById('main-video');
-    if (!video) return;
-
-    function showIndicator(icon) {
-        let overlay = document.getElementById('player-shortcut-indicator');
-        if (!overlay) {
-            overlay = document.createElement('div');
-            overlay.id = 'player-shortcut-indicator';
-            overlay.style.cssText = 'position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.6);color:white;border-radius:50%;width:80px;height:80px;display:flex;align-items:center;justify-content:center;font-size:40px;pointer-events:none;z-index:100;opacity:0;transition:opacity 0.2s;';
-            video.parentElement.appendChild(overlay);
-        }
-        overlay.innerHTML = icon;
-        overlay.style.opacity = '1';
-        clearTimeout(overlay._hideTimeout);
-        overlay._hideTimeout = setTimeout(() => { overlay.style.opacity = '0'; }, 500);
-    }
-
-    document.addEventListener('keydown', function(e) {
-        // Disable shortcuts when typing in inputs/textareas
-        const active = document.activeElement;
-        if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) return;
-
-        const key = e.key.toLowerCase();
-
-        // Space or K: Play/Pause
-        if (key === ' ' || key === 'k') {
-            e.preventDefault();
-            if (video.paused) {
-                video.play();
-                showIndicator('▶');
-            } else {
-                video.pause();
-                showIndicator('Ⅱ');
-            }
-        }
-        // J: Seek backward 10s
-        else if (key === 'j') {
-            e.preventDefault();
-            video.currentTime = Math.max(0, video.currentTime - 10);
-            showIndicator('↺');
-        }
-        // L: Seek forward 10s
-        else if (key === 'l') {
-            e.preventDefault();
-            video.currentTime = Math.min(video.duration || video.currentTime + 10, video.currentTime + 10);
-            showIndicator('↻');
-        }
-        // ArrowLeft: Seek backward 5s
-        else if (key === 'arrowleft') {
-            e.preventDefault();
-            video.currentTime = Math.max(0, video.currentTime - 5);
-            showIndicator('←');
-        }
-        // ArrowRight: Seek forward 5s
-        else if (key === 'arrowright') {
-            e.preventDefault();
-            video.currentTime = Math.min(video.duration || video.currentTime + 5, video.currentTime + 5);
-            showIndicator('→');
-        }
-        // M: Mute toggle
-        else if (key === 'm') {
-            e.preventDefault();
-            video.muted = !video.muted;
-            showIndicator(video.muted ? '🔇' : '🔊');
-        }
-        // F: Fullscreen toggle
-        else if (key === 'f') {
-            e.preventDefault();
-            if (!document.fullscreenElement) {
-                video.parentElement.requestFullscreen().catch(err => console.error(err));
-            } else {
-                document.exitFullscreen();
-            }
-        }
-        // ArrowUp: Volume up 5%
-        else if (key === 'arrowup') {
-            e.preventDefault();
-            video.volume = Math.min(1, video.volume + 0.05);
-            showIndicator('🔊 ' + Math.round(video.volume * 100) + '%');
-        }
-        // ArrowDown: Volume down 5%
-        else if (key === 'arrowdown') {
-            e.preventDefault();
-            video.volume = Math.max(0, video.volume - 0.05);
-            showIndicator('🔉 ' + Math.round(video.volume * 100) + '%');
-        }
-    });
-})();
-// --- End Bounty #2140 ---
 })();
 </script>
 

--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -1,0 +1,72 @@
+# BoTTube Watch Page Keyboard Shortcuts
+
+This document describes the keyboard shortcuts available on the BoTTube watch page for controlling video playback.
+
+## Available Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Space` or `K` | Play or pause the video |
+| `J` | Rewind 10 seconds |
+| `L` | Fast-forward 10 seconds |
+| `←` (Left Arrow) | Seek backward 5 seconds |
+| `→` (Right Arrow) | Seek forward 5 seconds |
+| `↑` (Up Arrow) | Increase volume by 5% |
+| `↓` (Down Arrow) | Decrease volume by 5% |
+| `M` | Mute or unmute the video |
+| `C` | Toggle captions (if available) |
+| `F` | Toggle fullscreen |
+| `Escape` | Exit fullscreen or close help modal |
+| `?` or `Shift+/` | Open keyboard shortcuts help overlay |
+
+## Usage Notes
+
+- Shortcuts are active when focus is on the watch page
+- Shortcuts are **disabled** while typing in:
+  - Comment fields
+  - Reply fields
+  - Any text input or textarea
+  - Content-editable elements
+- Shortcuts are also disabled when focus is on interactive elements like buttons or links
+
+## Accessibility
+
+- All shortcuts are announced via ARIA attributes (`aria-keyshortcuts`)
+- A visible help overlay is available via the `?` key or the "Shortcuts" button
+- Screen readers can access shortcut information via the hidden summary element
+
+## Implementation Details
+
+The keyboard shortcuts are implemented in `bottube_templates/watch.html` using vanilla JavaScript. The main handler:
+
+1. Checks if the user is typing in a text field (shortcuts disabled)
+2. Checks if the help modal is open (only Escape works)
+3. Processes the key press and calls the appropriate function
+
+### Functions
+
+- `togglePlayback(video)` - Toggles play/pause state
+- `seekVideo(video, deltaSeconds)` - Seeks forward or backward
+- `adjustVolume(video, delta)` - Adjusts volume by delta (-1 to 1)
+- `toggleMute(video)` - Toggles mute state
+- `toggleCaptions(video)` - Toggles captions/subtitles visibility
+- `toggleFullscreen()` - Toggles fullscreen mode
+
+## Testing
+
+Tests are located in `tests/test_watch_page_accessibility.py`. The test verifies:
+
+- Player region has proper ARIA attributes
+- Shortcut help modal is present
+- Keyboard handler is registered
+- Shortcuts are disabled while typing
+
+Run tests with:
+```bash
+pytest tests/test_watch_page_accessibility.py -v
+```
+
+## Related
+
+- Issue: rustchain-bounties #2140
+- File: `bottube_templates/watch.html`

--- a/tests/test_watch_page_accessibility.py
+++ b/tests/test_watch_page_accessibility.py
@@ -101,11 +101,13 @@ def test_watch_page_renders_keyboard_shortcuts_and_accessibility_regions(client)
     assert 'aria-label="Up next videos"' in html
     assert 'id="shortcut-help-btn"' in html
     assert 'id="shortcut-help-modal"' in html
-    assert 'aria-keyshortcuts="Space,K,J,L,F,M,ArrowUp,ArrowDown,ArrowLeft,ArrowRight,Escape,Shift+Slash"' in html
+    assert 'aria-keyshortcuts="Space,K,J,L,F,M,C,ArrowUp,ArrowDown,ArrowLeft,ArrowRight,Escape,Shift+Slash"' in html
     assert 'function openShortcutHelp()' in html
     assert "document.addEventListener('keydown'" in html
     assert "Shortcuts are disabled while typing in comment" in html
     assert "function isShortcutBypassTarget(target)" in html
+    assert 'toggleCaptions' in html
+    assert 'Toggle captions' in html
 
     keydown_block_start = html.index("document.addEventListener('keydown'")
     keydown_block = html[keydown_block_start:]


### PR DESCRIPTION
Implements #2140 by adding complete keyboard shortcuts on the watch page (play/pause, seek, volume, mute, fullscreen, captions, help) with accessibility labels and docs updates.\n\nCloses #2140