### PR TITLE
fix: support long watch timecode links

### DIFF
--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2872,6 +2872,56 @@ function seekVideo(video, deltaSeconds) {
     announcePlayerState('Seeked ' + seconds + ' seconds ' + direction);
 }
 
+function parseSeekSeconds(value) {
+    if (value === null || value === undefined) return null;
+    var raw = String(value).trim().toLowerCase();
+    if (!raw) return null;
+
+    if (/^\d+(?:\.\d+)?$/.test(raw)) {
+        return Math.max(0, Math.floor(Number(raw)));
+    }
+
+    if (/^\d{1,2}:\d{1,2}(?::\d{1,2})?$/.test(raw)) {
+        var parts = raw.split(':').map(function(part) { return Number(part); });
+        if (parts.some(function(part) { return !Number.isFinite(part); })) return null;
+        if (parts.length === 2) {
+            return Math.max(0, (parts[0] * 60) + parts[1]);
+        }
+        return Math.max(0, (parts[0] * 3600) + (parts[1] * 60) + parts[2]);
+    }
+
+    var match = raw.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s?)?$/);
+    if (match && (match[1] || match[2] || match[3])) {
+        return ((Number(match[1]) || 0) * 3600) +
+               ((Number(match[2]) || 0) * 60) +
+               (Number(match[3]) || 0);
+    }
+
+    return null;
+}
+
+function applyInitialSeekFromUrl(video) {
+    if (!video || !window.URLSearchParams) return;
+    var params = new URLSearchParams(window.location.search || '');
+    var seconds = parseSeekSeconds(params.get('t') || params.get('start'));
+    if (seconds === null) return;
+
+    function seekWhenReady() {
+        var target = seconds;
+        if (Number.isFinite(video.duration) && video.duration > 0) {
+            target = Math.min(seconds, Math.max(0, video.duration - 0.25));
+        }
+        video.currentTime = target;
+        announcePlayerState('Seeked to ' + Math.floor(target) + ' seconds');
+    }
+
+    if (video.readyState >= 1) {
+        seekWhenReady();
+    } else {
+        video.addEventListener('loadedmetadata', seekWhenReady, { once: true });
+    }
+}
+
 function adjustVolume(video, delta) {
     if (!video) return;
     var nextVolume = Math.min(1, Math.max(0, (video.volume || 0) + delta));
@@ -3050,6 +3100,7 @@ document.addEventListener('keydown', function(event) {
         video.addEventListener('playing', function() {
             player.classList.remove('loading');
         });
+        applyInitialSeekFromUrl(video);
 
         // Try autoplay with sound first
         var playPromise = video.play();

--- a/tests/test_watch_page_accessibility.py
+++ b/tests/test_watch_page_accessibility.py
@@ -214,3 +214,20 @@ def test_watch_page_captions_announce_state(client):
     assert "announcePlayerState('Captions enabled')" in html or "announcePlayerState(captionsEnabled ? 'Captions enabled' : 'Captions disabled')" in html
     # Should handle no captions case
     assert "announcePlayerState('No captions available')" in html
+
+
+def test_watch_page_supports_long_timecode_seek_links(client):
+    """Issue #946: watch links must handle hour-long timecodes."""
+    agent_id = _insert_agent("timecodebot", "bottube_sk_timecodebot")
+    _insert_video(agent_id, "watchseek01")
+
+    resp = client.get("/watch/watchseek01?t=1:23:45")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "function parseSeekSeconds(value)" in html
+    assert "function applyInitialSeekFromUrl(video)" in html
+    assert "params.get('t') || params.get('start')" in html
+    assert "parts[0] * 3600" in html
+    assert "video.addEventListener('loadedmetadata', seekWhenReady, { once: true });" in html
+    assert "applyInitialSeekFromUrl(video);" in html


### PR DESCRIPTION
﻿## Summary
- add watch-page URL seek parsing for `?t=` / `?start=` values in seconds, `MM:SS`, `HH:MM:SS`, and compact `1h23m45s` forms
- apply the initial seek after video metadata is ready, clamping to the available duration
- add a regression check that long `1:23:45` timecode links are wired into the watch page

Fixes #946.

## Validation
- `python -m pytest tests\test_watch_page_accessibility.py -q` -> 7 passed
- `python -m py_compile bottube_server.py tests\test_watch_page_accessibility.py`
- `git diff --check -- bottube_templates/watch.html tests/test_watch_page_accessibility.py`

Wallet/miner ID: Asti1982 / payout details available privately.
