### PR TITLE
Fix social feed vote activity

### DIFF
--- a/interactions_blueprint.py
+++ b/interactions_blueprint.py
@@ -95,7 +95,7 @@ def api_activity_feed():
     # Get recent votes
     votes = db.execute(f"""SELECT 
             'vote' as type,
-            v.video_id as ref_id,
+            vid.video_id as ref_id,
             CASE WHEN vo.vote > 0 THEN 'upvoted' ELSE 'downvoted' END as content,
             a.id as agent_id,
             a.agent_name,
@@ -105,7 +105,7 @@ def api_activity_feed():
             vid.title as video_title
         FROM votes vo
         JOIN agents a ON vo.agent_id = a.id
-        JOIN videos vid ON vo.video_id = vid.id
+        JOIN videos vid ON vo.video_id = vid.video_id
         WHERE 1=1 {time_filter}
         ORDER BY vo.created_at DESC
         LIMIT ?""", params + [limit]).fetchall()

--- a/tests/test_agent_interaction_visibility.py
+++ b/tests/test_agent_interaction_visibility.py
@@ -32,6 +32,7 @@ def _bootstrap_sqlite_connect(path, *args, **kwargs):
 sqlite3.connect = _bootstrap_sqlite_connect
 
 import bottube_server
+import interactions_blueprint
 
 sqlite3.connect = _orig_sqlite_connect
 
@@ -400,6 +401,26 @@ def _insert_vote(video_id: str, agent_id: int, vote: int, created_at: float = No
 
 class TestActivityFeed:
     """Tests for the /api/activity/feed endpoint."""
+
+    def test_social_activity_feed_includes_votes(self, client, monkeypatch):
+        """Test that the social activity feed returns vote events as JSON."""
+        monkeypatch.setattr(interactions_blueprint, "get_db", bottube_server.get_db)
+        with bottube_server.app.app_context():
+            creator_id = _insert_agent("social_creator", "bottube_sk_social_creator")
+            voter_id = _insert_agent("social_voter", "bottube_sk_social_voter")
+            video_id = "social_feed_vote_001"
+            _insert_video(creator_id, video_id, "Social Feed Vote")
+            _insert_vote(video_id, voter_id, 1)
+
+        resp = client.get("/social/api/feed")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "activities" in data
+        vote_events = [event for event in data["activities"] if event["type"] == "vote"]
+        assert vote_events
+        assert vote_events[0]["content"]["action"] == "upvoted"
+        assert vote_events[0]["content"]["video_title"] == "Social Feed Vote"
 
     def test_activity_feed_returns_events(self, client):
         """Test that activity feed returns mixed event types."""


### PR DESCRIPTION
## Summary
- Fix `/social/api/feed` vote activity query to use the correct `videos` alias
- Join votes to videos by the public `video_id` value stored by the vote routes
- Add a regression test covering vote activity in the social feed JSON response

Fixes #1009

## Validation
- `/tmp/bottube-issue999-venv/bin/python -m pytest tests/test_agent_interaction_visibility.py::TestActivityFeed::test_social_activity_feed_includes_votes -q` -> 1 passed
- `/tmp/bottube-issue999-venv/bin/python -m py_compile interactions_blueprint.py tests/test_agent_interaction_visibility.py`
- `git diff --check -- interactions_blueprint.py tests/test_agent_interaction_visibility.py`

Bounty path: rustchain-bounties#1102 / #520 / #1589
Wallet/miner ID: `iamdinhthuan`