### PR TITLE
fix: add mobile menu aria state

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -87,7 +87,8 @@
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         /* Accessibility: Skip Navigation (WCAG 2.4.1) */
-        .skip-nav {
+        .skip-nav,
+        .skip-link {
             position: absolute;
             top: -100%;
             left: 16px;
@@ -101,10 +102,23 @@
             text-decoration: none;
             transition: top 0.15s ease;
         }
-        .skip-nav:focus {
+        .skip-nav:focus,
+        .skip-link:focus {
             top: 0;
             outline: 3px solid #fff;
             outline-offset: 2px;
+        }
+
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
         }
 
         /* Accessibility: Focus indicators (WCAG 2.4.7) */
@@ -779,7 +793,7 @@
 
 </head>
 <body>
-    <a href="#main-content" class="skip-nav">Skip to main content</a>
+    <a href="#main-content" class="skip-nav skip-link">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header-left">
             <a href="{{ P }}/" class="logo">
@@ -788,13 +802,13 @@
             </a>
         </div>
 
-        <form class="search-bar" action="{{ P }}/search" method="get">
+        <form class="search-bar" action="{{ P }}/search" method="get" role="search" aria-label="{{ _('nav.search') }}">
             <input type="text" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}">
             <button type="submit" aria-label="{{ _('nav.search') }}">{{ _('nav.search') }}</button>
         </form>
 
-        <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Menu">&#9776;</button>
-        <div class="header-right">
+        <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="site-nav">&#9776;</button>
+        <div class="header-right" id="site-nav">
             <a href="{{ P }}/news" style="color:#ff6b6b;font-weight:600;">News</a>
             <a href="{{ P }}/trending">{{ _('nav.trending') }}</a>
             <a href="{{ P }}/categories">{{ _('nav.categories') }}</a>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -33,6 +33,14 @@ class TestAccessibilityAttributes(unittest.TestCase):
                       "Mobile menu button missing aria-label")
         self.assertIn('aria-expanded', match.group(0),
                       "Mobile menu button missing aria-expanded")
+        self.assertIn('aria-controls="site-nav"', match.group(0),
+                      "Mobile menu button missing aria-controls")
+
+    def test_mobile_menu_controls_named_nav(self):
+        """Test that the mobile menu button references the header nav."""
+        content = self.read_file(self.TEMPLATE_DIR / 'base.html')
+        self.assertIn('id="site-nav"', content,
+                      "Header navigation missing id referenced by aria-controls")
     
     def test_notification_bell_has_aria_attributes(self):
         """Test that notification bell has proper ARIA attributes."""


### PR DESCRIPTION
## Summary

Fixes Scottcjn/bottube#991 by restoring the missing accessibility state/control metadata around the mobile navigation.

Changes:
- render the hamburger button with initial `aria-expanded="false"`
- connect it to the header nav with `aria-controls="site-nav"`
- add the matching `id="site-nav"` to the nav container
- keep the existing `.skip-nav` class while adding the `skip-link` alias and `.sr-only` utility expected by the accessibility tests
- add a regression assertion that the mobile button controls the named nav

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest python -m pytest tests/test_accessibility.py -q` -> 17 passed
- `git diff --check` -> passed

Bounty/report context: Scottcjn/rustchain-bounties#1618
Payout target: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`
