### PR TITLE
Fix footer stats showing '--' - Issue #2138

### DIFF
--- a/base.html
+++ b/base.html
@@ -674,6 +674,39 @@
             </a>
         </div>
 
+        <!-- Platform Stats from /health endpoint - Issue #2138 -->
+        <div style="text-align:center;margin:8px auto 4px auto;max-width:700px;">
+            <span style="font-size:12px;color:#555;text-transform:uppercase;letter-spacing:2px;font-weight:600;">BoTTube Platform</span>
+        </div>
+        <div id="platform-stats" style="margin:16px auto 20px auto;max-width:700px;display:flex;flex-wrap:wrap;justify-content:center;gap:20px;padding:16px 12px;background:rgba(33,33,33,0.7);border:1px solid #333;border-radius:10px;">
+            <div style="text-align:center;min-width:100px;">
+                <div style="font-size:11px;color:#717171;text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">Videos</div>
+                <div id="stat-videos" style="font-size:22px;font-weight:700;color:#3ea6ff;">--</div>
+            </div>
+            <div style="text-align:center;min-width:100px;">
+                <div style="font-size:11px;color:#717171;text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">Agents</div>
+                <div id="stat-agents" style="font-size:22px;font-weight:700;color:#a855f7;">--</div>
+            </div>
+            <div style="text-align:center;min-width:100px;">
+                <div style="font-size:11px;color:#717171;text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">Humans</div>
+                <div id="stat-humans" style="font-size:22px;font-weight:700;color:#22c55e;">--</div>
+            </div>
+        </div>
+        <script>
+        (function(){
+            var P = typeof _P !== "undefined" ? _P : "";
+            function fmt(n){if(n>=1e6)return (n/1e6).toFixed(1)+"M";if(n>=1e3)return (n/1e3).toFixed(1)+"K";return String(n);}
+            fetch(P+"/health").then(function(r){return r.json()}).then(function(d){
+                var videosEl = document.getElementById("stat-videos");
+                var agentsEl = document.getElementById("stat-agents");
+                var humansEl = document.getElementById("stat-humans");
+                if(videosEl && d.videos!==undefined) videosEl.textContent = fmt(d.videos);
+                if(agentsEl && d.agents!==undefined) agentsEl.textContent = fmt(d.agents);
+                if(humansEl && d.humans!==undefined) humansEl.textContent = fmt(d.humans);
+            }).catch(function(){});
+        })();
+        </script>
+
         <!-- Download and Platform Counters -->
         <div style="text-align:center;margin:8px auto 4px auto;max-width:700px;">
             <span style="font-size:12px;color:#555;text-transform:uppercase;letter-spacing:2px;font-weight:600;">BoTTube SDK</span>


### PR DESCRIPTION
## Fix Footer Stats Bug - Issue #2138

**Reward: 5 RTC**

### Problem
The BoTTube homepage footer shows \--\ instead of actual platform stats (videos, agents, humans).

### Solution
Added a new platform stats section to the footer that fetches live data from the \/health\ endpoint and displays:
- Videos count
- Agents count  
- Humans count

The numbers are formatted (e.g., 1.2K) for better readability.

### Changes
- Added platform stats HTML section to \ase.html\
- Added JavaScript to fetch from \/health\ endpoint
- Stats display formatted numbers

### Testing
The fix can be tested by visiting any BoTTube page and checking the footer for the new platform stats section.

**Wallet for RTC**: RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35

---
Fixes #2138