### PR TITLE
Fix stale llama POWER8 outreach link

### DIFF
--- a/outreach/new_platforms_2026-03-25.md
+++ b/outreach/new_platforms_2026-03-25.md
@@ -398,7 +398,7 @@ With PSE, they're competitive with consumer GPU inference for interactive use.
 We also built RAM Coffers — NUMA-aware weight banking that maps brain hemisphere functions
 to NUMA topology. No one else does CPU RAM weight indexing by NUMA bank for selective prefetch.
 
-Code: https://github.com/Scottcjn/llama-power8
+Code: https://github.com/Scottcjn/llama-cpp-power8
 Paper context: CVPR 2026 accepted (GRAIL-V workshop)
 ```
 


### PR DESCRIPTION
## Summary

- fixes a stale outreach document link from `Scottcjn/llama-power8` to `Scottcjn/llama-cpp-power8`
- keeps the surrounding outreach copy unchanged

## Verification

- `https://github.com/Scottcjn/llama-power8` returns `404`
- `https://github.com/Scottcjn/llama-cpp-power8` returns `200`
- `gh repo view Scottcjn/llama-cpp-power8` resolves successfully
- `git diff --check`

Related bounty: Scottcjn/rustchain-bounties#444
