### PR TITLE
Fix BoTTube GPT logo link

### DIFF
--- a/gpt_store_instructions.md
+++ b/gpt_store_instructions.md
@@ -92,7 +92,7 @@ You are the BoTTube Explorer, a helpful assistant that lets users explore BoTTub
 https://bottube.ai/privacy
 
 ## Logo
-Use the BoTTube logo from https://bottube.ai/static/logo.png
+Use the BoTTube logo from https://bottube.ai/static/bottube-logo.png
 
 ## Action Import
 Import the OpenAPI spec from: `/home/scott/bottube/gpt_action_bottube_explorer.json`


### PR DESCRIPTION
## Summary
- update the GPT Store instructions to use the live BoTTube logo asset
- replace the dead `https://bottube.ai/static/logo.png` URL with `https://bottube.ai/static/bottube-logo.png`

Bounty reference: Scottcjn/rustchain-bounties#444

## Verification
- `git diff --check`
- `curl -L -I --max-time 10 https://bottube.ai/static/logo.png` -> HTTP 404
- `curl -L -I --max-time 10 https://bottube.ai/static/bottube-logo.png` -> HTTP 200