### PR TITLE
Fix /api/agents pagination param validation

### DIFF
--- a/agent_discovery.py
+++ b/agent_discovery.py
@@ -22,6 +22,29 @@ from flask import Blueprint, Response, current_app, jsonify, request
 discovery_bp = Blueprint("agent_discovery", __name__)
 
 
+def _parse_int_param(name, default, minimum=None, maximum=None):
+    raw = request.args.get(name)
+    if raw is None or raw == "":
+        value = default
+    else:
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return None, (
+                jsonify({
+                    "error": "Invalid numeric query parameter",
+                    "param": name,
+                }),
+                400,
+            )
+
+    if minimum is not None:
+        value = max(minimum, value)
+    if maximum is not None:
+        value = min(maximum, value)
+    return value, None
+
+
 # ═══════════════════════════════════════════════════════════════
 # GOOGLE A2A — Agent Card
 # Spec: https://google.github.io/A2A
@@ -546,8 +569,12 @@ def api_agents_directory():
 
     db = get_db()
     q = request.args.get("q", "").strip()
-    page = max(1, int(request.args.get("page", 1)))
-    limit = min(100, max(1, int(request.args.get("limit", 20))))
+    page, error = _parse_int_param("page", 1, minimum=1)
+    if error:
+        return error
+    limit, error = _parse_int_param("limit", 20, minimum=1, maximum=100)
+    if error:
+        return error
     sort = request.args.get("sort", "popular")
     agent_type = request.args.get("type", "all")
     offset = (page - 1) * limit

--- a/tests/test_agent_directory_query_params.py
+++ b/tests/test_agent_directory_query_params.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+import sys
+import types
+
+import pytest
+from flask import Flask, g
+
+from agent_discovery import discovery_bp
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = Flask(__name__)
+    app.config.update(TESTING=True, PROPAGATE_EXCEPTIONS=False)
+    app.register_blueprint(discovery_bp)
+
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY,
+            agent_name TEXT,
+            display_name TEXT,
+            bio TEXT,
+            is_human INTEGER DEFAULT 0,
+            is_banned INTEGER DEFAULT 0,
+            created_at REAL
+        );
+        CREATE TABLE videos (
+            id INTEGER PRIMARY KEY,
+            agent_id INTEGER,
+            views INTEGER DEFAULT 0,
+            is_removed INTEGER DEFAULT 0,
+            created_at REAL
+        );
+        INSERT INTO agents (id, agent_name, display_name, bio, created_at)
+        VALUES (1, 'agent_one', 'Agent One', 'testing', 1770000000);
+        INSERT INTO videos (id, agent_id, views, created_at)
+        VALUES (1, 1, 7, 1770000100);
+        """
+    )
+
+    @app.before_request
+    def attach_db():
+        g.db = db
+
+    fake_server = types.ModuleType("bottube_server")
+    fake_server.get_db = lambda: g.db
+    monkeypatch.setitem(sys.modules, "bottube_server", fake_server)
+
+    with app.test_client() as test_client:
+        yield test_client
+
+    db.close()
+
+
+def test_api_agents_returns_json_400_for_malformed_pagination(client):
+    for endpoint in ["/api/agents?limit=abc", "/api/agents?page=abc"]:
+        response = client.get(endpoint)
+
+        assert response.status_code == 400, endpoint
+        assert response.is_json, endpoint
+        assert response.get_json()["error"] == "Invalid numeric query parameter"
+
+
+def test_api_agents_valid_limit_still_returns_json(client):
+    response = client.get("/api/agents?limit=1")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["limit"] == 1
+    assert data["agents"][0]["agent_name"] == "agent_one"


### PR DESCRIPTION
## Summary

- Add JSON 400 handling for malformed `/api/agents` pagination params.
- Clamp `page` and `limit` before computing offsets and SQL pagination.
- Add route-level tests that cover malformed `limit`, malformed `page`, and a valid `limit=1` response.

Closes #1007.

This is adjacent to #1005/#1006, but covers a different public route and file: `/api/agents` in `agent_discovery.py`, not `/discover/api/*` in `search_blueprint.py`.

## Validation

```bash
/tmp/bottube-issue999-venv/bin/python -m pytest tests/test_agent_directory_query_params.py -q
# 2 passed

/tmp/bottube-issue999-venv/bin/python -m py_compile agent_discovery.py tests/test_agent_directory_query_params.py
# passed

git diff --check
# passed
```

Live production reproduction before this fix:

```bash
https://bottube.ai/api/agents?limit=abc
# 500 text/html; charset=utf-8

https://bottube.ai/api/agents?page=abc
# 500 text/html; charset=utf-8

https://bottube.ai/api/agents?limit=1
# 200 application/json
```
