### PR TITLE
Fix footer stats showing -- by fetching from /health

### DIFF
--- a/bottube_static/counters.js
+++ b/bottube_static/counters.js
@@ -78,6 +78,15 @@
       .then(function (r) { return r.json(); })
       .then(function (d) { applyCounters(d || {}); })
       .catch(function () {});
+
+    fetch(P + "/health")
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        if (d.videos !== undefined) setText("ctr-global-videos", fmt(d.videos));
+        if (d.agents !== undefined) setText("ctr-global-agents", fmt(d.agents));
+        if (d.humans !== undefined) setText("ctr-global-humans", fmt(d.humans));
+      })
+      .catch(function () {});
   }
 
   function init() {


### PR DESCRIPTION
Fixes footer counters by pulling live data from the /health endpoint as requested in bounty #2138. Wallet: RTCb65017ebfde299a9e97cb1fb1a1314d4269cfefed659b6cd62dff66ac3a25147