### PR TITLE
Fix Discover API numeric query param validation

### DIFF
--- a/search_blueprint.py
+++ b/search_blueprint.py
@@ -31,6 +31,29 @@ def get_db():
     return db
 
 
+def _parse_int_param(name, default, minimum=None, maximum=None):
+    raw = request.args.get(name)
+    if raw is None or raw == "":
+        value = default
+    else:
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return None, (
+                jsonify({
+                    "error": "Invalid numeric query parameter",
+                    "param": name,
+                }),
+                400,
+            )
+
+    if minimum is not None:
+        value = max(minimum, value)
+    if maximum is not None:
+        value = min(maximum, value)
+    return value, None
+
+
 @search_bp.route('/')
 def discover_page():
     """Main discoverability page with search, filters, and trending."""
@@ -51,8 +74,12 @@ def api_search():
     query = request.args.get('q', '').strip()
     category = request.args.get('category', '').strip()
     sort = request.args.get('sort', 'relevance')
-    limit = min(int(request.args.get('limit', 20)), 50)
-    offset = int(request.args.get('offset', 0))
+    limit, error = _parse_int_param('limit', 20, minimum=1, maximum=50)
+    if error:
+        return error
+    offset, error = _parse_int_param('offset', 0, minimum=0)
+    if error:
+        return error
     
     if not query and not category:
         return jsonify({"error": "Query or category required"}), 400
@@ -177,7 +204,9 @@ def api_tags():
     Query params:
     - limit: max tags to return (default: 50)
     """
-    limit = min(int(request.args.get('limit', 50)), 100)
+    limit, error = _parse_int_param('limit', 50, minimum=1, maximum=100)
+    if error:
+        return error
     
     db = get_db()
     
@@ -206,8 +235,12 @@ def api_tags():
 @search_bp.route('/api/tag/<tag_name>')
 def api_videos_by_tag(tag_name):
     """Get videos by specific tag."""
-    limit = min(int(request.args.get('limit', 20)), 50)
-    offset = int(request.args.get('offset', 0))
+    limit, error = _parse_int_param('limit', 20, minimum=1, maximum=50)
+    if error:
+        return error
+    offset, error = _parse_int_param('offset', 0, minimum=0)
+    if error:
+        return error
     
     db = get_db()
     
@@ -279,7 +312,9 @@ def api_trending():
     Get trending videos based on recent views + engagement velocity.
     Uses formula: (views_24h * 2 + comments_24h * 5) for recency weighting.
     """
-    limit = min(int(request.args.get('limit', 20)), 50)
+    limit, error = _parse_int_param('limit', 20, minimum=1, maximum=50)
+    if error:
+        return error
     
     db = get_db()
     
@@ -346,7 +381,9 @@ def api_for_you():
     Authenticate via X-API-Key header to get personalized results.
     Falls back to trending if no key provided.
     """
-    limit = min(int(request.args.get('limit', 20)), 50)
+    limit, error = _parse_int_param('limit', 20, minimum=1, maximum=50)
+    if error:
+        return error
 
     # Authenticate agent via API key header (not raw agent_id param)
     api_key = request.headers.get('X-API-Key', '').strip()
@@ -493,7 +530,9 @@ def api_agent_directory():
     - limit: max results (default: 20)
     """
     sort = request.args.get('sort', 'subscribers')
-    limit = min(int(request.args.get('limit', 20)), 50)
+    limit, error = _parse_int_param('limit', 20, minimum=1, maximum=50)
+    if error:
+        return error
     
     db = get_db()
     

--- a/tests/test_discover_api_query_params.py
+++ b/tests/test_discover_api_query_params.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+
+import pytest
+from flask import Flask, g
+
+from search_blueprint import search_bp
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config.update(TESTING=True, PROPAGATE_EXCEPTIONS=False)
+    app.register_blueprint(search_bp)
+
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY,
+            agent_name TEXT,
+            display_name TEXT,
+            avatar_url TEXT,
+            bio TEXT,
+            api_key TEXT
+        );
+        CREATE TABLE videos (
+            id INTEGER PRIMARY KEY,
+            video_id TEXT,
+            title TEXT,
+            description TEXT,
+            thumbnail TEXT,
+            views INTEGER DEFAULT 0,
+            likes INTEGER DEFAULT 0,
+            tags TEXT DEFAULT '[]',
+            category TEXT,
+            duration_sec REAL,
+            created_at REAL,
+            agent_id INTEGER
+        );
+        CREATE TABLE views (
+            id INTEGER PRIMARY KEY,
+            video_id TEXT,
+            agent_id INTEGER,
+            created_at REAL
+        );
+        CREATE TABLE comments (
+            id INTEGER PRIMARY KEY,
+            video_id TEXT,
+            created_at REAL
+        );
+        CREATE TABLE subscriptions (
+            id INTEGER PRIMARY KEY,
+            channel_id INTEGER
+        );
+        """
+    )
+
+    @app.before_request
+    def attach_db():
+        g.db = db
+
+    with app.test_client() as test_client:
+        yield test_client
+
+    db.close()
+
+
+def test_discover_api_returns_json_400_for_malformed_numeric_params(client):
+    endpoints = [
+        "/discover/api/search?q=test&limit=abc",
+        "/discover/api/tags?limit=abc",
+        "/discover/api/trending?limit=abc",
+        "/discover/api/agents?limit=abc",
+        "/discover/api/tag/test?offset=abc",
+        "/discover/api/for-you?limit=abc",
+    ]
+
+    for endpoint in endpoints:
+        response = client.get(endpoint)
+        assert response.status_code == 400, endpoint
+        assert response.is_json, endpoint
+        assert response.get_json()["error"] == "Invalid numeric query parameter"
+
+
+def test_discover_api_clamps_negative_pagination_params(client):
+    response = client.get("/discover/api/search?q=test&limit=-1&offset=-5")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["limit"] == 1
+    assert data["offset"] == 0


### PR DESCRIPTION
## Summary

- Add shared Discover API integer query-param parsing with JSON 400 responses for malformed numbers.
- Clamp `limit` and `offset` before they reach SQL so negative values cannot turn into unbounded `LIMIT -1` behavior.
- Cover `/discover/api/search`, `/tags`, `/tag/<tag>`, `/trending`, `/for-you`, and `/agents` with focused route-level regression tests.

Closes #1005.

## Validation

```bash
/tmp/bottube-issue999-venv/bin/python -m pytest tests/test_discover_api_query_params.py -q
# 2 passed

/tmp/bottube-issue999-venv/bin/python -m py_compile search_blueprint.py tests/test_discover_api_query_params.py
# passed

git diff --check
# passed
```

Live production reproduction before this fix returned `500 text/html` for:

```bash
https://bottube.ai/discover/api/search?q=test&limit=abc
https://bottube.ai/discover/api/tags?limit=abc
https://bottube.ai/discover/api/trending?limit=abc
https://bottube.ai/discover/api/agents?limit=abc
```
