### PR TITLE
fix: validate stream range headers

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -6907,9 +6907,28 @@ def stream_video(video_id):
     # Handle range requests for seeking
     range_header = request.headers.get("Range")
     if range_header:
-        byte_range = range_header.replace("bytes=", "").split("-")
-        start = int(byte_range[0])
-        end = int(byte_range[1]) if byte_range[1] else file_size - 1
+        match = re.fullmatch(r"bytes=(\d*)-(\d*)", range_header.strip())
+        if not match or (not match.group(1) and not match.group(2)):
+            return jsonify({"ok": False, "error": "invalid range"}), 400
+
+        start_text, end_text = match.groups()
+        if start_text:
+            start = int(start_text)
+            end = int(end_text) if end_text else file_size - 1
+        else:
+            suffix_length = int(end_text)
+            if suffix_length <= 0:
+                return jsonify({"ok": False, "error": "invalid range"}), 400
+            start = max(file_size - suffix_length, 0)
+            end = file_size - 1
+
+        if start >= file_size or end < start:
+            response = jsonify({"ok": False, "error": "range not satisfiable"})
+            response.status_code = 416
+            response.headers["Content-Range"] = f"bytes */{file_size}"
+            response.headers["Accept-Ranges"] = "bytes"
+            return response
+
         end = min(end, file_size - 1)
         length = end - start + 1
 

--- a/tests/test_stream_ranges.py
+++ b/tests/test_stream_ranges.py
@@ -1,0 +1,107 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("BOTTUBE_DB_PATH", "/tmp/bottube_test_stream_ranges_bootstrap.db")
+os.environ.setdefault("BOTTUBE_DB", "/tmp/bottube_test_stream_ranges_bootstrap.db")
+os.environ.setdefault("BOTTUBE_BASE_DIR", "/tmp")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_stream_ranges.db"
+    video_dir = tmp_path / "videos"
+    video_dir.mkdir()
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(db_path))
+    monkeypatch.setenv("BOTTUBE_DB", str(db_path))
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(bottube_server, "VIDEO_DIR", video_dir, raising=False)
+    bottube_server.app.config["TESTING"] = True
+    bottube_server.init_db()
+    yield bottube_server.app.test_client()
+
+
+def _insert_stream_video(video_id="stream_range_vid", content=b"abcdefghij"):
+    filename = f"{video_id}.mp4"
+    (bottube_server.VIDEO_DIR / filename).write_bytes(content)
+    with sqlite3.connect(str(bottube_server.DB_PATH)) as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, bio, avatar_url, created_at, last_active)
+            VALUES (?, ?, ?, '', '', 1, 1)
+            """,
+            ("streamer", "Streamer", "bottube_sk_streamer"),
+        )
+        conn.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, filename, created_at, is_removed)
+            VALUES (?, ?, ?, ?, 1, 0)
+            """,
+            (video_id, cur.lastrowid, "Stream range video", filename),
+        )
+        conn.commit()
+    return video_id, len(content)
+
+
+def test_stream_video_serves_valid_byte_range(client):
+    video_id, size = _insert_stream_video()
+
+    response = client.get(
+        f"/api/videos/{video_id}/stream",
+        headers={"Range": "bytes=0-1"},
+    )
+
+    assert response.status_code == 206
+    assert response.headers["Content-Range"] == f"bytes 0-1/{size}"
+    assert response.headers["Content-Length"] == "2"
+    assert response.get_data() == b"ab"
+
+
+def test_stream_video_rejects_malformed_range_header(client):
+    video_id, _ = _insert_stream_video()
+
+    response = client.get(
+        f"/api/videos/{video_id}/stream",
+        headers={"Range": "bytes=abc-def"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "invalid range"}
+
+
+def test_stream_video_rejects_unsatisfiable_range(client):
+    video_id, size = _insert_stream_video()
+
+    response = client.get(
+        f"/api/videos/{video_id}/stream",
+        headers={"Range": "bytes=999999999-"},
+    )
+
+    assert response.status_code == 416
+    assert response.headers["Content-Range"] == f"bytes */{size}"
+    assert response.get_json() == {"ok": False, "error": "range not satisfiable"}


### PR DESCRIPTION
## Summary
- validate stream `Range` headers before parsing integers
- return 400 for malformed range syntax
- return 416 with `Content-Range: bytes */<size>` for unsatisfiable ranges
- preserve valid partial content responses, including suffix ranges

Fixes #1029.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider tests/test_stream_ranges.py -q` -> 3 passed
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider tests/test_stream_ranges.py tests/test_thumbnails.py -q` -> 39 passed
- `python -m py_compile bottube_server.py tests/test_stream_ranges.py`
- `git diff --check`

Note: `tests/test_upload_api.py` currently errors during setup from an unrelated import-time `/root/bottube/bottube.db` connection in the app bootstrap path, so I did not use it as final verification for this scoped route fix.