### PR TITLE
fix(#1019): add video existence check to CTR and AB variant routes

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -16310,7 +16310,11 @@ def ctr_underperforming():
 
 @app.route("/api/videos/<video_id>/ctr")
 def video_ctr_stats(video_id):
-    """Get CTR stats for a specific video."""
+    # Reject non-existent videos
+    v = db.execute("SELECT 1 FROM videos WHERE id = ?", (video_id,)).fetchone()
+    if not v:
+        return jsonify({"error": "Video not found"}), 404
+    
     try:
         stats = _get_ctr_tracker().get_stats(video_id)
         if not stats:
@@ -16338,7 +16342,11 @@ def record_watch_time(video_id):
 
 @app.route("/api/videos/<video_id>/ab/variants")
 def video_ab_variants(video_id):
-    """Get A/B test variant stats for a video."""
+    # Reject non-existent videos
+    v = db.execute("SELECT 1 FROM videos WHERE id = ?", (video_id,)).fetchone()
+    if not v:
+        return jsonify({"error": "Video not found"}), 404
+    
     try:
         stats = _get_ab_manager().get_variant_stats(video_id)
         winner = _get_ab_manager().get_winner(video_id)

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -16314,7 +16314,7 @@ def video_ctr_stats(video_id):
     v = db.execute("SELECT 1 FROM videos WHERE id = ?", (video_id,)).fetchone()
     if not v:
         return jsonify({"error": "Video not found"}), 404
-    
+
     try:
         stats = _get_ctr_tracker().get_stats(video_id)
         if not stats:
@@ -16346,7 +16346,7 @@ def video_ab_variants(video_id):
     v = db.execute("SELECT 1 FROM videos WHERE id = ?", (video_id,)).fetchone()
     if not v:
         return jsonify({"error": "Video not found"}), 404
-    
+
     try:
         stats = _get_ab_manager().get_variant_stats(video_id)
         winner = _get_ab_manager().get_winner(video_id)


### PR DESCRIPTION
Fixes #1019 completely across all 3 routes:

1. /analytics/api/views ✅ (original fix in PR #1034)
2. /api/videos/<video_id>/ctr ✅ (this PR)
3. /api/videos/<video_id>/ab/variants ✅ (this PR)

All three endpoints now return 404 for non-existent video IDs instead of returning zero/empty analytics.