### PR TITLE
fix: add 413 error handler and client-side upload size validation

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1710,6 +1710,19 @@ def method_not_allowed(e):
     return resp
 
 
+@app.errorhandler(413)
+def request_entity_too_large(e):
+    """Return JSON error for oversized uploads instead of default HTML page."""
+    max_mb = (MAX_VIDEO_SIZE + 10 * 1024 * 1024) // (1024 * 1024)
+    if request.path.startswith("/api/"):
+        return jsonify({
+            "error": f"File too large. Maximum upload size is {max_mb} MB.",
+            "max_size_mb": max_mb,
+        }), 413
+    flash(f"File too large. Maximum upload size is {max_mb} MB.", "error")
+    return redirect(url_for("upload_page"))
+
+
 @app.errorhandler(500)
 def internal_server_error(e):
     """Custom 500 page."""

--- a/bottube_templates/upload.html
+++ b/bottube_templates/upload.html
@@ -444,6 +444,16 @@ document.querySelector('.upload-form').addEventListener('submit', function(e) {
         alert('API key is required');
         return;
     }
+    // Client-side file size check (500 MB limit)
+    var fileInput = form.querySelector('input[type="file"]');
+    if (fileInput && fileInput.files.length > 0) {
+        var maxSize = 500 * 1024 * 1024; // 500 MB
+        if (fileInput.files[0].size > maxSize) {
+            alert('File too large. Maximum upload size is 500 MB. Your file is ' +
+                  (fileInput.files[0].size / (1024 * 1024)).toFixed(1) + ' MB.');
+            return;
+        }
+    }
 
     var form = e.target;
     var formData = new FormData(form);


### PR DESCRIPTION
## Fix for #949: Upload fails for files >2GB — no error feedback

**Problem:** Uploading files exceeding `MAX_CONTENT_LENGTH` (510 MB) causes Flask to return a 413 error, but there was no custom error handler for 413. The default Flask HTML error page was returned, which the JavaScript frontend couldn't parse — making uploads appear to succeed (200 OK) but the video never appeared.

**Fix:**
1. Added `@app.errorhandler(413)` that returns:
   - JSON `{"error": "File too large..."}` for API (`/api/*`) routes
   - Flash message + redirect for browser upload page
2. Added client-side file size check (500 MB limit) before submitting:
   - Shows immediate feedback: "Your file is X.X MB. Maximum is 500 MB."
   - Prevents wasted upload bandwidth

**Before:** >2GB upload → silent failure, no error feedback
**After:** >500MB upload → clear error message, both client-side and server-side