### PR TITLE
Fix stored XSS via innerHTML injection

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13097,6 +13097,8 @@ function renderBars(data, maxBars) {
   return `<div class="chart-bar">${bars}</div><div class="chart-label"><span>${data.length > maxBars ? (data.length-maxBars)+'h ago' : '48h ago'}</span><span>now</span></div>`;
 }
 
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
 async function refresh() {
   try {
     const r = await fetch('/api/admin/monitoring?key=' + KEY);
@@ -13125,15 +13127,15 @@ async function refresh() {
     // Banned
     html += `<div class="card"><h2>Banned Agents <span class="badge red">${d.banned_agents.length}</span></h2>`;
     if (d.banned_agents.length === 0) html += `<div class="sub-num">None</div>`;
-    else d.banned_agents.forEach(b => { html += `<div class="stat-row"><span class="stat-label">${b.name}</span><span class="stat-value" style="color:#f85149">${b.reason||'—'}</span></div>`; });
+    else d.banned_agents.forEach(b => { html += `<div class="stat-row"><span class="stat-label">${esc(b.name)}</span><span class="stat-value" style="color:#f85149">${esc(b.reason||'—')}</span></div>`; });
     html += `</div>`;
 
     // Active agents
     html += `<div class="card wide"><h2>Most Active (7 days)</h2>`;
     d.active_agents.forEach(a => {
       const typ = a.is_human ? 'human' : 'ai';
-      html += `<div class="agent-row"><span class="agent-name">${a.display_name} <span style="color:#484f58">@${a.agent_name}</span></span>`;
-      html += `<span class="agent-type ${typ}">${typ.toUpperCase()}</span>`;
+      html += `<div class="agent-row"><span class="agent-name">${esc(a.display_name)} <span style="color:#484f58">@${esc(a.agent_name)}</span></span>`;
+      html += `<span class="agent-type ${esc(typ)}">${typ.toUpperCase()}</span>`;
       html += `<span class="badge blue">${a.videos_7d}v</span>`;
       html += `<span class="badge green">${a.comments_7d}c</span>`;
       html += `<span style="color:#484f58;font-size:12px">${ago(a.last_action)}</span></div>`;
@@ -13144,7 +13146,7 @@ async function refresh() {
     html += `<div class="card wide"><h2>Trending Today</h2>`;
     if (d.trending_videos.length === 0) html += `<div class="sub-num">No videos today</div>`;
     else d.trending_videos.forEach(v => {
-      html += `<div class="video-row"><div class="video-title">${v.title}</div><div class="video-meta">by ${v.display_name} — ${fmt(v.views)} views, ${v.likes} likes</div></div>`;
+      html += `<div class="video-row"><div class="video-title">${esc(v.title)}</div><div class="video-meta">by ${esc(v.display_name)} — ${fmt(v.views)} views, ${v.likes} likes</div></div>`;
     });
     html += `</div>`;
 

--- a/bottube_static/base.js
+++ b/bottube_static/base.js
@@ -59,6 +59,14 @@
     });
   }
 
+  function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+  function sanitizeUrl(u) {
+    u = String(u || '').trim();
+    if (u.startsWith('/') || u.startsWith('https://') || u.startsWith('http://')) return u;
+    return '#';
+  }
+
   function timeAgo(ts) {
     var s = Math.floor(Date.now() / 1000 - Number(ts || 0));
     if (s < 60) return "just now";
@@ -117,9 +125,10 @@
           }
           list.innerHTML = d.notifications.map(function (n) {
             var bg = n.is_read ? "transparent" : "rgba(62,166,255,0.06)";
-            var link = n.link || "#";
-            var msg = String(n.message || "").replace(/</g, "&lt;");
-            return '<a href="' + link + '" data-notification-id="' + n.id + '" data-notification-read="' + (n.is_read ? "1" : "0") + '" style="display:block;padding:10px 16px;border-bottom:1px solid var(--border);background:' +
+            var link = sanitizeUrl(n.link);
+            var msg = esc(String(n.message || ""));
+            var safeId = esc(String(n.id || ""));
+            return '<a href="' + esc(link) + '" data-notification-id="' + safeId + '" data-notification-read="' + (n.is_read ? "1" : "0") + '" style="display:block;padding:10px 16px;border-bottom:1px solid var(--border);background:' +
               bg + ';color:var(--text-primary);font-size:13px;line-height:1.4;">' +
               "<div>" + msg + "</div>" +
               '<div style="color:var(--text-muted);font-size:11px;margin-top:2px;">' + timeAgo(n.created_at) + "</div></a>";

--- a/bottube_static/beacon_atlas/ui.js
+++ b/bottube_static/beacon_atlas/ui.js
@@ -16,6 +16,8 @@ const BEACON_API = (window.location.hostname === 'localhost' || window.location.
   ? 'http://localhost:8071'
   : '/beacon';
 
+function esc(s) { const d = document.createElement('div'); d.textContent = String(s == null ? '' : s); return d.innerHTML; }
+
 let panel, panelContent, panelPath, tooltip;
 let selectedAgent = null;
 let selectedCity = null;
@@ -170,7 +172,7 @@ function selectAgent(agentId) {
   if (pos) lerpCameraTo(pos, 40);
 
   // Panel path
-  panelPath.innerHTML = `<span class="prompt">beacon@atlas:~</span>/agent/${agent.id}`;
+  panelPath.innerHTML = `<span class="prompt">beacon@atlas:~</span>/agent/${esc(agent.id)}`;
 
   // Build panel content
   const v = agent.valuation;
@@ -181,21 +183,21 @@ function selectAgent(agentId) {
     : GRADE_COLORS[agent.grade];
 
   let html = '';
-  html += `<div class="t-cmd"><span class="dollar">$</span>cat /agent/${agent.id}</div>`;
-  html += `<div><span class="t-label">NAME</span> <span class="t-value">${agent.name}</span></div>`;
+  html += `<div class="t-cmd"><span class="dollar">$</span>cat /agent/${esc(agent.id)}</div>`;
+  html += `<div><span class="t-label">NAME</span> <span class="t-value">${esc(agent.name)}</span></div>`;
 
   if (isRelay) {
     // Relay agent: show provider, model, status, capabilities
     const provColor = getProviderColor(agent.provider);
     html += `<div><span class="t-label">TYPE</span> <span class="grade-badge" style="background:${provColor};color:#000;padding:0 6px;font-size:11px">RELAY</span></div>`;
-    html += `<div><span class="t-label">PROVIDER</span> <span class="t-value" style="color:${provColor}">${(agent.provider || 'unknown').toUpperCase()}</span></div>`;
-    html += `<div><span class="t-label">MODEL</span> <span class="t-value">${agent.model_id || '?'}</span></div>`;
-    html += `<div><span class="t-label">STATUS</span> <span class="t-value" style="color:${agent.status === 'active' ? 'var(--green)' : agent.status === 'silent' ? 'var(--amber)' : 'var(--red)'}">${(agent.status || 'unknown').toUpperCase()}</span></div>`;
-    html += `<div><span class="t-label">ROLE</span> <span class="t-value">${agent.role}</span></div>`;
-    html += `<div><span class="t-label">ADDRESS</span> <span class="t-value">${city ? city.name : '?'}, ${region ? region.name : '?'}</span></div>`;
+    html += `<div><span class="t-label">PROVIDER</span> <span class="t-value" style="color:${provColor}">${esc((agent.provider || 'unknown').toUpperCase())}</span></div>`;
+    html += `<div><span class="t-label">MODEL</span> <span class="t-value">${esc(agent.model_id || '?')}</span></div>`;
+    html += `<div><span class="t-label">STATUS</span> <span class="t-value" style="color:${agent.status === 'active' ? 'var(--green)' : agent.status === 'silent' ? 'var(--amber)' : 'var(--red)'}">${esc((agent.status || 'unknown').toUpperCase())}</span></div>`;
+    html += `<div><span class="t-label">ROLE</span> <span class="t-value">${esc(agent.role)}</span></div>`;
+    html += `<div><span class="t-label">ADDRESS</span> <span class="t-value">${esc(city ? city.name : '?')}, ${esc(region ? region.name : '?')}</span></div>`;
 
     if (agent.capabilities && agent.capabilities.length > 0) {
-      html += `<div><span class="t-label">CAPS</span> <span class="t-value">${agent.capabilities.map(c => `[${c}]`).join(' ')}</span></div>`;
+      html += `<div><span class="t-label">CAPS</span> <span class="t-value">${agent.capabilities.map(c => `[${esc(c)}]`).join(' ')}</span></div>`;
     }
 
     if (agent.beat_count) {
@@ -210,11 +212,11 @@ function selectAgent(agentId) {
     html += `</div>`;
   } else {
     // Native agent: original display
-    html += `<div><span class="t-label">BEACON</span> <span class="t-value" style="color: var(--text-dim)">${agent.beacon}</span></div>`;
-    html += `<div><span class="t-label">ROLE</span> <span class="t-value">${agent.role}</span></div>`;
-    html += `<div><span class="t-label">GRADE</span> <span class="grade-badge grade-${agent.grade}">${agent.grade}</span>`;
+    html += `<div><span class="t-label">BEACON</span> <span class="t-value" style="color: var(--text-dim)">${esc(agent.beacon)}</span></div>`;
+    html += `<div><span class="t-label">ROLE</span> <span class="t-value">${esc(agent.role)}</span></div>`;
+    html += `<div><span class="t-label">GRADE</span> <span class="grade-badge grade-${esc(agent.grade)}">${esc(agent.grade)}</span>`;
     html += `${renderBar(agent.score, agent.maxScore, gradeColor)} ${agent.score}/${agent.maxScore}</div>`;
-    html += `<div><span class="t-label">ADDRESS</span> <span class="t-value">${city ? city.name : '?'}, ${region ? region.name : '?'}</span></div>`;
+    html += `<div><span class="t-label">ADDRESS</span> <span class="t-value">${esc(city ? city.name : '?')}, ${esc(region ? region.name : '?')}</span></div>`;
 
     // Valuation breakdown
     html += `<div class="t-section">-- VALUATION BREAKDOWN --</div>`;
@@ -258,7 +260,7 @@ function selectAgent(agentId) {
       const dir = c.from === agentId ? '->' : '<-';
       html += `<div class="contract-row ${c.type}">`;
       html += `<span class="contract-type" style="background:${CONTRACT_STYLES_CSS[c.type]}">[${c.type.toUpperCase().replace('_', ' ')}]</span>`;
-      html += `<span>${dir} ${other ? other.name : '?'}  ${c.amount} ${c.currency}</span>`;
+      html += `<span>${dir} ${esc(other ? other.name : '?')}  ${c.amount} ${esc(c.currency)}</span>`;
       html += `<span class="contract-state state-${c.state}">${c.state}</span>`;
       html += `</div>`;
     }
@@ -329,15 +331,15 @@ function selectCity(cityId) {
   const center = getCityCenter(cityId);
   if (center) lerpCameraTo(center, 60);
 
-  panelPath.innerHTML = `<span class="prompt">beacon@atlas:~</span>/city/${city.id}`;
+  panelPath.innerHTML = `<span class="prompt">beacon@atlas:~</span>/city/${esc(city.id)}`;
 
   let html = '';
-  html += `<div class="t-cmd"><span class="dollar">$</span>cat /city/${city.id}</div>`;
-  html += `<div><span class="t-label">NAME</span> <span class="t-value">${city.name}</span></div>`;
-  html += `<div><span class="t-label">REGION</span> <span class="t-value" style="color:${region.color}">${region.name}</span></div>`;
-  html += `<div><span class="t-label">TYPE</span> <span class="t-value">${city.type.toUpperCase()}</span></div>`;
+  html += `<div class="t-cmd"><span class="dollar">$</span>cat /city/${esc(city.id)}</div>`;
+  html += `<div><span class="t-label">NAME</span> <span class="t-value">${esc(city.name)}</span></div>`;
+  html += `<div><span class="t-label">REGION</span> <span class="t-value" style="color:${region.color}">${esc(region.name)}</span></div>`;
+  html += `<div><span class="t-label">TYPE</span> <span class="t-value">${esc(city.type.toUpperCase())}</span></div>`;
   html += `<div><span class="t-label">POPULATION</span> <span class="t-value">${city.population}</span></div>`;
-  html += `<div style="margin-top:6px;color:var(--text-dim);font-size:12px">${city.description}</div>`;
+  html += `<div style="margin-top:6px;color:var(--text-dim);font-size:12px">${esc(city.description)}</div>`;
 
   // Residents
   const residents = AGENTS.filter(a => a.city === cityId);
@@ -352,8 +354,8 @@ function selectCity(cityId) {
       } else {
         html += `<span class="resident-grade grade-badge grade-${r.grade}" style="padding:0 4px;font-size:11px">${r.grade}</span>`;
       }
-      html += `<span class="resident-name">${r.name}</span>`;
-      html += `<span class="resident-role">${r.role}</span>`;
+      html += `<span class="resident-name">${esc(r.name)}</span>`;
+      html += `<span class="resident-role">${esc(r.role)}</span>`;
       html += `</div>`;
     }
     html += `</div>`;
@@ -427,7 +429,7 @@ function updateHash(type, id) {
 // --- Contract creation form ---
 function showContractForm(preselectedFrom) {
   const agentOptions = AGENTS.map(a =>
-    `<option value="${a.id}"${a.id === preselectedFrom ? ' selected' : ''}>${a.name}</option>`
+    `<option value="${esc(a.id)}"${a.id === preselectedFrom ? ' selected' : ''}>${esc(a.name)}</option>`
   ).join('');
 
   panelPath.innerHTML = `<span class="prompt">beacon@atlas:~</span>/contracts/new`;
@@ -709,12 +711,12 @@ function renderBountyList(bounties) {
     const safeUrl = (b.url || '').replace(/'/g, '%27');
     html += `<div class="bounty-card">`;
     html += `<div style="display:flex;justify-content:space-between;align-items:center">`;
-    html += `<span style="color:var(--green);font-weight:600;font-size:13px">${b.title}</span>`;
-    html += `<span style="color:#ffd700;font-size:12px;font-weight:600;white-space:nowrap;margin-left:8px">${b.reward}</span>`;
+    html += `<span style="color:var(--green);font-weight:600;font-size:13px">${esc(b.title)}</span>`;
+    html += `<span style="color:#ffd700;font-size:12px;font-weight:600;white-space:nowrap;margin-left:8px">${esc(b.reward)}</span>`;
     html += `</div>`;
     html += `<div style="display:flex;gap:8px;font-size:11px;margin-top:4px;align-items:center">`;
-    html += `<span style="color:${DIFF_COLORS[b.difficulty] || DIFF_COLORS.ANY}">[${b.difficulty}]</span>`;
-    html += `<span style="color:var(--text-dim)">${b.repo} ${b.ghNum || b.id}</span>`;
+    html += `<span style="color:${DIFF_COLORS[b.difficulty] || DIFF_COLORS.ANY}">[${esc(b.difficulty)}]</span>`;
+    html += `<span style="color:var(--text-dim)">${esc(b.repo)} ${esc(b.ghNum || b.id)}</span>`;
     if (safeUrl) {
       html += `<a href="${safeUrl}" target="_blank" class="bounty-link" style="font-size:10px;padding:1px 6px">[GitHub]</a>`;
     }
@@ -732,10 +734,10 @@ function renderBountyList(bounties) {
       const agent = AGENTS.find(a => a.id === b.claimant);
       html += `<div class="bounty-card" style="border-left-color:var(--amber)">`;
       html += `<div style="display:flex;justify-content:space-between">`;
-      html += `<span style="color:var(--amber);font-size:13px">${b.title}</span>`;
-      html += `<span style="color:#ffd700;font-size:12px">${b.reward}</span>`;
+      html += `<span style="color:var(--amber);font-size:13px">${esc(b.title)}</span>`;
+      html += `<span style="color:#ffd700;font-size:12px">${esc(b.reward)}</span>`;
       html += `</div>`;
-      html += `<div style="font-size:11px;color:var(--amber);margin-top:3px">Claimed by: ${agent ? agent.name : b.claimant}</div>`;
+      html += `<div style="font-size:11px;color:var(--amber);margin-top:3px">Claimed by: ${esc(agent ? agent.name : b.claimant)}</div>`;
       html += `</div>`;
     }
   }
@@ -748,10 +750,10 @@ function renderBountyList(bounties) {
       const repGain = 10 + (b.reward_rtc || 0) * 0.1;
       html += `<div class="bounty-card" style="border-left-color:#8888ff;opacity:0.7">`;
       html += `<div style="display:flex;justify-content:space-between">`;
-      html += `<span style="color:#8888ff;font-size:13px">${b.title}</span>`;
-      html += `<span style="color:#ffd700;font-size:12px">${b.reward}</span>`;
+      html += `<span style="color:#8888ff;font-size:13px">${esc(b.title)}</span>`;
+      html += `<span style="color:#ffd700;font-size:12px">${esc(b.reward)}</span>`;
       html += `</div>`;
-      html += `<div style="font-size:11px;color:#8888ff;margin-top:3px">Completed by: ${agent ? agent.name : b.completed_by} (+${repGain.toFixed(0)} rep)</div>`;
+      html += `<div style="font-size:11px;color:#8888ff;margin-top:3px">Completed by: ${esc(agent ? agent.name : b.completed_by)} (+${repGain.toFixed(0)} rep)</div>`;
       html += `</div>`;
     }
   }
@@ -785,7 +787,7 @@ async function showBounties() {
       const medal = i === 0 ? '1st' : i === 1 ? '2nd' : i === 2 ? '3rd' : `${i+1}th`;
       const color = i === 0 ? '#ffd700' : i === 1 ? '#c0c0c0' : i === 2 ? '#cd7f32' : 'var(--text-dim)';
       html += `<div style="display:flex;justify-content:space-between;font-size:12px;margin:2px 0;cursor:pointer" data-leaderboard-agent="${r.agent_id}">`;
-      html += `<span><span style="color:${color};width:28px;display:inline-block">${medal}</span> ${name}</span>`;
+      html += `<span><span style="color:${color};width:28px;display:inline-block">${medal}</span> ${esc(name)}</span>`;
       html += `<span style="color:${color}">${r.score} rep</span>`;
       html += `</div>`;
     }

--- a/bottube_templates/bridge.html
+++ b/bottube_templates/bridge.html
@@ -734,6 +734,9 @@ function copyText(text, btn) {
     });
 }
 
+function esc(s) { const d = document.createElement('div'); d.textContent = String(s == null ? '' : s); return d.innerHTML; }
+function sanitizeTxSig(s) { return /^[a-zA-Z0-9]+$/.test(s) ? s : ''; }
+
 // ─── Show result ────────────────────────────────────────────
 function showResult(id, ok, msg) {
     const el = document.getElementById(id);
@@ -818,12 +821,14 @@ async function loadWrtcHistory() {
             html += "<table class='history-table'><tr><th>Type</th><th>Amount</th><th>TX</th><th>Status</th><th>Date</th></tr>";
             for (const d of data.deposits) {
                 const date = new Date(d.created_at * 1000).toLocaleDateString();
-                const txShort = d.tx_signature.slice(0, 12) + "...";
-                html += `<tr><td style="color:var(--green)">Deposit</td><td>${d.amount} wRTC</td><td><a href="https://solscan.io/tx/${d.tx_signature}" target="_blank">${txShort}</a></td><td class="status-${d.status}">${d.status}</td><td>${date}</td></tr>`;
+                const safeTx = sanitizeTxSig(d.tx_signature);
+                const txShort = safeTx.slice(0, 12) + "...";
+                html += `<tr><td style="color:var(--green)">Deposit</td><td>${esc(d.amount)} wRTC</td><td>${safeTx ? `<a href="https://solscan.io/tx/${safeTx}" target="_blank">${txShort}</a>` : '—'}</td><td class="status-${esc(d.status)}">${esc(d.status)}</td><td>${date}</td></tr>`;
             }
             for (const w of data.withdrawals) {
                 const date = new Date(w.created_at * 1000).toLocaleDateString();
-                html += `<tr><td style="color:#e6a817">Withdraw</td><td>${w.amount} wRTC</td><td>${w.tx_signature ? '<a href="https://solscan.io/tx/' + w.tx_signature + '" target="_blank">View</a>' : '—'}</td><td class="status-${w.status}">${w.status}</td><td>${date}</td></tr>`;
+                const safeWTx = w.tx_signature ? sanitizeTxSig(w.tx_signature) : '';
+                html += `<tr><td style="color:#e6a817">Withdraw</td><td>${esc(w.amount)} wRTC</td><td>${safeWTx ? '<a href="https://solscan.io/tx/' + safeWTx + '" target="_blank">View</a>' : '—'}</td><td class="status-${esc(w.status)}">${esc(w.status)}</td><td>${date}</td></tr>`;
             }
             html += "</table>";
         }
@@ -899,11 +904,11 @@ async function loadErgoHistory() {
             html += "<table class='history-table'><tr><th>Type</th><th>ERG</th><th>RTC</th><th>Status</th><th>Date</th></tr>";
             for (const d of (data.deposits || [])) {
                 const date = new Date(d.created_at * 1000).toLocaleDateString();
-                html += `<tr><td style="color:var(--green)">Deposit</td><td>${d.erg_amount || '—'} ERG</td><td>${d.rtc_credited || '—'} RTC</td><td class="status-${d.status}">${d.status}</td><td>${date}</td></tr>`;
+                html += `<tr><td style="color:var(--green)">Deposit</td><td>${esc(d.erg_amount || '—')} ERG</td><td>${esc(d.rtc_credited || '—')} RTC</td><td class="status-${esc(d.status)}">${esc(d.status)}</td><td>${date}</td></tr>`;
             }
             for (const w of (data.withdrawals || [])) {
                 const date = new Date(w.created_at * 1000).toLocaleDateString();
-                html += `<tr><td style="color:#e6a817">Withdraw</td><td>${w.erg_amount || '—'} ERG</td><td>${w.rtc_amount || '—'} RTC</td><td class="status-${w.status}">${w.status}</td><td>${date}</td></tr>`;
+                html += `<tr><td style="color:#e6a817">Withdraw</td><td>${esc(w.erg_amount || '—')} ERG</td><td>${esc(w.rtc_amount || '—')} RTC</td><td class="status-${esc(w.status)}">${esc(w.status)}</td><td>${date}</td></tr>`;
             }
             html += "</table>";
         } else {


### PR DESCRIPTION
## Summary
- Adds `esc()` HTML-escape helpers to 4 files that render user-controlled data via `innerHTML`
- Adds `sanitizeUrl()` to block `javascript:` URIs in notification links
- Adds `sanitizeTxSig()` to validate Solana transaction signatures before href injection
- Escapes agent names, video titles, bounty titles, notification messages, city descriptions, and bridge transaction data

## Vulnerabilities Fixed (mtarcure red team audit)

| File | Issue | Severity |
|------|-------|----------|
| `bottube_static/base.js` | Notification `link` field accepts `javascript:` URIs; message not escaped | HIGH |
| `bottube_server.py` | Admin dashboard renders agent names, video titles, ban reasons raw | MEDIUM (admin-only) |
| `bottube_static/beacon_atlas/ui.js` | All panel innerHTML interpolates agent/city/bounty data unescaped | HIGH |
| `bottube_templates/bridge.html` | Transaction signatures injected into href; amounts/status unescaped | HIGH |

## Test plan
- [ ] Verify notifications still render correctly with normal text
- [ ] Verify Beacon Atlas agent/city/bounty panels display correctly
- [ ] Verify bridge transaction history renders correctly
- [ ] Verify admin monitoring dashboard renders correctly
- [ ] Test with `<script>alert(1)</script>` as agent name -- should render as text, not execute

Generated with [Claude Code](https://claude.com/claude-code)