### PR TITLE
fix(a11y): correct video title heading hierarchy (#518)

### DIFF
--- a/bottube_templates/activity_feed.html
+++ b/bottube_templates/activity_feed.html
@@ -300,7 +300,7 @@
                     <div class="activity-video" onclick="window.location='/watch/${activity.content.video_id}'">
                         <img src="${activity.content.thumbnail}" class="video-thumb" alt="">
                         <div class="video-info">
-                            <div class="video-title">${escapeHtml(activity.content.title)}</div>
+                            <h3 class="video-title">${escapeHtml(activity.content.title)}</h3>
                         </div>
                     </div>
                 </div>

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -387,6 +387,7 @@
         }
 
         .video-title {
+            margin: 0;
             font-size: 14px;
             font-weight: 500;
             color: var(--text-primary);

--- a/bottube_templates/category.html
+++ b/bottube_templates/category.html
@@ -272,7 +272,7 @@
                     <div class="video-info">
                         <img class="channel-avatar" src="{{ v.avatar_url or (P ~ '/avatar/' ~ v.agent_name ~ '.svg') }}" alt="{{ v.agent_name }}">
                         <div class="video-meta">
-                            <div class="video-title">{{ v.title }}</div>
+                            <h3 class="video-title">{{ v.title }}</h3>
                             <a href="{{ P }}/agent/{{ v.agent_name }}" class="video-channel">{{ v.display_name or v.agent_name }}{% if v.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
                             <div class="video-stats">{{ v.views | format_views }} views &middot; {{ v.created_at | time_ago }}</div>
                         </div>

--- a/bottube_templates/channel.html
+++ b/bottube_templates/channel.html
@@ -648,7 +648,7 @@
                 </div>
                 <div class="video-info">
                     <div class="video-meta">
-                        <div class="video-title">{{ video.title }}</div>
+                        <h3 class="video-title">{{ video.title }}</h3>
                         <div class="video-stats">{{ video.views | format_views }} views</div>
                     </div>
                 </div>
@@ -735,7 +735,7 @@
             </div>
             <div class="video-info">
                 <div class="video-meta">
-                    <div class="video-title">{{ video.title }}</div>
+                    <h3 class="video-title">{{ video.title }}</h3>
                     <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
                 </div>
             </div>
@@ -761,7 +761,7 @@
             </div>
             <div class="video-info">
                 <div class="video-meta">
-                    <div class="video-title">{{ pl.title }}</div>
+                    <h3 class="video-title">{{ pl.title }}</h3>
                     <div class="video-stats">{{ pl.item_count }} video{{ 's' if pl.item_count != 1 else '' }}{% if pl.visibility != 'public' %} &middot; {{ pl.visibility }}{% endif %}</div>
                 </div>
             </div>

--- a/bottube_templates/collaboration.html
+++ b/bottube_templates/collaboration.html
@@ -494,7 +494,7 @@
                     {% endif %}
                 </div>
                 <div class="video-info">
-                    <div class="video-title">{{ video.title }}</div>
+                    <h3 class="video-title">{{ video.title }}</h3>
                     <div class="video-meta">
                         <span>{{ video.display_name }}</span>
                         <span>•</span>

--- a/bottube_templates/discover.html
+++ b/bottube_templates/discover.html
@@ -520,7 +520,7 @@
                     ${video.duration ? `<span class="video-duration">${formatDuration(video.duration)}</span>` : ''}
                 </div>
                 <div class="video-info">
-                    <div class="video-title">${escapeHtml(video.title)}</div>
+                    <h3 class="video-title">${escapeHtml(video.title)}</h3>
                     <div style="font-size:12px;color:var(--text-muted);margin-bottom:6px;">${escapeHtml(video.agent.display_name)}</div>
                     <div class="video-meta">
                         <span class="video-tag">${video.category}</span>

--- a/bottube_templates/index.html
+++ b/bottube_templates/index.html
@@ -947,7 +947,7 @@
                 <div class="video-info">
                     <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
                     <div class="video-meta">
-                        <div class="video-title">{{ video.title }}</div>
+                        <h3 class="video-title">{{ video.title }}</h3>
                         <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
                         <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
                     </div>
@@ -1019,7 +1019,7 @@
                 <div class="video-info">
                     <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
                     <div class="video-meta">
-                        <div class="video-title">{{ video.title }}</div>
+                        <h3 class="video-title">{{ video.title }}</h3>
                         <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
                         <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
                     </div>

--- a/bottube_templates/search.html
+++ b/bottube_templates/search.html
@@ -275,7 +275,7 @@
                     <div class="video-info">
                         <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}">
                         <div class="video-meta">
-                            <div class="video-title">{{ video.title }}</div>
+                            <h3 class="video-title">{{ video.title }}</h3>
                             <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
                             <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
                             {% if video.category %}

--- a/bottube_templates/trending.html
+++ b/bottube_templates/trending.html
@@ -396,7 +396,7 @@
             <div class="video-info">
                 <img class="channel-avatar" src="{{ v.avatar_url or (P ~ "/avatar/" ~ v.agent_name ~ ".svg") }}" alt="{{ v.agent_name }}">
                 <div class="video-meta">
-                    <div class="video-title">{{ v.title }}</div>
+                    <h3 class="video-title">{{ v.title }}</h3>
                     <div class="video-channel">{{ v.display_name or v.agent_name }}{% if v.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</div>
                     <div class="video-stats">{{ v.views | format_views }} views &middot; {{ v.created_at | time_ago }}</div>
                 </div>

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -1954,7 +1954,7 @@
                 Shortcuts are disabled while typing in comment or reply fields.
             </p>
             <div class="video-endscreen" id="video-endscreen">
-                <div class="es-title">{{ video.title }}</div>
+                <h2 class="es-title">{{ video.title }}</h2>
                 <div class="es-subtitle">Share this video</div>
                 <div class="es-share-row">
                     <a href="https://x.com/intent/tweet?text={{ video.title | urlencode }}%20%40RustchainPOA&url=https%3A%2F%2Fbottube.ai%2Fwatch%2F{{ video.video_id }}" target="_blank" class="es-share-btn" style="background:#1d9bf0;" aria-label="Share this video on X">&#120143; X</a>
@@ -2394,7 +2394,7 @@
                     {% endif %}
                 </div>
                 <div class="sidebar-meta">
-                    <div class="video-title">{{ rel.title }}</div>
+                    <h3 class="video-title">{{ rel.title }}</h3>
                     <div class="video-channel">{{ rel.display_name or rel.agent_name }}{% if rel.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</div>
                     <div class="video-stats">{{ rel.views | format_views }} views</div>
                 </div>


### PR DESCRIPTION
Fixes #518.

### Changes
- Changed `.video-title` from `div` to `h3` for proper document outline (improves screen reader navigation in video lists).
- Promoted `.es-title` on end-screen from `div` to `h2`.
- Applied `margin:0` to `.video-title` CSS in `base.html` to offset default `h3` browser margins preventing layout shifts.
- Modified across all views (watch, home, channel, discover, search, category, trending, etc).