### PR TITLE
Add unit tests for translations.py and x402_payment.py (Bounty #1589)

### DIFF
--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for translations.py — BoTTube video translation module.
+
+Covers:
+  - get_all_translations(): returns full data structure
+  - get_video_translations(): lookup by URL, missing URL edge case
+  - get_translations_by_language(): filter by language, unsupported language
+  - get_supported_languages(): returns expected language list
+  - Edge cases: empty string URL, None-like inputs, case sensitivity
+"""
+
+import pytest
+from translations import (
+    get_all_translations,
+    get_video_translations,
+    get_translations_by_language,
+    get_supported_languages,
+    TRANSLATION_DATA,
+)
+
+
+class TestGetAllTranslations:
+    """Tests for get_all_translations()."""
+
+    def test_returns_dict_with_videos_key(self):
+        result = get_all_translations()
+        assert isinstance(result, dict)
+        assert "videos" in result
+        assert "metadata" in result
+
+    def test_videos_is_non_empty_list(self):
+        result = get_all_translations()
+        assert isinstance(result["videos"], list)
+        assert len(result["videos"]) > 0
+
+    def test_each_video_has_required_keys(self):
+        result = get_all_translations()
+        for video in result["videos"]:
+            assert "video_url" in video, f"Missing video_url in {video}"
+            assert "original_title" in video
+            assert "original_description" in video
+            assert "translations" in video
+            assert isinstance(video["translations"], dict)
+
+    def test_metadata_has_languages(self):
+        result = get_all_translations()
+        meta = result["metadata"]
+        assert "languages" in meta
+        assert isinstance(meta["languages"], list)
+        assert len(meta["languages"]) >= 5
+
+
+class TestGetVideoTranslations:
+    """Tests for get_video_translations(url)."""
+
+    def test_existing_url_returns_video(self):
+        url = "https://bottube.ai/watch/tech-revolution-2024"
+        result = get_video_translations(url)
+        assert result is not None
+        assert result["video_url"] == url
+        assert "translations" in result
+
+    def test_nonexistent_url_returns_none(self):
+        result = get_video_translations("https://bottube.ai/watch/nonexistent-video")
+        assert result is None
+
+    def test_empty_string_url_returns_none(self):
+        result = get_video_translations("")
+        assert result is None
+
+    def test_url_is_case_sensitive(self):
+        """URLs should match exactly — uppercase should not match."""
+        url = "https://bottube.ai/watch/tech-revolution-2024"
+        result_exact = get_video_translations(url)
+        result_upper = get_video_translations(url.upper())
+        assert result_exact is not None
+        assert result_upper is None
+
+    def test_returned_video_has_translations_for_all_languages(self):
+        url = "https://bottube.ai/watch/crypto-trading-guide"
+        result = get_video_translations(url)
+        assert result is not None
+        supported = get_supported_languages()
+        for lang in supported:
+            assert lang in result["translations"], f"Missing translation for {lang}"
+            assert "title" in result["translations"][lang]
+            assert "description" in result["translations"][lang]
+
+
+class TestGetTranslationsByLanguage:
+    """Tests for get_translations_by_language(language)."""
+
+    def test_chinese_returns_all_videos(self):
+        result = get_translations_by_language("chinese")
+        assert isinstance(result, list)
+        assert len(result) == len(TRANSLATION_DATA["videos"])
+
+    def test_spanish_returns_correct_structure(self):
+        result = get_translations_by_language("spanish")
+        for entry in result:
+            assert "video_url" in entry
+            assert "original_title" in entry
+            assert "original_description" in entry
+            assert "translation" in entry
+            assert "title" in entry["translation"]
+            assert "description" in entry["translation"]
+
+    def test_unsupported_language_returns_empty_list(self):
+        result = get_translations_by_language("klingon")
+        assert result == []
+
+    def test_empty_string_language_returns_empty_list(self):
+        result = get_translations_by_language("")
+        assert result == []
+
+    def test_language_key_is_case_sensitive(self):
+        """Language keys are lowercase; uppercase should return empty."""
+        result_lower = get_translations_by_language("french")
+        result_upper = get_translations_by_language("French")
+        assert len(result_lower) > 0
+        assert result_upper == []
+
+
+class TestGetSupportedLanguages:
+    """Tests for get_supported_languages()."""
+
+    def test_returns_list(self):
+        result = get_supported_languages()
+        assert isinstance(result, list)
+
+    def test_contains_expected_languages(self):
+        result = get_supported_languages()
+        expected = ["chinese", "spanish", "french", "portuguese", "german"]
+        for lang in expected:
+            assert lang in result, f"Missing language: {lang}"
+
+    def test_no_empty_strings_in_languages(self):
+        result = get_supported_languages()
+        for lang in result:
+            assert lang.strip() != "", "Empty string found in supported languages"
+
+    def test_languages_are_lowercase(self):
+        result = get_supported_languages()
+        for lang in result:
+            assert lang == lang.lower(), f"Language not lowercase: {lang}"

--- a/tests/test_x402_payment.py
+++ b/tests/test_x402_payment.py
@@ -1,0 +1,195 @@
+"""
+Unit tests for x402_payment.py — BoTTube x402 payment protocol helpers.
+
+Covers:
+  - _amount_to_raw(): USDC amount to raw integer conversion
+  - _parse_payment_receipt(): JSON receipt parsing and validation
+  - _cleanup_payment_cache(): cache expiry logic
+  - _supported_networks(): network listing
+  - Edge cases: invalid amounts, malformed JSON, missing fields, negative values
+"""
+
+import json
+import time
+
+import pytest
+
+# Import the module — patch Flask request context dependencies first
+import sys
+import types
+
+# Create a minimal Flask stub so the module can be imported without a running app
+flask_stub = types.ModuleType("flask")
+flask_stub.Blueprint = lambda *a, **kw: types.SimpleNamespace(route=lambda *a, **kw: lambda f: f)
+flask_stub.request = types.SimpleNamespace(
+    method="GET", full_path="/", headers={}, args={}
+)
+flask_stub.jsonify = lambda d: d
+flask_stub.g = types.SimpleNamespace()
+sys.modules.setdefault("flask", flask_stub)
+
+# Stub requests module
+requests_stub = types.ModuleType("requests")
+requests_stub.post = lambda *a, **kw: None
+sys.modules.setdefault("requests", requests_stub)
+
+from x402_payment import (
+    _amount_to_raw,
+    _parse_payment_receipt,
+    _cleanup_payment_cache,
+    _supported_networks,
+    _payment_cache,
+    USDC_DECIMALS,
+    CACHE_TTL,
+)
+
+
+class TestAmountToRaw:
+    """Tests for _amount_to_raw() — USDC decimal to raw integer."""
+
+    def test_zero_amount(self):
+        assert _amount_to_raw(0) == 0
+
+    def test_one_usdc(self):
+        # 1 USDC = 1_000_000 raw (6 decimals)
+        assert _amount_to_raw(1) == 1_000_000
+
+    def test_small_amount(self):
+        # 0.001 USDC = 1000 raw
+        assert _amount_to_raw(0.001) == 1000
+
+    def test_very_small_amount(self):
+        # 0.000001 USDC = 1 raw (smallest unit)
+        assert _amount_to_raw(0.000001) == 1
+
+    def test_string_amount(self):
+        # Function accepts string representation
+        assert _amount_to_raw("0.01") == 10_000
+
+    def test_large_amount(self):
+        # 1000 USDC
+        assert _amount_to_raw(1000) == 1_000_000_000
+
+    def test_rounds_down_truncation(self):
+        # Amounts with more than 6 decimal places should be truncated (ROUND_DOWN)
+        # 0.0000001 USDC = 0.1 raw -> rounds down to 0
+        assert _amount_to_raw(0.0000001) == 0
+
+    def test_decimal_type_input(self):
+        from decimal import Decimal
+        assert _amount_to_raw(Decimal("0.5")) == 500_000
+
+
+class TestParsePaymentReceipt:
+    """Tests for _parse_payment_receipt() — JSON receipt parsing."""
+
+    def test_valid_receipt(self):
+        data = json.dumps({
+            "tx_hash": "0x" + "ab" * 32,
+            "network": "base",
+            "recipient": "0xd10A6AbFED84dDD28F89bB3d836BD20D5da8fEBf",
+            "amount": 0.001,
+        })
+        result = _parse_payment_receipt(data)
+        assert result["tx_hash"] == "0x" + "ab" * 32
+        assert result["network"] == "base"
+        assert result["recipient"] == "0xd10a6abfed84ddd28f89bb3d836bd20d5da8febf"
+        assert result["amount_raw"] == 1000
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="invalid_payment_format"):
+            _parse_payment_receipt("")
+
+    def test_non_json_raises(self):
+        with pytest.raises(ValueError, match="invalid_payment_format"):
+            _parse_payment_receipt("not json at all")
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(ValueError, match="invalid_payment_format"):
+            _parse_payment_receipt("[1, 2, 3]")
+
+    def test_missing_tx_hash_defaults_empty(self):
+        data = json.dumps({"network": "base", "recipient": "0xabc", "amount": 1})
+        result = _parse_payment_receipt(data)
+        assert result["tx_hash"] == ""
+
+    def test_missing_amount_defaults_none(self):
+        data = json.dumps({
+            "tx_hash": "0x" + "ab" * 32,
+            "network": "base",
+            "recipient": "0xabc",
+        })
+        result = _parse_payment_receipt(data)
+        assert result["amount_raw"] is None
+
+    def test_network_is_lowercased(self):
+        data = json.dumps({
+            "tx_hash": "0x" + "ab" * 32,
+            "network": "BASE",
+            "recipient": "0xABC",
+        })
+        result = _parse_payment_receipt(data)
+        assert result["network"] == "base"
+        assert result["recipient"] == "0xabc"
+
+    def test_invalid_amount_raises(self):
+        data = json.dumps({
+            "tx_hash": "0x" + "ab" * 32,
+            "network": "base",
+            "recipient": "0xabc",
+            "amount": "not_a_number",
+        })
+        with pytest.raises(ValueError, match="invalid_amount"):
+            _parse_payment_receipt(data)
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError, match="invalid_payment_format"):
+            _parse_payment_receipt("   ")
+
+    def test_json_with_whitespace_prefix(self):
+        """JSON with leading whitespace should still parse."""
+        data = '  {"tx_hash": "0x' + 'ab' * 32 + '", "network": "base"}'
+        result = _parse_payment_receipt(data)
+        assert result["network"] == "base"
+
+
+class TestCleanupPaymentCache:
+    """Tests for _cleanup_payment_cache()."""
+
+    def test_removes_expired_entries(self):
+        _payment_cache.clear()
+        _payment_cache["old_tx"] = {"time": time.time() - CACHE_TTL - 100, "fingerprint": "x"}
+        _payment_cache["new_tx"] = {"time": time.time(), "fingerprint": "y"}
+        _cleanup_payment_cache()
+        assert "old_tx" not in _payment_cache
+        assert "new_tx" in _payment_cache
+        _payment_cache.clear()
+
+    def test_keeps_fresh_entries(self):
+        _payment_cache.clear()
+        _payment_cache["fresh"] = {"time": time.time(), "fingerprint": "z"}
+        _cleanup_payment_cache()
+        assert "fresh" in _payment_cache
+        _payment_cache.clear()
+
+    def test_empty_cache_no_error(self):
+        _payment_cache.clear()
+        _cleanup_payment_cache()  # Should not raise
+        assert len(_payment_cache) == 0
+
+
+class TestSupportedNetworks:
+    """Tests for _supported_networks()."""
+
+    def test_returns_list(self):
+        result = _supported_networks()
+        assert isinstance(result, list)
+
+    def test_base_always_supported(self):
+        result = _supported_networks()
+        assert "base" in result
+
+    def test_no_empty_strings(self):
+        result = _supported_networks()
+        for net in result:
+            assert net.strip() != "", "Empty string in supported networks"


### PR DESCRIPTION
## Bounty #1589 — Write unit tests for untested Python functions

This PR adds pytest unit tests covering 2+ edge cases for previously untested functions in the BoTTube repo.

### Files added:

**tests/test_translations.py** (18 tests)
- `TestGetAllTranslations`: 4 tests — validates data structure, required keys, non-empty lists
- `TestGetVideoTranslations`: 5 tests — existing URL, nonexistent URL, empty string, case sensitivity, all-language coverage
- `TestGetTranslationsByLanguage`: 5 tests — Chinese/Spanish lookups, unsupported language, empty string, case sensitivity
- `TestGetSupportedLanguages`: 4 tests — list type, expected languages, no empty strings, lowercase check

**tests/test_x402_payment.py** (24 tests)
- `TestAmountToRaw`: 8 tests — zero, 1 USDC, small amounts, string input, large amounts, truncation, Decimal input
- `TestParsePaymentReceipt`: 9 tests — valid receipt, empty string, non-JSON, non-object JSON, missing fields, case normalization, invalid amount, whitespace
- `TestCleanupPaymentCache`: 3 tests — expired removal, fresh retention, empty cache
- `TestSupportedNetworks`: 3 tests — list type, base always present, no empty strings

### Edge cases covered:
- Empty string inputs
- Case sensitivity in URL/language lookups
- Invalid JSON formats (non-object, whitespace-only, plain text)
- Missing optional fields (amount defaults to None)
- USDC decimal truncation (ROUND_DOWN for sub-6-decimal amounts)
- Cache expiry and cleanup behavior

All 42 tests pass locally with pytest.

Wallet: RTCe92afbf2156da6009fbabcace9ed46f5ddaaa0f2