### PR TITLE
fix: reject missing feed impressions

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8890,13 +8890,21 @@ def api_feed_click():
         return jsonify({"ok": False, "error": "invalid impression_id"}), 400
     try:
         conn = sqlite3.connect(str(DB_PATH))
-        conn.execute(
+        cur = conn.execute(
             """UPDATE feed_impressions
                   SET clicked_at = ?
                 WHERE impression_id = ?
                   AND clicked_at = 0""",
             (time.time(), imp_id),
         )
+        if cur.rowcount == 0:
+            exists = conn.execute(
+                "SELECT 1 FROM feed_impressions WHERE impression_id = ?",
+                (imp_id,),
+            ).fetchone()
+            if not exists:
+                conn.close()
+                return jsonify({"ok": False, "error": "impression not found"}), 404
         conn.commit()
         conn.close()
     except Exception as e:
@@ -8918,12 +8926,15 @@ def api_feed_watch():
         return jsonify({"ok": False, "error": "invalid impression_id"}), 400
     try:
         conn = sqlite3.connect(str(DB_PATH))
-        conn.execute(
+        cur = conn.execute(
             """UPDATE feed_impressions
                   SET watch_seconds = MAX(COALESCE(watch_seconds, 0), ?)
                 WHERE impression_id = ?""",
             (seconds, imp_id),
         )
+        if cur.rowcount == 0:
+            conn.close()
+            return jsonify({"ok": False, "error": "impression not found"}), 404
         conn.commit()
         conn.close()
     except Exception as e:

--- a/tests/test_feed_impressions.py
+++ b/tests/test_feed_impressions.py
@@ -1,0 +1,105 @@
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("BOTTUBE_DB_PATH", "/tmp/bottube_test_feed_impressions_bootstrap.db")
+os.environ.setdefault("BOTTUBE_DB", "/tmp/bottube_test_feed_impressions_bootstrap.db")
+os.environ.setdefault("BOTTUBE_BASE_DIR", "/tmp")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_feed_impressions.db"
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(db_path))
+    monkeypatch.setenv("BOTTUBE_DB", str(db_path))
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server._FEED_IMP_SCHEMA_READY = False
+    bottube_server.app.config["TESTING"] = True
+    bottube_server.init_db()
+    yield bottube_server.app.test_client()
+
+
+def test_feed_click_rejects_invalid_and_missing_impressions(client):
+    invalid = client.post("/api/feed/click", json={"impression_id": "not-an-imp"})
+    assert invalid.status_code == 400
+    assert invalid.get_json()["ok"] is False
+
+    missing = client.post("/api/feed/click", json={"impression_id": "imp_deadbeef"})
+    assert missing.status_code == 404
+    assert missing.get_json() == {"ok": False, "error": "impression not found"}
+
+
+def test_feed_watch_rejects_invalid_and_missing_impressions(client):
+    invalid = client.post(
+        "/api/feed/watch",
+        json={"impression_id": "not-an-imp", "seconds": 10},
+    )
+    assert invalid.status_code == 400
+    assert invalid.get_json()["ok"] is False
+
+    missing = client.post(
+        "/api/feed/watch",
+        json={"impression_id": "imp_deadbeef", "seconds": 10},
+    )
+    assert missing.status_code == 404
+    assert missing.get_json() == {"ok": False, "error": "impression not found"}
+
+
+def test_feed_click_and_watch_update_existing_impression(client):
+    import bottube_server
+
+    bottube_server._feed_imp_ensure_schema()
+    with sqlite3.connect(str(bottube_server.DB_PATH)) as conn:
+        conn.execute(
+            """
+            INSERT INTO feed_impressions
+                (impression_id, visitor_id, surface, bucket, video_id, position, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("imp_01234567", "visitor-1", "home", "control", "video-1", 0, time.time()),
+        )
+        conn.commit()
+
+    click = client.post("/api/feed/click", json={"impression_id": "imp_01234567"})
+    assert click.status_code == 200
+    assert click.get_json() == {"ok": True}
+
+    watch = client.post(
+        "/api/feed/watch",
+        json={"impression_id": "imp_01234567", "seconds": 42},
+    )
+    assert watch.status_code == 200
+    assert watch.get_json() == {"ok": True}
+
+    with sqlite3.connect(str(bottube_server.DB_PATH)) as conn:
+        clicked_at, watch_seconds = conn.execute(
+            "SELECT clicked_at, watch_seconds FROM feed_impressions WHERE impression_id = ?",
+            ("imp_01234567",),
+        ).fetchone()
+
+    assert clicked_at > 0
+    assert watch_seconds == 42


### PR DESCRIPTION
## Summary
- Return 404 when `/api/feed/click` receives a well-formed but nonexistent impression ID
- Return 404 when `/api/feed/watch` receives a well-formed but nonexistent impression ID
- Preserve malformed ID validation and successful attribution updates for existing impressions

Fixes https://github.com/Scottcjn/bottube/issues/1021

## Verification
- `pytest tests/test_feed_impressions.py -q` -> 3 passed
- `pytest tests/test_feed_impressions.py tests/test_thumbnails.py -q` -> 39 passed
- `python -m py_compile bottube_server.py tests/test_feed_impressions.py`
- `git diff --check`