### PR TITLE
Validate analytics query params

### DIFF
--- a/analytics_blueprint.py
+++ b/analytics_blueprint.py
@@ -15,6 +15,12 @@ from functools import wraps
 
 analytics_bp = Blueprint('analytics', __name__, url_prefix='/analytics')
 
+VALID_PERIODS = {
+    '7d': 7,
+    '30d': 30,
+    '90d': 90,
+}
+
 
 def get_db():
     """Get database connection from Flask app context or create new one."""
@@ -37,6 +43,19 @@ def login_required(f):
     return decorated_function
 
 
+def _parse_period(value):
+    period = (value or '30d').lower()
+    return period, VALID_PERIODS.get(period)
+
+
+def _parse_limit(value, default=10, maximum=50):
+    try:
+        limit = int(value if value is not None else default)
+    except (TypeError, ValueError):
+        return None
+    return min(max(limit, 1), maximum)
+
+
 @analytics_bp.route('/')
 def analytics_dashboard():
     """Render the analytics dashboard page."""
@@ -55,11 +74,12 @@ def api_views():
     if not agent_id:
         return jsonify({"error": "agent_id required"}), 400
     
-    period = request.args.get('period', '30d')
+    period, days = _parse_period(request.args.get('period', '30d'))
+    if days is None:
+        return jsonify({"error": "period must be one of: 7d, 30d, 90d"}), 400
     video_id = request.args.get('video_id')
     
     # Calculate date range
-    days = int(period.replace('d', ''))
     start_date = datetime.now() - timedelta(days=days)
     start_timestamp = start_date.timestamp()
     
@@ -131,8 +151,9 @@ def api_engagement():
     if not agent_id:
         return jsonify({"error": "agent_id required"}), 400
     
-    period = request.args.get('period', '30d')
-    days = int(period.replace('d', ''))
+    period, days = _parse_period(request.args.get('period', '30d'))
+    if days is None:
+        return jsonify({"error": "period must be one of: 7d, 30d, 90d"}), 400
     start_date = datetime.now() - timedelta(days=days)
     start_timestamp = start_date.timestamp()
     
@@ -228,7 +249,9 @@ def api_top_videos():
         return jsonify({"error": "agent_id required"}), 400
     
     metric = request.args.get('metric', 'views')
-    limit = min(int(request.args.get('limit', 10)), 50)
+    limit = _parse_limit(request.args.get('limit'), default=10, maximum=50)
+    if limit is None:
+        return jsonify({"error": "limit must be an integer"}), 400
     
     db = get_db()
     

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -374,6 +374,29 @@ class TestAnalyticsApiPeriod:
 
 
 # =============================================================================
+# Analytics Blueprint Query Param Validation Tests
+# =============================================================================
+
+class TestAnalyticsBlueprintQueryParams:
+    """Test public analytics blueprint query parameter validation."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/analytics/api/views?agent_id=scout&period=abc",
+            "/analytics/api/engagement?agent_id=scout&period=abc",
+            "/analytics/api/top-videos?agent_id=scout&limit=abc",
+        ],
+    )
+    def test_malformed_query_params_return_json_400(self, client, path):
+        response = client.get(path)
+
+        assert response.status_code == 400
+        assert response.content_type.startswith("application/json")
+        assert "error" in response.get_json()
+
+
+# =============================================================================
 # Analytics Dashboard Integration Tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- fix malformed `period` and `limit` query params on public analytics API endpoints returning `500 text/html`
- add focused JSON 400 validation for invalid periods and non-integer limits
- add regression coverage for `/analytics/api/views`, `/analytics/api/engagement`, and `/analytics/api/top-videos`

Fixes #1011

## Verification
- Live repro before fix: `/analytics/api/views?agent_id=scout&period=abc`, `/analytics/api/engagement?agent_id=scout&period=abc`, and `/analytics/api/top-videos?agent_id=scout&limit=abc` returned `500 text/html`
- RED before fix: `/tmp/bottube-issue999-venv/bin/python -m pytest tests/test_analytics_dashboard.py::TestAnalyticsBlueprintQueryParams::test_malformed_query_params_return_json_400 -q` failed with `ValueError` from `analytics_blueprint.py`
- GREEN after fix: `/tmp/bottube-issue999-venv/bin/python -m pytest tests/test_analytics_dashboard.py::TestAnalyticsBlueprintQueryParams::test_malformed_query_params_return_json_400 -q` -> 3 passed
- `/tmp/bottube-issue999-venv/bin/python -m py_compile analytics_blueprint.py tests/test_analytics_dashboard.py` -> passed
- `git diff --check -- analytics_blueprint.py tests/test_analytics_dashboard.py` -> passed

## Known existing test state
- Running all of `tests/test_analytics_dashboard.py` currently shows unrelated baseline failures outside this patch: `/analytics` returns 308 in two page tests, and `/api/dashboard/analytics` fails in `bottube_server.py` because `datetime.utcfromtimestamp` is unavailable on the imported `datetime` module. The new focused regression class passes.