### PR TITLE
a11y: add prefers-reduced-motion media query (WCAG 2.3.3)

### DIFF
--- a/base.html
+++ b/base.html
@@ -583,6 +583,15 @@
         .skeleton-hidden {
             display: none;
         }
+    /* Accessibility: Respect reduced motion preference (WCAG 2.3.3) */
+    @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after {
+            animation-duration: 0.01ms !important;
+            animation-iteration-count: 1 !important;
+            transition-duration: 0.01ms !important;
+            scroll-behavior: auto !important;
+        }
+    }
     </style>
     {% block extra_css %}{% endblock %}
 </head>

--- a/bottube_static/beacon_atlas/styles.css
+++ b/bottube_static/beacon_atlas/styles.css
@@ -784,3 +784,13 @@ html, body {
     grid-template-columns: 1fr !important;
   }
 }
+
+/* Accessibility: Respect user's reduced motion preference (WCAG 2.3.3) */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Fix for #950: Missing prefers-reduced-motion support

**Problem:** BoTTube uses CSS animations and transitions but does not respect the `prefers-reduced-motion` accessibility setting. Users with motion sensitivity who enable 'Reduce Motion' in their OS still see all animations.

**Fix:**
Added `@media (prefers-reduced-motion: reduce)` to:
- `bottube_static/beacon_atlas/styles.css`
- `base.html` inline styles

The rule disables all animations and transitions for users who prefer reduced motion:
```css
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

**WCAG Conformance:** 2.3.3 Animation from Interactions (Level AAA)