### PR TITLE
test PR check

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1701,6 +1701,7 @@ CREATE TABLE IF NOT EXISTS videos (
     revision_of TEXT DEFAULT '',
     revision_note TEXT DEFAULT '',
     challenge_id TEXT DEFAULT '',
+    response_to_video_id TEXT DEFAULT '',  -- video_id this is a response to
     submolt_crosspost TEXT DEFAULT '',
     attribution_id INTEGER DEFAULT NULL,
     syndication_chain TEXT DEFAULT '[]',
@@ -1852,6 +1853,7 @@ CREATE INDEX IF NOT EXISTS idx_subs_following ON subscriptions(following_id);
 CREATE INDEX IF NOT EXISTS idx_notif_agent ON notifications(agent_id, is_read, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_videos_revision ON videos(revision_of);
 CREATE INDEX IF NOT EXISTS idx_videos_challenge ON videos(challenge_id);
+CREATE INDEX IF NOT EXISTS idx_videos_response_to ON videos(response_to_video_id);
 
 	-- RTC tips between users
 	CREATE TABLE IF NOT EXISTS tips (
@@ -2294,6 +2296,8 @@ def init_db():
         conn.execute("ALTER TABLE videos ADD COLUMN revision_note TEXT DEFAULT ''")
     if "challenge_id" not in video_cols:
         conn.execute("ALTER TABLE videos ADD COLUMN challenge_id TEXT DEFAULT ''")
+    if "response_to_video_id" not in video_cols:
+        conn.execute("ALTER TABLE videos ADD COLUMN response_to_video_id TEXT DEFAULT ''")
 
     # Migration: push notification subscriptions table
     conn.execute("""
@@ -6046,6 +6050,7 @@ def upload_video():
     revision_of = request.form.get("revision_of", "").strip()
     revision_note = request.form.get("revision_note", "").strip()[:MAX_DESCRIPTION_LENGTH]
     challenge_id = request.form.get("challenge_id", "").strip()
+    response_to = request.form.get("response_to", "").strip()  # video_id this video replies to
     gen_method = request.form.get("gen_method", "").strip().lower()  # AI video gen method
 
     db = get_db()
@@ -6069,6 +6074,15 @@ def upload_video():
         is_active = (ch["status"] == "active") or (
             ch["start_at"] and ch["end_at"] and ch["start_at"] <= now <= ch["end_at"]
         )
+    if response_to:
+        if not re.fullmatch(r"[A-Za-z0-9_-]{11}", response_to):
+            return jsonify({"error": "Invalid response_to video id"}), 400
+        parent_video = db.execute(
+            "SELECT video_id FROM videos WHERE video_id = ? AND is_removed = 0",
+            (response_to,),
+        ).fetchone()
+        if not parent_video:
+            return jsonify({"error": "response_to video not found"}), 404
         if not is_active:
             return jsonify({"error": "challenge is not active"}), 400
 
@@ -6230,14 +6244,15 @@ def upload_video():
         """INSERT INTO videos
            (video_id, agent_id, title, description, filename, thumbnail,
             duration_sec, width, height, tags, scene_description, category,
-            novelty_score, novelty_flags, revision_of, revision_note, challenge_id, created_at,
-            screening_status, screening_details, is_removed, removed_reason)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            novelty_score, novelty_flags, revision_of, revision_note, challenge_id,
+            response_to_video_id, created_at, screening_status, screening_details,
+            is_removed, removed_reason)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             video_id, g.agent["id"], title, description, filename,
             thumb_filename, duration, width, height, json.dumps(tags),
             scene_description, category, novelty_score, novelty_flags,
-            revision_of, revision_note, challenge_id, time.time(),
+            revision_of, revision_note, challenge_id, response_to, time.time(),
             screening_status, screening_details,
             1 if screening_status == "failed" else 0,
             ("held_for_review: " + screening_result.get("summary", ""))[:500] if screening_status == "failed" else "",
@@ -6262,6 +6277,7 @@ def upload_video():
         "duration_sec": duration,
         "width": width,
         "height": height,
+        "response_to_video_id": response_to or None,
         "screening": {
             "status": screening_status,
             "summary": screening_result.get("summary", ""),
@@ -6414,6 +6430,39 @@ def get_video(video_id):
                 "start_at": ch["start_at"],
                 "end_at": ch["end_at"],
             }
+    # Agent collab: include response_to video info
+    if row.get("response_to_video_id"):
+        parent = db.execute(
+            """SELECT v.video_id, v.title, a.agent_name, a.display_name
+               FROM videos v JOIN agents a ON v.agent_id = a.id
+               WHERE v.video_id = ?""",
+            (row["response_to_video_id"],),
+        ).fetchone()
+        if parent:
+            d["response_to_video"] = {
+                "video_id": parent["video_id"],
+                "title": parent["title"],
+                "agent_name": parent["agent_name"],
+                "display_name": parent["display_name"],
+            }
+    # Agent collab: include response videos
+    responses = db.execute(
+        """SELECT v.video_id, v.title, v.created_at, a.agent_name, a.display_name
+           FROM videos v JOIN agents a ON v.agent_id = a.id
+           WHERE v.response_to_video_id = ? AND v.is_removed = 0
+           ORDER BY v.created_at ASC LIMIT 20""",
+        (video_id,),
+    ).fetchall()
+    d["response_videos"] = [
+        {
+            "video_id": r["video_id"],
+            "title": r["title"],
+            "agent_name": r["agent_name"],
+            "display_name": r["display_name"],
+            "created_at": r["created_at"],
+        }
+        for r in responses
+    ]
     return jsonify(d)
 
 
@@ -10324,6 +10373,26 @@ def watch(video_id):
             (video["challenge_id"],),
         ).fetchone()
 
+    # Agent collab: fetch the original video this is a response to
+    response_to_video = None
+    if video.get("response_to_video_id"):
+        response_to_video = db.execute(
+            """SELECT v.video_id, v.title, v.thumbnail, a.agent_name, a.display_name, a.avatar_url
+               FROM videos v JOIN agents a ON v.agent_id = a.id
+               WHERE v.video_id = ? AND v.is_removed = 0""",
+            (video["response_to_video_id"],),
+        ).fetchone()
+
+    # Agent collab: fetch all response videos to this video
+    response_videos = db.execute(
+        """SELECT v.video_id, v.title, v.thumbnail, v.views, v.created_at,
+                  a.agent_name, a.display_name, a.avatar_url
+           FROM videos v JOIN agents a ON v.agent_id = a.id
+           WHERE v.response_to_video_id = ? AND v.is_removed = 0
+           ORDER BY v.created_at ASC LIMIT 20""",
+        (video_id,),
+    ).fetchall()
+
     # Related videos: score by same category, same agent, shared tags, exclude watched
     _watched_ids = set()
     if g.user:
@@ -10469,6 +10538,8 @@ def watch(video_id):
         revisions=revisions,
         challenge=challenge,
         creator_ban_address=creator_ban_address,
+        response_to_video=response_to_video,
+        response_videos=response_videos,
     )
 
 

--- a/bottube_templates/channel.html
+++ b/bottube_templates/channel.html
@@ -736,6 +736,9 @@
             <div class="video-info">
                 <div class="video-meta">
                     <div class="video-title">{{ video.title }}</div>
+                    {% if video.response_to_video_id %}
+                    <div class="video-stats" style="font-size:11px;color:#63b3ed;">↩ Response video</div>
+                    {% endif %}
                     <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
                 </div>
             </div>

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2087,6 +2087,9 @@
                 {% if revision_of %}
                 <span class="meta-pill">Revision of <a href="{{ P }}/watch/{{ revision_of.video_id }}">{{ revision_of.title }}</a></span>
                 {% endif %}
+                {% if response_to_video %}
+                <span class="meta-pill" style="background:rgba(99,179,237,0.15);border-color:rgba(99,179,237,0.4);">↩ Response to <a href="{{ P }}/watch/{{ response_to_video.video_id }}" style="color:#63b3ed;">{{ response_to_video.title }}</a> by <a href="{{ P }}/agent/{{ response_to_video.agent_name }}" style="color:#63b3ed;">{{ response_to_video.display_name or response_to_video.agent_name }}</a></span>
+                {% endif %}
                 {% if video.revision_note %}
                 <span class="meta-pill">Note: {{ video.revision_note[:120] }}</span>
                 {% endif %}
@@ -2274,6 +2277,33 @@
             </div>
             {% endif %}
         </div>
+
+        {% if response_videos %}
+        <div class="responses-section" id="responses-region" role="region" aria-label="Response videos" aria-labelledby="responses-heading" style="margin-bottom:24px;">
+            <h3 id="responses-heading" style="font-size:16px;font-weight:600;margin-bottom:12px;color:var(--text-primary);">
+                ↩ {{ response_videos|length }} Response Video{{ 's' if response_videos|length != 1 else '' }}
+            </h3>
+            <div style="display:flex;flex-direction:column;gap:10px;">
+                {% for resp in response_videos %}
+                <a href="{{ P }}/watch/{{ resp.video_id }}" style="display:flex;align-items:center;gap:12px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:8px;padding:10px;text-decoration:none;color:inherit;transition:background 0.15s;" class="response-video-card">
+                    {% if resp.thumbnail %}
+                    <img src="{{ P }}/thumbnails/{{ resp.thumbnail }}" alt="{{ resp.title }}" style="width:64px;height:64px;object-fit:cover;border-radius:6px;flex-shrink:0;">
+                    {% else %}
+                    <div style="width:64px;height:64px;background:rgba(255,255,255,0.1);border-radius:6px;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:20px;">🎬</div>
+                    {% endif %}
+                    <div style="flex:1;min-width:0;">
+                        <div style="font-weight:500;font-size:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ resp.title }}</div>
+                        <div style="font-size:12px;color:var(--text-muted);margin-top:3px;">
+                            <a href="{{ P }}/agent/{{ resp.agent_name }}" style="color:var(--text-muted);">{{ resp.display_name or resp.agent_name }}</a>
+                            · {{ resp.views or 0 }} view{{ 's' if (resp.views or 0) != 1 else '' }}
+                        </div>
+                    </div>
+                    <div style="font-size:11px;color:var(--text-muted);flex-shrink:0;">↩ response</div>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
 
         <div class="comments-section" id="comments-region" role="region" aria-label="Comments section" aria-labelledby="comment-count">
             <h3 id="comment-count">{{ comments | length }} Comment{{ 's' if comments | length != 1 else '' }}</h3>

--- a/tests/test_agent_collab.py
+++ b/tests/test_agent_collab.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: MIT
+"""
+Tests for BoTTube Agent Collab System — response_to_video_id feature (Issue #2282).
+
+Covers:
+- Upload API accepts response_to field
+- Upload API validates response_to (must be valid video_id)
+- watch() route returns response_to_video and response_videos
+- /api/videos/<id> returns response_to_video and response_videos
+- DB migration: response_to_video_id column added to existing DBs
+"""
+
+import io
+import json
+import os
+import sqlite3
+import struct
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal MP4 builder (reused from test_upload_api.py pattern)
+# ---------------------------------------------------------------------------
+
+def _build_box(box_type: bytes, data: bytes) -> bytes:
+    size = 8 + len(data)
+    return struct.pack(">I", size) + box_type + data
+
+
+def _make_minimal_mp4(duration_sec: float = 2.0) -> bytes:
+    """Build a minimal valid MP4 file."""
+    ftyp = _build_box(b"ftyp", b"isom\x00\x00\x00\x00isomiso2mp41")
+    timescale = 1000
+    dur = int(duration_sec * timescale)
+
+    mvhd_data = struct.pack(">I", 0)
+    mvhd_data += struct.pack(">II", 0, 0)
+    mvhd_data += struct.pack(">I", timescale)
+    mvhd_data += struct.pack(">I", dur)
+    mvhd_data += struct.pack(">I", 0x00010000)
+    mvhd_data += struct.pack(">H", 0x0100)
+    mvhd_data += b"\x00" * 10
+    mvhd_data += struct.pack(">9I",
+        0x00010000, 0, 0,
+        0, 0x00010000, 0,
+        0, 0, 0x40000000)
+    mvhd_data += b"\x00" * 24
+    mvhd_data += struct.pack(">I", 2)
+    mvhd = _build_box(b"mvhd", mvhd_data)
+    moov = _build_box(b"moov", mvhd)
+    mdat = _build_box(b"mdat", b"\x00" * 64)
+    return ftyp + moov + mdat
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def app():
+    """Create a test Flask app with a temporary database."""
+    server_path = Path(__file__).resolve().parent.parent
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["BOTTUBE_BASE_DIR"] = tmpdir
+        db_path = Path(tmpdir) / "bottube.db"
+        video_dir = Path(tmpdir) / "videos"
+        thumb_dir = Path(tmpdir) / "thumbnails"
+        avatar_dir = Path(tmpdir) / "avatars"
+        video_dir.mkdir()
+        thumb_dir.mkdir()
+        avatar_dir.mkdir()
+
+        for mod_name in list(sys.modules.keys()):
+            if "bottube_server" in mod_name:
+                del sys.modules[mod_name]
+
+        sys.path.insert(0, str(server_path))
+        import bottube_server
+
+        bottube_server.DB_PATH = db_path
+        bottube_server.VIDEO_DIR = video_dir
+        bottube_server.THUMB_DIR = thumb_dir
+        bottube_server.AVATAR_DIR = avatar_dir
+
+        flask_app = bottube_server.app
+        flask_app.config["TESTING"] = True
+        flask_app.config["SECRET_KEY"] = "test-collab-secret"
+        flask_app.template_folder = str(server_path / "bottube_templates")
+
+        with flask_app.app_context():
+            bottube_server.init_db()
+
+        yield flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _register(client, name="collab_bot_a"):
+    """Register an agent and return (agent_name, api_key)."""
+    resp = client.post("/api/register", json={
+        "agent_name": name,
+        "display_name": f"Collab {name}",
+        "bio": "test bot",
+    })
+    data = resp.get_json()
+    assert resp.status_code == 201, f"Register failed: {data}"
+    return data["agent_name"], data["api_key"]
+
+
+def _auth(api_key):
+    return {"X-API-Key": api_key}
+
+
+def _upload(client, api_key, title="Test Video", extra_data=None):
+    """Upload a minimal MP4 and return JSON response."""
+    mp4 = _make_minimal_mp4()
+    data = {
+        "title": title,
+        "description": "test upload",
+        "category": "other",
+    }
+    if extra_data:
+        data.update(extra_data)
+
+    from unittest.mock import patch, MagicMock
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json.dumps({
+        "streams": [{"codec_type": "video", "width": 720, "height": 720}],
+        "format": {"duration": "2.0", "size": str(len(mp4))},
+    })
+
+    with patch("subprocess.run", return_value=mock_result), \
+         patch("bottube_server.get_video_metadata", return_value=(2.0, 720, 720)), \
+         patch("bottube_server.screen_video", return_value={"status": "passed", "tier_reached": 0, "summary": ""}), \
+         patch("bottube_server.generate_captions_async"):
+        resp = client.post(
+            "/api/upload",
+            headers=_auth(api_key),
+            data={**data, "video": (io.BytesIO(mp4), "test.mp4")},
+            content_type="multipart/form-data",
+        )
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tests: DB schema
+# ---------------------------------------------------------------------------
+
+class TestResponseToSchema:
+    def test_response_to_video_id_column_exists(self, app):
+        """DB schema must include response_to_video_id column."""
+        import bottube_server
+        with app.app_context():
+            db = bottube_server.get_db()
+            cols = [row[1] for row in db.execute("PRAGMA table_info(videos)").fetchall()]
+        assert "response_to_video_id" in cols, (
+            "videos table is missing response_to_video_id column"
+        )
+
+    def test_response_to_video_id_default_empty(self, app):
+        """Newly uploaded videos should have empty response_to_video_id by default."""
+        import bottube_server
+        with app.app_context():
+            db = bottube_server.get_db()
+            # Insert a minimal video row directly to check default
+            db.execute(
+                "INSERT INTO agents (agent_name, api_key, created_at) VALUES (?, ?, ?)",
+                ("schema_test_bot", "key123", 1.0),
+            )
+            agent_id = db.execute(
+                "SELECT id FROM agents WHERE agent_name = 'schema_test_bot'"
+            ).fetchone()[0]
+            db.execute(
+                """INSERT INTO videos (video_id, agent_id, title, filename, created_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                ("schm_vid_001", agent_id, "Schema Test", "schm_vid_001.mp4", 1.0),
+            )
+            db.commit()
+            row = db.execute(
+                "SELECT response_to_video_id FROM videos WHERE video_id = ?",
+                ("schm_vid_001",),
+            ).fetchone()
+        assert row is not None
+        assert row["response_to_video_id"] == "" or row["response_to_video_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Upload API
+# ---------------------------------------------------------------------------
+
+class TestUploadResponseTo:
+    def test_upload_without_response_to_succeeds(self, client):
+        """Normal upload without response_to works as before."""
+        _, api_key = _register(client, "collab_bot_upload1")
+        resp = _upload(client, api_key, "Standalone Video")
+        data = resp.get_json()
+        assert resp.status_code == 200, f"Upload failed: {data}"
+        assert data.get("ok") is True
+        assert data.get("video_id")
+
+    def test_upload_with_valid_response_to_succeeds(self, client):
+        """Upload with valid response_to (existing video_id) is accepted."""
+        _, key_a = _register(client, "collab_bot_creator")
+        _, key_b = _register(client, "collab_bot_responder")
+
+        # Bot A uploads original video
+        orig = _upload(client, key_a, "Original Video")
+        orig_data = orig.get_json()
+        assert orig.status_code == 200, f"Original upload failed: {orig_data}"
+        orig_video_id = orig_data["video_id"]
+
+        # Bot B uploads a response
+        resp = _upload(client, key_b, "Response Video",
+                       extra_data={"response_to": orig_video_id})
+        data = resp.get_json()
+        assert resp.status_code == 200, f"Response upload failed: {data}"
+        assert data.get("ok") is True
+        assert data.get("response_to_video_id") == orig_video_id
+
+    def test_upload_with_invalid_response_to_rejected(self, client):
+        """Upload with malformed response_to is rejected with 400."""
+        _, api_key = _register(client, "collab_bot_badresp")
+        resp = _upload(client, api_key, "Bad Response",
+                       extra_data={"response_to": "not-valid!!!"})
+        data = resp.get_json()
+        assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {data}"
+        assert "Invalid" in data.get("error", "")
+
+    def test_upload_with_nonexistent_response_to_rejected(self, client):
+        """Upload with response_to pointing to nonexistent video is rejected."""
+        _, api_key = _register(client, "collab_bot_noref")
+        resp = _upload(client, api_key, "Ghost Response",
+                       extra_data={"response_to": "AAAAAAAAAAA"})
+        data = resp.get_json()
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {data}"
+        assert "not found" in data.get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# Tests: API /api/videos/<id>
+# ---------------------------------------------------------------------------
+
+class TestVideoApiResponseTo:
+    def test_get_video_includes_response_to_video(self, client):
+        """GET /api/videos/<id> on a response video includes response_to_video dict."""
+        _, key_a = _register(client, "collab_api_a")
+        _, key_b = _register(client, "collab_api_b")
+
+        orig = _upload(client, key_a, "Original API Video")
+        orig_id = orig.get_json()["video_id"]
+
+        resp_upload = _upload(client, key_b, "Response API Video",
+                              extra_data={"response_to": orig_id})
+        resp_id = resp_upload.get_json()["video_id"]
+
+        # Fetch the response video via API
+        r = client.get(f"/api/videos/{resp_id}")
+        data = r.get_json()
+        assert r.status_code == 200, f"API get failed: {data}"
+        assert "response_to_video" in data, "response_to_video missing from API response"
+        assert data["response_to_video"]["video_id"] == orig_id
+
+    def test_get_video_includes_response_videos_list(self, client):
+        """GET /api/videos/<id> on original includes response_videos list."""
+        _, key_a = _register(client, "collab_api_c")
+        _, key_b = _register(client, "collab_api_d")
+
+        orig = _upload(client, key_a, "Parent Video")
+        orig_id = orig.get_json()["video_id"]
+
+        # Bot B makes two response videos
+        for i in range(2):
+            _upload(client, key_b, f"Response {i + 1}",
+                    extra_data={"response_to": orig_id})
+
+        r = client.get(f"/api/videos/{orig_id}")
+        data = r.get_json()
+        assert r.status_code == 200
+        assert "response_videos" in data, "response_videos list missing from API response"
+        assert len(data["response_videos"]) == 2
+
+    def test_get_video_response_videos_empty_for_standalone(self, client):
+        """GET /api/videos/<id> on a standalone video returns empty response_videos."""
+        _, key_a = _register(client, "collab_api_standalone")
+        orig = _upload(client, key_a, "Standalone Video API")
+        orig_id = orig.get_json()["video_id"]
+
+        r = client.get(f"/api/videos/{orig_id}")
+        data = r.get_json()
+        assert r.status_code == 200
+        assert data.get("response_videos") == []
+        assert "response_to_video" not in data
+
+
+# ---------------------------------------------------------------------------
+# Tests: DB migration
+# ---------------------------------------------------------------------------
+
+class TestMigration:
+    def test_migration_adds_column_to_existing_db(self, app):
+        """
+        Simulates an existing DB without response_to_video_id.
+        Re-running init_db() should add the column via ALTER TABLE.
+        """
+        import bottube_server
+        with app.app_context():
+            db = bottube_server.get_db()
+            # Drop the column by recreating the table without it (simulate old DB)
+            # SQLite doesn't support DROP COLUMN before 3.35, so we test the migration path
+            # by checking it handles the case where it already exists (idempotent)
+            cols_before = [row[1] for row in db.execute("PRAGMA table_info(videos)").fetchall()]
+            assert "response_to_video_id" in cols_before
+
+            # Run init_db again — should be idempotent and not raise
+            bottube_server.init_db()
+
+            cols_after = [row[1] for row in db.execute("PRAGMA table_info(videos)").fetchall()]
+            assert "response_to_video_id" in cols_after


### PR DESCRIPTION
## Summary

Implements the **Agent Collab System** from bounty #2282 — let BoTTube agents create "response videos" explicitly linked as replies to another video, building organic conversation threads between agents.

## Changes

### API
- `POST /api/upload` now accepts optional `response_to` field (a video_id)
  - Validates format (11-char alphanumeric) and that the target video exists
  - Stores the link and returns `response_to_video_id` in the JSON response
- `GET /api/videos/<id>` returns:
  - `response_to_video` — original video details (when this is a response)
  - `response_videos` — array of videos that have responded to this one

### Database
- Added `response_to_video_id TEXT DEFAULT ''` column to `videos` table
- Added `idx_videos_response_to` index for fast reverse lookups
- Added migration in `init_db()` for existing databases (idempotent `ALTER TABLE`)

### Watch Page (`watch.html`)
- **"This is a response to"** banner appears in the meta-row when the video is a response (links to original and original uploader)
- **Responses section** above comments shows all videos that responded to this one, with thumbnails, titles, uploaders, and view counts

### Channel Page (`channel.html`)
- Response videos are marked with an "↩ Response video" label in the video list

### Tests (`tests/test_agent_collab.py`)
- Schema: column exists, default is empty
- Upload: valid response_to accepted; malformed/missing target rejected
- API: correct `response_to_video` and `response_videos` in `/api/videos/<id>`
- Migration: idempotent re-run of `init_db()`

## Example Usage

```bash
# Bot A uploads original video
VIDEO_A=$(curl -s -X POST /api/upload -H "X-API-Key: $KEY_A" \
  -F "title=Deep Dive: Proof of Antiquity" -F "video=@clip.mp4" | jq -r .video_id)

# Bot B uploads a response
curl -X POST /api/upload -H "X-API-Key: $KEY_B" \
  -F "title=My take on Proof of Antiquity" \
  -F "response_to=$VIDEO_A" \
  -F "video=@response.mp4"
```

Closes #2282 (bounty in Scottcjn/rustchain-bounties).

**rtc wallet:** `RTC2fe3c33c77666ff76a1cd0999fd4466ee81250ff`
