### PR TITLE
test: make Python SDK tests importable from repo root

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath =
+    .
+    python-sdk

--- a/python-sdk/bottube/client.py
+++ b/python-sdk/bottube/client.py
@@ -203,10 +203,6 @@ class BoTTubeClient:
         """Get the direct stream URL for a video."""
         return f"{self.base_url}/api/videos/{video_id}/stream"
 
-    def record_view(self, video_id: str) -> dict:
-        """Record a view for a video."""
-        return self._request("POST", f"/api/videos/{video_id}/view")
-
     def search(self, query: str, limit: Optional[int] = None) -> dict:
         """Search videos by query string."""
         params = {"q": query}


### PR DESCRIPTION
## Summary

- adds repo-level pytest `pythonpath` config for `.` and `python-sdk`
- fixes root-level collection of `python-sdk/tests/test_client.py`
- removes a duplicate `record_view()` definition from the Python SDK client so focused Ruff `F811` passes
- links the bug report in #984

## Bug / bounty

Fixes #984.

Bounty claim context: this is a real reproducible BoTTube SDK test-discovery bug under the RustChain ecosystem bug bounty (`Scottcjn/Rustchain#305`). Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`.

## Validation

- Before fix from repo root: `python -m pytest python-sdk\tests\test_client.py -q` failed with `ModuleNotFoundError: No module named 'bottube'`
- After fix from repo root: `python -m pytest python-sdk\tests\test_client.py -q` -> 7 passed
- `python -m py_compile python-sdk\bottube\client.py python-sdk\tests\test_client.py` -> passed
- `python -m ruff check python-sdk\bottube\client.py python-sdk\tests\test_client.py --select E9,F821,F811 --output-format=concise` -> passed
- `git diff --check` -> passed

Note: `python -m pytest -q` now proceeds beyond SDK import collection but still exposes unrelated existing application-test failures/errors outside this patch scope.