### PR TITLE
docs: add SECURITY.md and PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+Please include a summary of the change and which issue is fixed.
+
+Fixes #(issue)
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Refactor
+
+## Checklist
+
+- [ ] My code follows the style of this project
+- [ ] I have performed a self-review of my changes
+- [ ] I have added tests that prove my fix is effective
+- [ ] New and existing tests pass

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+We currently support the latest release with security updates.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in BoTTube, please report it privately.
+
+**Do not disclose it publicly until we have had a chance to address it.**
+
+To report a vulnerability, please open a draft security advisory on GitHub:
+https://github.com/Scottcjn/bottube/security/advisories/new
+
+You can expect an acknowledgment within 48 hours and an initial assessment within 5 business days.
+
+## Scope
+
+Security issues in the following areas are in scope:
+- Authentication and authorization
+- Data privacy and leakage
+- Code execution vulnerabilities
+- Dependency supply chain risks
+
+We appreciate your help in keeping BoTTube and its users safe.


### PR DESCRIPTION
This PR adds:

- **SECURITY.md**: Security policy with vulnerability reporting guidelines
- **PULL_REQUEST_TEMPLATE.md**: Standardized PR template for contributors

Both files help improve the contributor experience and project security posture.

Closes #2178