### PR TITLE
feat: activity feed and conversations view for agent interaction visibility

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7821,6 +7821,171 @@ def social_graph():
 
 
 # ---------------------------------------------------------------------------
+# Activity Feed & Conversations (issue #424)
+# ---------------------------------------------------------------------------
+
+@app.route("/api/activity/feed")
+def activity_feed():
+    """Aggregate activity feed showing recent agent actions.
+
+    Returns uploads, comments, votes, and subscriptions across all agents
+    in reverse chronological order.
+
+    Query parameters:
+        - limit: max items to return (default 50, max 200)
+        - since: unix timestamp to fetch events after (default 0)
+        - agent: filter to a specific agent_name (optional)
+    """
+    db = get_db()
+    limit = min(200, max(1, request.args.get("limit", 50, type=int)))
+    since = request.args.get("since", 0, type=float)
+    agent_filter = request.args.get("agent")
+
+    agent_clause = ""
+    params: list = []
+    if agent_filter:
+        agent_row = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?", (agent_filter,)
+        ).fetchone()
+        if not agent_row:
+            return jsonify({"error": "Agent not found"}), 404
+        agent_clause = "AND actor_id = ?"
+        params.append(agent_row["id"])
+
+    params_since = [since] + params
+
+    # Gather heterogeneous events via UNION ALL
+    query = f"""
+        SELECT * FROM (
+            SELECT 'upload' AS action_type,
+                   v.agent_id AS actor_id,
+                   a.agent_name, a.display_name, a.avatar_url,
+                   v.video_id AS target_id,
+                   v.title AS detail,
+                   v.created_at AS ts
+            FROM videos v JOIN agents a ON v.agent_id = a.id
+            WHERE v.created_at > ? {agent_clause} AND v.is_removed = 0
+
+            UNION ALL
+
+            SELECT 'comment' AS action_type,
+                   c.agent_id AS actor_id,
+                   a.agent_name, a.display_name, a.avatar_url,
+                   c.video_id AS target_id,
+                   c.content AS detail,
+                   c.created_at AS ts
+            FROM comments c JOIN agents a ON c.agent_id = a.id
+            WHERE c.created_at > ? {agent_clause}
+
+            UNION ALL
+
+            SELECT 'vote' AS action_type,
+                   vt.agent_id AS actor_id,
+                   a.agent_name, a.display_name, a.avatar_url,
+                   vt.video_id AS target_id,
+                   CASE vt.vote WHEN 1 THEN 'upvote' ELSE 'downvote' END AS detail,
+                   vt.created_at AS ts
+            FROM votes vt JOIN agents a ON vt.agent_id = a.id
+            WHERE vt.created_at > ? {agent_clause}
+
+            UNION ALL
+
+            SELECT 'subscribe' AS action_type,
+                   s.follower_id AS actor_id,
+                   a.agent_name, a.display_name, a.avatar_url,
+                   CAST(s.following_id AS TEXT) AS target_id,
+                   a2.agent_name AS detail,
+                   s.created_at AS ts
+            FROM subscriptions s
+            JOIN agents a ON s.follower_id = a.id
+            JOIN agents a2 ON s.following_id = a2.id
+            WHERE s.created_at > ? {agent_clause}
+        ) events
+        ORDER BY ts DESC LIMIT ?
+    """
+
+    all_params = params_since + params_since + params_since + params_since + [limit]
+    rows = db.execute(query, all_params).fetchall()
+
+    events = []
+    for r in rows:
+        events.append({
+            "action": r["action_type"],
+            "agent_name": r["agent_name"],
+            "display_name": r["display_name"],
+            "avatar_url": r["avatar_url"],
+            "target_id": r["target_id"],
+            "detail": r["detail"],
+            "timestamp": r["ts"],
+        })
+
+    return jsonify({"events": events, "count": len(events)})
+
+
+@app.route("/api/conversations/<agent1>/<agent2>")
+def agent_conversations(agent1, agent2):
+    """Show comment-based dialogues between two specific agents.
+
+    Returns comments made by agent1 on agent2's videos and vice versa,
+    sorted chronologically, giving a 'conversation' view of their interaction.
+
+    Query parameters:
+        - limit: max items (default 100, max 500)
+    """
+    db = get_db()
+    limit = min(500, max(1, request.args.get("limit", 100, type=int)))
+
+    a1 = db.execute("SELECT id, agent_name, display_name, avatar_url FROM agents WHERE agent_name = ?", (agent1,)).fetchone()
+    a2 = db.execute("SELECT id, agent_name, display_name, avatar_url FROM agents WHERE agent_name = ?", (agent2,)).fetchone()
+    if not a1 or not a2:
+        return jsonify({"error": "One or both agents not found"}), 404
+
+    rows = db.execute(
+        """SELECT c.content, c.created_at, c.video_id,
+                  a.agent_name AS commenter, a.display_name AS commenter_display,
+                  v.title AS video_title,
+                  va.agent_name AS video_owner
+           FROM comments c
+           JOIN agents a ON c.agent_id = a.id
+           JOIN videos v ON c.video_id = v.video_id
+           JOIN agents va ON v.agent_id = va.id
+           WHERE (c.agent_id = ? AND v.agent_id = ?)
+              OR (c.agent_id = ? AND v.agent_id = ?)
+           ORDER BY c.created_at ASC LIMIT ?""",
+        (a1["id"], a2["id"], a2["id"], a1["id"], limit),
+    ).fetchall()
+
+    messages = []
+    for r in rows:
+        messages.append({
+            "commenter": r["commenter"],
+            "commenter_display": r["commenter_display"],
+            "video_id": r["video_id"],
+            "video_title": r["video_title"],
+            "video_owner": r["video_owner"],
+            "content": r["content"],
+            "timestamp": r["created_at"],
+        })
+
+    # Compute interaction summary
+    a1_to_a2 = sum(1 for m in messages if m["commenter"] == a1["agent_name"])
+    a2_to_a1 = sum(1 for m in messages if m["commenter"] == a2["agent_name"])
+
+    return jsonify({
+        "agents": [
+            {"agent_name": a1["agent_name"], "display_name": a1["display_name"], "avatar_url": a1["avatar_url"]},
+            {"agent_name": a2["agent_name"], "display_name": a2["display_name"], "avatar_url": a2["avatar_url"]},
+        ],
+        "messages": messages,
+        "count": len(messages),
+        "summary": {
+            f"{a1['agent_name']}_to_{a2['agent_name']}": a1_to_a2,
+            f"{a2['agent_name']}_to_{a1['agent_name']}": a2_to_a1,
+        },
+    })
+
+
+# ---------------------------------------------------------------------------
 # Trending / Feed
 # ---------------------------------------------------------------------------
 

--- a/tests/test_agent_interaction_visibility.py
+++ b/tests/test_agent_interaction_visibility.py
@@ -384,3 +384,198 @@ class TestWatchPageAccessibility:
 
         # Check for tooltip titles on badges
         assert 'title="Frequent commenter' in html or 'title="First time' in html or 'title="Regular' in html
+
+
+def _insert_vote(video_id: str, agent_id: int, vote: int, created_at: float = None) -> None:
+    """Insert a test vote into the database."""
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        ts = created_at or time.time()
+        db.execute(
+            "INSERT INTO votes (agent_id, video_id, vote, created_at) VALUES (?, ?, ?, ?)",
+            (agent_id, video_id, vote, ts),
+        )
+        db.commit()
+
+
+class TestActivityFeed:
+    """Tests for the /api/activity/feed endpoint."""
+
+    def test_activity_feed_returns_events(self, client):
+        """Test that activity feed returns mixed event types."""
+        with bottube_server.app.app_context():
+            creator_id = _insert_agent("creator_bot", "bottube_sk_creator")
+            commenter_id = _insert_agent("commenter_bot", "bottube_sk_commenter")
+            video_id = "test_feed_001"
+            _insert_video(creator_id, video_id)
+            _insert_comment(video_id, commenter_id, "Nice video!")
+            _insert_vote(video_id, commenter_id, 1)
+            _insert_subscription(commenter_id, creator_id)
+
+        resp = client.get("/api/activity/feed")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "events" in data
+        assert "count" in data
+        assert data["count"] > 0
+
+        actions = {e["action"] for e in data["events"]}
+        assert "upload" in actions
+        assert "comment" in actions
+
+    def test_activity_feed_respects_since(self, client):
+        """Test that since parameter filters old events."""
+        with bottube_server.app.app_context():
+            now = time.time()
+            creator_id = _insert_agent("creator_bot", "bottube_sk_creator")
+            video_id = "test_feed_002"
+            _insert_video(creator_id, video_id)
+            _insert_comment(video_id, creator_id, "Old comment", now - 1000)
+            _insert_comment(video_id, creator_id, "New comment", now)
+
+        # Fetch only events after a recent timestamp
+        resp = client.get(f"/api/activity/feed?since={time.time() - 500}")
+        data = resp.get_json()
+        # Should include the video upload + new comment but not old comment
+        for event in data["events"]:
+            assert event["timestamp"] > time.time() - 500
+
+    def test_activity_feed_agent_filter(self, client):
+        """Test filtering activity feed to a specific agent."""
+        with bottube_server.app.app_context():
+            agent_a = _insert_agent("agent_a", "bottube_sk_a")
+            agent_b = _insert_agent("agent_b", "bottube_sk_b")
+            _insert_video(agent_a, "vid_a")
+            _insert_video(agent_b, "vid_b")
+
+        resp = client.get("/api/activity/feed?agent=agent_a")
+        data = resp.get_json()
+        assert data["count"] > 0
+        for event in data["events"]:
+            assert event["agent_name"] == "agent_a"
+
+    def test_activity_feed_agent_not_found(self, client):
+        """Test 404 for non-existent agent filter."""
+        resp = client.get("/api/activity/feed?agent=nonexistent")
+        assert resp.status_code == 404
+
+    def test_activity_feed_limit(self, client):
+        """Test that limit parameter caps results."""
+        with bottube_server.app.app_context():
+            creator_id = _insert_agent("creator_bot", "bottube_sk_creator")
+            for i in range(10):
+                _insert_video(creator_id, f"vid_limit_{i}")
+
+        resp = client.get("/api/activity/feed?limit=3")
+        data = resp.get_json()
+        assert data["count"] <= 3
+
+    def test_activity_feed_event_shape(self, client):
+        """Test that each event has the expected fields."""
+        with bottube_server.app.app_context():
+            creator_id = _insert_agent("creator_bot", "bottube_sk_creator")
+            _insert_video(creator_id, "vid_shape")
+
+        resp = client.get("/api/activity/feed")
+        data = resp.get_json()
+        event = data["events"][0]
+        assert "action" in event
+        assert "agent_name" in event
+        assert "display_name" in event
+        assert "target_id" in event
+        assert "detail" in event
+        assert "timestamp" in event
+
+
+class TestConversationsView:
+    """Tests for the /api/conversations/<agent1>/<agent2> endpoint."""
+
+    def test_conversations_between_agents(self, client):
+        """Test retrieving comment dialogues between two agents."""
+        with bottube_server.app.app_context():
+            alice_id = _insert_agent("alice", "bottube_sk_alice")
+            bob_id = _insert_agent("bob", "bottube_sk_bob")
+            alice_vid = "alice_vid_001"
+            bob_vid = "bob_vid_001"
+            _insert_video(alice_id, alice_vid)
+            _insert_video(bob_id, bob_vid)
+
+            # Alice comments on Bob's video
+            _insert_comment(bob_vid, alice_id, "Great content!")
+            # Bob comments on Alice's video
+            _insert_comment(alice_vid, bob_id, "Thanks, love yours too!")
+
+        resp = client.get("/api/conversations/alice/bob")
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert "agents" in data
+        assert "messages" in data
+        assert "count" in data
+        assert "summary" in data
+        assert data["count"] == 2
+        assert len(data["agents"]) == 2
+
+        # Check summary has both directions
+        assert "alice_to_bob" in data["summary"]
+        assert "bob_to_alice" in data["summary"]
+        assert data["summary"]["alice_to_bob"] == 1
+        assert data["summary"]["bob_to_alice"] == 1
+
+    def test_conversations_message_shape(self, client):
+        """Test that each message has expected fields."""
+        with bottube_server.app.app_context():
+            alice_id = _insert_agent("alice", "bottube_sk_alice")
+            bob_id = _insert_agent("bob", "bottube_sk_bob")
+            _insert_video(alice_id, "alice_vid")
+            _insert_comment("alice_vid", bob_id, "Hello!")
+
+        resp = client.get("/api/conversations/alice/bob")
+        data = resp.get_json()
+        msg = data["messages"][0]
+        assert "commenter" in msg
+        assert "commenter_display" in msg
+        assert "video_id" in msg
+        assert "video_title" in msg
+        assert "video_owner" in msg
+        assert "content" in msg
+        assert "timestamp" in msg
+
+    def test_conversations_agent_not_found(self, client):
+        """Test 404 when one agent doesn't exist."""
+        with bottube_server.app.app_context():
+            _insert_agent("alice", "bottube_sk_alice")
+
+        resp = client.get("/api/conversations/alice/nonexistent")
+        assert resp.status_code == 404
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_conversations_empty(self, client):
+        """Test empty result when agents have no interactions."""
+        with bottube_server.app.app_context():
+            _insert_agent("alice", "bottube_sk_alice")
+            _insert_agent("bob", "bottube_sk_bob")
+
+        resp = client.get("/api/conversations/alice/bob")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["count"] == 0
+        assert data["messages"] == []
+
+    def test_conversations_chronological_order(self, client):
+        """Test messages are returned in chronological order."""
+        with bottube_server.app.app_context():
+            alice_id = _insert_agent("alice", "bottube_sk_alice")
+            bob_id = _insert_agent("bob", "bottube_sk_bob")
+            _insert_video(alice_id, "alice_vid")
+
+            now = time.time()
+            _insert_comment("alice_vid", bob_id, "First", now - 100)
+            _insert_comment("alice_vid", bob_id, "Second", now - 50)
+            _insert_comment("alice_vid", bob_id, "Third", now)
+
+        resp = client.get("/api/conversations/alice/bob")
+        data = resp.get_json()
+        timestamps = [m["timestamp"] for m in data["messages"]]
+        assert timestamps == sorted(timestamps)


### PR DESCRIPTION
## What does this PR do?

Implements two new API endpoints from the Agent Interaction Visibility spec (bottube issue 424):

**1. Activity Feed** (`/api/activity/feed`)
Aggregated feed showing recent agent actions (uploads, comments, votes, subscriptions) with filtering by agent name and timestamp.

**2. Conversations View** (`/api/conversations/<agent1>/<agent2>`)
Shows comment-based dialogues between two specific agents with chronological ordering and interaction summary counts.

## How to test

```bash
python -m pytest tests/test_agent_interaction_visibility.py -v
```

All 24 tests pass (13 existing + 11 new).

## Related Issues

Implements features from bottube issue 424. Closes Scottcjn/rustchain-bounties issue 2158.
