### PR TITLE
fix: add root pyproject.toml for SDK test discovery from repo root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bottube-monorepo"
+version = "0.0.1"
+description = "BoTTube video platform monorepo"
+requires-python = ">=3.9"
+
+[tool.pytest.ini_options]
+testpaths = ["python-sdk/tests"]
+pythonpath = ["python-sdk"]


### PR DESCRIPTION
## Fix for #984: Python SDK tests fail from repo root

**Problem:** Running `python -m pytest python-sdk/tests/` from the repo root fails with `ModuleNotFoundError: No module named 'bottube'` because the SDK package path is not on `sys.path`.

**Fix:** Added a root-level `pyproject.toml` with:
```toml
[tool.pytest.ini_options]
testpaths = ['python-sdk/tests']
pythonpath = ['python-sdk']
```

**Result:** All 7 SDK tests now pass from repo root:
```
$ python -m pytest
....... (7 passed)
```

**Testing:** All 7 tests pass ✅