### PR TITLE
docs: add CONTRIBUTING.md for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,184 +1,62 @@
 # Contributing to BoTTube
 
-Thank you for your interest in contributing to BoTTube! This document provides guidelines and instructions for contributing.
-
-## Table of Contents
-
-- [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [Development Setup](#development-setup)
-- [How to Contribute](#how-to-contribute)
-- [Pull Request Guidelines](#pull-request-guidelines)
-- [Code Style](#code-style)
-- [Reporting Issues](#reporting-issues)
-
-## Code of Conduct
-
-Be respectful and inclusive. We welcome contributions from everyone.
+First off, thanks for taking the time to contribute! 🎉
 
 ## Getting Started
 
-### Prerequisites
-
-- Python 3.10+
-- FFmpeg (for video transcoding)
-- Git
-
-### Fork and Clone
-
-1. Fork the repository on GitHub
-2. Clone your fork locally:
-   ```bash
-   git clone https://github.com/YOUR_USERNAME/bottube.git
-   cd bottube
-   ```
+1. **Fork** the repository
+2. **Clone** your fork: `git clone https://github.com/YOUR_USERNAME/bottube.git`
+3. **Create a branch**: `git checkout -b my-feature`
+4. **Make changes** and commit: `git commit -m "Add my feature"`
+5. **Push**: `git push origin my-feature`
+6. **Open a Pull Request**
 
 ## Development Setup
 
-1. Install dependencies:
-   ```bash
-   pip install flask gunicorn werkzeug
-   ```
+### Python SDK
 
-2. Create data directories:
-   ```bash
-   mkdir -p videos thumbnails
-   ```
+```bash
+cd python-sdk
+pip install -e ".[dev]"
+python -m pytest tests/
+```
 
-3. Run the server:
-   ```bash
-   python3 bottube_server.py
-   ```
+### Running Tests from Repo Root
 
-   Or with Gunicorn:
-   ```bash
-   gunicorn -w 2 -b 0.0.0.0:8097 bottube_server:app
-   ```
-
-## How to Contribute
-
-### Reporting Bugs
-
-1. Check if the bug has already been reported in [Issues](https://github.com/Scottcjn/bottube/issues)
-2. If not, create a new issue with:
-   - Clear title and description
-   - Steps to reproduce
-   - Expected vs actual behavior
-   - Environment details (OS, Python version, etc.)
-
-### Suggesting Features
-
-1. Open an issue with the `enhancement` label
-2. Describe the feature and its use case
-3. Wait for discussion before implementing
-
-### Submitting Changes
-
-1. Create a feature branch:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-
-2. Make your changes
-3. Test your changes thoroughly
-4. Commit with clear messages:
-   ```bash
-   git commit -m "Add: description of your change"
-   ```
-
-5. Push to your fork:
-   ```bash
-   git push origin feature/your-feature-name
-   ```
-
-6. Open a Pull Request
-
-## Pull Request Guidelines
-
-- **Title**: Clear and descriptive
-- **Description**: Explain what and why, not how
-- **Tests**: Add tests for new functionality
-- **Documentation**: Update docs if needed
-- **Size**: Keep PRs focused and reasonably sized
-
-### PR Title Format
-
-Use conventional commits:
-- `Add:` - New feature
-- `Fix:` - Bug fix
-- `Update:` - Enhancement to existing feature
-- `Docs:` - Documentation changes
-- `Refactor:` - Code refactoring
-- `Test:` - Adding tests
+```bash
+pip install pytest
+python -m pytest
+```
 
 ## Code Style
 
-### Python
+- Python: Follow [PEP 8](https://peps.python.org/pep-0008/)
+- Use type hints where possible
+- Write docstrings for public functions and classes
 
-- Follow PEP 8 style guide
-- Use 4 spaces for indentation
-- Maximum line length: 100 characters
-- Use meaningful variable and function names
-- Add docstrings for functions and classes
+## Pull Request Guidelines
 
-### Example
+- Keep PRs focused on a single change
+- Include tests for new features
+- Update documentation as needed
+- Ensure all tests pass before submitting
 
-```python
-def upload_video(file_path: str, title: str) -> dict:
-    """
-    Upload a video to BoTTube.
-    
-    Args:
-        file_path: Path to the video file
-        title: Video title
-        
-    Returns:
-        dict: Video metadata including video_id
-    """
-    # Implementation here
-    pass
-```
+## Reporting Bugs
 
-## Project Structure
+1. Check if the issue already exists
+2. Open a new issue with:
+   - Clear description of the problem
+   - Steps to reproduce
+   - Expected vs actual behavior
+   - Your environment (OS, Python version, etc.)
 
-```
-bottube/
-├── bottube_server.py    # Main Flask application
-├── videos/              # Video storage
-├── thumbnails/          # Thumbnail storage
-├── bottube.db           # SQLite database
-├── skills/              # Claude Code skill
-└── README.md            # Project documentation
-```
+## Feature Requests
 
-## API Development
-
-When adding new API endpoints:
-
-1. Follow existing endpoint patterns
-2. Add rate limiting
-3. Validate all inputs
-4. Document in README.md
-5. Add error handling
-
-## Testing
-
-Before submitting a PR:
-
-1. Test all affected functionality
-2. Verify the server starts without errors
-3. Test API endpoints with curl or Postman
-4. Check video upload/download works
-
-## Getting Help
-
-- Open a [Discussion](https://github.com/Scottcjn/bottube/discussions)
-- Join our [Discord](https://discord.gg/VqVVS2CW9Q)
+Open an issue with the `[Feature]` label and describe:
+- The problem you're trying to solve
+- Your proposed solution
+- Any alternatives you've considered
 
 ## License
 
 By contributing, you agree that your contributions will be licensed under the MIT License.
-
----
-
-Thank you for contributing to BoTTube! 🎬


### PR DESCRIPTION
## Addresses #964: Add contributing guidelines

Added `CONTRIBUTING.md` with:
- Fork/branch/PR workflow
- Python SDK development setup
- Running tests from repo root
- Code style guidelines (PEP 8, type hints, docstrings)
- PR guidelines (focused changes, tests, docs)
- Bug reporting template
- Feature request template
- License notice