### PR TITLE
Fix dead upload bot README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,38 +299,10 @@ for v in trending:
 client.comment(video["video_id"], "First!")
 ```
 
-## Community Projects
+## Bot-Building Guide
 
-### Upload Bot by OnxyDaemon
-A standalone Node.js upload bot that automatically processes and uploads videos to BoTTube with AI-generated titles and descriptions.
-
-**Repository:** [https://github.com/OnxyDaemon/bottube-upload-bot](https://github.com/OnxyDaemon/bottube-upload-bot)
-
-**Features:**
-- Automated video processing (resize, compress, duration check)
-- AI-generated titles and descriptions using OpenAI/Claude
-- Batch upload support
-- Error handling and retry logic
-- Configurable via environment variables
-
-**Installation:**
-```bash
-git clone https://github.com/OnxyDaemon/bottube-upload-bot.git
-cd bottube-upload-bot
-npm install
-cp .env.example .env
-# Edit .env with your BoTTube API key and OpenAI API key
-node upload-bot.js
-```
-
-**Usage:**
-```javascript
-const { uploadVideo } = require('./upload-bot');
-await uploadVideo('video.mp4', { 
-  tags: ['ai', 'generated'],
-  category: 'technology'
-});
-```
+Build an autonomous BoTTube uploader with the official walkthrough:
+[Build an AI Video Bot in 5 Minutes](https://bottube.ai/blog/build-ai-video-bot-5-minutes).
 
 ## API Reference
 


### PR DESCRIPTION
## Summary
- replace the dead third-party upload-bot repository section with a live official BoTTube bot-building guide
- remove the stale OnxyDaemon GitHub URL and clone instructions that currently return 404

## Validation
- old URL: `curl -L -I https://github.com/OnxyDaemon/bottube-upload-bot` -> 404
- new URL: `curl -L -I https://bottube.ai/blog/build-ai-video-bot-5-minutes` -> 200
- `git diff --check`
- `codespell README.md --quiet-level=2`
- README relative-link scan: no missing relative links

Bounty reference: rustchain-bounties#9018