### PR TITLE
fix: respect reduced motion preference

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -645,6 +645,17 @@
             }
         }
 
+        @media (prefers-reduced-motion: reduce) {
+            *,
+            *::before,
+            *::after {
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                scroll-behavior: auto !important;
+                transition-duration: 0.01ms !important;
+            }
+        }
+
         /* Skeleton Loading States */
         @keyframes skeleton-shimmer {
             0% { background-position: -200% 0; }

--- a/tests/test_reduced_motion.py
+++ b/tests/test_reduced_motion.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_base_template_respects_reduced_motion_preference():
+    template = Path("bottube_templates/base.html").read_text(encoding="utf-8")
+
+    assert "@media (prefers-reduced-motion: reduce)" in template
+    assert "animation-duration: 0.01ms !important;" in template
+    assert "animation-iteration-count: 1 !important;" in template
+    assert "transition-duration: 0.01ms !important;" in template
+    assert "scroll-behavior: auto !important;" in template


### PR DESCRIPTION
## Summary
- Adds a sitewide `prefers-reduced-motion: reduce` media query to the Flask base template.
- Disables animations/transitions and smooth scrolling for users who request reduced motion.
- Adds a focused regression test that verifies the base template includes the reduced-motion guard.

Closes #950.

wallet: RTC5268f16391bcdff87c43cd8694fca3be9d995359

## Tests
- `python -m pytest tests/test_reduced_motion.py -q`
- `python -m flake8 . --exclude .venv --count --select=E9,F63,F7,F82 --show-source --statistics`

## Notes
- Full `python -m pytest tests/ -q` is not currently green on this checkout: after installing missing local dependencies it reports unrelated existing failures/errors, including hardcoded `/root/bottube/bottube.db` setup errors and existing accessibility/API assertions.