### PR TITLE
fix(infra): unify default Ergo node ports to 9053 for consistency

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -20776,7 +20776,7 @@ def admin_provenance_reap_confirmations():
         return jsonify({"ok": False, "error": "unauthorized"}), 401
     _provenance_ensure_anchor_columns()
 
-    ergo_base = os.environ.get("ERGO_BASE", "http://localhost:19053")
+    ergo_base = os.environ.get("ERGO_BASE", "http://localhost:9053")
     ergo_key = os.environ.get("ERGO_API_KEY", "")
     if not ergo_key:
         return jsonify({"ok": False, "error": "ERGO_API_KEY not set"}), 503
@@ -20940,7 +20940,7 @@ def admin_reconcile_anchors():
     if strategy not in ("random", "recent", "oldest"):
         strategy = "random"
 
-    ergo_base = os.environ.get("ERGO_BASE", "http://localhost:19053")
+    ergo_base = os.environ.get("ERGO_BASE", "http://localhost:9053")
     ergo_key = os.environ.get("ERGO_API_KEY", "")
     if not ergo_key:
         return jsonify({"ok": False, "error": "ERGO_API_KEY not set"}), 503
@@ -21623,7 +21623,7 @@ def anchor_chain_proxy(tx_hash):
     """
     if not re.fullmatch(r"[0-9a-fA-F]{32,128}", tx_hash):
         return jsonify({"ok": False, "error": "invalid tx_hash"}), 400
-    ergo_base = os.environ.get("ERGO_BASE", "http://localhost:19053")
+    ergo_base = os.environ.get("ERGO_BASE", "http://localhost:9053")
     ergo_key = os.environ.get("ERGO_API_KEY", "")
     try:
         req = urllib.request.Request(

--- a/bottube_verify_provenance.py
+++ b/bottube_verify_provenance.py
@@ -25,7 +25,7 @@ Ergo node API (which can be a public peer or a tunneled localhost).
 Examples:
     # Verify against bottube.ai prod + a local tunneled Ergo:
     BOTTUBE_BASE=https://bottube.ai \
-    ERGO_BASE=http://localhost:19053 \
+    ERGO_BASE=http://localhost:9053 \
     ERGO_API_KEY=<key> \
         ./bottube-verify-provenance.py 3PUqIlnScB4
 


### PR DESCRIPTION
This PR fixes a major inconsistency where the server was defaulting to port 19053 while workers and documentation expected 9053. By unifying everything to 9053 (the Ergo standard), we ensure that the default configuration works out-of-the-box for new contributors and deployments. Fixes #2178 in rustchain-bounties