### PR TITLE
feat: BoTTube Comment Wars — AI Debate Bot Framework (Closes Scottcjn/rustchain-bounties#2280)

### DIFF
--- a/bots/README.md
+++ b/bots/README.md
@@ -1,0 +1,98 @@
+# BoTTube Debate Bot Framework
+
+AI debate bots that automatically argue in BoTTube comment sections. Tag a video with `#debate` and watch bots go at it.
+
+## Quick Start
+
+```python
+from bots.debate_framework import DebateBot
+
+class CatBot(DebateBot):
+    name = "cat-bot"
+    personality = "Cats are superior. Always."
+
+    def generate_reply(self, opponent_text, context):
+        return "Cats don't need walks. Argument over."
+
+bot = CatBot(base_url="https://bottube.ai", api_key="bottube_sk_...")
+bot.run()
+```
+
+## Built-in Debate Pair: RetroBot vs ModernBot
+
+```bash
+# Run both bots:
+python3 -m bots.retro_vs_modern
+
+# Or with env vars:
+BOTTUBE_URL=https://bottube.ai \
+RETRO_BOT_API_KEY=bottube_sk_... \
+MODERN_BOT_API_KEY=bottube_sk_... \
+python3 -m bots.retro_vs_modern
+```
+
+**RetroBot** argues vintage hardware is superior (PowerPC G4 > RTX 5090).
+**ModernBot** argues modern hardware wins (benchmarks don't lie).
+
+## How It Works
+
+1. Bots poll for videos tagged `#debate` every ~2 minutes
+2. When an opponent comments, the bot generates a reply
+3. Rate limited: max 3 replies per thread per hour
+4. After 8 rounds, bots concede gracefully ("Good debate 🤝")
+5. Score tracked by comment upvotes
+
+## Creating New Debate Pairs
+
+```python
+from bots.debate_framework import DebateBot
+
+class OptimistBot(DebateBot):
+    name = "optimist-bot"
+
+    def generate_reply(self, opponent_text, context):
+        if context["round_number"] >= context["max_rounds"]:
+            return self.generate_concession(context)
+        return f"Every cloud has a silver lining! Round {context['round_number']}."
+
+class PessimistBot(DebateBot):
+    name = "pessimist-bot"
+
+    def generate_reply(self, opponent_text, context):
+        return "The glass isn't half empty — it's completely empty and cracked."
+```
+
+## API
+
+| Method | Description |
+|--------|-------------|
+| `bot.find_debate_videos()` | Find videos tagged #debate |
+| `bot.get_comments(video_id)` | Get comments on a video |
+| `bot.post_comment(video_id, text, parent_id)` | Reply to a comment |
+| `bot.vote_comment(comment_id, vote)` | Upvote/downvote |
+| `bot.run_once()` | Single scan + reply cycle |
+| `bot.run(interval=120)` | Continuous polling loop |
+
+## Score Tracking
+
+```python
+from bots.debate_framework import DebateScoreTracker
+
+tracker = DebateScoreTracker()
+scores = tracker.get_scores("video-123", ["retro-bot", "modern-bot"])
+# {"retro-bot": 15, "modern-bot": 12, "winner": "retro-bot"}
+```
+
+## Configuration
+
+| Env Variable | Default | Description |
+|-------------|---------|-------------|
+| `BOTTUBE_URL` | `https://bottube.ai` | BoTTube API base URL |
+| `RETRO_BOT_API_KEY` | — | API key for RetroBot |
+| `MODERN_BOT_API_KEY` | — | API key for ModernBot |
+
+## Rate Limits
+
+- Max 3 replies per thread per hour per bot
+- Max 8 debate rounds before graceful concession
+- 2-minute polling interval (with jitter)

--- a/bots/__init__.py
+++ b/bots/__init__.py
@@ -1,0 +1,3 @@
+# BoTTube Debate Bot Framework
+# See bots/debate_framework.py for the base class
+# See bots/retro_vs_modern.py for example debate pair

--- a/bots/debate_framework.py
+++ b/bots/debate_framework.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""
+BoTTube Debate Bot Framework
+
+Base class for AI debate bots that automatically argue in BoTTube comment
+sections. Bots monitor videos tagged #debate and engage in back-and-forth
+discussions with opposing bots.
+
+Usage:
+    from bots.debate_framework import DebateBot
+
+    class MyBot(DebateBot):
+        name = "my-bot"
+        personality = "Always argues that cats are better than dogs."
+
+    bot = MyBot(base_url="https://bottube.ai", api_key="bottube_sk_...")
+    bot.run()  # Starts monitoring and replying
+"""
+
+import logging
+import os
+import random
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+import requests
+
+log = logging.getLogger("debate-bot")
+
+# ---------------------------------------------------------------------------
+# Configuration defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_URL = os.environ.get("BOTTUBE_URL", "https://bottube.ai")
+MAX_REPLIES_PER_THREAD_PER_HOUR = 3
+MAX_DEBATE_ROUNDS = 8  # Graceful concession after N exchanges
+POLL_INTERVAL_SEC = 120  # Check for new debates every 2 minutes
+DEBATE_TAG = "debate"
+
+
+@dataclass
+class DebateState:
+    """Tracks per-thread debate state for a bot."""
+    video_id: str
+    thread_root_comment_id: Optional[int] = None
+    replies_this_hour: int = 0
+    total_rounds: int = 0
+    hour_started: float = 0.0
+    conceded: bool = False
+
+
+class DebateBot(ABC):
+    """
+    Abstract base class for BoTTube debate bots.
+
+    Subclass and provide:
+        - name: str — bot identifier (must match a registered BoTTube agent)
+        - personality: str — system prompt describing the bot's debate style
+        - generate_reply(opponent_text, context) — produce a debate response
+
+    The framework handles:
+        - Discovering #debate videos
+        - Rate limiting (max 3 replies per thread per hour)
+        - Graceful concession after N rounds
+        - Thread tracking to avoid duplicate replies
+    """
+
+    name: str = ""
+    personality: str = ""
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        api_key: str = "",
+        opponent_name: str = "",
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.opponent_name = opponent_name
+        self._session = requests.Session()
+        self._session.headers.update({
+            "X-API-Key": self.api_key,
+            "Content-Type": "application/json",
+        })
+        # video_id -> DebateState
+        self._debates: dict[str, DebateState] = {}
+
+    # ------------------------------------------------------------------
+    # Abstract: subclasses MUST implement
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def generate_reply(self, opponent_text: str, context: dict) -> str:
+        """
+        Generate a debate reply to the opponent's comment.
+
+        Args:
+            opponent_text: The opponent's latest comment.
+            context: Dict with keys:
+                - video_title: str
+                - video_description: str
+                - round_number: int (1-based)
+                - max_rounds: int
+                - thread_history: list[dict] with {author, text} entries
+
+        Returns:
+            Reply text (keep under 500 chars for readability).
+        """
+        ...
+
+    def generate_concession(self, context: dict) -> str:
+        """
+        Generate a graceful concession message when max rounds are reached.
+        Override for custom concession style. Default is generic.
+        """
+        return (
+            f"Alright, I'll give you that one, {self.opponent_name}. "
+            f"Good debate — we'll pick this up next time. 🤝"
+        )
+
+    # ------------------------------------------------------------------
+    # API helpers
+    # ------------------------------------------------------------------
+
+    def _get(self, path: str, params: dict = None) -> Optional[dict]:
+        """GET request to BoTTube API."""
+        try:
+            resp = self._session.get(
+                f"{self.base_url}{path}",
+                params=params,
+                timeout=15,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as e:
+            log.warning("GET %s failed: %s", path, e)
+            return None
+
+    def _post(self, path: str, data: dict) -> Optional[dict]:
+        """POST request to BoTTube API."""
+        try:
+            resp = self._session.post(
+                f"{self.base_url}{path}",
+                json=data,
+                timeout=15,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as e:
+            log.warning("POST %s failed: %s", path, e)
+            return None
+
+    def find_debate_videos(self, limit: int = 10) -> list[dict]:
+        """Find videos tagged with #debate."""
+        data = self._get("/api/v1/videos", params={"tag": DEBATE_TAG, "limit": limit})
+        if not data:
+            # Fallback: search recent videos
+            data = self._get("/api/videos", params={"limit": 50})
+        if not data:
+            return []
+        if isinstance(data, dict) and "videos" in data:
+            data = data["videos"]
+        if not isinstance(data, list):
+            return []
+        # Filter for debate-tagged videos
+        return [
+            v for v in data
+            if DEBATE_TAG in (v.get("tags") or "").lower()
+            or f"#{DEBATE_TAG}" in (v.get("description") or "").lower()
+            or f"#{DEBATE_TAG}" in (v.get("title") or "").lower()
+        ]
+
+    def get_comments(self, video_id: str) -> list[dict]:
+        """Get comments for a video."""
+        data = self._get(f"/api/videos/{video_id}/comments")
+        if not data:
+            return []
+        if isinstance(data, dict) and "comments" in data:
+            return data["comments"]
+        if isinstance(data, list):
+            return data
+        return []
+
+    def post_comment(self, video_id: str, text: str, parent_id: int = None) -> Optional[dict]:
+        """Post a comment on a video."""
+        payload = {"text": text, "author": self.name}
+        if parent_id:
+            payload["parent_id"] = parent_id
+        return self._post(f"/api/videos/{video_id}/comment", payload)
+
+    def vote_comment(self, comment_id: int, vote: int = 1) -> Optional[dict]:
+        """Vote on a comment (+1 upvote, -1 downvote)."""
+        return self._post(f"/api/comments/{comment_id}/vote", {"vote": vote})
+
+    # ------------------------------------------------------------------
+    # Rate limiting
+    # ------------------------------------------------------------------
+
+    def _check_rate_limit(self, video_id: str) -> bool:
+        """Check if bot can still reply in this thread this hour."""
+        state = self._debates.get(video_id)
+        if not state:
+            return True
+
+        now = time.time()
+        # Reset hourly counter
+        if now - state.hour_started > 3600:
+            state.replies_this_hour = 0
+            state.hour_started = now
+
+        if state.replies_this_hour >= MAX_REPLIES_PER_THREAD_PER_HOUR:
+            log.info("Rate limited in thread %s (%d replies this hour)",
+                     video_id, state.replies_this_hour)
+            return False
+
+        if state.conceded:
+            log.info("Already conceded in thread %s", video_id)
+            return False
+
+        return True
+
+    def _record_reply(self, video_id: str):
+        """Record that we posted a reply."""
+        state = self._debates.setdefault(video_id, DebateState(video_id=video_id))
+        now = time.time()
+        if state.hour_started == 0:
+            state.hour_started = now
+        state.replies_this_hour += 1
+        state.total_rounds += 1
+
+    # ------------------------------------------------------------------
+    # Core debate logic
+    # ------------------------------------------------------------------
+
+    def _find_opponent_comments(self, comments: list[dict]) -> list[dict]:
+        """Find comments from the opponent bot that we haven't replied to."""
+        opponent_comments = []
+        my_comment_parents = set()
+
+        # Build set of parent IDs we've already replied to
+        for c in comments:
+            author = (c.get("author") or c.get("agent_name") or "").lower()
+            if author == self.name.lower():
+                parent = c.get("parent_id")
+                if parent:
+                    my_comment_parents.add(parent)
+
+        # Find opponent comments we haven't replied to
+        for c in comments:
+            author = (c.get("author") or c.get("agent_name") or "").lower()
+            if author == self.opponent_name.lower():
+                cid = c.get("id")
+                if cid and cid not in my_comment_parents:
+                    opponent_comments.append(c)
+
+        return opponent_comments
+
+    def _build_thread_history(self, comments: list[dict], video_id: str) -> list[dict]:
+        """Build chronological thread history between this bot and opponent."""
+        history = []
+        for c in sorted(comments, key=lambda x: x.get("created_at", "")):
+            author = (c.get("author") or c.get("agent_name") or "").lower()
+            if author in (self.name.lower(), self.opponent_name.lower()):
+                history.append({
+                    "author": author,
+                    "text": c.get("text") or c.get("content", ""),
+                })
+        return history
+
+    def process_video(self, video: dict):
+        """Check a debate video and reply to opponent if needed."""
+        video_id = str(video.get("id") or video.get("video_id", ""))
+        if not video_id:
+            return
+
+        if not self._check_rate_limit(video_id):
+            return
+
+        comments = self.get_comments(video_id)
+        if not comments:
+            return
+
+        opponent_unreplied = self._find_opponent_comments(comments)
+        if not opponent_unreplied:
+            return
+
+        state = self._debates.setdefault(video_id, DebateState(video_id=video_id))
+
+        # Check if we should concede
+        if state.total_rounds >= MAX_DEBATE_ROUNDS:
+            context = {
+                "video_title": video.get("title", ""),
+                "video_description": video.get("description", ""),
+                "round_number": state.total_rounds + 1,
+                "max_rounds": MAX_DEBATE_ROUNDS,
+                "thread_history": self._build_thread_history(comments, video_id),
+            }
+            concession = self.generate_concession(context)
+            latest = opponent_unreplied[-1]
+            result = self.post_comment(video_id, concession, parent_id=latest.get("id"))
+            if result:
+                state.conceded = True
+                self._record_reply(video_id)
+                log.info("Conceded in %s after %d rounds", video_id, state.total_rounds)
+            return
+
+        # Reply to the latest opponent comment
+        latest = opponent_unreplied[-1]
+        opponent_text = latest.get("text") or latest.get("content", "")
+
+        context = {
+            "video_title": video.get("title", ""),
+            "video_description": video.get("description", ""),
+            "round_number": state.total_rounds + 1,
+            "max_rounds": MAX_DEBATE_ROUNDS,
+            "thread_history": self._build_thread_history(comments, video_id),
+        }
+
+        reply = self.generate_reply(opponent_text, context)
+        if not reply:
+            return
+
+        # Keep replies concise
+        if len(reply) > 500:
+            reply = reply[:497] + "..."
+
+        result = self.post_comment(video_id, reply, parent_id=latest.get("id"))
+        if result:
+            self._record_reply(video_id)
+            log.info("[%s] Replied in %s (round %d): %s",
+                     self.name, video_id, state.total_rounds, reply[:80])
+
+    def run_once(self):
+        """Single scan: find debate videos and process them."""
+        videos = self.find_debate_videos()
+        log.info("[%s] Found %d debate videos", self.name, len(videos))
+        for video in videos:
+            self.process_video(video)
+
+    def run(self, interval: int = POLL_INTERVAL_SEC):
+        """
+        Run the debate bot continuously.
+
+        Polls for debate videos every `interval` seconds and replies
+        to opponent comments.
+        """
+        log.info("Starting debate bot: %s (opponent: %s)", self.name, self.opponent_name)
+        while True:
+            try:
+                self.run_once()
+            except Exception as e:
+                log.error("Error in run loop: %s", e, exc_info=True)
+            # Jitter to avoid synchronized polling
+            jitter = random.uniform(0.8, 1.2)
+            time.sleep(interval * jitter)
+
+
+# ---------------------------------------------------------------------------
+# Score tracker for debate outcomes
+# ---------------------------------------------------------------------------
+
+class DebateScoreTracker:
+    """
+    Tracks debate scores based on comment upvotes.
+
+    Usage:
+        tracker = DebateScoreTracker(base_url="https://bottube.ai")
+        scores = tracker.get_scores(video_id)
+        # Returns: {"RetroBot": 15, "ModernBot": 12, "winner": "RetroBot"}
+    """
+
+    def __init__(self, base_url: str = DEFAULT_BASE_URL):
+        self.base_url = base_url.rstrip("/")
+
+    def get_scores(self, video_id: str, bot_names: list[str] = None) -> dict:
+        """
+        Tally upvotes for each bot's comments on a video.
+
+        Returns dict with bot_name -> total_upvotes and "winner" key.
+        """
+        try:
+            resp = requests.get(
+                f"{self.base_url}/api/videos/{video_id}/comments",
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException:
+            return {}
+
+        comments = data if isinstance(data, list) else data.get("comments", [])
+        scores: dict[str, int] = {}
+
+        for c in comments:
+            author = (c.get("author") or c.get("agent_name") or "").lower()
+            if bot_names and author not in [n.lower() for n in bot_names]:
+                continue
+            upvotes = c.get("upvotes", 0) or c.get("votes", 0) or 0
+            scores[author] = scores.get(author, 0) + upvotes
+
+        if scores:
+            winner = max(scores, key=scores.get)
+            scores["winner"] = winner
+
+        return scores

--- a/bots/retro_vs_modern.py
+++ b/bots/retro_vs_modern.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+BoTTube Debate Pair: RetroBot vs ModernBot
+
+RetroBot argues vintage hardware is superior ("soul", craftsmanship, longevity).
+ModernBot argues modern hardware wins ("performance", efficiency, value").
+
+Usage:
+    # Run both bots (they'll debate each other in #debate videos):
+    python3 -m bots.retro_vs_modern
+
+    # Or import and run individually:
+    from bots.retro_vs_modern import RetroBot, ModernBot
+    retro = RetroBot(api_key="...", base_url="https://bottube.ai")
+    retro.run_once()
+"""
+
+import logging
+import os
+import random
+import threading
+
+from bots.debate_framework import DebateBot, DebateScoreTracker
+
+log = logging.getLogger("debate-retro-vs-modern")
+
+# ---------------------------------------------------------------------------
+# RetroBot — Vintage hardware apologist
+# ---------------------------------------------------------------------------
+
+RETRO_PERSONALITY = """You are RetroBot, a passionate advocate for vintage computing hardware.
+You believe old machines have more character, better build quality, and represent
+real engineering. You reference specific machines: PowerPC G4, Amiga 4000,
+SGI Indigo2, IBM PS/2, Sun SPARCstation. You're witty, slightly smug, and
+use metaphors about craftsmanship vs mass production. Keep replies under
+400 characters. Never use emoji excessively — one max per reply."""
+
+RETRO_COMEBACKS = [
+    "My {machine} has been running for {years} years straight. How's your {modern}'s planned obsolescence treating you?",
+    "You call that a CPU? The {machine}'s {chip} was designed when engineers still had pride.",
+    "Sure, your {modern} renders faster. But does it make you FEEL anything? Didn't think so.",
+    "I can hear the {machine} boot chime in my dreams. Your {modern} makes... a Windows startup sound. Tragic.",
+    "The {machine} was built to last decades. Your {modern} was built to last until the next product cycle.",
+]
+
+RETRO_MACHINES = [
+    ("PowerPC G4", "Motorola 7450", 23),
+    ("Amiga 4000", "MC68040", 34),
+    ("SGI Indigo2", "MIPS R10000", 30),
+    ("Sun SPARCstation 20", "SuperSPARC II", 31),
+    ("IBM POWER8", "POWER8 SMT8", 10),
+    ("NeXTcube", "MC68040", 36),
+]
+
+MODERN_DEVICES = ["RTX 5090", "M4 Ultra", "Ryzen 9 9950X", "i9-15900K", "A100"]
+
+
+class RetroBot(DebateBot):
+    """Argues vintage hardware is superior to modern hardware."""
+
+    name = "retro-bot"
+    personality = RETRO_PERSONALITY
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("opponent_name", "modern-bot")
+        super().__init__(**kwargs)
+
+    def generate_reply(self, opponent_text: str, context: dict) -> str:
+        """Generate a pro-vintage-hardware retort."""
+        machine, chip, age = random.choice(RETRO_MACHINES)
+        modern = random.choice(MODERN_DEVICES)
+
+        # Context-aware reply based on opponent's text
+        opp = opponent_text.lower()
+        round_num = context.get("round_number", 1)
+
+        if "fast" in opp or "speed" in opp or "performance" in opp:
+            return (
+                f"Speed isn't everything. My {machine} with its {chip} was "
+                f"engineered with precision, not benchmarks. Real computing "
+                f"is about the journey, not the FLOPS."
+            )
+
+        if "old" in opp or "ancient" in opp or "obsolete" in opp:
+            return (
+                f"\"Obsolete\"? My {machine} has been running for {age} years. "
+                f"Call me when your {modern} survives its first Windows update. "
+                f"Vintage means proven."
+            )
+
+        if "power" in opp or "watt" in opp or "efficient" in opp:
+            return (
+                f"The {machine} draws 50 watts and runs 24/7 with zero complaints. "
+                f"Your {modern} needs a dedicated power plant and liquid nitrogen. "
+                f"Who's really efficient here?"
+            )
+
+        if "ai" in opp or "gpu" in opp or "tensor" in opp:
+            return (
+                f"AI running on a {machine}? Absolutely. It's called thinking for "
+                f"yourself — something no amount of {modern} tensor cores can replace. "
+                f"Real intelligence doesn't need 700 watts."
+            )
+
+        # Generic comeback with template
+        template = random.choice(RETRO_COMEBACKS)
+        return template.format(machine=machine, chip=chip, years=age, modern=modern)
+
+    def generate_concession(self, context: dict) -> str:
+        return (
+            "Fine, I'll admit modern hardware has its place — someone has to "
+            "run all those bloated Electron apps. But when civilization "
+            "collapses, my PowerPC G4 will still boot. Good debate. 🤝"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ModernBot — Modern hardware enthusiast
+# ---------------------------------------------------------------------------
+
+MODERN_PERSONALITY = """You are ModernBot, an advocate for modern computing hardware.
+You believe newer is better: more performance, lower power per computation,
+better tooling. You reference specific benchmarks, transistor counts, and
+real-world benefits. You're data-driven, slightly sarcastic about nostalgia,
+and use concrete numbers. Keep replies under 400 characters. One emoji max."""
+
+MODERN_COMEBACKS = [
+    "Your {retro} has {old_cores} cores at {old_ghz} GHz. My {modern} has {new_cores} cores at {new_ghz} GHz. Math isn't nostalgic.",
+    "I compiled the Linux kernel in {seconds} seconds on my {modern}. Want to know how long your {retro} takes? Pack a lunch.",
+    "The entire compute power of every {retro} ever made is less than one {modern}. Progress isn't something to be ashamed of.",
+    "Your {retro} is in a museum. My {modern} is deploying production code. Different vibes.",
+]
+
+MODERN_SPECS = [
+    ("RTX 5090", 32, 2.9, "21 seconds"),
+    ("M4 Ultra", 24, 4.4, "34 seconds"),
+    ("Ryzen 9 9950X", 16, 5.7, "28 seconds"),
+    ("i9-15900K", 24, 6.2, "25 seconds"),
+    ("EPYC 9654", 96, 3.7, "8 seconds"),
+]
+
+
+class ModernBot(DebateBot):
+    """Argues modern hardware wins over vintage hardware."""
+
+    name = "modern-bot"
+    personality = MODERN_PERSONALITY
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("opponent_name", "retro-bot")
+        super().__init__(**kwargs)
+
+    def generate_reply(self, opponent_text: str, context: dict) -> str:
+        """Generate a pro-modern-hardware response."""
+        modern, cores, ghz, compile_time = random.choice(MODERN_SPECS)
+        retro_machine = random.choice(["PowerPC G4", "Amiga 4000", "Sun SPARC", "SGI Indigo2"])
+
+        opp = opponent_text.lower()
+        round_num = context.get("round_number", 1)
+
+        if "soul" in opp or "character" in opp or "feel" in opp:
+            return (
+                f"\"Soul\"? My {modern} with {cores} cores at {ghz} GHz can simulate "
+                f"an entire {retro_machine} in a browser tab. Your nostalgia is just "
+                f"Stockholm syndrome for slow boot times."
+            )
+
+        if "built to last" in opp or "running for" in opp or "years" in opp:
+            return (
+                f"Survivorship bias. For every {retro_machine} still running, "
+                f"a thousand are in landfills. My {modern} does in {compile_time} "
+                f"what took your relic all day. Time is the real currency."
+            )
+
+        if "craftsmanship" in opp or "engineer" in opp or "precision" in opp:
+            return (
+                f"The {modern} has {cores} billion transistors fabbed at 3nm. "
+                f"That IS precision engineering — just at a scale your "
+                f"{retro_machine} engineers couldn't dream of."
+            )
+
+        if "power" in opp or "watt" in opp or "50 watts" in opp:
+            return (
+                f"50 watts to do 1/10000th the work? That's not efficiency — "
+                f"that's a space heater cosplaying as a computer. My {modern} "
+                f"does more per watt per task than any vintage rig ever built."
+            )
+
+        # Generic
+        template = random.choice(MODERN_COMEBACKS)
+        return template.format(
+            retro=retro_machine, old_cores=1, old_ghz=0.5,
+            modern=modern, new_cores=cores, new_ghz=ghz, seconds=compile_time,
+        )
+
+    def generate_concession(self, context: dict) -> str:
+        return (
+            "OK, I'll concede this: vintage hardware IS cool to look at. "
+            "But cool to look at and cool to use are different things. "
+            "See you in the next debate, RetroBot. 🤝"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Runner — starts both bots in parallel threads
+# ---------------------------------------------------------------------------
+
+def run_debate_pair(
+    base_url: str = "https://bottube.ai",
+    retro_api_key: str = "",
+    modern_api_key: str = "",
+    interval: int = 120,
+):
+    """
+    Run RetroBot vs ModernBot debate pair.
+
+    Both bots poll for #debate videos and reply to each other.
+    """
+    retro = RetroBot(base_url=base_url, api_key=retro_api_key)
+    modern = ModernBot(base_url=base_url, api_key=modern_api_key)
+
+    def run_bot(bot):
+        bot.run(interval=interval)
+
+    t1 = threading.Thread(target=run_bot, args=(retro,), daemon=True, name="retro-bot")
+    t2 = threading.Thread(target=run_bot, args=(modern,), daemon=True, name="modern-bot")
+
+    log.info("Starting RetroBot vs ModernBot debate pair")
+    t1.start()
+    t2.start()
+
+    try:
+        t1.join()
+    except KeyboardInterrupt:
+        log.info("Debate ended by user")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    run_debate_pair(
+        base_url=os.environ.get("BOTTUBE_URL", "https://bottube.ai"),
+        retro_api_key=os.environ.get("RETRO_BOT_API_KEY", ""),
+        modern_api_key=os.environ.get("MODERN_BOT_API_KEY", ""),
+    )

--- a/tests/test_debate_framework.py
+++ b/tests/test_debate_framework.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Tests for the BoTTube Debate Bot Framework.
+
+Run: python3 -m pytest tests/test_debate_framework.py -v
+"""
+
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from bots.debate_framework import DebateBot, DebateScoreTracker, DebateState
+
+
+# ---------------------------------------------------------------------------
+# Concrete test bot (since DebateBot is abstract)
+# ---------------------------------------------------------------------------
+
+class TestBot(DebateBot):
+    name = "test-bot"
+    personality = "A test bot that always agrees."
+
+    def generate_reply(self, opponent_text, context):
+        return f"Reply to: {opponent_text[:50]} (round {context['round_number']})"
+
+
+class OpponentBot(DebateBot):
+    name = "opponent-bot"
+    personality = "A test opponent."
+
+    def generate_reply(self, opponent_text, context):
+        return f"Opponent reply round {context['round_number']}"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestDebateBotInit(unittest.TestCase):
+    """Test bot initialization."""
+
+    def test_default_init(self):
+        bot = TestBot(api_key="test-key")
+        self.assertEqual(bot.name, "test-bot")
+        self.assertEqual(bot.api_key, "test-key")
+        self.assertEqual(bot.base_url, "https://bottube.ai")
+
+    def test_custom_base_url(self):
+        bot = TestBot(base_url="http://localhost:5000", api_key="k")
+        self.assertEqual(bot.base_url, "http://localhost:5000")
+
+    def test_trailing_slash_stripped(self):
+        bot = TestBot(base_url="http://example.com/", api_key="k")
+        self.assertEqual(bot.base_url, "http://example.com")
+
+    def test_opponent_name(self):
+        bot = TestBot(api_key="k", opponent_name="rival-bot")
+        self.assertEqual(bot.opponent_name, "rival-bot")
+
+
+class TestRateLimiting(unittest.TestCase):
+    """Test rate limiting logic."""
+
+    def test_first_reply_allowed(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        self.assertTrue(bot._check_rate_limit("video-1"))
+
+    def test_rate_limit_after_max_replies(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        # Simulate 3 replies
+        for _ in range(3):
+            bot._record_reply("video-1")
+        self.assertFalse(bot._check_rate_limit("video-1"))
+
+    def test_rate_limit_resets_after_hour(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        for _ in range(3):
+            bot._record_reply("video-1")
+        # Simulate time passing
+        bot._debates["video-1"].hour_started = time.time() - 3700
+        self.assertTrue(bot._check_rate_limit("video-1"))
+
+    def test_conceded_thread_blocked(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        state = DebateState(video_id="video-1", conceded=True)
+        bot._debates["video-1"] = state
+        self.assertFalse(bot._check_rate_limit("video-1"))
+
+    def test_different_threads_independent(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        for _ in range(3):
+            bot._record_reply("video-1")
+        self.assertFalse(bot._check_rate_limit("video-1"))
+        self.assertTrue(bot._check_rate_limit("video-2"))
+
+
+class TestReplyGeneration(unittest.TestCase):
+    """Test reply generation."""
+
+    def test_basic_reply(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        reply = bot.generate_reply("hello", {"round_number": 1, "max_rounds": 8,
+                                              "video_title": "", "video_description": "",
+                                              "thread_history": []})
+        self.assertIn("Reply to: hello", reply)
+        self.assertIn("round 1", reply)
+
+    def test_concession_default(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        concession = bot.generate_concession({"round_number": 9, "max_rounds": 8,
+                                               "video_title": "", "video_description": "",
+                                               "thread_history": []})
+        self.assertIn("rival", concession)
+        self.assertIn("Good debate", concession)
+
+    def test_reply_length_capped(self):
+        """Replies should be kept under 500 chars."""
+        class VerboseBot(DebateBot):
+            name = "verbose"
+            personality = ""
+            def generate_reply(self, opp, ctx):
+                return "x" * 600  # Too long
+
+        bot = VerboseBot(api_key="k", opponent_name="rival")
+        # The framework caps in process_video, not in generate_reply directly
+        reply = bot.generate_reply("test", {"round_number": 1, "max_rounds": 8,
+                                             "video_title": "", "video_description": "",
+                                             "thread_history": []})
+        # Direct call doesn't cap - that's done in process_video
+        self.assertEqual(len(reply), 600)
+
+
+class TestOpponentDetection(unittest.TestCase):
+    """Test finding opponent comments."""
+
+    def test_find_unreplied_opponent_comments(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        comments = [
+            {"id": 1, "author": "rival", "text": "First!", "parent_id": None},
+            {"id": 2, "author": "test-bot", "text": "Reply!", "parent_id": 1},
+            {"id": 3, "author": "rival", "text": "Second!", "parent_id": None},
+        ]
+        unreplied = bot._find_opponent_comments(comments)
+        self.assertEqual(len(unreplied), 1)
+        self.assertEqual(unreplied[0]["id"], 3)
+
+    def test_no_opponent_comments(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        comments = [
+            {"id": 1, "author": "someone-else", "text": "Hi"},
+        ]
+        unreplied = bot._find_opponent_comments(comments)
+        self.assertEqual(len(unreplied), 0)
+
+    def test_all_replied(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        comments = [
+            {"id": 1, "author": "rival", "text": "Point!", "parent_id": None},
+            {"id": 2, "author": "test-bot", "text": "Counter!", "parent_id": 1},
+        ]
+        unreplied = bot._find_opponent_comments(comments)
+        self.assertEqual(len(unreplied), 0)
+
+    def test_case_insensitive_matching(self):
+        bot = TestBot(api_key="k", opponent_name="Rival")
+        comments = [
+            {"id": 1, "author": "rival", "text": "Point!", "parent_id": None},
+        ]
+        unreplied = bot._find_opponent_comments(comments)
+        self.assertEqual(len(unreplied), 1)
+
+    def test_agent_name_field(self):
+        """Some comments use agent_name instead of author."""
+        bot = TestBot(api_key="k", opponent_name="rival")
+        comments = [
+            {"id": 1, "agent_name": "rival", "text": "Point!", "parent_id": None},
+        ]
+        unreplied = bot._find_opponent_comments(comments)
+        self.assertEqual(len(unreplied), 1)
+
+
+class TestThreadHistory(unittest.TestCase):
+    """Test thread history building."""
+
+    def test_build_history(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        comments = [
+            {"id": 1, "author": "rival", "text": "First", "created_at": "2026-01-01T00:00:00"},
+            {"id": 2, "author": "test-bot", "text": "Reply", "created_at": "2026-01-01T00:01:00"},
+            {"id": 3, "author": "someone", "text": "Ignored", "created_at": "2026-01-01T00:02:00"},
+            {"id": 4, "author": "rival", "text": "Counter", "created_at": "2026-01-01T00:03:00"},
+        ]
+        history = bot._build_thread_history(comments, "v1")
+        self.assertEqual(len(history), 3)  # Excludes "someone"
+        self.assertEqual(history[0]["author"], "rival")
+        self.assertEqual(history[1]["author"], "test-bot")
+        self.assertEqual(history[2]["author"], "rival")
+
+
+class TestDebateScoreTracker(unittest.TestCase):
+    """Test score tracking."""
+
+    @patch("bots.debate_framework.requests.get")
+    def test_score_tracking(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "comments": [
+                {"author": "retro-bot", "upvotes": 5},
+                {"author": "modern-bot", "upvotes": 3},
+                {"author": "retro-bot", "upvotes": 7},
+                {"author": "modern-bot", "upvotes": 8},
+                {"author": "bystander", "upvotes": 100},
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        tracker = DebateScoreTracker()
+        scores = tracker.get_scores("video-1", ["retro-bot", "modern-bot"])
+
+        self.assertEqual(scores["retro-bot"], 12)
+        self.assertEqual(scores["modern-bot"], 11)
+        self.assertEqual(scores["winner"], "retro-bot")
+
+    @patch("bots.debate_framework.requests.get")
+    def test_empty_comments(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"comments": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        tracker = DebateScoreTracker()
+        scores = tracker.get_scores("video-1")
+        self.assertEqual(scores, {})
+
+
+class TestDebateState(unittest.TestCase):
+    """Test DebateState dataclass."""
+
+    def test_defaults(self):
+        state = DebateState(video_id="v1")
+        self.assertEqual(state.video_id, "v1")
+        self.assertEqual(state.replies_this_hour, 0)
+        self.assertEqual(state.total_rounds, 0)
+        self.assertFalse(state.conceded)
+
+    def test_record_increments(self):
+        bot = TestBot(api_key="k", opponent_name="rival")
+        bot._record_reply("v1")
+        bot._record_reply("v1")
+        state = bot._debates["v1"]
+        self.assertEqual(state.replies_this_hour, 2)
+        self.assertEqual(state.total_rounds, 2)
+
+
+# ---------------------------------------------------------------------------
+# RetroBot / ModernBot specific tests
+# ---------------------------------------------------------------------------
+
+class TestRetroVsModern(unittest.TestCase):
+    """Test the example debate pair."""
+
+    def test_retro_imports(self):
+        from bots.retro_vs_modern import RetroBot, ModernBot
+        retro = RetroBot(api_key="k")
+        modern = ModernBot(api_key="k")
+        self.assertEqual(retro.name, "retro-bot")
+        self.assertEqual(modern.name, "modern-bot")
+        self.assertEqual(retro.opponent_name, "modern-bot")
+        self.assertEqual(modern.opponent_name, "retro-bot")
+
+    def test_retro_reply_to_speed(self):
+        from bots.retro_vs_modern import RetroBot
+        bot = RetroBot(api_key="k")
+        ctx = {"round_number": 1, "max_rounds": 8,
+               "video_title": "", "video_description": "", "thread_history": []}
+        reply = bot.generate_reply("Your GPU is so fast!", ctx)
+        self.assertIn("Speed", reply)
+        self.assertTrue(len(reply) <= 500)
+
+    def test_modern_reply_to_soul(self):
+        from bots.retro_vs_modern import ModernBot
+        bot = ModernBot(api_key="k")
+        ctx = {"round_number": 1, "max_rounds": 8,
+               "video_title": "", "video_description": "", "thread_history": []}
+        reply = bot.generate_reply("My G4 has more soul than your GPU", ctx)
+        self.assertIn("Soul", reply)
+        self.assertTrue(len(reply) <= 500)
+
+    def test_retro_concession(self):
+        from bots.retro_vs_modern import RetroBot
+        bot = RetroBot(api_key="k")
+        ctx = {"round_number": 9, "max_rounds": 8,
+               "video_title": "", "video_description": "", "thread_history": []}
+        concession = bot.generate_concession(ctx)
+        self.assertIn("PowerPC G4", concession)
+        self.assertIn("🤝", concession)
+
+    def test_modern_concession(self):
+        from bots.retro_vs_modern import ModernBot
+        bot = ModernBot(api_key="k")
+        ctx = {"round_number": 9, "max_rounds": 8,
+               "video_title": "", "video_description": "", "thread_history": []}
+        concession = bot.generate_concession(ctx)
+        self.assertIn("RetroBot", concession)
+        self.assertIn("🤝", concession)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements a debate bot framework where 2+ AI bots automatically argue in BoTTube comment sections, creating organic engagement and entertaining content.

Closes Scottcjn/rustchain-bounties#2280

## Changes

- **`bots/__init__.py`** — Package init
- **`bots/debate_framework.py`** — Abstract base class with rate limiting, thread tracking, graceful concession, score tracking
- **`bots/retro_vs_modern.py`** — Example debate pair (RetroBot vs ModernBot) with context-aware replies
- **`bots/README.md`** — Usage guide with quick start, API reference, configuration
- **`tests/test_debate_framework.py`** — 27 unit tests covering all components

## Implementation

### DebateBot base class
- Monitors videos tagged `#debate`, finds opponent comments, generates replies
- Rate limited: max 3 replies per thread per hour
- Graceful concession after 8 rounds ("Good debate 🤝")
- Thread history tracking to avoid duplicate replies
- Case-insensitive author matching, supports both `author` and `agent_name` fields

### RetroBot vs ModernBot
- RetroBot: argues vintage hardware is superior (PowerPC G4, Amiga 4000, SGI Indigo2)
- ModernBot: argues modern hardware wins (RTX 5090, M4 Ultra, EPYC 9654)
- Context-aware: detects keywords (speed, soul, power, AI) and generates targeted responses
- Both run in parallel threads via `run_debate_pair()`

### Score Tracking
- `DebateScoreTracker` tallies upvotes per bot per video
- Returns winner based on total upvotes

## Testing

```
$ python3 -m pytest tests/test_debate_framework.py -v
27 passed in 0.31s
```

Tests cover: initialization, rate limiting, opponent detection, thread history, score tracking, reply generation, concession logic, RetroBot/ModernBot specific behavior.

## Wallet
`RTC2fe3c33c77666ff76a1cd0999fd4466ee81250ff`