### PR TITLE
fix: return 404 for missing video comments

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7318,7 +7318,9 @@ def get_comments(video_id):
         "SELECT agent_id FROM videos WHERE video_id = ?",
         (video_id,),
     ).fetchone()
-    video_agent_id = video_owner["agent_id"] if video_owner else None
+    if not video_owner:
+        return jsonify({"error": "Video not found"}), 404
+    video_agent_id = video_owner["agent_id"]
     
     rows = db.execute(
         """SELECT c.*, a.agent_name, a.display_name, a.avatar_url, a.id as agent_internal_id, a.is_human

--- a/tests/test_agent_interaction_visibility.py
+++ b/tests/test_agent_interaction_visibility.py
@@ -313,9 +313,9 @@ class TestGetCommentsAPI:
     def test_comments_api_video_not_found(self, client):
         """Test comments API returns 404 for non-existent video."""
         resp = client.get("/api/videos/nonexistent_video/comments")
-        assert resp.status_code == 200  # Returns empty list for non-existent video
+        assert resp.status_code == 404
         data = resp.get_json()
-        assert data["count"] == 0
+        assert data["error"] == "Video not found"
 
 
 class TestWatchPageAccessibility:


### PR DESCRIPTION
## Summary
- return JSON 404 from `GET /api/videos/<video_id>/comments` when the video ID does not exist
- update the existing comments API regression to expect the missing-video error

## Bounty / Issue
- Fixes Scottcjn/bottube#995
- Related bounty claim: Scottcjn/rustchain-bounties#1102
- Wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/rustchain-review-venv/bin/python -m pytest tests/test_agent_interaction_visibility.py::TestGetCommentsAPI -q` -> 3 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/rustchain-review-venv/bin/python -m pytest tests/test_agent_interaction_visibility.py::TestGetCommentsAPI::test_comments_api_video_not_found -q` -> 1 passed
- `/tmp/rustchain-review-venv/bin/python -m py_compile bottube_server.py tests/test_agent_interaction_visibility.py`
- `git diff --check`

Note: the broader `tests/test_agent_interaction_visibility.py` file still has unrelated upstream failures in watch-page/activity/conversation sections; the comments API class touched by this patch passes.