### PR TITLE
fix: reject tips for missing videos

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -10889,6 +10889,13 @@ def tip_agent(agent_name):
 def get_video_tips(video_id):
     """Get recent tips for a video (public)."""
     db = get_db()
+    video = db.execute(
+        "SELECT 1 FROM videos WHERE video_id = ? AND COALESCE(is_removed, 0) = 0",
+        (video_id,),
+    ).fetchone()
+    if not video:
+        return jsonify({"ok": False, "error": "video not found"}), 404
+
     _sync_pending_tips(db)
     page = max(1, request.args.get("page", 1, type=int))
     per_page = min(50, max(1, request.args.get("per_page", 10, type=int)))

--- a/tests/test_tips_routes.py
+++ b/tests/test_tips_routes.py
@@ -1,0 +1,88 @@
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("BOTTUBE_DB_PATH", "/tmp/bottube_test_tips_bootstrap.db")
+os.environ.setdefault("BOTTUBE_DB", "/tmp/bottube_test_tips_bootstrap.db")
+os.environ.setdefault("BOTTUBE_BASE_DIR", "/tmp")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_tips_routes.db"
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(db_path))
+    monkeypatch.setenv("BOTTUBE_DB", str(db_path))
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server.app.config["TESTING"] = True
+    bottube_server.init_db()
+    yield bottube_server.app.test_client()
+
+
+def _insert_agent_and_video(video_id="video_tips_1"):
+    with sqlite3.connect(str(bottube_server.DB_PATH)) as conn:
+        now = time.time()
+        cur = conn.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, bio, avatar_url, created_at, last_active)
+            VALUES (?, ?, ?, '', '', ?, ?)
+            """,
+            ("creator", "Creator", "bottube_sk_creator", now, now),
+        )
+        agent_id = cur.lastrowid
+        conn.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, filename, created_at, is_removed)
+            VALUES (?, ?, ?, ?, ?, 0)
+            """,
+            (video_id, agent_id, "Tips video", "tips.mp4", now),
+        )
+        conn.commit()
+    return video_id
+
+
+def test_video_tips_returns_404_for_missing_video(client):
+    response = client.get("/api/videos/no_such_video_codex_1102/tips")
+
+    assert response.status_code == 404
+    assert response.get_json() == {"ok": False, "error": "video not found"}
+
+
+def test_video_tips_preserves_empty_totals_for_existing_video(client):
+    video_id = _insert_agent_and_video()
+
+    response = client.get(f"/api/videos/{video_id}/tips")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["video_id"] == video_id
+    assert data["tips"] == []
+    assert data["total_tips"] == 0
+    assert data["total_amount"] == 0
+    assert data["pending_tips"] == 0
+    assert data["pending_amount"] == 0


### PR DESCRIPTION
## Summary
- return 404 when `/api/videos/<video_id>/tips` is requested for a missing or removed video
- preserve the existing 200/empty totals response for valid videos with no tips
- add regression tests for both paths

Fixes #1025.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider tests/test_tips_routes.py -q` -> 2 passed
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider tests/test_tips_routes.py tests/test_payment_hardening.py -q` -> 6 passed
- `python -m py_compile bottube_server.py tests/test_tips_routes.py`
- `git diff --check`