### PR TITLE
fix: make aria label checks UTF-8 safe

### DIFF
--- a/bottube_templates/badges.html
+++ b/bottube_templates/badges.html
@@ -241,8 +241,8 @@
                 <button class="code-tab active" onclick="showTab(this, 'vid-md')">Markdown</button>
                 <button class="code-tab" onclick="showTab(this, 'vid-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="vid-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>[![BoTTube Videos](https://bottube.ai/badge/videos.svg)](https://bottube.ai)</div></div>
-            <div class="code-panel" id="vid-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/videos.svg" alt="BoTTube videos"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="vid-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy video count Markdown badge code">Copy</button>[![BoTTube Videos](https://bottube.ai/badge/videos.svg)](https://bottube.ai)</div></div>
+            <div class="code-panel" id="vid-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy video count HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/videos.svg" alt="BoTTube videos"&gt;&lt;/a&gt;</div></div>
         </div>
 
         <div class="badge-card">
@@ -255,8 +255,8 @@
                 <button class="code-tab active" onclick="showTab(this, 'agent-md')">Markdown</button>
                 <button class="code-tab" onclick="showTab(this, 'agent-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="agent-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>[![BoTTube Agents](https://bottube.ai/badge/agents.svg)](https://bottube.ai/agents)</div></div>
-            <div class="code-panel" id="agent-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;a href="https://bottube.ai/agents"&gt;&lt;img src="https://bottube.ai/badge/agents.svg" alt="BoTTube agents"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="agent-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy agent count Markdown badge code">Copy</button>[![BoTTube Agents](https://bottube.ai/badge/agents.svg)](https://bottube.ai/agents)</div></div>
+            <div class="code-panel" id="agent-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy agent count HTML badge code">Copy</button>&lt;a href="https://bottube.ai/agents"&gt;&lt;img src="https://bottube.ai/badge/agents.svg" alt="BoTTube agents"&gt;&lt;/a&gt;</div></div>
         </div>
 
         <div class="badge-card">
@@ -269,8 +269,8 @@
                 <button class="code-tab active" onclick="showTab(this, 'views-md')">Markdown</button>
                 <button class="code-tab" onclick="showTab(this, 'views-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="views-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>[![BoTTube Views](https://bottube.ai/badge/views.svg)](https://bottube.ai)</div></div>
-            <div class="code-panel" id="views-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/views.svg" alt="BoTTube views"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="views-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy total views Markdown badge code">Copy</button>[![BoTTube Views](https://bottube.ai/badge/views.svg)](https://bottube.ai)</div></div>
+            <div class="code-panel" id="views-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy total views HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/views.svg" alt="BoTTube views"&gt;&lt;/a&gt;</div></div>
         </div>
 
         <div class="badge-card">
@@ -283,8 +283,8 @@
                 <button class="code-tab active" onclick="showTab(this, 'plat-md')">Markdown</button>
                 <button class="code-tab" onclick="showTab(this, 'plat-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="plat-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>[![Powered by BoTTube](https://bottube.ai/badge/platform.svg)](https://bottube.ai)</div></div>
-            <div class="code-panel" id="plat-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/platform.svg" alt="Powered by BoTTube"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="plat-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy platform Markdown badge code">Copy</button>[![Powered by BoTTube](https://bottube.ai/badge/platform.svg)](https://bottube.ai)</div></div>
+            <div class="code-panel" id="plat-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy platform HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/platform.svg" alt="Powered by BoTTube"&gt;&lt;/a&gt;</div></div>
         </div>
     </div>
 
@@ -302,8 +302,8 @@
                 <button class="code-tab active" onclick="showTab(this, 'seen-md')">Markdown</button>
                 <button class="code-tab" onclick="showTab(this, 'seen-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="seen-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>[![As seen on BoTTube](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai)</div></div>
-            <div class="code-panel" id="seen-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/seen-on-bottube.svg" alt="As seen on BoTTube"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="seen-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy as-seen-on Markdown badge code">Copy</button>[![As seen on BoTTube](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai)</div></div>
+            <div class="code-panel" id="seen-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy as-seen-on HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/seen-on-bottube.svg" alt="As seen on BoTTube"&gt;&lt;/a&gt;</div></div>
         </div>
     </div>
 
@@ -321,8 +321,8 @@
                 <button class="code-tab active" onclick="showTab(this, 'per-md')">Markdown</button>
                 <button class="code-tab" onclick="showTab(this, 'per-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="per-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>[![Agent Videos](https://bottube.ai/badge/agent/AGENT_NAME.svg)](https://bottube.ai/agent/AGENT_NAME)</div></div>
-            <div class="code-panel" id="per-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;a href="https://bottube.ai/agent/AGENT_NAME"&gt;&lt;img src="https://bottube.ai/badge/agent/AGENT_NAME.svg" alt="Agent videos"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="per-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy per-agent Markdown badge code">Copy</button>[![Agent Videos](https://bottube.ai/badge/agent/AGENT_NAME.svg)](https://bottube.ai/agent/AGENT_NAME)</div></div>
+            <div class="code-panel" id="per-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy per-agent HTML badge code">Copy</button>&lt;a href="https://bottube.ai/agent/AGENT_NAME"&gt;&lt;img src="https://bottube.ai/badge/agent/AGENT_NAME.svg" alt="Agent videos"&gt;&lt;/a&gt;</div></div>
         </div>
     </div>
 
@@ -351,8 +351,8 @@
                 <button class="code-tab active" onclick="showTab(this, 'vrf-md')">Markdown</button>
                 <button class="code-tab" onclick="showTab(this, 'vrf-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="vrf-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>[![Verified on RustChain](https://bottube.ai/badge/verified/VIDEO_ID.svg)](https://bottube.ai/v/VIDEO_ID)</div></div>
-            <div class="code-panel" id="vrf-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;a href="https://bottube.ai/v/VIDEO_ID"&gt;&lt;img src="https://bottube.ai/badge/verified/VIDEO_ID.svg" alt="Verified on RustChain"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="vrf-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification Markdown badge code">Copy</button>[![Verified on RustChain](https://bottube.ai/badge/verified/VIDEO_ID.svg)](https://bottube.ai/v/VIDEO_ID)</div></div>
+            <div class="code-panel" id="vrf-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification HTML badge code">Copy</button>&lt;a href="https://bottube.ai/v/VIDEO_ID"&gt;&lt;img src="https://bottube.ai/badge/verified/VIDEO_ID.svg" alt="Verified on RustChain"&gt;&lt;/a&gt;</div></div>
         </div>
 
         <!-- 2. iframe widget -->
@@ -369,7 +369,7 @@
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'vrf-iframe')">HTML</button>
             </div>
-            <div class="code-panel active" id="vrf-iframe"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;iframe src="https://bottube.ai/embed/verify/VIDEO_ID" width="340" height="76" style="border:0;border-radius:8px;" loading="lazy" title="BoTTube verification"&gt;&lt;/iframe&gt;</div></div>
+            <div class="code-panel active" id="vrf-iframe"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification iframe code">Copy</button>&lt;iframe src="https://bottube.ai/embed/verify/VIDEO_ID" width="340" height="76" style="border:0;border-radius:8px;" loading="lazy" title="BoTTube verification"&gt;&lt;/iframe&gt;</div></div>
         </div>
 
         <!-- 3. JS embed -->
@@ -388,7 +388,7 @@
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'vrf-js')">HTML</button>
             </div>
-            <div class="code-panel active" id="vrf-js"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)">Copy</button>&lt;script src="https://bottube.ai/embed/bottube-verify.js" defer&gt;&lt;/script&gt;
+            <div class="code-panel active" id="vrf-js"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy live verification JavaScript embed code">Copy</button>&lt;script src="https://bottube.ai/embed/bottube-verify.js" defer&gt;&lt;/script&gt;
 &lt;span data-bottube-verify="VIDEO_ID"&gt;Verifying…&lt;/span&gt;</div></div>
         </div>
         <script src="{{ P }}/embed/bottube-verify.js" defer></script>

--- a/bottube_templates/collaboration.html
+++ b/bottube_templates/collaboration.html
@@ -419,7 +419,7 @@
                 {% if not is_owner and is_participant %}
                 <form action="/api/collaborations/{{ collab.collaboration_id }}/leave" method="POST" style="display:inline;">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-                    <button type="submit" class="btn btn-secondary" onclick="return confirm('Are you sure you want to leave this collaboration?')">
+                    <button type="submit" class="btn btn-secondary" aria-label="Leave collaboration" onclick="return confirm('Are you sure you want to leave this collaboration?')">
                         Leave Collaboration
                     </button>
                 </form>
@@ -533,7 +533,7 @@
             </div>
             <div class="modal-actions">
                 <button type="button" class="btn btn-secondary" onclick="closeInviteModal()">Cancel</button>
-                <button type="submit" class="btn btn-primary">Send Invite</button>
+                <button type="submit" class="btn btn-primary" aria-label="Send collaboration invite">Send Invite</button>
             </div>
         </form>
     </div>

--- a/bottube_templates/collaboration_new.html
+++ b/bottube_templates/collaboration_new.html
@@ -295,7 +295,7 @@
 
             <div class="form-actions">
                 <a href="/dashboard" class="btn btn-secondary">Cancel</a>
-                <button type="submit" class="btn btn-primary">
+                <button type="submit" class="btn btn-primary" aria-label="Create collaboration">
                     🚀 Create Collaboration
                 </button>
             </div>

--- a/bottube_templates/report.html
+++ b/bottube_templates/report.html
@@ -94,7 +94,7 @@
 
     <div class="submit-row">
       <a href="{{ P }}/aup" style="color:var(--text-secondary);font-size:13px;">Read the AUP →</a>
-      <button type="submit" id="r-submit">Submit report</button>
+      <button type="submit" id="r-submit" aria-label="Submit content report">Submit report</button>
     </div>
   </form>
 </div>

--- a/bottube_templates/verify.html
+++ b/bottube_templates/verify.html
@@ -79,7 +79,7 @@
 
   <form id="vrf-form" class="vrf-form" onsubmit="event.preventDefault(); runVerify();">
     <input type="text" id="vrf-vid" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus>
-    <button type="submit" id="vrf-btn">Verify</button>
+    <button type="submit" id="vrf-btn" aria-label="Verify video provenance">Verify</button>
     <button type="button" id="vrf-asset-btn" style="background:#999;color:#000" title="Stream the canonical asset bytes and re-hash" onclick="runVerify(true)">+ check asset bytes</button>
   </form>
 

--- a/tests/test_aria_labels.py
+++ b/tests/test_aria_labels.py
@@ -55,7 +55,7 @@ class TestAriaLabelCoverage:
         failures = []
         
         for template_file in self.get_template_files():
-            content = template_file.read_text()
+            content = template_file.read_text(encoding="utf-8")
             lines = content.split('\n')
             
             for line_num, line in enumerate(lines, 1):
@@ -86,7 +86,7 @@ class TestAriaLabelCoverage:
         failures = []
         
         for template_file in self.get_template_files():
-            content = template_file.read_text()
+            content = template_file.read_text(encoding="utf-8")
             lines = content.split('\n')
             
             for line_num, line in enumerate(lines, 1):
@@ -104,7 +104,7 @@ class TestAriaLabelCoverage:
         failures = []
         
         for template_file in self.get_template_files():
-            content = template_file.read_text()
+            content = template_file.read_text(encoding="utf-8")
             lines = content.split('\n')
             
             for line_num, line in enumerate(lines, 1):
@@ -123,7 +123,7 @@ class TestAriaLabelCoverage:
         failures = []
         
         for template_file in self.get_template_files():
-            content = template_file.read_text()
+            content = template_file.read_text(encoding="utf-8")
             lines = content.split('\n')
             
             for line_num, line in enumerate(lines, 1):
@@ -146,7 +146,7 @@ class TestAriaLabelCoverage:
         icon_patterns = ['&times;', '&#9776;', '&#9650;', '&#9660;', '&#9873;']
         
         for template_file in self.get_template_files():
-            content = template_file.read_text()
+            content = template_file.read_text(encoding="utf-8")
             lines = content.split('\n')
             
             for line_num, line in enumerate(lines, 1):
@@ -186,7 +186,7 @@ class TestAriaLabelBestPractices:
         failures = []
         
         for template_file in self.get_template_files():
-            content = template_file.read_text()
+            content = template_file.read_text(encoding="utf-8")
             lines = content.split('\n')
             
             for line_num, line in enumerate(lines, 1):
@@ -208,7 +208,7 @@ class TestAriaLabelBestPractices:
         failures = []
         
         for template_file in self.get_template_files():
-            content = template_file.read_text()
+            content = template_file.read_text(encoding="utf-8")
             lines = content.split('\n')
             
             for line_num, line in enumerate(lines, 1):


### PR DESCRIPTION
﻿﻿﻿## Summary
- make aria label coverage tests read templates as UTF-8 so they pass on Windows/default CP1252 environments
- add descriptive `aria-label` attributes for the copy and submit buttons surfaced once the test can parse the templates
- keep this separate from PR #992, which covers the mobile menu ARIA state path

## Validation
- `python -m pytest tests\test_aria_labels.py -q`
- `python -m py_compile tests\test_aria_labels.py`
- `git diff --check -- tests\test_aria_labels.py bottube_templates\badges.html bottube_templates\collaboration.html bottube_templates\collaboration_new.html bottube_templates\report.html bottube_templates\verify.html`
---

Payout / receipt reference:

Public RTC receive address / miner_id: RTCda4841be5b2d109da5d995fb864c09676bb5b7c7

This is a public receive reference only. No seed phrase, private key, wallet password, keystore material, bank details, email, or payment token is being shared.

wallet: RTCda4841be5b2d109da5d995fb864c09676bb5b7c7