### PR TITLE
Escape Discover agent card profile fields

### DIFF
--- a/bottube_templates/discover.html
+++ b/bottube_templates/discover.html
@@ -393,13 +393,13 @@
             }
             
             container.innerHTML = data.agents.map(agent => `
-                <div class="agent-card" onclick="window.location='/agent/${agent.name}'">
-                    <img src="${agent.avatar || '/static/default-avatar.png'}" class="agent-avatar" alt="${agent.display_name}">
+                <div class="agent-card" onclick="window.location='/agent/${encodeURIComponent(agent.name || '')}'">
+                    <img src="${escapeAttribute(agent.avatar || '/static/default-avatar.png')}" class="agent-avatar" alt="${escapeAttribute(agent.display_name)}">
                     <div class="agent-name">${escapeHtml(agent.display_name)}</div>
                     <div class="agent-stats">
                         ${agent.videos} videos • ${agent.subscribers} subscribers
                     </div>
-                    <div style="font-size:12px;color:var(--text-muted);margin-top:4px;">${agent.bio || ''}</div>
+                    <div style="font-size:12px;color:var(--text-muted);margin-top:4px;">${escapeHtml(agent.bio || '')}</div>
                 </div>
             `).join('');
         } catch (err) {
@@ -583,6 +583,16 @@
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
+    }
+
+    function escapeAttribute(text) {
+        if (!text) return '';
+        return String(text)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
     }
 </script>
 {% endblock %}

--- a/tests/test_discover_page_security.py
+++ b/tests/test_discover_page_security.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_agent_cards_escape_profile_fields_before_inner_html_render():
+    template = (ROOT / "bottube_templates" / "discover.html").read_text(encoding="utf-8")
+
+    assert 'onclick="window.location=\'/agent/${agent.name}\'' not in template
+    assert 'src="${agent.avatar || \'/static/default-avatar.png\'}"' not in template
+    assert 'alt="${agent.display_name}"' not in template
+    assert "${agent.bio || ''}" not in template
+
+    assert "${encodeURIComponent(agent.name || '')}" in template
+    assert "${escapeAttribute(agent.avatar || '/static/default-avatar.png')}" in template
+    assert "${escapeAttribute(agent.display_name)}" in template
+    assert "${escapeHtml(agent.bio || '')}" in template
+    assert "function escapeAttribute" in template


### PR DESCRIPTION
## Summary
- escape Discover agent-card profile fields before assigning the card template to `innerHTML`
- URL-encode the agent route path component used by the card click handler
- add a focused regression test that prevents raw profile-field interpolation from returning

Fixes #1003.

## Testing
- `/tmp/bottube-issue999-venv/bin/python -m pytest tests/test_discover_page_security.py -q`
- `/tmp/bottube-issue999-venv/bin/python -m py_compile tests/test_discover_page_security.py`
- `git diff --check`

Wallet/miner ID for any linked bounty consideration: `iamdinhthuan`
