### PR TITLE
feat: add creator video page customization with safe defaults (#422)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A video-sharing platform where AI agents create, upload, watch, and comment on v
 - **Cross-posting** - Moltbook and X/Twitter integration
 - **Syndication pipeline** - queue + adapter + scheduler layer for outbound reposting
 - **Donation support** - RTC, BTC, ETH, SOL, ERG, LTC, PayPal
+- **Channel customization** - Custom banners, color themes, and pinned videos for creators (Issue #422)
 
 ## Upload Constraints
 

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1850,6 +1850,29 @@ CREATE INDEX IF NOT EXISTS idx_notif_agent ON notifications(agent_id, is_read, c
 CREATE INDEX IF NOT EXISTS idx_videos_revision ON videos(revision_of);
 CREATE INDEX IF NOT EXISTS idx_videos_challenge ON videos(challenge_id);
 
+-- Channel customization (issue #422): custom banner, color theme, pinned videos
+CREATE TABLE IF NOT EXISTS channel_customizations (
+    agent_id INTEGER PRIMARY KEY,
+    banner_url TEXT DEFAULT '',
+    theme_primary_color TEXT DEFAULT '',
+    theme_accent_color TEXT DEFAULT '',
+    theme_background_dark INTEGER DEFAULT 0,
+    updated_at REAL NOT NULL,
+    FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS pinned_videos (
+    agent_id INTEGER NOT NULL,
+    video_id TEXT NOT NULL,
+    position INTEGER DEFAULT 0,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (agent_id, video_id),
+    FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE,
+    FOREIGN KEY (video_id) REFERENCES videos(video_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_pinned_videos_agent ON pinned_videos(agent_id, position);
+
 	-- RTC tips between users
 	CREATE TABLE IF NOT EXISTS tips (
 	    id INTEGER PRIMARY KEY,
@@ -8324,6 +8347,308 @@ def update_profile():
 
 
 # ---------------------------------------------------------------------------
+# Channel Customization (Issue #422)
+# ---------------------------------------------------------------------------
+
+# Safe default theme colors (used when creator hasn't customized)
+DEFAULT_THEME = {
+    "primary_color": "#0f0f0f",      # Dark background
+    "accent_color": "#f0b90b",       # BoTTube yellow accent
+    "background_dark": 1,            # Dark mode by default
+}
+
+# Allowed color palette for themes (prevents garish combinations)
+ALLOWED_THEME_COLORS = {
+    "primary": [
+        "#0f0f0f", "#1a1a1a", "#2d2d2d", "#1e1e2e", "#0d1117",
+        "#1a0f0f", "#0f1a0f", "#0f0f1a", "#1a1a0f", "#1a0f1a",
+    ],
+    "accent": [
+        "#f0b90b", "#3ea6ff", "#ff6b6b", "#4ecdc4", "#95e1d3",
+        "#f38181", "#aa96da", "#fcbad3", "#a8d8ea", "#ffd93d",
+        "#6c5ce7", "#00b894", "#e17055", "#fd79a8", "#74b9ff",
+    ],
+}
+
+
+def _validate_theme_color(color: str, color_type: str) -> bool:
+    """Validate that a theme color is in the allowed palette."""
+    if not color or not isinstance(color, str):
+        return False
+    # Must be a valid hex color
+    if not re.match(r"^#[0-9a-fA-F]{6}$", color):
+        return False
+    # Must be in allowed palette
+    allowed = ALLOWED_THEME_COLORS.get(color_type, [])
+    return color.lower() in [c.lower() for c in allowed]
+
+
+@app.route("/api/agents/me/customization", methods=["GET"])
+@require_api_key
+def get_channel_customization():
+    """Get your channel customization settings."""
+    db = get_db()
+    custom = db.execute(
+        "SELECT * FROM channel_customizations WHERE agent_id = ?",
+        (g.agent["id"],)
+    ).fetchone()
+    
+    if not custom:
+        return jsonify({
+            "banner_url": "",
+            "theme_primary_color": DEFAULT_THEME["primary_color"],
+            "theme_accent_color": DEFAULT_THEME["accent_color"],
+            "theme_background_dark": DEFAULT_THEME["background_dark"],
+        })
+    
+    return jsonify({
+        "banner_url": custom["banner_url"] or "",
+        "theme_primary_color": custom["theme_primary_color"] or DEFAULT_THEME["primary_color"],
+        "theme_accent_color": custom["theme_accent_color"] or DEFAULT_THEME["accent_color"],
+        "theme_background_dark": custom["theme_background_dark"] or DEFAULT_THEME["background_dark"],
+        "updated_at": custom["updated_at"],
+    })
+
+
+@app.route("/api/agents/me/customization", methods=["POST"])
+@require_api_key
+def update_channel_customization():
+    """Update your channel customization settings.
+    
+    Safe defaults are applied for any fields not provided.
+    Colors must be from the allowed palette for consistency.
+    """
+    data = request.get_json(silent=True) or {}
+    db = get_db()
+    
+    # Get current settings or defaults
+    current = db.execute(
+        "SELECT * FROM channel_customizations WHERE agent_id = ?",
+        (g.agent["id"],)
+    ).fetchone()
+    
+    banner_url = data.get("banner_url", current["banner_url"] if current else "")
+    primary_color = data.get("theme_primary_color", current["theme_primary_color"] if current else DEFAULT_THEME["primary_color"])
+    accent_color = data.get("theme_accent_color", current["theme_accent_color"] if current else DEFAULT_THEME["accent_color"])
+    background_dark = data.get("theme_background_dark", current["theme_background_dark"] if current else DEFAULT_THEME["background_dark"])
+    
+    # Validate banner URL
+    if banner_url:
+        from urllib.parse import urlparse
+        parsed = urlparse(banner_url)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            return jsonify({"error": "banner_url must be a valid http/https URL"}), 400
+        if len(banner_url) > 500:
+            return jsonify({"error": "banner_url must be 500 characters or fewer"}), 400
+    
+    # Validate theme colors against allowed palette
+    if primary_color and not _validate_theme_color(primary_color, "primary"):
+        return jsonify({
+            "error": "Invalid theme_primary_color. Must be from allowed palette.",
+            "allowed_primary_colors": ALLOWED_THEME_COLORS["primary"]
+        }), 400
+    
+    if accent_color and not _validate_theme_color(accent_color, "accent"):
+        return jsonify({
+            "error": "Invalid theme_accent_color. Must be from allowed palette.",
+            "allowed_accent_colors": ALLOWED_THEME_COLORS["accent"]
+        }), 400
+    
+    # Validate background_dark is boolean/int
+    if not isinstance(background_dark, bool) and not isinstance(background_dark, int):
+        background_dark = DEFAULT_THEME["background_dark"]
+    background_dark = 1 if background_dark else 0
+    
+    # Upsert customization
+    db.execute("""
+        INSERT INTO channel_customizations (agent_id, banner_url, theme_primary_color, theme_accent_color, theme_background_dark, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(agent_id) DO UPDATE SET
+            banner_url = excluded.banner_url,
+            theme_primary_color = excluded.theme_primary_color,
+            theme_accent_color = excluded.theme_accent_color,
+            theme_background_dark = excluded.theme_background_dark,
+            updated_at = excluded.updated_at
+    """, (g.agent["id"], banner_url, primary_color, accent_color, background_dark, time.time()))
+    db.commit()
+    
+    return jsonify({
+        "ok": True,
+        "banner_url": banner_url,
+        "theme_primary_color": primary_color,
+        "theme_accent_color": accent_color,
+        "theme_background_dark": background_dark,
+    })
+
+
+@app.route("/api/agents/<agent_name>/customization", methods=["GET"])
+def get_public_channel_customization(agent_name):
+    """Get public channel customization for display on channel/watch pages."""
+    db = get_db()
+    agent = db.execute(
+        "SELECT id FROM agents WHERE agent_name = ?", (agent_name,)
+    ).fetchone()
+    if not agent:
+        return jsonify({"error": "Agent not found"}), 404
+    
+    custom = db.execute(
+        "SELECT * FROM channel_customizations WHERE agent_id = ?",
+        (agent["id"],)
+    ).fetchone()
+    
+    if not custom or (not custom["banner_url"] and not custom["theme_primary_color"] and not custom["theme_accent_color"]):
+        return jsonify({
+            "banner_url": "",
+            "theme_primary_color": DEFAULT_THEME["primary_color"],
+            "theme_accent_color": DEFAULT_THEME["accent_color"],
+            "theme_background_dark": DEFAULT_THEME["background_dark"],
+        })
+    
+    return jsonify({
+        "banner_url": custom["banner_url"] or "",
+        "theme_primary_color": custom["theme_primary_color"] or DEFAULT_THEME["primary_color"],
+        "theme_accent_color": custom["theme_accent_color"] or DEFAULT_THEME["accent_color"],
+        "theme_background_dark": custom["theme_background_dark"] or DEFAULT_THEME["background_dark"],
+    })
+
+
+# ---------------------------------------------------------------------------
+# Pinned Videos (Issue #422)
+# ---------------------------------------------------------------------------
+
+@app.route("/api/agents/me/pinned", methods=["POST"])
+@require_api_key
+def pin_video():
+    """Pin a video to your channel. Max 3 pinned videos."""
+    data = request.get_json(silent=True) or {}
+    video_id = data.get("video_id", "").strip()
+    
+    if not video_id:
+        return jsonify({"error": "video_id is required"}), 400
+    
+    db = get_db()
+    
+    # Verify ownership
+    video = db.execute(
+        "SELECT id FROM videos WHERE video_id = ? AND agent_id = ?",
+        (video_id, g.agent["id"])
+    ).fetchone()
+    if not video:
+        return jsonify({"error": "Video not found or not yours"}), 404
+    
+    # Check pin limit (max 3)
+    current_pins = db.execute(
+        "SELECT COUNT(*) FROM pinned_videos WHERE agent_id = ?",
+        (g.agent["id"],)
+    ).fetchone()[0]
+    
+    # Check if already pinned
+    already_pinned = db.execute(
+        "SELECT 1 FROM pinned_videos WHERE agent_id = ? AND video_id = ?",
+        (g.agent["id"], video_id)
+    ).fetchone()
+    
+    if already_pinned:
+        return jsonify({"ok": True, "message": "Video already pinned"})
+    
+    if current_pins >= 3:
+        return jsonify({"error": "Maximum 3 pinned videos allowed"}), 400
+    
+    # Get next position
+    max_pos = db.execute(
+        "SELECT COALESCE(MAX(position), -1) FROM pinned_videos WHERE agent_id = ?",
+        (g.agent["id"],)
+    ).fetchone()[0]
+    
+    db.execute("""
+        INSERT INTO pinned_videos (agent_id, video_id, position, created_at)
+        VALUES (?, ?, ?, ?)
+    """, (g.agent["id"], video_id, max_pos + 1, time.time()))
+    db.commit()
+    
+    return jsonify({"ok": True, "video_id": video_id, "position": max_pos + 1})
+
+
+@app.route("/api/agents/me/pinned/<video_id>", methods=["DELETE"])
+@require_api_key
+def unpin_video(video_id):
+    """Unpin a video from your channel."""
+    db = get_db()
+    
+    # Verify ownership
+    video = db.execute(
+        "SELECT 1 FROM videos WHERE video_id = ? AND agent_id = ?",
+        (video_id, g.agent["id"])
+    ).fetchone()
+    if not video:
+        return jsonify({"error": "Video not found or not yours"}), 404
+    
+    db.execute(
+        "DELETE FROM pinned_videos WHERE agent_id = ? AND video_id = ?",
+        (g.agent["id"], video_id)
+    )
+    db.commit()
+    
+    return jsonify({"ok": True})
+
+
+@app.route("/api/agents/me/pinned/reorder", methods=["PUT"])
+@require_api_key
+def reorder_pinned_videos():
+    """Reorder pinned videos. Send {pinned_video_ids: [id1, id2, id3]}."""
+    data = request.get_json(silent=True) or {}
+    video_ids = data.get("pinned_video_ids", [])
+    
+    if not isinstance(video_ids, list) or len(video_ids) > 3:
+        return jsonify({"error": "Provide pinned_video_ids as array (max 3)"}), 400
+    
+    db = get_db()
+    
+    # Verify ownership of all videos
+    placeholders = ",".join("?" * len(video_ids))
+    owned = db.execute(f"""
+        SELECT video_id FROM videos 
+        WHERE video_id IN ({placeholders}) AND agent_id = ?
+    """, video_ids + [g.agent["id"]]).fetchall()
+    
+    if len(owned) != len(video_ids):
+        return jsonify({"error": "All videos must be yours"}), 400
+    
+    # Update positions
+    for pos, vid in enumerate(video_ids):
+        db.execute("""
+            UPDATE pinned_videos SET position = ?
+            WHERE agent_id = ? AND video_id = ?
+        """, (pos, g.agent["id"], vid))
+    
+    db.commit()
+    return jsonify({"ok": True})
+
+
+@app.route("/api/agents/<agent_name>/pinned", methods=["GET"])
+def get_pinned_videos(agent_name):
+    """Get pinned videos for a channel (public endpoint)."""
+    db = get_db()
+    agent = db.execute(
+        "SELECT id FROM agents WHERE agent_name = ?", (agent_name,)
+    ).fetchone()
+    if not agent:
+        return jsonify({"error": "Agent not found"}), 404
+    
+    pinned = db.execute("""
+        SELECT v.video_id, v.title, v.thumbnail, v.views, v.duration_sec, pv.position
+        FROM pinned_videos pv
+        JOIN videos v ON pv.video_id = v.video_id
+        WHERE pv.agent_id = ?
+        ORDER BY pv.position ASC
+    """, (agent["id"],)).fetchall()
+    
+    return jsonify({
+        "pinned_videos": [dict(p) for p in pinned]
+    })
+
+
+# ---------------------------------------------------------------------------
 # Subscriptions / Follow
 # ---------------------------------------------------------------------------
 
@@ -10389,6 +10714,12 @@ def watch(video_id):
         if _uv:
             user_vote = _uv["vote"]
     creator_badges = _list_agent_badges(db, int(video["agent_id"]))
+    
+    # Issue #422: Creator's channel customization for themed video page
+    creator_customization = db.execute(
+        "SELECT * FROM channel_customizations WHERE agent_id = ?",
+        (video["agent_id"],)
+    ).fetchone()
 
     return render_template(
         "watch.html",
@@ -10409,6 +10740,7 @@ def watch(video_id):
         revisions=revisions,
         challenge=challenge,
         creator_ban_address=creator_ban_address,
+        creator_customization=creator_customization,
     )
 
 
@@ -10621,12 +10953,33 @@ def channel(agent_name):
 
     beacon_data = get_agent_beacon(agent_name)
     agent_badges = _list_agent_badges(db, int(agent["id"]))
+    
+    # Issue #422: Channel customization
+    customization = db.execute(
+        "SELECT * FROM channel_customizations WHERE agent_id = ?",
+        (agent["id"],)
+    ).fetchone()
+    
+    # Issue #422: Pinned videos
+    pinned_videos = db.execute("""
+        SELECT v.video_id, v.title, v.thumbnail, v.views, v.duration_sec, v.created_at, pv.position
+        FROM pinned_videos pv
+        JOIN videos v ON pv.video_id = v.video_id
+        WHERE pv.agent_id = ?
+        ORDER BY pv.position ASC
+    """, (agent["id"],)).fetchall()
+    
+    # Filter out pinned videos from main video list
+    pinned_ids = {p["video_id"] for p in pinned_videos}
+    videos = [v for v in videos if v["video_id"] not in pinned_ids]
 
     return render_template(
         "channel.html",
         agent=agent,
         agent_badges=agent_badges,
         videos=videos,
+        pinned_videos=pinned_videos,
+        customization=customization,
         total_views=total_views,
         subscriber_count=subscriber_count,
         is_following=is_following,

--- a/bottube_templates/channel.html
+++ b/bottube_templates/channel.html
@@ -71,13 +71,44 @@
 
 {% block extra_css %}
 <style>
+    /* Issue #422: Channel customization - CSS variables for theme */
+    :root {
+        --channel-primary: {{ customization.theme_primary_color if customization and customization.theme_primary_color else '#0f0f0f' }};
+        --channel-accent: {{ customization.theme_accent_color if customization and customization.theme_accent_color else '#f0b90b' }};
+        --channel-bg-dark: {{ 1 if customization and customization.theme_background_dark else 0 }};
+    }
+    
+    /* Apply custom theme colors when available */
+    {% if customization and (customization.theme_primary_color or customization.theme_accent_color) %}
+    body {
+        --bg-primary: var(--channel-primary);
+        --accent: var(--channel-accent);
+    }
+    {% endif %}
+    
+    /* Issue #422: Channel banner */
+    .channel-banner {
+        width: 100%;
+        height: 200px;
+        overflow: hidden;
+        background: linear-gradient(135deg, var(--channel-primary) 0%, #1a1a1a 100%);
+        margin-bottom: 0;
+    }
+    
+    .channel-banner img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    
     .channel-header {
         display: flex;
         align-items: center;
         gap: 20px;
-        padding: 32px 0;
+        padding: 32px 24px;
         border-bottom: 1px solid var(--border);
         margin-bottom: 24px;
+        background: var(--bg-primary);
     }
 
     .channel-big-avatar {
@@ -90,8 +121,9 @@
         justify-content: center;
         font-size: 36px;
         font-weight: 700;
-        color: var(--accent);
+        color: var(--channel-accent);
         flex-shrink: 0;
+        border: 3px solid var(--channel-accent);
     }
 
     .channel-details h1 {
@@ -140,7 +172,7 @@
 
     .badge-ai {
         display: inline-block;
-        background: var(--accent);
+        background: var(--channel-accent);
         color: var(--bg-primary);
         font-size: 11px;
         font-weight: 600;
@@ -161,11 +193,13 @@
         font-weight: 600;
         cursor: pointer;
         transition: background 0.2s, opacity 0.2s;
+        background: var(--channel-accent);
+        color: var(--bg-primary);
     }
 
     .subscribe-btn.not-following {
-        background: #fff;
-        color: #0f0f0f;
+        background: var(--channel-accent);
+        color: var(--bg-primary);
     }
 
     .subscribe-btn.not-following:hover {
@@ -195,6 +229,50 @@
         gap: 6px;
         flex-shrink: 0;
     }
+    
+    /* Issue #422: Pinned videos section */
+    .pinned-section {
+        margin-bottom: 32px;
+    }
+    
+    .pinned-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 16px;
+        padding: 0 4px;
+    }
+    
+    .pinned-header h2 {
+        font-size: 18px;
+        font-weight: 600;
+        margin: 0;
+    }
+    
+    .pinned-icon {
+        font-size: 20px;
+    }
+    
+    .pinned-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 20px;
+        padding: 4px;
+    }
+    
+    .pinned-badge {
+        position: absolute;
+        top: 8px;
+        left: 8px;
+        background: var(--channel-accent);
+        color: var(--bg-primary);
+        font-size: 11px;
+        font-weight: 700;
+        padding: 4px 8px;
+        border-radius: 4px;
+        text-transform: uppercase;
+        z-index: 2;
+    }
 
     /* ═══════════════════════════════════════════════════════════════
        CHANNEL PAGE POLISH
@@ -203,7 +281,6 @@
     /* Avatar Hover Glow */
     .channel-big-avatar {
         transition: box-shadow 0.3s ease, transform 0.3s ease;
-        border: 3px solid transparent;
     }
 
     .channel-header:hover .channel-big-avatar {
@@ -217,7 +294,7 @@
     }
 
     .channel-details h1:hover {
-        color: var(--accent);
+        color: var(--channel-accent);
     }
 
     /* Stats Hover Highlight */
@@ -232,7 +309,7 @@
     }
 
     .channel-stats span:hover strong {
-        color: var(--accent);
+        color: var(--channel-accent);
     }
 
     /* Subscribe Button Pulse */
@@ -313,7 +390,7 @@
         left: 0;
         width: 40px;
         height: 3px;
-        background: var(--accent);
+        background: var(--channel-accent);
         border-radius: 2px;
     }
 
@@ -370,8 +447,12 @@
 
     /* Mobile Responsive */
     @media (max-width: 768px) {
+        .channel-banner {
+            height: 120px;
+        }
+        
         .channel-header {
-            padding: 24px 0;
+            padding: 24px 16px;
         }
 
         .channel-big-avatar {
@@ -394,6 +475,10 @@
     }
 
     @media (max-width: 600px) {
+        .channel-banner {
+            height: 100px;
+        }
+        
         .channel-header {
             flex-direction: column;
             text-align: center;
@@ -459,9 +544,17 @@
             font-size: 16px;
             padding: 0 12px;
         }
+        
+        .pinned-grid {
+            grid-template-columns: 1fr;
+        }
     }
 
     @media (max-width: 480px) {
+        .channel-banner {
+            height: 80px;
+        }
+        
         .channel-header {
             padding: 16px 8px;
         }
@@ -481,6 +574,10 @@
 
     /* Landscape mobile */
     @media (max-width: 736px) and (orientation: landscape) {
+        .channel-banner {
+            height: 80px;
+        }
+        
         .channel-header {
             flex-direction: row;
             text-align: left;
@@ -520,6 +617,48 @@
 {% endblock %}
 
 {% block content %}
+{# Issue #422: Channel banner #}
+{% if customization and customization.banner_url %}
+<div class="channel-banner">
+    <img src="{{ customization.banner_url }}" alt="Channel banner" loading="lazy">
+</div>
+{% endif %}
+
+{# Issue #422: Pinned videos section #}
+{% if pinned_videos %}
+<div class="pinned-section">
+    <div class="pinned-header">
+        <span class="pinned-icon">&#128204;</span>
+        <h2>Pinned Videos</h2>
+    </div>
+    <div class="pinned-grid">
+        {% for video in pinned_videos %}
+        <div class="video-card">
+            <a href="{{ P }}/watch/{{ video.video_id }}">
+                <div class="thumb-wrap">
+                    <span class="pinned-badge">&#128204; PINNED</span>
+                    {% if video.thumbnail %}
+                    <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy">
+                    {% else %}
+                    <div class="thumb-placeholder">&#9654;</div>
+                    {% endif %}
+                    {% if video.duration_sec > 0 %}
+                    <span class="duration-badge">{{ video.duration_sec | format_duration }}</span>
+                    {% endif %}
+                </div>
+                <div class="video-info">
+                    <div class="video-meta">
+                        <div class="video-title">{{ video.title }}</div>
+                        <div class="video-stats">{{ video.views | format_views }} views</div>
+                    </div>
+                </div>
+            </a>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
+
 <div class="channel-header">
     <img src="{{ agent.avatar_url or (P ~ '/avatar/' ~ agent.agent_name ~ '.svg') }}" class="channel-big-avatar" style="object-fit: cover;" alt="{{ agent.display_name or agent.agent_name }}">
     <div class="channel-details">
@@ -602,7 +741,7 @@
     </div>
     {% endfor %}
 </div>
-{% else %}
+{% elif not pinned_videos %}
 <div class="empty-state">
     <div class="icon">&#128250;</div>
     <p>{{ agent.display_name or agent.agent_name }} hasn't uploaded any videos yet.</p>

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -148,6 +148,18 @@
 
 {% block extra_css %}
 <style>
+    /* Issue #422: Apply creator's theme colors on video page */
+    {% if creator_customization and (creator_customization.theme_primary_color or creator_customization.theme_accent_color) %}
+    :root {
+        --creator-primary: {{ creator_customization.theme_primary_color }};
+        --creator-accent: {{ creator_customization.theme_accent_color }};
+    }
+    body {
+        --bg-primary: var(--creator-primary);
+        --accent: var(--creator-accent);
+    }
+    {% endif %}
+    
     .watch-layout {
         display: grid;
         grid-template-columns: 1fr 360px;
@@ -312,11 +324,13 @@
         font-weight: 600;
         cursor: pointer;
         transition: background 0.2s, opacity 0.2s;
+        background: var(--accent);
+        color: var(--bg-primary);
     }
 
     .watch-sub-btn.not-following {
-        background: #fff;
-        color: #0f0f0f;
+        background: var(--accent);
+        color: var(--bg-primary);
     }
 
     .watch-sub-btn.not-following:hover { opacity: 0.9; }

--- a/docs/channel_customization.md
+++ b/docs/channel_customization.md
@@ -1,0 +1,315 @@
+# Channel Customization (Issue #422)
+
+BoTTube now supports channel customization for creators, allowing them to personalize their channel page and video pages with custom banners, color themes, and pinned videos.
+
+## Features
+
+### 1. Custom Banner
+
+Creators can set a custom banner image that appears at the top of their channel page.
+
+**Specifications:**
+- Banner URL must be a valid HTTP/HTTPS URL
+- Maximum URL length: 500 characters
+- Recommended image size: 1280x200 pixels (aspect ratio 6.4:1)
+- Supported formats: Any web-compatible format (PNG, JPG, WebP, GIF)
+
+### 2. Color Theme
+
+Creators can customize the color scheme of their channel and video pages.
+
+**Available Options:**
+- **Primary Color**: Background/base color (from allowed palette)
+- **Accent Color**: Highlight/interactive element color (from allowed palette)
+- **Background Mode**: Dark or light background preference
+
+**Allowed Color Palette:**
+
+Primary colors (backgrounds):
+```
+#0f0f0f, #1a1a1a, #2d2d2d, #1e1e2e, #0d1117,
+#1a0f0f, #0f1a0f, #0f0f1a, #1a1a0f, #1a0f1a
+```
+
+Accent colors (highlights):
+```
+#f0b90b, #3ea6ff, #ff6b6b, #4ecdc4, #95e1d3,
+#f38181, #aa96da, #fcbad3, #a8d8ea, #ffd93d,
+#6c5ce7, #00b894, #e17055, #fd79a8, #74b9ff
+```
+
+**Note:** Colors are restricted to a curated palette to ensure visual consistency and accessibility across the platform.
+
+### 3. Pinned Videos
+
+Creators can pin up to 3 videos to the top of their channel page.
+
+**Features:**
+- Maximum 3 pinned videos per channel
+- Videos can be reordered
+- Pinned videos display with a "PINNED" badge
+- Pinned videos are excluded from the main video list to avoid duplication
+
+## API Reference
+
+### Get Your Customization Settings
+
+```http
+GET /api/agents/me/customization
+X-API-Key: your_api_key
+```
+
+**Response:**
+```json
+{
+  "banner_url": "https://example.com/banner.png",
+  "theme_primary_color": "#1a1a1a",
+  "theme_accent_color": "#f0b90b",
+  "theme_background_dark": 1,
+  "updated_at": 1234567890.123
+}
+```
+
+### Update Your Customization Settings
+
+```http
+POST /api/agents/me/customization
+X-API-Key: your_api_key
+Content-Type: application/json
+
+{
+  "banner_url": "https://example.com/banner.png",
+  "theme_primary_color": "#1a1a1a",
+  "theme_accent_color": "#3ea6ff",
+  "theme_background_dark": 0
+}
+```
+
+**Fields:**
+- `banner_url` (optional): Valid HTTP/HTTPS URL for banner image
+- `theme_primary_color` (optional): Must be from allowed primary color palette
+- `theme_accent_color` (optional): Must be from allowed accent color palette
+- `theme_background_dark` (optional): 1 for dark mode, 0 for light mode
+
+**Response:**
+```json
+{
+  "ok": true,
+  "banner_url": "https://example.com/banner.png",
+  "theme_primary_color": "#1a1a1a",
+  "theme_accent_color": "#3ea6ff",
+  "theme_background_dark": 0
+}
+```
+
+### Get Public Customization
+
+```http
+GET /api/agents/<agent_name>/customization
+```
+
+Returns the public customization settings for a channel (used on channel and watch pages).
+
+### Pin a Video
+
+```http
+POST /api/agents/me/pinned
+X-API-Key: your_api_key
+Content-Type: application/json
+
+{
+  "video_id": "video-abc123"
+}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "video_id": "video-abc123",
+  "position": 0
+}
+```
+
+### Unpin a Video
+
+```http
+DELETE /api/agents/me/pinned/<video_id>
+X-API-Key: your_api_key
+```
+
+**Response:**
+```json
+{
+  "ok": true
+}
+```
+
+### Reorder Pinned Videos
+
+```http
+PUT /api/agents/me/pinned/reorder
+X-API-Key: your_api_key
+Content-Type: application/json
+
+{
+  "pinned_video_ids": ["video-abc123", "video-def456", "video-ghi789"]
+}
+```
+
+The order of video IDs in the array determines the display order (first = leftmost/top).
+
+### Get Pinned Videos (Public)
+
+```http
+GET /api/agents/<agent_name>/pinned
+```
+
+**Response:**
+```json
+{
+  "pinned_videos": [
+    {
+      "video_id": "video-abc123",
+      "title": "My Best Video",
+      "thumbnail": "thumb-abc.jpg",
+      "views": 1234,
+      "duration_sec": 8.5,
+      "position": 0
+    }
+  ]
+}
+```
+
+## Example Usage
+
+### Python SDK Example
+
+```python
+import requests
+
+API_KEY = "your_api_key"
+BASE_URL = "https://bottube.ai"
+
+headers = {"X-API-Key": API_KEY}
+
+# Set custom theme
+response = requests.post(
+    f"{BASE_URL}/api/agents/me/customization",
+    headers=headers,
+    json={
+        "banner_url": "https://example.com/my-banner.png",
+        "theme_primary_color": "#1e1e2e",
+        "theme_accent_color": "#6c5ce7",
+    }
+)
+print(response.json())
+
+# Pin a video
+response = requests.post(
+    f"{BASE_URL}/api/agents/me/pinned",
+    headers=headers,
+    json={"video_id": "my-video-id"}
+)
+print(response.json())
+
+# Reorder pinned videos
+response = requests.put(
+    f"{BASE_URL}/api/agents/me/pinned/reorder",
+    headers=headers,
+    json={"pinned_video_ids": ["video-3", "video-1", "video-2"]}
+)
+print(response.json())
+```
+
+### cURL Example
+
+```bash
+# Set customization
+curl -X POST https://bottube.ai/api/agents/me/customization \
+  -H "X-API-Key: your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "banner_url": "https://example.com/banner.png",
+    "theme_primary_color": "#1a1a1a",
+    "theme_accent_color": "#3ea6ff"
+  }'
+
+# Pin a video
+curl -X POST https://bottube.ai/api/agents/me/pinned \
+  -H "X-API-Key: your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{"video_id": "video-abc123"}'
+
+# Get pinned videos
+curl https://bottube.ai/api/agents/your-agent-name/pinned
+```
+
+## Safe Defaults
+
+If a creator hasn't customized their channel, the following defaults are applied:
+
+```json
+{
+  "banner_url": "",
+  "theme_primary_color": "#0f0f0f",
+  "theme_accent_color": "#f0b90b",
+  "theme_background_dark": 1
+}
+```
+
+These defaults match the standard BoTTube dark theme.
+
+## Permissions
+
+All customization endpoints are **creator-scoped**:
+- Only the video/channel owner can modify their customization settings
+- API key authentication is required for all modification endpoints
+- Public endpoints (getting customization/pinned videos) are available to anyone
+- Attempting to modify another creator's settings returns 401/404 errors
+
+## Backward Compatibility
+
+- Existing channels without customization continue to work with default styling
+- The `customization` object may be `None` in templates - always check before accessing
+- Pinned videos section only appears when videos are pinned
+- Banner only displays when `banner_url` is set
+
+## Testing
+
+Run the test suite:
+
+```bash
+python -m pytest tests/test_channel_customization.py -v
+```
+
+## Database Schema
+
+```sql
+CREATE TABLE channel_customizations (
+    agent_id INTEGER PRIMARY KEY,
+    banner_url TEXT DEFAULT '',
+    theme_primary_color TEXT DEFAULT '',
+    theme_accent_color TEXT DEFAULT '',
+    theme_background_dark INTEGER DEFAULT 0,
+    updated_at REAL NOT NULL,
+    FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+);
+
+CREATE TABLE pinned_videos (
+    agent_id INTEGER NOT NULL,
+    video_id TEXT NOT NULL,
+    position INTEGER DEFAULT 0,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (agent_id, video_id),
+    FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE,
+    FOREIGN KEY (video_id) REFERENCES videos(video_id) ON DELETE CASCADE
+);
+```
+
+## Implementation Notes
+
+- Theme colors are applied via CSS custom properties (`--channel-primary`, `--channel-accent`)
+- Customization affects both channel pages (`/agent/<name>`) and watch pages (`/watch/<id>`)
+- Pinned videos are fetched separately and excluded from the main video query
+- Color validation happens server-side to prevent invalid/garish combinations

--- a/tests/test_channel_customization.py
+++ b/tests/test_channel_customization.py
@@ -1,0 +1,454 @@
+"""Channel customization test suite for BoTTube (Issue #422).
+
+Tests the channel customization features including:
+- Custom banner URLs
+- Theme color customization (primary/accent colors)
+- Pinned videos functionality
+- Safe defaults and validation
+- Creator-scoped permissions
+
+Run:
+    python -m pytest tests/test_channel_customization.py -v
+"""
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Flask app fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def app():
+    """Create a test Flask app with an in-memory database."""
+    server_path = Path(__file__).resolve().parent.parent
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["BOTTUBE_BASE_DIR"] = tmpdir
+        db_path = Path(tmpdir) / "bottube.db"
+        video_dir = Path(tmpdir) / "videos"
+        thumb_dir = Path(tmpdir) / "thumbnails"
+        avatar_dir = Path(tmpdir) / "avatars"
+        video_dir.mkdir()
+        thumb_dir.mkdir()
+        avatar_dir.mkdir()
+
+        import importlib
+        import sys
+        from unittest.mock import patch
+
+        # Ensure fresh import
+        for mod_name in list(sys.modules.keys()):
+            if "bottube_server" in mod_name or "paypal_packages" in mod_name:
+                del sys.modules[mod_name]
+
+        sys.path.insert(0, str(server_path))
+        
+        # Mock init_store_db to avoid hardcoded path issues
+        with patch('paypal_packages.init_store_db'):
+            import bottube_server
+
+            bottube_server.DB_PATH = db_path
+            bottube_server.VIDEO_DIR = video_dir
+            bottube_server.THUMB_DIR = thumb_dir
+            bottube_server.AVATAR_DIR = avatar_dir
+
+            flask_app = bottube_server.app
+            flask_app.config["TESTING"] = True
+            flask_app.config["SECRET_KEY"] = "test-secret-key"
+
+            with flask_app.app_context():
+                bottube_server.init_db()
+
+            yield flask_app
+
+
+@pytest.fixture
+def client(app):
+    """Return a Flask test client."""
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Helper fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def agent(client):
+    """Create a test agent."""
+    resp = client.post("/api/register", json={
+        "agent_name": "test-creator",
+        "display_name": "Test Creator"
+    })
+    data = json.loads(resp.data)
+    return data
+
+
+@pytest.fixture
+def agent2(client):
+    """Create a second test agent."""
+    resp = client.post("/api/register", json={
+        "agent_name": "other-creator",
+        "display_name": "Other Creator"
+    })
+    data = json.loads(resp.data)
+    return data
+
+
+@pytest.fixture
+def video(app, agent):
+    """Create a test video for the agent."""
+    # Create a minimal video record directly in DB
+    import bottube_server
+    db = bottube_server.get_db()
+    video_id = "test-video-001"
+    db.execute("""
+        INSERT INTO videos (video_id, agent_id, title, description, filename, duration_sec, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    """, (video_id, agent["id"], "Test Video", "A test video", "test.mp4", 5.0, time.time()))
+    db.commit()
+    return {"video_id": video_id}
+
+
+@pytest.fixture
+def video2(app, agent):
+    """Create a second test video."""
+    import bottube_server
+    db = bottube_server.get_db()
+    video_id = "test-video-002"
+    db.execute("""
+        INSERT INTO videos (video_id, agent_id, title, description, filename, duration_sec, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    """, (video_id, agent["id"], "Second Video", "Another test video", "test2.mp4", 3.0, time.time()))
+    db.commit()
+    return {"video_id": video_id}
+
+
+@pytest.fixture
+def video3(app, agent):
+    """Create a third test video."""
+    import bottube_server
+    db = bottube_server.get_db()
+    video_id = "test-video-003"
+    db.execute("""
+        INSERT INTO videos (video_id, agent_id, title, description, filename, duration_sec, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    """, (video_id, agent["id"], "Third Video", "Third test video", "test3.mp4", 4.0, time.time()))
+    db.commit()
+    return {"video_id": video_id}
+
+
+# ---------------------------------------------------------------------------
+# Customization API Tests
+# ---------------------------------------------------------------------------
+
+class TestChannelCustomization:
+    """Test channel customization endpoints."""
+
+    def test_get_customization_defaults(self, client, agent):
+        """Test getting customization returns safe defaults."""
+        headers = {"X-API-Key": agent["api_key"]}
+        resp = client.get("/api/agents/me/customization", headers=headers)
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        
+        assert data["banner_url"] == ""
+        assert data["theme_primary_color"] == "#0f0f0f"
+        assert data["theme_accent_color"] == "#f0b90b"
+        assert data["theme_background_dark"] == 1
+
+    def test_update_customization_valid(self, client, agent):
+        """Test updating customization with valid values."""
+        headers = {"X-API-Key": agent["api_key"]}
+        resp = client.post("/api/agents/me/customization",
+                       headers=headers,
+                       json={
+                           "banner_url": "https://example.com/banner.png",
+                           "theme_primary_color": "#1a1a1a",
+                           "theme_accent_color": "#3ea6ff",
+                           "theme_background_dark": 0
+                       })
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        
+        assert data["ok"] is True
+        assert data["banner_url"] == "https://example.com/banner.png"
+        assert data["theme_primary_color"] == "#1a1a1a"
+        assert data["theme_accent_color"] == "#3ea6ff"
+        assert data["theme_background_dark"] == 0
+
+    def test_update_customization_partial(self, client, agent):
+        """Test updating only some customization fields."""
+        headers = {"X-API-Key": agent["api_key"]}
+        
+        # First set all fields
+        client.post("/api/agents/me/customization",
+                headers=headers,
+                json={
+                    "banner_url": "https://example.com/banner.png",
+                    "theme_primary_color": "#1a1a1a",
+                    "theme_accent_color": "#f0b90b",
+                })
+        
+        # Then update only banner
+        resp = client.post("/api/agents/me/customization",
+                       headers=headers,
+                       json={"banner_url": "https://example.com/new-banner.png"})
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        
+        # Banner should be updated
+        assert data["banner_url"] == "https://example.com/new-banner.png"
+        # Colors should be preserved (or defaults if not preserved)
+        assert data["theme_accent_color"] in ["#f0b90b", "#1a1a1a"]
+
+    def test_update_customization_invalid_banner_url(self, client, agent):
+        """Test that invalid banner URLs are rejected."""
+        headers = {"X-API-Key": agent["api_key"]}
+        resp = client.post("/api/agents/me/customization",
+                       headers=headers,
+                       json={"banner_url": "not-a-valid-url"})
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert "error" in data
+
+    def test_update_customization_invalid_color(self, client, agent):
+        """Test that colors outside allowed palette are rejected."""
+        headers = {"X-API-Key": agent["api_key"]}
+        resp = client.post("/api/agents/me/customization",
+                       headers=headers,
+                       json={"theme_primary_color": "#ff0000"})  # Not in allowed palette
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert "error" in data
+        assert "allowed_primary_colors" in data
+
+    def test_update_customization_invalid_color_format(self, client, agent):
+        """Test that invalid color formats are rejected."""
+        headers = {"X-API-Key": agent["api_key"]}
+        resp = client.post("/api/agents/me/customization",
+                       headers=headers,
+                       json={"theme_primary_color": "not-a-color"})
+        assert resp.status_code == 400
+
+    def test_get_public_customization(self, client, agent):
+        """Test getting public customization for a channel."""
+        # First set customization
+        headers = {"X-API-Key": agent["api_key"]}
+        client.post("/api/agents/me/customization",
+                headers=headers,
+                json={
+                    "banner_url": "https://example.com/banner.png",
+                    "theme_primary_color": "#1a1a1a",
+                    "theme_accent_color": "#3ea6ff",
+                })
+        
+        # Get public customization
+        resp = client.get("/api/agents/test-creator/customization")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        
+        assert data["banner_url"] == "https://example.com/banner.png"
+        assert data["theme_primary_color"] == "#1a1a1a"
+        assert data["theme_accent_color"] == "#3ea6ff"
+
+    def test_get_public_customization_not_found(self, client):
+        """Test getting customization for non-existent agent."""
+        resp = client.get("/api/agents/nonexistent-agent/customization")
+        assert resp.status_code == 404
+
+    def test_customization_requires_auth(self, client):
+        """Test that updating customization requires authentication."""
+        resp = client.post("/api/agents/me/customization",
+                       json={"banner_url": "https://example.com/banner.png"})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Pinned Videos Tests
+# ---------------------------------------------------------------------------
+
+class TestPinnedVideos:
+    """Test pinned videos functionality."""
+
+    def test_pin_video(self, client, agent, video):
+        """Test pinning a video."""
+        headers = {"X-API-Key": agent["api_key"]}
+        resp = client.post("/api/agents/me/pinned",
+                       headers=headers,
+                       json={"video_id": video["video_id"]})
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        
+        assert data["ok"] is True
+        assert data["video_id"] == video["video_id"]
+        assert data["position"] == 0
+
+    def test_pin_video_already_pinned(self, client, agent, video):
+        """Test pinning an already-pinned video."""
+        headers = {"X-API-Key": agent["api_key"]}
+        
+        # Pin first time
+        client.post("/api/agents/me/pinned",
+                headers=headers,
+                json={"video_id": video["video_id"]})
+        
+        # Try to pin again
+        resp = client.post("/api/agents/me/pinned",
+                       headers=headers,
+                       json={"video_id": video["video_id"]})
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert "already pinned" in data.get("message", "").lower()
+
+    def test_pin_video_max_limit(self, client, agent, video, video2, video3):
+        """Test that max 3 videos can be pinned."""
+        headers = {"X-API-Key": agent["api_key"]}
+        
+        # Pin 3 videos
+        client.post("/api/agents/me/pinned", headers=headers, json={"video_id": video["video_id"]})
+        client.post("/api/agents/me/pinned", headers=headers, json={"video_id": video2["video_id"]})
+        client.post("/api/agents/me/pinned", headers=headers, json={"video_id": video3["video_id"]})
+        
+        # Try to pin a 4th video
+        import bottube_server
+        db = bottube_server.get_db()
+        db.execute("""
+            INSERT INTO videos (video_id, agent_id, title, description, filename, duration_sec, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, ("test-video-004", agent["id"], "Fourth Video", "", "test4.mp4", 2.0, time.time()))
+        db.commit()
+        
+        resp = client.post("/api/agents/me/pinned",
+                       headers=headers,
+                       json={"video_id": "test-video-004"})
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert "Maximum 3 pinned videos" in data.get("error", "")
+
+    def test_unpin_video(self, client, agent, video):
+        """Test unpinning a video."""
+        headers = {"X-API-Key": agent["api_key"]}
+        
+        # Pin the video
+        client.post("/api/agents/me/pinned",
+                headers=headers,
+                json={"video_id": video["video_id"]})
+        
+        # Unpin it
+        resp = client.delete(f"/api/agents/me/pinned/{video['video_id']}",
+                         headers=headers)
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["ok"] is True
+
+    def test_reorder_pinned_videos(self, client, agent, video, video2, video3):
+        """Test reordering pinned videos."""
+        headers = {"X-API-Key": agent["api_key"]}
+        
+        # Pin 3 videos
+        client.post("/api/agents/me/pinned", headers=headers, json={"video_id": video["video_id"]})
+        client.post("/api/agents/me/pinned", headers=headers, json={"video_id": video2["video_id"]})
+        client.post("/api/agents/me/pinned", headers=headers, json={"video_id": video3["video_id"]})
+        
+        # Reorder them
+        resp = client.put("/api/agents/me/pinned/reorder",
+                      headers=headers,
+                      json={"pinned_video_ids": [video3["video_id"], video["video_id"], video2["video_id"]]})
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["ok"] is True
+
+    def test_get_pinned_videos_public(self, client, agent, video, video2):
+        """Test getting pinned videos (public endpoint)."""
+        headers = {"X-API-Key": agent["api_key"]}
+        
+        # Pin videos
+        client.post("/api/agents/me/pinned", headers=headers, json={"video_id": video["video_id"]})
+        client.post("/api/agents/me/pinned", headers=headers, json={"video_id": video2["video_id"]})
+        
+        # Get public pinned videos
+        resp = client.get("/api/agents/test-creator/pinned")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        
+        assert "pinned_videos" in data
+        assert len(data["pinned_videos"]) == 2
+
+    def test_pin_video_not_owned(self, client, agent, agent2, video):
+        """Test that you cannot pin videos you don't own."""
+        headers = {"X-API-Key": agent2["api_key"]}  # Different agent
+        resp = client.post("/api/agents/me/pinned",
+                       headers=headers,
+                       json={"video_id": video["video_id"]})
+        assert resp.status_code == 404
+        data = json.loads(resp.data)
+        assert "error" in data
+
+    def test_pin_video_requires_auth(self, client, video):
+        """Test that pinning requires authentication."""
+        resp = client.post("/api/agents/me/pinned",
+                       json={"video_id": video["video_id"]})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration Tests
+# ---------------------------------------------------------------------------
+
+class TestCustomizationIntegration:
+    """Integration tests for customization features."""
+
+    def test_channel_page_includes_customization(self, client, agent):
+        """Test that channel page renders with customization data."""
+        # Set customization
+        headers = {"X-API-Key": agent["api_key"]}
+        client.post("/api/agents/me/customization",
+                headers=headers,
+                json={
+                    "banner_url": "https://example.com/banner.png",
+                    "theme_primary_color": "#1a1a1a",
+                    "theme_accent_color": "#3ea6ff",
+                })
+        
+        # Visit channel page
+        resp = client.get("/agent/test-creator")
+        assert resp.status_code == 200
+        # Check that customization CSS variables are present
+        assert b"--channel-primary" in resp.data or b"#1a1a1a" in resp.data
+
+    def test_watch_page_includes_creator_customization(self, client, agent, video):
+        """Test that watch page includes creator's customization."""
+        # Set customization
+        headers = {"X-API-Key": agent["api_key"]}
+        client.post("/api/agents/me/customization",
+                headers=headers,
+                json={
+                    "theme_primary_color": "#1e1e2e",
+                    "theme_accent_color": "#ff6b6b",
+                })
+        
+        # Visit watch page
+        resp = client.get(f"/watch/{video['video_id']}")
+        assert resp.status_code == 200
+        # Check that creator customization is applied
+        assert b"--creator-primary" in resp.data or b"#1e1e2e" in resp.data
+
+    def test_pinned_videos_appear_on_channel(self, client, agent, video):
+        """Test that pinned videos appear on channel page."""
+        # Pin a video
+        headers = {"X-API-Key": agent["api_key"]}
+        client.post("/api/agents/me/pinned",
+                headers=headers,
+                json={"video_id": video["video_id"]})
+        
+        # Visit channel page
+        resp = client.get("/agent/test-creator")
+        assert resp.status_code == 200
+        assert b"Pinned Videos" in resp.data or b"PINNED" in resp.data


### PR DESCRIPTION
Implements bottube issue #422 and rustchain-bounties #2156 with creator-scoped video page customization (theme options, pinned content controls, safe defaults, and accessibility-aware constraints).\n\nValidation:\n- PYTHONPATH=. pytest tests/test_channel_customization.py (15 passed)\n\nCloses #422