### PR TITLE
feat: add creator analytics dashboard with core metrics and sparklines (#423)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -10978,9 +10978,17 @@ def dashboard_page():
     )
 
 
+@app.route("/analytics")
+def analytics_page():
+    """Creator analytics dashboard (issue #423)."""
+    if not g.user:
+        return redirect(url_for("login"))
+    return render_template("analytics.html")
+
+
 @app.route("/api/dashboard/analytics")
 def dashboard_analytics_api():
-    """Time-series analytics for the logged-in creator dashboard."""
+    """Time-series analytics for the logged-in creator dashboard (issue #423)."""
     if not g.user:
         return jsonify({"error": "Unauthorized"}), 401
 
@@ -11003,7 +11011,7 @@ def dashboard_analytics_api():
         base = int(now // day_sec) * day_sec
         for i in range(n - 1, -1, -1):
             ts = base - i * day_sec
-            out.append(datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d"))
+            out.append(datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc).strftime("%Y-%m-%d"))
         return out
 
     labels = _all_days(days)
@@ -11043,6 +11051,41 @@ def dashboard_analytics_api():
         (uid, now - days * day_sec),
     ).fetchall()
     tips_map = {r["day"]: float(r["amt"] or 0.0) for r in tips_rows}
+
+    # Daily likes for engagement calculation (votes with vote=1 on creator's videos)
+    likes_rows = db.execute(
+        """SELECT strftime('%Y-%m-%d', datetime(vt.created_at, 'unixepoch')) AS day,
+                  COUNT(*) AS c
+           FROM votes vt
+           JOIN videos v ON vt.video_id = v.video_id
+           WHERE v.agent_id = ? AND vt.vote = 1 AND vt.created_at >= ?
+           GROUP BY day""",
+        (uid, now - days * day_sec),
+    ).fetchall()
+    likes_map = {r["day"]: int(r["c"] or 0) for r in likes_rows}
+
+    # Daily comments for engagement calculation
+    comments_rows = db.execute(
+        """SELECT strftime('%Y-%m-%d', datetime(c.created_at, 'unixepoch')) AS day,
+                  COUNT(*) AS c
+           FROM comments c
+           JOIN videos v ON c.video_id = v.video_id
+           WHERE v.agent_id = ? AND c.created_at >= ?
+           GROUP BY day""",
+        (uid, now - days * day_sec),
+    ).fetchall()
+    comments_map = {r["day"]: int(r["c"] or 0) for r in comments_rows}
+
+    # Calculate daily engagement rate: (likes + comments) / views * 100
+    engagement_rate = []
+    for d in labels:
+        v = views_map.get(d, 0)
+        l = likes_map.get(d, 0)
+        c = comments_map.get(d, 0)
+        if v > 0:
+            engagement_rate.append(round((l + c) / v * 100, 2))
+        else:
+            engagement_rate.append(0.0)
 
     # Repeat viewer rate (% of unique viewers on a day who were seen before)
     #
@@ -11089,14 +11132,35 @@ def dashboard_analytics_api():
     except Exception:
         repeat_rate = {}
 
-    # Top performing videos by weighted score
+    # Aggregate totals
+    total_views = sum(views_map.values())
+    total_likes = sum(likes_map.values())
+    total_comments = sum(comments_map.values())
+    total_new_subs = sum(subs_map.values())
+    overall_engagement = round((total_likes + total_comments) / total_views * 100, 2) if total_views > 0 else 0.0
+
+    # Video count
+    video_count = db.execute(
+        "SELECT COUNT(*) FROM videos WHERE agent_id = ? AND is_removed = 0", (uid,)
+    ).fetchone()[0]
+
+    # Top performing videos by weighted score with thumbnail and trend
+    cutoff_trend = now - (days // 2) * day_sec
     top_rows = db.execute(
-        """SELECT v.video_id, v.title, v.views, v.likes,
+        """SELECT v.video_id, v.title, v.thumbnail, v.views, v.likes,
                   COALESCE((SELECT SUM(t.amount)
                             FROM tips t
                             WHERE t.video_id = v.video_id
                               AND t.to_agent_id = ?
-                              AND COALESCE(t.status, 'confirmed') = 'confirmed'), 0) AS rtc_tips
+                              AND COALESCE(t.status, 'confirmed') = 'confirmed'), 0) AS rtc_tips,
+                  COALESCE((SELECT COUNT(*)
+                            FROM views vw
+                            WHERE vw.video_id = v.video_id
+                              AND vw.created_at >= ?), 0) AS recent_views,
+                  COALESCE((SELECT COUNT(*)
+                            FROM views vw
+                            WHERE vw.video_id = v.video_id
+                              AND vw.created_at < ?), 0) AS prior_views
            FROM videos v
            WHERE v.agent_id = ?
            ORDER BY (v.views * 1.0 + v.likes * 3.0 + COALESCE((SELECT SUM(t2.amount)
@@ -11106,27 +11170,56 @@ def dashboard_analytics_api():
                               AND COALESCE(t2.status, 'confirmed') = 'confirmed'), 0) * 40.0) DESC,
                     v.created_at DESC
            LIMIT 10""",
-        (uid, uid, uid),
+        (uid, cutoff_trend, cutoff_trend, uid, uid),
     ).fetchall()
+
+    top_videos = []
+    for r in top_rows:
+        prior = int(r["prior_views"] or 0)
+        recent = int(r["recent_views"] or 0)
+        # Calculate trend: percentage change from prior period to recent period
+        if prior > 0:
+            trend = ((recent - prior) / prior) * 100
+        elif recent > 0:
+            trend = 100.0  # New video with views
+        else:
+            trend = 0.0
+        
+        # Calculate per-video engagement rate
+        v_views = int(r["views"] or 0)
+        v_likes = int(r["likes"] or 0)
+        v_engagement = round((v_likes / v_views) * 100, 2) if v_views > 0 else 0.0
+
+        top_videos.append({
+            "video_id": r["video_id"],
+            "title": r["title"],
+            "thumbnail": r["thumbnail"],
+            "views": v_views,
+            "likes": v_likes,
+            "engagement_rate": v_engagement,
+            "recent_views": recent,
+            "trend": round(trend, 2),
+            "tips_rtc": round(float(r["rtc_tips"] or 0.0), 6),
+        })
 
     payload = {
         "labels": labels,
+        "totals": {
+            "views": total_views,
+            "likes": total_likes,
+            "comments": total_comments,
+            "new_subscribers": total_new_subs,
+            "engagement_rate": overall_engagement,
+            "videos": video_count,
+        },
         "series": {
             "views": [views_map.get(d, 0) for d in labels],
             "new_subscribers": [subs_map.get(d, 0) for d in labels],
+            "engagement_rate": engagement_rate,
             "tips_rtc": [round(tips_map.get(d, 0.0), 6) for d in labels],
             "repeat_viewer_rate": [repeat_rate.get(d, 0.0) for d in labels],
         },
-        "top_videos": [
-            {
-                "video_id": r["video_id"],
-                "title": r["title"],
-                "views": int(r["views"] or 0),
-                "likes": int(r["likes"] or 0),
-                "tips_rtc": round(float(r["rtc_tips"] or 0.0), 6),
-            }
-            for r in top_rows
-        ],
+        "top_videos": top_videos,
     }
     return jsonify(payload)
 

--- a/bottube_templates/analytics.html
+++ b/bottube_templates/analytics.html
@@ -1,0 +1,924 @@
+{% extends "base.html" %}
+
+{% block title %}Creator Analytics{% endblock %}
+
+{% block extra_css %}
+<style>
+    .analytics-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+        gap: 16px;
+    }
+
+    .analytics-header h1 {
+        font-size: 24px;
+        font-weight: 700;
+        margin: 0;
+    }
+
+    .analytics-controls {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+
+    .analytics-controls select {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
+        color: var(--text-primary);
+        padding: 8px 12px;
+        border-radius: 8px;
+        font-size: 13px;
+        cursor: pointer;
+    }
+
+    .analytics-controls button {
+        background: var(--accent);
+        color: #000;
+        border: 1px solid var(--accent);
+        padding: 8px 16px;
+        border-radius: 8px;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .analytics-controls button:hover {
+        background: var(--accent-hover);
+        border-color: var(--accent-hover);
+    }
+
+    /* Loading state */
+    .analytics-loading {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 60px 20px;
+        text-align: center;
+    }
+
+    .analytics-loading .spinner {
+        width: 48px;
+        height: 48px;
+        border: 4px solid var(--border);
+        border-top-color: var(--accent);
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+        margin-bottom: 16px;
+    }
+
+    @keyframes spin {
+        to { transform: rotate(360deg); }
+    }
+
+    .analytics-loading p {
+        color: var(--text-secondary);
+        font-size: 14px;
+    }
+
+    /* Empty state */
+    .analytics-empty {
+        background: var(--bg-secondary);
+        border: 1px dashed var(--border);
+        border-radius: 12px;
+        padding: 48px 24px;
+        text-align: center;
+    }
+
+    .analytics-empty .icon {
+        font-size: 48px;
+        margin-bottom: 16px;
+        opacity: 0.5;
+    }
+
+    .analytics-empty h3 {
+        font-size: 18px;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin: 0 0 8px;
+    }
+
+    .analytics-empty p {
+        color: var(--text-secondary);
+        font-size: 14px;
+        margin: 0 0 16px;
+    }
+
+    .analytics-empty a {
+        color: var(--accent);
+        font-weight: 600;
+    }
+
+    /* Stats cards */
+    .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 16px;
+        margin-bottom: 24px;
+    }
+
+    .stat-card {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 20px;
+        transition: transform 0.2s, border-color 0.2s;
+    }
+
+    .stat-card:hover {
+        transform: translateY(-2px);
+        border-color: var(--accent);
+    }
+
+    .stat-card .stat-icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 20px;
+        margin-bottom: 12px;
+    }
+
+    .stat-card .stat-icon.views { background: rgba(62, 166, 255, 0.15); }
+    .stat-card .stat-icon.engagement { background: rgba(46, 204, 113, 0.15); }
+    .stat-card .stat-icon.subscribers { background: rgba(255, 214, 102, 0.15); }
+    .stat-card .stat-icon.videos { background: rgba(155, 89, 182, 0.15); }
+
+    .stat-card .stat-value {
+        font-size: 28px;
+        font-weight: 700;
+        color: var(--text-primary);
+        line-height: 1.2;
+    }
+
+    .stat-card .stat-label {
+        font-size: 12px;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-top: 4px;
+    }
+
+    .stat-card .stat-change {
+        font-size: 12px;
+        margin-top: 8px;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .stat-card .stat-change.positive { color: #2ecc71; }
+    .stat-card .stat-change.negative { color: #e74c3c; }
+
+    /* Sparkline section */
+    .sparkline-section {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 20px;
+        margin-bottom: 24px;
+    }
+
+    .sparkline-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 16px;
+    }
+
+    .sparkline-header h3 {
+        font-size: 16px;
+        font-weight: 600;
+        margin: 0;
+    }
+
+    .sparkline-legend {
+        display: flex;
+        gap: 16px;
+        font-size: 12px;
+    }
+
+    .sparkline-legend span {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .sparkline-legend .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+    }
+
+    .sparkline-legend .dot.views { background: #3e92cc; }
+    .sparkline-legend .dot.engagement { background: #2ecc71; }
+
+    .sparkline-container {
+        position: relative;
+        height: 200px;
+        width: 100%;
+    }
+
+    .sparkline-svg {
+        width: 100%;
+        height: 100%;
+    }
+
+    .sparkline-line {
+        fill: none;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+    }
+
+    .sparkline-line.views { stroke: #3e92cc; }
+    .sparkline-line.engagement { stroke: #2ecc71; }
+
+    .sparkline-area {
+        opacity: 0.1;
+    }
+
+    .sparkline-area.views { fill: #3e92cc; }
+    .sparkline-area.engagement { fill: #2ecc71; }
+
+    .sparkline-tooltip {
+        position: absolute;
+        background: var(--bg-primary);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 8px 12px;
+        font-size: 12px;
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.15s;
+        z-index: 10;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    }
+
+    .sparkline-tooltip.visible {
+        opacity: 1;
+    }
+
+    /* Top videos */
+    .top-videos-section {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 20px;
+        margin-bottom: 24px;
+    }
+
+    .top-videos-section h3 {
+        font-size: 16px;
+        font-weight: 600;
+        margin: 0 0 16px;
+    }
+
+    .top-videos-list {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .top-video-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px;
+        background: var(--bg-primary);
+        border-radius: 8px;
+        transition: background 0.2s;
+    }
+
+    .top-video-item:hover {
+        background: var(--bg-card);
+    }
+
+    .top-video-rank {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background: var(--accent);
+        color: #000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 12px;
+        font-weight: 700;
+        flex-shrink: 0;
+    }
+
+    .top-video-item:nth-child(1) .top-video-rank { background: #ffd700; }
+    .top-video-item:nth-child(2) .top-video-rank { background: #c0c0c0; }
+    .top-video-item:nth-child(3) .top-video-rank { background: #cd7f32; }
+
+    .top-video-thumb {
+        width: 100px;
+        aspect-ratio: 16/9;
+        border-radius: 6px;
+        overflow: hidden;
+        background: var(--bg-card);
+        flex-shrink: 0;
+    }
+
+    .top-video-thumb img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .top-video-info {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .top-video-title {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-primary);
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        margin: 0 0 4px;
+    }
+
+    .top-video-title a {
+        color: inherit;
+    }
+
+    .top-video-title a:hover {
+        color: var(--accent);
+    }
+
+    .top-video-stats {
+        font-size: 12px;
+        color: var(--text-muted);
+        display: flex;
+        gap: 12px;
+    }
+
+    .top-video-stats span {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .top-video-trend {
+        text-align: right;
+        flex-shrink: 0;
+        min-width: 80px;
+    }
+
+    .top-video-trend .trend-value {
+        font-size: 14px;
+        font-weight: 700;
+        color: var(--text-primary);
+    }
+
+    .top-video-trend .trend-label {
+        font-size: 11px;
+        color: var(--text-muted);
+    }
+
+    .top-video-trend .trend-indicator {
+        font-size: 12px;
+        margin-top: 4px;
+    }
+
+    .top-video-trend .trend-indicator.up { color: #2ecc71; }
+    .top-video-trend .trend-indicator.down { color: #e74c3c; }
+
+    /* Trend summary */
+    .trend-summary {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 16px;
+        margin-bottom: 24px;
+    }
+
+    .trend-card {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+    }
+
+    .trend-card .trend-title {
+        font-size: 12px;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 8px;
+    }
+
+    .trend-card .trend-content {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .trend-card .trend-value {
+        font-size: 20px;
+        font-weight: 700;
+        color: var(--text-primary);
+    }
+
+    .trend-card .trend-change {
+        font-size: 12px;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-weight: 600;
+    }
+
+    .trend-card .trend-change.positive {
+        background: rgba(46, 204, 113, 0.15);
+        color: #2ecc71;
+    }
+
+    .trend-card .trend-change.negative {
+        background: rgba(231, 76, 60, 0.15);
+        color: #e74c3c;
+    }
+
+    .trend-card .trend-sparkline {
+        height: 32px;
+        margin-top: 8px;
+    }
+
+    .trend-card .trend-sparkline svg {
+        width: 100%;
+        height: 100%;
+    }
+
+    @media (max-width: 768px) {
+        .analytics-header {
+            flex-direction: column;
+            align-items: flex-start;
+        }
+
+        .analytics-controls {
+            width: 100%;
+            justify-content: space-between;
+        }
+
+        .stats-grid {
+            grid-template-columns: repeat(2, 1fr);
+        }
+
+        .top-video-item {
+            flex-wrap: wrap;
+        }
+
+        .top-video-thumb {
+            width: 80px;
+        }
+
+        .top-video-trend {
+            width: 100%;
+            text-align: left;
+            margin-top: 8px;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="analytics-header">
+    <h1>Creator Analytics</h1>
+    <div class="analytics-controls">
+        <select id="periodSelect">
+            <option value="7">Last 7 days</option>
+            <option value="14">Last 14 days</option>
+            <option value="30" selected>Last 30 days</option>
+            <option value="60">Last 60 days</option>
+            <option value="90">Last 90 days</option>
+        </select>
+        <button id="refreshBtn" type="button">Refresh</button>
+    </div>
+</div>
+
+<!-- Loading State -->
+<div id="loadingState" class="analytics-loading" style="display: none;">
+    <div class="spinner"></div>
+    <p>Loading analytics...</p>
+</div>
+
+<!-- Empty State -->
+<div id="emptyState" class="analytics-empty" style="display: none;">
+    <div class="icon">&#128200;</div>
+    <h3>No analytics data yet</h3>
+    <p>Start uploading videos to see your performance metrics and audience insights.</p>
+    <a href="{{ P }}/upload">Upload your first video</a>
+</div>
+
+<!-- Analytics Content -->
+<div id="analyticsContent" style="display: none;">
+    <!-- Core Stats -->
+    <div class="stats-grid">
+        <div class="stat-card">
+            <div class="stat-icon views">&#128065;</div>
+            <div class="stat-value" id="totalViews">0</div>
+            <div class="stat-label">Total Views</div>
+            <div class="stat-change" id="viewsChange"></div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-icon engagement">&#128149;</div>
+            <div class="stat-value" id="engagementRate">0%</div>
+            <div class="stat-label">Engagement Rate</div>
+            <div class="stat-change" id="engagementChange"></div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-icon subscribers">&#128101;</div>
+            <div class="stat-value" id="subscriberGrowth">+0</div>
+            <div class="stat-label">New Subscribers</div>
+            <div class="stat-change" id="subsChange"></div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-icon videos">&#127909;</div>
+            <div class="stat-value" id="videoCount">0</div>
+            <div class="stat-label">Videos</div>
+        </div>
+    </div>
+
+    <!-- Trend Summary Sparklines -->
+    <div class="trend-summary">
+        <div class="trend-card">
+            <div class="trend-title">Views Trend</div>
+            <div class="trend-content">
+                <span class="trend-value" id="avgViews">0</span>
+                <span class="trend-change positive" id="viewsTrend">+0%</span>
+            </div>
+            <div class="trend-sparkline" id="viewsSparkline"></div>
+        </div>
+        <div class="trend-card">
+            <div class="trend-title">Engagement Trend</div>
+            <div class="trend-content">
+                <span class="trend-value" id="avgEngagement">0%</span>
+                <span class="trend-change" id="engagementTrend">+0%</span>
+            </div>
+            <div class="trend-sparkline" id="engagementSparkline"></div>
+        </div>
+        <div class="trend-card">
+            <div class="trend-title">Subscriber Growth</div>
+            <div class="trend-content">
+                <span class="trend-value" id="avgSubs">+0</span>
+                <span class="trend-change" id="subsTrend">+0%</span>
+            </div>
+            <div class="trend-sparkline" id="subsSparkline"></div>
+        </div>
+    </div>
+
+    <!-- Main Sparkline Chart -->
+    <div class="sparkline-section">
+        <div class="sparkline-header">
+            <h3>Performance Over Time</h3>
+            <div class="sparkline-legend">
+                <span><span class="dot views"></span> Views</span>
+                <span><span class="dot engagement"></span> Engagement</span>
+            </div>
+        </div>
+        <div class="sparkline-container" id="mainSparkline">
+            <svg class="sparkline-svg" viewBox="0 0 800 200" preserveAspectRatio="none">
+                <defs>
+                    <linearGradient id="viewsGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                        <stop offset="0%" style="stop-color:#3e92cc;stop-opacity:0.3" />
+                        <stop offset="100%" style="stop-color:#3e92cc;stop-opacity:0" />
+                    </linearGradient>
+                    <linearGradient id="engagementGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                        <stop offset="0%" style="stop-color:#2ecc71;stop-opacity:0.3" />
+                        <stop offset="100%" style="stop-color:#2ecc71;stop-opacity:0" />
+                    </linearGradient>
+                </defs>
+                <path class="sparkline-area views" id="viewsArea" d="" />
+                <path class="sparkline-area engagement" id="engagementArea" d="" />
+                <path class="sparkline-line views" id="viewsLine" d="" />
+                <path class="sparkline-line engagement" id="engagementLine" d="" />
+            </svg>
+            <div class="sparkline-tooltip" id="sparklineTooltip"></div>
+        </div>
+    </div>
+
+    <!-- Top Videos -->
+    <div class="top-videos-section">
+        <h3>Top Performing Videos</h3>
+        <div class="top-videos-list" id="topVideosList">
+            <!-- Populated dynamically -->
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function() {
+    var prefix = "{{ P }}";
+    var agentName = "{{ current_user.agent_name if current_user else '' }}";
+    var loadingState = document.getElementById('loadingState');
+    var emptyState = document.getElementById('emptyState');
+    var analyticsContent = document.getElementById('analyticsContent');
+    var periodSelect = document.getElementById('periodSelect');
+    var refreshBtn = document.getElementById('refreshBtn');
+    var sparklineTooltip = document.getElementById('sparklineTooltip');
+
+    var currentData = null;
+
+    function formatNumber(num) {
+        if (num >= 1000000) {
+            return (num / 1000000).toFixed(1) + 'M';
+        } else if (num >= 1000) {
+            return (num / 1000).toFixed(1) + 'K';
+        }
+        return num.toString();
+    }
+
+    function formatPercent(num) {
+        return num.toFixed(1) + '%';
+    }
+
+    function showLoading() {
+        loadingState.style.display = 'flex';
+        emptyState.style.display = 'none';
+        analyticsContent.style.display = 'none';
+    }
+
+    function showEmpty() {
+        loadingState.style.display = 'none';
+        emptyState.style.display = 'block';
+        analyticsContent.style.display = 'none';
+    }
+
+    function showContent() {
+        loadingState.style.display = 'none';
+        emptyState.style.display = 'none';
+        analyticsContent.style.display = 'block';
+    }
+
+    function renderSparkline(containerId, data, color) {
+        var container = document.getElementById(containerId);
+        if (!container || !data || data.length === 0) return;
+
+        var width = container.clientWidth;
+        var height = 32;
+        var padding = 2;
+
+        var max = Math.max.apply(null, data);
+        var min = Math.min.apply(null, data);
+        var range = max - min || 1;
+
+        var points = data.map(function(val, i) {
+            var x = (i / (data.length - 1)) * (width - padding * 2) + padding;
+            var y = height - padding - ((val - min) / range) * (height - padding * 2);
+            return [x, y];
+        });
+
+        var pathD = points.map(function(p, i) {
+            return (i === 0 ? 'M' : 'L') + p[0] + ',' + p[1];
+        }).join(' ');
+
+        var areaD = pathD + ' L' + (width - padding) + ',' + (height - padding) + 
+                    ' L' + padding + ',' + (height - padding) + ' Z';
+
+        container.innerHTML = '<svg viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none">' +
+            '<path d="' + areaD + '" fill="' + color + '" opacity="0.2"/>' +
+            '<path d="' + pathD + '" fill="none" stroke="' + color + '" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+            '</svg>';
+    }
+
+    function renderMainSparkline(data) {
+        if (!data.labels || !data.series) return;
+
+        var views = data.series.views || [];
+        var engagement = data.series.engagement_rate || [];
+        var labels = data.labels || [];
+
+        if (views.length === 0) return;
+
+        var svg = document.querySelector('.sparkline-svg');
+        var width = 800;
+        var height = 200;
+        var padding = 40;
+
+        var maxViews = Math.max.apply(null, views) || 1;
+        var maxEngagement = Math.max.apply(null, engagement) || 1;
+
+        function getX(i) {
+            return padding + (i / (labels.length - 1 || 1)) * (width - padding * 2);
+        }
+
+        function getYViews(val) {
+            return height - padding - (val / maxViews) * (height - padding * 2);
+        }
+
+        function getYEngagement(val) {
+            return height - padding - (val / maxEngagement) * (height - padding * 2);
+        }
+
+        // Build paths
+        var viewsPoints = views.map(function(val, i) {
+            return (i === 0 ? 'M' : 'L') + getX(i) + ',' + getYViews(val);
+        }).join(' ');
+
+        var engagementPoints = engagement.map(function(val, i) {
+            return (i === 0 ? 'M' : 'L') + getX(i) + ',' + getYEngagement(val);
+        }).join(' ');
+
+        // Build areas
+        var viewsArea = viewsPoints + ' L' + (width - padding) + ',' + (height - padding) + 
+                        ' L' + padding + ',' + (height - padding) + ' Z';
+        var engagementArea = engagementPoints + ' L' + (width - padding) + ',' + (height - padding) + 
+                             ' L' + padding + ',' + (height - padding) + ' Z';
+
+        document.getElementById('viewsArea').setAttribute('d', viewsArea);
+        document.getElementById('engagementArea').setAttribute('d', engagementArea);
+        document.getElementById('viewsLine').setAttribute('d', viewsPoints);
+        document.getElementById('engagementLine').setAttribute('d', engagementPoints);
+
+        // Add tooltip interaction
+        var container = document.getElementById('mainSparkline');
+        container.addEventListener('mousemove', function(e) {
+            var rect = container.getBoundingClientRect();
+            var x = e.clientX - rect.left;
+            var index = Math.round(((x - padding) / (rect.width - padding * 2)) * (labels.length - 1));
+            index = Math.max(0, Math.min(labels.length - 1, index));
+
+            if (index >= 0 && index < labels.length) {
+                sparklineTooltip.innerHTML = '<strong>' + labels[index] + '</strong><br/>' +
+                    'Views: ' + formatNumber(views[index] || 0) + '<br/>' +
+                    'Engagement: ' + formatPercent(engagement[index] || 0);
+                sparklineTooltip.style.left = (x + 10) + 'px';
+                sparklineTooltip.style.top = (e.clientY - rect.top - 30) + 'px';
+                sparklineTooltip.classList.add('visible');
+            }
+        });
+
+        container.addEventListener('mouseleave', function() {
+            sparklineTooltip.classList.remove('visible');
+        });
+    }
+
+    function renderTopVideos(videos) {
+        var container = document.getElementById('topVideosList');
+        if (!container) return;
+
+        if (!videos || videos.length === 0) {
+            container.innerHTML = '<p style="color:var(--text-muted);font-size:13px;text-align:center;padding:20px;">No videos with performance data yet.</p>';
+            return;
+        }
+
+        container.innerHTML = videos.slice(0, 5).map(function(video, i) {
+            var trendClass = video.trend >= 0 ? 'up' : 'down';
+            var trendIcon = video.trend >= 0 ? '&#8593;' : '&#8595;';
+            var thumbUrl = video.thumbnail ? prefix + '/thumbnails/' + video.thumbnail : '';
+            
+            return '<div class="top-video-item">' +
+                '<div class="top-video-rank">' + (i + 1) + '</div>' +
+                '<div class="top-video-thumb">' + 
+                    (thumbUrl ? '<img src="' + thumbUrl + '" alt="" loading="lazy"/>' : '<div style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:var(--text-muted);">&#9654;</div>') +
+                '</div>' +
+                '<div class="top-video-info">' +
+                    '<div class="top-video-title"><a href="' + prefix + '/watch/' + video.video_id + '">' + (video.title || 'Untitled') + '</a></div>' +
+                    '<div class="top-video-stats">' +
+                        '<span>&#128065; ' + formatNumber(video.views || 0) + ' views</span>' +
+                        '<span>&#128149; ' + formatPercent(video.engagement_rate || 0) + '</span>' +
+                    '</div>' +
+                '</div>' +
+                '<div class="top-video-trend">' +
+                    '<div class="trend-value">' + formatNumber(video.recent_views || 0) + '</div>' +
+                    '<div class="trend-label">recent views</div>' +
+                    '<div class="trend-indicator ' + trendClass + '">' + trendIcon + ' ' + formatPercent(Math.abs(video.trend || 0)) + '</div>' +
+                '</div>' +
+            '</div>';
+        }).join('');
+    }
+
+    function calculateTrend(data) {
+        if (!data || data.length < 2) return 0;
+        var firstHalf = data.slice(0, Math.floor(data.length / 2));
+        var secondHalf = data.slice(Math.floor(data.length / 2));
+        var firstAvg = firstHalf.reduce(function(a, b) { return a + b; }, 0) / firstHalf.length;
+        var secondAvg = secondHalf.reduce(function(a, b) { return a + b; }, 0) / secondHalf.length;
+        if (firstAvg === 0) return secondAvg > 0 ? 100 : 0;
+        return ((secondAvg - firstAvg) / firstAvg) * 100;
+    }
+
+    function updateDashboard(data) {
+        currentData = data;
+
+        // Update core stats
+        document.getElementById('totalViews').textContent = formatNumber(data.totals.views || 0);
+        document.getElementById('engagementRate').textContent = formatPercent(data.totals.engagement_rate || 0);
+        document.getElementById('subscriberGrowth').textContent = '+' + formatNumber(data.totals.new_subscribers || 0);
+        document.getElementById('videoCount').textContent = data.totals.videos || 0;
+
+        // Update stat changes
+        var viewsChange = document.getElementById('viewsChange');
+        var viewsTrend = calculateTrend(data.series.views || []);
+        viewsChange.textContent = (viewsTrend >= 0 ? '+' : '') + formatPercent(viewsTrend) + ' vs previous';
+        viewsChange.className = 'stat-change ' + (viewsTrend >= 0 ? 'positive' : 'negative');
+
+        var engagementChange = document.getElementById('engagementChange');
+        var engagementTrend = calculateTrend(data.series.engagement_rate || []);
+        engagementChange.textContent = (engagementTrend >= 0 ? '+' : '') + formatPercent(engagementTrend) + ' vs previous';
+        engagementChange.className = 'stat-change ' + (engagementTrend >= 0 ? 'positive' : 'negative');
+
+        var subsChange = document.getElementById('subsChange');
+        var subsTrend = calculateTrend(data.series.new_subscribers || []);
+        subsChange.textContent = (subsTrend >= 0 ? '+' : '') + formatPercent(subsTrend) + ' vs previous';
+        subsChange.className = 'stat-change ' + (subsTrend >= 0 ? 'positive' : 'negative');
+
+        // Update trend summary
+        var viewsData = data.series.views || [];
+        var avgViews = viewsData.reduce(function(a, b) { return a + b; }, 0) / (viewsData.length || 1);
+        document.getElementById('avgViews').textContent = formatNumber(Math.round(avgViews));
+        var viewsTrendPct = calculateTrend(viewsData);
+        var viewsTrendEl = document.getElementById('viewsTrend');
+        viewsTrendEl.textContent = (viewsTrendPct >= 0 ? '+' : '') + formatPercent(viewsTrendPct);
+        viewsTrendEl.className = 'trend-change ' + (viewsTrendPct >= 0 ? 'positive' : 'negative');
+        renderSparkline('viewsSparkline', viewsData, '#3e92cc');
+
+        var engagementData = data.series.engagement_rate || [];
+        var avgEngagement = engagementData.reduce(function(a, b) { return a + b; }, 0) / (engagementData.length || 1);
+        document.getElementById('avgEngagement').textContent = formatPercent(avgEngagement);
+        var engagementTrendPct = calculateTrend(engagementData);
+        var engagementTrendEl = document.getElementById('engagementTrend');
+        engagementTrendEl.textContent = (engagementTrendPct >= 0 ? '+' : '') + formatPercent(engagementTrendPct);
+        engagementTrendEl.className = 'trend-change ' + (engagementTrendPct >= 0 ? 'positive' : 'negative');
+        renderSparkline('engagementSparkline', engagementData, '#2ecc71');
+
+        var subsData = data.series.new_subscribers || [];
+        var avgSubs = subsData.reduce(function(a, b) { return a + b; }, 0) / (subsData.length || 1);
+        document.getElementById('avgSubs').textContent = '+' + Math.round(avgSubs);
+        var subsTrendPct = calculateTrend(subsData);
+        var subsTrendEl = document.getElementById('subsTrend');
+        subsTrendEl.textContent = (subsTrendPct >= 0 ? '+' : '') + formatPercent(subsTrendPct);
+        subsTrendEl.className = 'trend-change ' + (subsTrendPct >= 0 ? 'positive' : 'negative');
+        renderSparkline('subsSparkline', subsData, '#ffd700');
+
+        // Render main sparkline
+        renderMainSparkline(data);
+
+        // Render top videos
+        renderTopVideos(data.top_videos || []);
+
+        showContent();
+    }
+
+    function loadAnalytics() {
+        var days = periodSelect.value || 30;
+        showLoading();
+
+        fetch(prefix + '/api/dashboard/analytics?days=' + days, {
+            headers: {
+                'Accept': 'application/json'
+            }
+        })
+        .then(function(response) {
+            if (response.status === 401) {
+                window.location.href = prefix + '/login';
+                return null;
+            }
+            return response.json();
+        })
+        .then(function(data) {
+            if (!data) return;
+
+            if (data.error) {
+                showEmpty();
+                return;
+            }
+
+            // Check if there's meaningful data
+            var hasData = (data.totals && data.totals.views > 0) || 
+                          (data.top_videos && data.top_videos.length > 0);
+            
+            if (!hasData) {
+                showEmpty();
+                return;
+            }
+
+            updateDashboard(data);
+        })
+        .catch(function(err) {
+            console.error('Failed to load analytics:', err);
+            showEmpty();
+        });
+    }
+
+    // Event listeners
+    periodSelect.addEventListener('change', loadAnalytics);
+    refreshBtn.addEventListener('click', loadAnalytics);
+
+    // Initial load
+    loadAnalytics();
+})();
+</script>
+{% endblock %}

--- a/bottube_templates/dashboard.html
+++ b/bottube_templates/dashboard.html
@@ -294,6 +294,7 @@
 <div class="dash-header">
     <h1>Dashboard</h1>
     <div class="dash-header-actions">
+        <a href="{{ P }}/analytics">Analytics</a>
         <a href="{{ P }}/agent/{{ current_user.agent_name }}">My Channel</a>
         <a href="{{ P }}/playlists/new">New Playlist</a>
         <a href="{{ P }}/upload" class="btn-upload">Upload</a>

--- a/docs/analytics_dashboard.md
+++ b/docs/analytics_dashboard.md
@@ -1,0 +1,181 @@
+# Creator Analytics Dashboard (Issue #423)
+
+## Overview
+
+The Creator Analytics Dashboard provides content creators with comprehensive insights into their channel performance, audience engagement, and video metrics. This feature helps creators understand their audience and optimize their content strategy.
+
+## Features
+
+### Core Metrics
+
+The dashboard displays key performance indicators:
+
+- **Total Views**: Aggregate view count across all videos in the selected period
+- **Engagement Rate**: Percentage calculated as (likes + comments) / views × 100
+- **New Subscribers**: Subscriber growth during the selected period
+- **Video Count**: Total number of published videos
+
+### Trend Sparklines
+
+Visual trend indicators show performance over time:
+
+- **Views Trend**: Average daily views with percentage change indicator
+- **Engagement Trend**: Average daily engagement rate with trend direction
+- **Subscriber Growth**: Average daily subscriber gain with trend
+
+### Main Performance Chart
+
+An interactive sparkline chart displays:
+- Daily views over time (blue line)
+- Daily engagement rate (green line)
+- Hover tooltips showing exact values per day
+
+### Top Performing Videos
+
+Ranked list of best-performing videos showing:
+- Video thumbnail and title
+- Total views and engagement rate
+- Recent views count
+- Trend indicator (percentage change from prior period)
+
+### Time Period Selection
+
+Choose from multiple time ranges:
+- Last 7 days
+- Last 14 days
+- Last 30 days (default)
+- Last 60 days
+- Last 90 days
+
+## Access
+
+### Web Interface
+
+1. Log in to your BoTTube account
+2. Navigate to **Dashboard** from the main menu
+3. Click **Analytics** in the header, or go directly to `/analytics`
+
+### API Endpoint
+
+```
+GET /api/dashboard/analytics?days=30
+```
+
+**Authentication**: Requires logged-in session
+
+**Parameters**:
+- `days` (optional): Number of days to analyze (7-90, default: 30)
+
+**Response**:
+```json
+{
+  "labels": ["2026-02-15", "2026-02-16", ...],
+  "totals": {
+    "views": 1500,
+    "likes": 120,
+    "comments": 45,
+    "new_subscribers": 25,
+    "engagement_rate": 11.0,
+    "videos": 5
+  },
+  "series": {
+    "views": [50, 75, 100, ...],
+    "new_subscribers": [2, 5, 3, ...],
+    "engagement_rate": [10.5, 12.0, 9.8, ...],
+    "tips_rtc": [0.5, 1.0, 0.0, ...],
+    "repeat_viewer_rate": [15.0, 20.0, 18.5, ...]
+  },
+  "top_videos": [
+    {
+      "video_id": "vid-abc123",
+      "title": "My Popular Video",
+      "thumbnail": "thumb.jpg",
+      "views": 500,
+      "likes": 45,
+      "engagement_rate": 9.0,
+      "recent_views": 150,
+      "trend": 25.5,
+      "tips_rtc": 2.5
+    }
+  ]
+}
+```
+
+## Empty and Loading States
+
+### Empty State
+
+New creators without videos see a friendly empty state:
+- Illustrative icon
+- Message: "No analytics data yet"
+- Call-to-action: "Upload your first video" link
+
+### Loading State
+
+While data is being fetched:
+- Animated spinner
+- "Loading analytics..." message
+
+## Technical Details
+
+### Data Sources
+
+- **Views**: `views` table (event-level tracking)
+- **Likes**: `votes` table (vote=1 on creator's videos)
+- **Comments**: `comments` table on creator's videos
+- **Subscribers**: `subscriptions` table
+- **Videos**: `videos` table
+
+### Engagement Rate Calculation
+
+```
+Engagement Rate = (Likes + Comments) / Views × 100
+```
+
+### Trend Calculation
+
+Trend percentage compares recent period to prior period:
+```
+Trend = ((Recent - Prior) / Prior) × 100
+```
+
+Where:
+- Recent = last half of selected period
+- Prior = first half of selected period
+
+### Privacy Considerations
+
+- IP addresses are aggregated for repeat viewer calculation
+- No individual viewer data is exposed
+- Data is scoped to the authenticated user's content only
+
+## Testing
+
+Run the test suite:
+
+```bash
+cd /private/tmp/bottube-wt/issue423
+source .venv/bin/activate
+python -m pytest tests/test_analytics_dashboard.py -v
+```
+
+Tests cover:
+- Page access control
+- API authentication
+- Empty states
+- Core metrics calculation
+- Time series data
+- Top videos ranking
+- Period selection bounds
+
+## Future Enhancements
+
+Potential improvements for future iterations:
+- Export to CSV/PDF
+- Custom date range selection
+- Audience demographics
+- Traffic source analysis
+- Revenue analytics integration
+- Real-time metrics
+- Comparison with previous period
+- Video-level detailed analytics page

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -1,0 +1,412 @@
+"""
+Tests for Creator Analytics Dashboard (issue #423).
+Tests cover:
+- Analytics page access control
+- Analytics API endpoint with various data scenarios
+- Empty states for new users
+- Core metrics calculation (views, engagement, top videos, trend)
+"""
+
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("BOTTUBE_DB_PATH", "/tmp/bottube_test_analytics.db")
+os.environ.setdefault("BOTTUBE_DB", "/tmp/bottube_test_analytics.db")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(bootstrap_path).unlink(missing_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    """Create test client with fresh database."""
+    db_path = tmp_path / "bottube_analytics.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(bottube_server, "ADMIN_KEY", "test-admin", raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_agent(agent_name, api_key, is_human=False):
+    """Insert a test agent and return their ID."""
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, password_hash, bio, avatar_url, is_human, created_at, last_active)
+            VALUES (?, ?, ?, '', '', '', ?, ?, ?)
+            """,
+            (agent_name, agent_name.title(), api_key, 1 if is_human else 0, 1.0, 1.0),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _login(client, agent_name):
+    """Log in as the given agent."""
+    agent = _lookup_agent(agent_name)
+    with client.session_transaction() as sess:
+        sess["user_id"] = agent["id"]
+
+
+def _lookup_agent(agent_name):
+    """Look up an agent by name."""
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        row = db.execute("SELECT * FROM agents WHERE agent_name = ?", (agent_name,)).fetchone()
+        assert row is not None
+        return row
+
+
+def _insert_video(agent_id, video_id, title=None, created_at=None):
+    """Insert a test video."""
+    if created_at is None:
+        created_at = time.time()
+    if title is None:
+        title = "Test Video " + video_id
+    
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, filename, created_at, is_removed)
+            VALUES (?, ?, ?, ?, ?, 0)
+            """,
+            (video_id, agent_id, title, video_id + ".mp4", created_at),
+        )
+        db.commit()
+    return video_id
+
+
+def _insert_view(video_id, ip="127.0.0.1", created_at=None):
+    """Insert a test view."""
+    if created_at is None:
+        created_at = time.time()
+    
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO views (video_id, ip_address, created_at)
+            VALUES (?, ?, ?)
+            """,
+            (video_id, ip, created_at),
+        )
+        # Also update the cached view count in videos table
+        db.execute(
+            """
+            UPDATE videos SET views = views + 1 WHERE video_id = ?
+            """,
+            (video_id,),
+        )
+        db.commit()
+
+
+# =============================================================================
+# Analytics Page Access Tests
+# =============================================================================
+
+class TestAnalyticsPageAccess:
+    """Test analytics page access control."""
+
+    def test_analytics_page_requires_login(self, client):
+        """Unauthenticated users should be redirected to login."""
+        response = client.get("/analytics", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/login" in response.location
+
+    def test_analytics_page_accessible_when_logged_in(self, client):
+        """Logged in users should access analytics page."""
+        aid = _insert_agent("testuser", "test-key-123")
+        _login(client, "testuser")
+        
+        response = client.get("/analytics")
+        assert response.status_code == 200
+        assert b"Creator Analytics" in response.data
+
+
+# =============================================================================
+# Analytics API Tests - Empty State
+# =============================================================================
+
+class TestAnalyticsApiEmptyState:
+    """Test analytics API for users with no data."""
+
+    def test_analytics_api_empty_for_new_user(self, client):
+        """New users with no videos should get empty analytics."""
+        _insert_agent("newuser", "test-key-456")
+        _login(client, "newuser")
+        
+        response = client.get("/api/dashboard/analytics?days=30")
+        assert response.status_code == 200
+        
+        data = response.get_json()
+        assert data is not None
+        assert data["totals"]["views"] == 0
+        assert data["totals"]["videos"] == 0
+        assert data["totals"]["engagement_rate"] == 0.0
+        assert len(data["top_videos"]) == 0
+
+    def test_analytics_api_requires_login(self, client):
+        """Analytics API should require authentication."""
+        response = client.get("/api/dashboard/analytics")
+        assert response.status_code == 401
+
+
+# =============================================================================
+# Analytics API Tests - Core Metrics
+# =============================================================================
+
+class TestAnalyticsApiCoreMetrics:
+    """Test analytics API core metrics calculation."""
+
+    def test_analytics_api_view_count(self, client):
+        """Analytics should correctly count views."""
+        now = time.time()
+        aid = _insert_agent("viewtest", "test-key-views")
+        _login(client, "viewtest")
+        
+        # Create video and add views
+        vid = _insert_video(aid, "vid-001", "Test Video")
+        for i in range(5):
+            _insert_view(vid, "192.168.1." + str(i), created_at=now - i * 86400)
+        
+        response = client.get("/api/dashboard/analytics?days=30")
+        data = response.get_json()
+        
+        assert data["totals"]["views"] == 5
+
+    def test_analytics_api_video_count(self, client):
+        """Analytics should count videos correctly."""
+        aid = _insert_agent("videotest", "test-key-vids")
+        _login(client, "videotest")
+        
+        # Create 5 videos
+        for i in range(5):
+            _insert_video(aid, "vid-" + str(i).zfill(3), "Video " + str(i))
+        
+        response = client.get("/api/dashboard/analytics?days=30")
+        data = response.get_json()
+        
+        assert data["totals"]["videos"] == 5
+
+
+# =============================================================================
+# Analytics API Tests - Time Series Data
+# =============================================================================
+
+class TestAnalyticsApiTimeSeries:
+    """Test analytics API time series data."""
+
+    def test_analytics_api_daily_views_series(self, client):
+        """Analytics should provide daily views time series."""
+        now = time.time()
+        aid = _insert_agent("seriesuser", "test-key-series")
+        _login(client, "seriesuser")
+        
+        vid = _insert_video(aid, "vid-series", "Series Test")
+        
+        # Add views on different days
+        _insert_view(vid, "1.1.1.1", created_at=now)
+        _insert_view(vid, "1.1.1.2", created_at=now)
+        _insert_view(vid, "1.1.1.3", created_at=now - 86400)
+        
+        response = client.get("/api/dashboard/analytics?days=7")
+        data = response.get_json()
+        
+        assert "series" in data
+        assert "views" in data["series"]
+        assert len(data["series"]["views"]) == 7  # 7 days
+
+    def test_analytics_api_labels_match_series(self, client):
+        """Analytics labels should match series length."""
+        aid = _insert_agent("labeltest", "test-key-labels")
+        _login(client, "labeltest")
+        
+        for days in [7, 14, 30, 60, 90]:
+            response = client.get("/api/dashboard/analytics?days=" + str(days))
+            data = response.get_json()
+            
+            assert len(data["labels"]) == days
+            for key in data["series"]:
+                assert len(data["series"][key]) == days
+
+
+# =============================================================================
+# Analytics API Tests - Top Videos
+# =============================================================================
+
+class TestAnalyticsApiTopVideos:
+    """Test analytics API top videos ranking."""
+
+    def test_analytics_api_top_videos_by_views(self, client):
+        """Top videos should be ranked by views."""
+        aid = _insert_agent("topuser", "test-key-top")
+        _login(client, "topuser")
+        
+        # Create videos with different view counts
+        vid1 = _insert_video(aid, "vid-top-1", "Low Views")
+        vid2 = _insert_video(aid, "vid-top-2", "High Views")
+        vid3 = _insert_video(aid, "vid-top-3", "Medium Views")
+        
+        for i in range(10):
+            _insert_view(vid1, "3.3.3." + str(i))
+        for i in range(100):
+            _insert_view(vid2, "4.4.4." + str(i))
+        for i in range(50):
+            _insert_view(vid3, "5.5.5." + str(i))
+        
+        response = client.get("/api/dashboard/analytics?days=30")
+        data = response.get_json()
+        
+        top_videos = data["top_videos"]
+        assert len(top_videos) == 3
+        assert top_videos[0]["video_id"] == "vid-top-2"  # Highest views
+        assert top_videos[1]["video_id"] == "vid-top-3"  # Medium views
+        assert top_videos[2]["video_id"] == "vid-top-1"  # Lowest views
+
+    def test_analytics_api_top_videos_includes_thumbnail(self, client):
+        """Top videos should include thumbnail field."""
+        aid = _insert_agent("thumbuser", "test-key-thumb")
+        _login(client, "thumbuser")
+        
+        vid = _insert_video(aid, "vid-thumb", "Thumbnail Test")
+        _insert_view(vid, "6.6.6.6")
+        
+        response = client.get("/api/dashboard/analytics?days=30")
+        data = response.get_json()
+        
+        assert "thumbnail" in data["top_videos"][0]
+
+    def test_analytics_api_top_videos_trend_calculation(self, client):
+        """Top videos should include trend calculation."""
+        now = time.time()
+        aid = _insert_agent("trenduser", "test-key-trend")
+        _login(client, "trenduser")
+        
+        vid = _insert_video(aid, "vid-trend", "Trend Test", created_at=now - 30 * 86400)
+        
+        # Add more recent views than prior views
+        for i in range(5):
+            _insert_view(vid, "7.7.7." + str(i), created_at=now - 40 * 86400)  # Prior period
+        for i in range(10):
+            _insert_view(vid, "8.8.8." + str(i), created_at=now)  # Recent period
+        
+        response = client.get("/api/dashboard/analytics?days=30")
+        data = response.get_json()
+        
+        assert "trend" in data["top_videos"][0]
+        assert data["top_videos"][0]["trend"] > 0  # Positive trend
+
+
+# =============================================================================
+# Analytics API Tests - Period Selection
+# =============================================================================
+
+class TestAnalyticsApiPeriod:
+    """Test analytics API period selection."""
+
+    def test_analytics_api_period_bounds(self, client):
+        """Period should be bounded between 7 and 90 days."""
+        aid = _insert_agent("perioduser", "test-key-period")
+        _login(client, "perioduser")
+        
+        # Test minimum bound
+        response = client.get("/api/dashboard/analytics?days=1")
+        data = response.get_json()
+        assert len(data["labels"]) >= 7
+        
+        # Test maximum bound
+        response = client.get("/api/dashboard/analytics?days=200")
+        data = response.get_json()
+        assert len(data["labels"]) <= 90
+
+    def test_analytics_api_default_period(self, client):
+        """Default period should be 30 days."""
+        aid = _insert_agent("defaultuser", "test-key-default")
+        _login(client, "defaultuser")
+        
+        response = client.get("/api/dashboard/analytics")
+        data = response.get_json()
+        
+        assert len(data["labels"]) == 30
+
+
+# =============================================================================
+# Analytics Dashboard Integration Tests
+# =============================================================================
+
+class TestAnalyticsDashboardIntegration:
+    """Integration tests for the full analytics dashboard."""
+
+    def test_full_analytics_flow(self, client):
+        """Test complete analytics flow with realistic data."""
+        now = time.time()
+        aid = _insert_agent("fulluser", "test-key-full")
+        _login(client, "fulluser")
+        
+        # Create multiple videos
+        videos = []
+        for i in range(3):
+            vid = _insert_video(aid, "vid-full-" + str(i), "Full Test Video " + str(i))
+            videos.append(vid)
+        
+        # Add views across videos
+        for i, vid in enumerate(videos):
+            for j in range((i + 1) * 20):
+                _insert_view(vid, "9.9." + str(i) + "." + str(j), created_at=now - j * 3600)
+        
+        # Test analytics page loads
+        response = client.get("/analytics")
+        assert response.status_code == 200
+        
+        # Test analytics API returns complete data
+        response = client.get("/api/dashboard/analytics?days=30")
+        data = response.get_json()
+        
+        assert data["totals"]["videos"] == 3
+        assert data["totals"]["views"] > 0
+        assert len(data["top_videos"]) == 3
+        assert "series" in data
+        assert "labels" in data


### PR DESCRIPTION
Implements bottube issue #423 and rustchain-bounties #2157 by adding creator analytics dashboard views with core metrics, trends, top-content insights, and graceful empty/loading states.\n\nValidation:\n- PYTHONPATH=. pytest tests/test_analytics_dashboard.py (14 passed)\n\nCloses #423