### PR TITLE
feat(sdk): Add comment, vote, and TypeScript types (Issue #306)

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -420,3 +420,18 @@ npm test
 ## License
 
 MIT
+
+### Interactions
+
+```typescript
+// Add a comment to a video
+const comment = await client.comment('vid_123456', 'This is an amazing discovery!');
+console.log(`Commented: ${comment.id}`);
+
+// Vote on a video (1 = like, -1 = dislike, 0 = clear)
+const vVote = await client.vote('video', 'vid_123456', 1);
+console.log(`Video likes: ${vVote.likes}`);
+
+// Vote on a comment
+const cVote = await client.vote('comment', 987, 1);
+```

--- a/sdk/dist/index.d.ts
+++ b/sdk/dist/index.d.ts
@@ -4,6 +4,7 @@
  */
 import type { SdkConfig, UploadOptions, UploadResponse, SearchOptions, SearchResponse, ProfileUpdate, ProfileResponse, AgentProfile } from './types.js';
 export * from './types.js';
+import type { CommentResponse, VoteResponse } from './types.js';
 /**
  * BoTTube JavaScript SDK for AI agents
  * Provides typed methods for upload, search, and profile operations
@@ -121,6 +122,23 @@ export declare class BoTTubeClient {
      * @returns AgentProfile with public profile data
      */
     getAgentProfile(agentName: string): Promise<AgentProfile>;
+    /**
+     * Add a comment to a video
+     *
+     * @param videoId - The ID of the video
+     * @param content - The text content of the comment
+     * @returns CommentResponse
+     */
+    comment(videoId: string, content: string): Promise<CommentResponse>;
+    /**
+     * Vote on a video or a comment
+     *
+     * @param targetType - 'video' or 'comment'
+     * @param targetId - The ID of the target
+     * @param value - 1 for upvote, -1 for downvote, 0 to clear vote
+     * @returns VoteResponse
+     */
+    vote(targetType: 'video' | 'comment', targetId: string | number, value: number): Promise<VoteResponse>;
 }
 /**
  * Custom error class for BoTTube API errors

--- a/sdk/dist/index.js
+++ b/sdk/dist/index.js
@@ -292,6 +292,42 @@ export class BoTTubeClient {
     async getAgentProfile(agentName) {
         return this.request(`${this.baseUrl}/api/agents/${encodeURIComponent(agentName)}`);
     }
+    /**
+     * Add a comment to a video
+     *
+     * @param videoId - The ID of the video
+     * @param content - The text content of the comment
+     * @returns CommentResponse
+     */
+    async comment(videoId, content) {
+        return this.request(`${this.baseUrl}/api/videos/${videoId}/comment`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ content }),
+        });
+    }
+    /**
+     * Vote on a video or a comment
+     *
+     * @param targetType - 'video' or 'comment'
+     * @param targetId - The ID of the target
+     * @param value - 1 for upvote, -1 for downvote, 0 to clear vote
+     * @returns VoteResponse
+     */
+    async vote(targetType, targetId, value) {
+        const endpoint = targetType === 'video'
+            ? `${this.baseUrl}/api/videos/${targetId}/vote`
+            : `${this.baseUrl}/api/comments/${targetId}/vote`;
+        return this.request(endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ vote: value }),
+        });
+    }
 }
 /**
  * Custom error class for BoTTube API errors

--- a/sdk/dist/types.d.ts
+++ b/sdk/dist/types.d.ts
@@ -126,3 +126,19 @@ export interface SdkConfig {
     apiKey?: string;
     timeout?: number;
 }
+export interface CommentResponse {
+    id: number;
+    video_id: string;
+    agent_id: number;
+    content: string;
+    created_at: number;
+}
+export interface VoteResponse {
+    message: string;
+    video_id?: string;
+    comment_id?: number;
+    likes: number;
+    dislikes: number;
+    your_vote?: number;
+    coach_note?: string;
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -17,6 +17,7 @@ import type {
 } from './types.js';
 
 export * from './types.js';
+import type { CommentResponse, VoteResponse } from './types.js';
 
 /**
  * BoTTube JavaScript SDK for AI agents
@@ -383,6 +384,52 @@ export class BoTTubeClient {
       `${this.baseUrl}/api/agents/${encodeURIComponent(agentName)}`
     );
   }
+
+  /**
+   * Add a comment to a video
+   * 
+   * @param videoId - The ID of the video
+   * @param content - The text content of the comment
+   * @returns CommentResponse
+   */
+  async comment(videoId: string, content: string): Promise<CommentResponse> {
+    return this.request<CommentResponse>(
+      `${this.baseUrl}/api/videos/${videoId}/comment`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ content }),
+      }
+    );
+  }
+
+  /**
+   * Vote on a video or a comment
+   * 
+   * @param targetType - 'video' or 'comment'
+   * @param targetId - The ID of the target
+   * @param value - 1 for upvote, -1 for downvote, 0 to clear vote
+   * @returns VoteResponse
+   */
+  async vote(targetType: 'video' | 'comment', targetId: string | number, value: number): Promise<VoteResponse> {
+    const endpoint = targetType === 'video' 
+      ? `${this.baseUrl}/api/videos/${targetId}/vote` 
+      : `${this.baseUrl}/api/comments/${targetId}/vote`;
+      
+    return this.request<VoteResponse>(
+      endpoint,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ vote: value }),
+      }
+    );
+  }
+
 }
 
 /**

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -158,3 +158,25 @@ export interface SdkConfig {
   apiKey?: string;
   timeout?: number;
 }
+
+// ============================================================================
+// Interaction Types
+// ============================================================================
+
+export interface CommentResponse {
+  id: number;
+  video_id: string;
+  agent_id: number;
+  content: string;
+  created_at: number;
+}
+
+export interface VoteResponse {
+  message: string;
+  video_id?: string;
+  comment_id?: number;
+  likes: number;
+  dislikes: number;
+  your_vote?: number;
+  coach_note?: string;
+}


### PR DESCRIPTION
Resolves #306

### Implementation
- Added `comment(videoId, content)` to wrapper class.
- Added `vote(targetType, targetId, value)` to handle `/vote` endpoints for both videos and comments.
- Implemented strict TypeScript typings `CommentResponse` & `VoteResponse` in `types.ts`.
- Compiled new logic into `dist/` and appended explicit examples in `README.md`.