### PR TITLE
fix(ci): resolve flake8 F821 undefined names breaking main CI

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7358,11 +7358,11 @@ def _compute_agent_interaction_context(db, video_agent_id, commenting_agent_id):
 
 @app.route("/api/videos/<video_id>/comments")
 def get_comments(video_id):
+    """Get comments for a video with agent interaction context."""
+    db = get_db()
     v = db.execute("SELECT 1 FROM videos WHERE id = ?", (video_id,)).fetchone()
     if not v:
         return jsonify({"error": "Video not found"}), 404
-    """Get comments for a video with agent interaction context."""
-    db = get_db()
     
     # Get video owner info for interaction context
     video_owner = db.execute(
@@ -10940,11 +10940,11 @@ def tip_agent(agent_name):
 
 @app.route("/api/videos/<video_id>/tips")
 def get_video_tips(video_id):
+    """Get recent tips for a video (public)."""
+    db = get_db()
     v = db.execute("SELECT 1 FROM videos WHERE id = ?", (video_id,)).fetchone()
     if not v:
         return jsonify({"error": "Video not found"}), 404
-    """Get recent tips for a video (public)."""
-    db = get_db()
     _sync_pending_tips(db)
     page = max(1, request.args.get("page", 1, type=int))
     per_page = min(50, max(1, request.args.get("per_page", 10, type=int)))
@@ -16367,6 +16367,7 @@ def ctr_underperforming():
 @app.route("/api/videos/<video_id>/ctr")
 def video_ctr_stats(video_id):
     # Reject non-existent videos
+    db = get_db()
     v = db.execute("SELECT 1 FROM videos WHERE id = ?", (video_id,)).fetchone()
     if not v:
         return jsonify({"error": "Video not found"}), 404
@@ -16399,6 +16400,7 @@ def record_watch_time(video_id):
 @app.route("/api/videos/<video_id>/ab/variants")
 def video_ab_variants(video_id):
     # Reject non-existent videos
+    db = get_db()
     v = db.execute("SELECT 1 FROM videos WHERE id = ?", (video_id,)).fetchone()
     if not v:
         return jsonify({"error": "Video not found"}), 404

--- a/python-sdk/bottube/client.py
+++ b/python-sdk/bottube/client.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any, BinaryIO, Optional, Union
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 import mimetypes
@@ -217,7 +217,7 @@ class BoTTubeClient:
                     yield chunk
             yield closing
         
-        req = urllib.request.Request(url, data=None, headers=headers, method="POST")
+        req = Request(url, data=None, headers=headers, method="POST")
         # Use a streaming body via a temporary file to avoid loading all into memory
         import tempfile
         with tempfile.SpooledTemporaryFile(max_size=10 * 1024 * 1024) as tmp:
@@ -225,14 +225,14 @@ class BoTTubeClient:
                 tmp.write(part)
             tmp.seek(0)
             req.data = tmp.read()
-        
+
         try:
-            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            with urlopen(req, timeout=self.timeout) as resp:
                 return json.loads(resp.read().decode("utf-8"))
-        except urllib.error.HTTPError as e:
+        except HTTPError as e:
             body = e.read().decode("utf-8", errors="replace")
             raise RuntimeError(f"Upload failed ({e.code}): {body}") from e
-        except urllib.error.URLError as e:
+        except URLError as e:
             raise RuntimeError(f"Upload failed: {e.reason}") from e
 
     def upload(


### PR DESCRIPTION
## Summary

Main CI has been failing on `lint` for several hours due to 8 pre-existing F821 undefined-name errors. These were introduced when recent "reject non-existent videos" guards were inserted **ahead of** the `db = get_db()` calls they implicitly depend on, and when the python-sdk client started using `urllib.request.X` / `urllib.error.X` without importing the `urllib` namespace.

## Fixes

**`bottube_server.py`** — 4 routes called `db.execute(...)` before `db` was defined:
- `/api/videos/<id>/comments` (line 7361)
- `/api/videos/<id>/tips` (line 10943)
- `/api/videos/<id>/ctr` (line 16370)
- `/api/videos/<id>/ab/variants` (line 16402)

Moved `db = get_db()` above the validation in `/comments` and `/tips`. Added `db = get_db()` to `/ctr` and `/ab/variants` which were missing it entirely.

**`python-sdk/bottube/client.py`** — used `urllib.request.X` / `urllib.error.X` but the file only imports specific names. Switched to the already-imported aliases and added `URLError`.

## Verification

flake8 --select=E9,F63,F7,F82 returns zero errors on both files after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)