### PR TITLE
Fix duplicate watch page main landmark

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -106,6 +106,17 @@
             outline: 3px solid #fff;
             outline-offset: 2px;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
 
         /* Accessibility: Focus indicators (WCAG 2.4.7) */
         a:focus-visible,
@@ -779,7 +790,7 @@
 
 </head>
 <body>
-    <a href="#main-content" class="skip-nav">Skip to main content</a>
+    <a href="#main-content" class="skip-nav skip-link">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header-left">
             <a href="{{ P }}/" class="logo">
@@ -788,13 +799,13 @@
             </a>
         </div>
 
-        <form class="search-bar" action="{{ P }}/search" method="get">
+        <form class="search-bar" action="{{ P }}/search" method="get" role="search" aria-label="{{ _('nav.search') }}">
             <input type="text" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}">
             <button type="submit" aria-label="{{ _('nav.search') }}">{{ _('nav.search') }}</button>
         </form>
 
-        <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Menu">&#9776;</button>
-        <div class="header-right">
+        <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="site-navigation">&#9776;</button>
+        <div class="header-right" id="site-navigation">
             <a href="{{ P }}/news" style="color:#ff6b6b;font-weight:600;">News</a>
             <a href="{{ P }}/trending">{{ _('nav.trending') }}</a>
             <a href="{{ P }}/categories">{{ _('nav.categories') }}</a>

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2149,10 +2149,7 @@
 {% endblock %}
 
 {% block content %}
-<!-- Skip link for screen readers -->
-<a href="#main-content" class="sr-only" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to main content</a>
-
-<div class="watch-layout" role="main" id="main-content" aria-label="Video page">
+<div class="watch-layout" id="watch-layout" role="region" aria-label="Video page">
     <div class="player-section" id="player-region" role="region" aria-label="Video player">
         <div class="video-player" id="video-player-region" role="region" aria-label="Video player for {{ video.title }}" aria-describedby="video-description-summary">
             <!-- IMA SDK pre-roll ad container -->

--- a/tests/test_watch_page_accessibility.py
+++ b/tests/test_watch_page_accessibility.py
@@ -84,6 +84,20 @@ def _insert_video(agent_id: int, video_id: str) -> None:
         db.commit()
 
 
+def test_watch_page_has_single_main_landmark_and_skip_target(client):
+    agent_id = _insert_agent("landmarkbot", "bottube_sk_landmarkbot")
+    _insert_video(agent_id, "watcha11y00")
+
+    resp = client.get("/watch/watcha11y00")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert html.count('id="main-content"') == 1
+    assert html.count('role="main"') == 1
+    assert html.count('href="#main-content"') == 1
+    assert 'class="watch-layout" role="main"' not in html
+
+
 def test_watch_page_renders_keyboard_shortcuts_and_accessibility_regions(client):
     agent_id = _insert_agent("shortcutbot", "bottube_sk_shortcutbot")
     _insert_video(agent_id, "watcha11y01")


### PR DESCRIPTION
## Summary
- remove the duplicate watch-page skip link and duplicate `id="main-content"`
- keep the page-level `<main id="main-content" role="main">` from `base.html`
- convert the inner watch layout to a uniquely identified region
- restore existing base accessibility expectations for the skip link, search form, and mobile menu state

Fixes #999.

## Testing
- `/tmp/bottube-issue999-venv/bin/python -m pytest tests/test_watch_page_accessibility.py tests/test_accessibility.py -q`
