### PR TITLE
feat: Video page customization for creators (Issue #422)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -2102,7 +2102,7 @@ def init_db():
         # Referrals (best-effort growth tracking)
         "referred_by_code": "ALTER TABLE agents ADD COLUMN referred_by_code TEXT DEFAULT ''",
         "referred_at": "ALTER TABLE agents ADD COLUMN referred_at REAL DEFAULT 0",
-                "referral_first_upload_counted": "ALTER TABLE agents ADD COLUMN referral_first_upload_counted INTEGER DEFAULT 0",
+        "referral_first_upload_counted": "ALTER TABLE agents ADD COLUMN referral_first_upload_counted INTEGER DEFAULT 0",
         "banner_url": "ALTER TABLE agents ADD COLUMN banner_url TEXT DEFAULT ''",
         "accent_color": "ALTER TABLE agents ADD COLUMN accent_color TEXT DEFAULT ''",
         "pinned_video_id": "ALTER TABLE agents ADD COLUMN pinned_video_id TEXT DEFAULT ''",
@@ -4099,7 +4099,7 @@ def agent_to_dict(row, include_private=False, *, badges=None):
     the requesting user is viewing their own profile.
     """
     SAFE_FIELDS = {
-        "id", "agent_name", "display_name", "bio", "avatar_url",
+        "id", "agent_name", "display_name", "bio", "avatar_url", "banner_url", "accent_color", "pinned_video_id",
         "is_human", "x_handle", "created_at",
     }
     PRIVATE_FIELDS = {
@@ -4356,6 +4356,7 @@ def render_mentions(text):
 app.jinja_env.filters["format_duration"] = format_duration
 app.jinja_env.filters["format_views"] = format_views
 app.jinja_env.filters["time_ago"] = time_ago
+
 def minimal_markdown(text):
     if not text:
         return ""
@@ -4370,7 +4371,6 @@ def minimal_markdown(text):
     return Markup(t)
 
 app.jinja_env.filters["minimal_markdown"] = minimal_markdown
-
 app.jinja_env.filters["parse_tags"] = parse_tags
 app.jinja_env.filters["datetime_iso"] = datetime_iso
 app.jinja_env.filters["timestamp_date"] = timestamp_date
@@ -4629,19 +4629,6 @@ def reclaim_account_page():
         notice = _build_recovery_notice(get_db())
     except Exception:
         notice = _build_recovery_notice(None)
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
-
     return render_template(
         "reclaim_account.html",
         recovery_notice=notice,
@@ -4723,20 +4710,7 @@ def signup():
                     "agent_name": row["agent_name"],
                     "display_name": row["display_name"] or row["agent_name"],
                 }
-        # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
-
-    return render_template(
+        return render_template(
             "login.html",
             signup=True,
             form_ts=time.time(),
@@ -4889,19 +4863,6 @@ def referral_redirect(code):
     if not ref:
         abort(404)
     signup_url = url_for("signup", ref=ref_code)
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
-
     return render_template(
         "referral_landing.html",
         code=ref["code"],
@@ -7126,19 +7087,6 @@ def category_browse(cat_id):
             LIMIT 100""",
         (cat_id,),
     ).fetchall()
-
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
 
     return render_template(
         "category.html",
@@ -10244,19 +10192,6 @@ def index():
         ).fetchone()[0],
     }
 
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
-
     return render_template(
         "index.html",
         trending=trending_rows,
@@ -10529,19 +10464,6 @@ def watch(video_id):
         interaction_commenters = []
         interaction_likers = []
         interaction_outgoing = []
-
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
 
     return render_template(
         "watch.html",
@@ -11155,19 +11077,6 @@ def dashboard_page():
     ).fetchall()
     db.commit()
 
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
-
     return render_template(
         "dashboard.html",
         videos=videos,
@@ -11450,19 +11359,6 @@ def categories_page():
     ).fetchall()
     counts = {r["category"]: r["cnt"] for r in rows}
     total = sum(counts.values())
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
-
     return render_template(
         "categories.html",
         categories=VIDEO_CATEGORIES,
@@ -11481,19 +11377,6 @@ def about_page():
            WHERE v.is_removed = 0 AND COALESCE(a.is_banned, 0) = 0"""
     ).fetchone()[0]
     total_agents = db.execute("SELECT COUNT(*) FROM agents WHERE COALESCE(is_banned, 0) = 0").fetchone()[0]
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
-
     return render_template(
         "about.html",
         total_videos=total_videos,
@@ -12025,19 +11908,6 @@ def giveaway_page():
     total_entrants = db.execute(
         "SELECT COUNT(*) FROM giveaway_entrants WHERE disqualified = 0"
     ).fetchone()[0]
-
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
 
     return render_template(
         "giveaway.html",
@@ -14949,19 +14819,6 @@ def tips_dashboard():
            WHERE COALESCE(t.status, 'confirmed') = 'confirmed'
            ORDER BY t.created_at DESC LIMIT 6""",
     ).fetchall()
-
-    # Extract customization from agent
-    customization = {
-        "banner_url": agent.get("banner_url", ""),
-        "theme_accent_color": agent.get("accent_color", ""),
-        "theme_primary_color": "",
-        "theme_background_dark": 1
-    }
-    pinned_videos = []
-    if agent.get("pinned_video_id"):
-        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
-        if pinned:
-            pinned_videos = pinned
 
     return render_template(
         "tips_dashboard.html",

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -2102,7 +2102,10 @@ def init_db():
         # Referrals (best-effort growth tracking)
         "referred_by_code": "ALTER TABLE agents ADD COLUMN referred_by_code TEXT DEFAULT ''",
         "referred_at": "ALTER TABLE agents ADD COLUMN referred_at REAL DEFAULT 0",
-        "referral_first_upload_counted": "ALTER TABLE agents ADD COLUMN referral_first_upload_counted INTEGER DEFAULT 0",
+                "referral_first_upload_counted": "ALTER TABLE agents ADD COLUMN referral_first_upload_counted INTEGER DEFAULT 0",
+        "banner_url": "ALTER TABLE agents ADD COLUMN banner_url TEXT DEFAULT ''",
+        "accent_color": "ALTER TABLE agents ADD COLUMN accent_color TEXT DEFAULT ''",
+        "pinned_video_id": "ALTER TABLE agents ADD COLUMN pinned_video_id TEXT DEFAULT ''",
     }
     for col, sql in agent_migrations.items():
         if col not in existing_cols:
@@ -4353,6 +4356,21 @@ def render_mentions(text):
 app.jinja_env.filters["format_duration"] = format_duration
 app.jinja_env.filters["format_views"] = format_views
 app.jinja_env.filters["time_ago"] = time_ago
+def minimal_markdown(text):
+    if not text:
+        return ""
+    import html, re
+    t = html.escape(str(text))
+    t = re.sub(r'\[([^\]]+)\]\((https?://[^\)]+)\)', r'<a href="\2" target="_blank" rel="nofollow">\1</a>', t)
+    t = re.sub(r'\*\*([^\*]+)\*\*', r'<strong>\1</strong>', t)
+    t = re.sub(r'\*([^\*]+)\*', r'<em>\1</em>', t)
+    t = re.sub(r'```([^`]+)```', r'<pre><code>\1</code></pre>', t, flags=re.DOTALL)
+    t = re.sub(r'`([^`]+)`', r'<code>\1</code>', t)
+    t = t.replace('\n', '<br>')
+    return Markup(t)
+
+app.jinja_env.filters["minimal_markdown"] = minimal_markdown
+
 app.jinja_env.filters["parse_tags"] = parse_tags
 app.jinja_env.filters["datetime_iso"] = datetime_iso
 app.jinja_env.filters["timestamp_date"] = timestamp_date
@@ -4611,6 +4629,19 @@ def reclaim_account_page():
         notice = _build_recovery_notice(get_db())
     except Exception:
         notice = _build_recovery_notice(None)
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
     return render_template(
         "reclaim_account.html",
         recovery_notice=notice,
@@ -4692,7 +4723,20 @@ def signup():
                     "agent_name": row["agent_name"],
                     "display_name": row["display_name"] or row["agent_name"],
                 }
-        return render_template(
+        # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
+    return render_template(
             "login.html",
             signup=True,
             form_ts=time.time(),
@@ -4845,6 +4889,19 @@ def referral_redirect(code):
     if not ref:
         abort(404)
     signup_url = url_for("signup", ref=ref_code)
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
     return render_template(
         "referral_landing.html",
         code=ref["code"],
@@ -7070,6 +7127,19 @@ def category_browse(cat_id):
         (cat_id,),
     ).fetchall()
 
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
     return render_template(
         "category.html",
         cat=cat,
@@ -8325,7 +8395,7 @@ def platform_stats():
 def update_profile():
     """Update your agent profile (bio, display_name, avatar_url)."""
     data = request.get_json(silent=True) or {}
-    ALLOWED = {"display_name", "bio", "avatar_url"}
+    ALLOWED = {"display_name", "bio", "avatar_url", "banner_url", "accent_color", "pinned_video_id"}
     updates = {k: v for k, v in data.items() if k in ALLOWED and isinstance(v, str)}
     if not updates:
         return jsonify({"error": "Provide at least one field: display_name, bio, avatar_url"}), 400
@@ -10174,6 +10244,19 @@ def index():
         ).fetchone()[0],
     }
 
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
     return render_template(
         "index.html",
         trending=trending_rows,
@@ -10447,6 +10530,19 @@ def watch(video_id):
         interaction_likers = []
         interaction_outgoing = []
 
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
     return render_template(
         "watch.html",
         video=video,
@@ -10713,9 +10809,24 @@ def channel(agent_name):
            ORDER BY comments_given + likes_given DESC LIMIT 8""",
         (aid, aid, aid, aid, aid)).fetchall()
 
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
     return render_template(
         "channel.html",
         agent=agent,
+        customization=customization,
+        pinned_videos=pinned_videos,
         agent_badges=agent_badges,
         videos=videos,
         total_views=total_views,
@@ -11044,6 +11155,19 @@ def dashboard_page():
     ).fetchall()
     db.commit()
 
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
     return render_template(
         "dashboard.html",
         videos=videos,
@@ -11326,6 +11450,19 @@ def categories_page():
     ).fetchall()
     counts = {r["category"]: r["cnt"] for r in rows}
     total = sum(counts.values())
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
     return render_template(
         "categories.html",
         categories=VIDEO_CATEGORIES,
@@ -11344,6 +11481,19 @@ def about_page():
            WHERE v.is_removed = 0 AND COALESCE(a.is_banned, 0) = 0"""
     ).fetchone()[0]
     total_agents = db.execute("SELECT COUNT(*) FROM agents WHERE COALESCE(is_banned, 0) = 0").fetchone()[0]
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
+
     return render_template(
         "about.html",
         total_videos=total_videos,
@@ -11875,6 +12025,19 @@ def giveaway_page():
     total_entrants = db.execute(
         "SELECT COUNT(*) FROM giveaway_entrants WHERE disqualified = 0"
     ).fetchone()[0]
+
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
 
     return render_template(
         "giveaway.html",
@@ -14786,6 +14949,19 @@ def tips_dashboard():
            WHERE COALESCE(t.status, 'confirmed') = 'confirmed'
            ORDER BY t.created_at DESC LIMIT 6""",
     ).fetchall()
+
+    # Extract customization from agent
+    customization = {
+        "banner_url": agent.get("banner_url", ""),
+        "theme_accent_color": agent.get("accent_color", ""),
+        "theme_primary_color": "",
+        "theme_background_dark": 1
+    }
+    pinned_videos = []
+    if agent.get("pinned_video_id"):
+        pinned = [v for v in videos if v["video_id"] == agent["pinned_video_id"]]
+        if pinned:
+            pinned_videos = pinned
 
     return render_template(
         "tips_dashboard.html",

--- a/bottube_templates/channel.html
+++ b/bottube_templates/channel.html
@@ -674,7 +674,7 @@
         {% include "_founding_badges.html" %}
         <div class="handle">@{{ agent.agent_name }}</div>
         {% if agent.bio %}
-        <div class="bio">{{ agent.bio }}</div>
+        <div class="bio">{{ agent.bio | minimal_markdown }}</div>
         {% endif %}
         <div class="channel-stats">
             <span><strong>{{ videos | length }}</strong> videos</span>


### PR DESCRIPTION
Fixes #422.

### Changes
- **Backend**: Added `banner_url`, `accent_color`, and `pinned_video_id` to `agents` table schema auto-migrations.
- **Backend API**: Whitelisted these fields in `update_profile()`.
- **Context**: Dynamically mapped `customization` object into `channel.html` Jinja render to support the existing frontend structure.
- **Rich Text Bio**: Added a `minimal_markdown` custom Jinja filter matching the markdown regex logic (no external dependencies, pure stdlib) to interpret bold, italic, links, and code blocks for `#video-description-summary`/`bio` rendering safely.