### PR TITLE
fix: report missing feed impressions

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8943,13 +8943,21 @@ def api_feed_click():
         return jsonify({"ok": False, "error": "invalid impression_id"}), 400
     try:
         conn = sqlite3.connect(str(DB_PATH))
-        conn.execute(
+        cursor = conn.execute(
             """UPDATE feed_impressions
                   SET clicked_at = ?
                 WHERE impression_id = ?
                   AND clicked_at = 0""",
             (time.time(), imp_id),
         )
+        if cursor.rowcount == 0:
+            exists = conn.execute(
+                "SELECT 1 FROM feed_impressions WHERE impression_id = ?",
+                (imp_id,),
+            ).fetchone()
+            if not exists:
+                conn.close()
+                return jsonify({"ok": False, "error": "impression not found"}), 404
         conn.commit()
         conn.close()
     except Exception as e:
@@ -8971,12 +8979,15 @@ def api_feed_watch():
         return jsonify({"ok": False, "error": "invalid impression_id"}), 400
     try:
         conn = sqlite3.connect(str(DB_PATH))
-        conn.execute(
+        cursor = conn.execute(
             """UPDATE feed_impressions
                   SET watch_seconds = MAX(COALESCE(watch_seconds, 0), ?)
                 WHERE impression_id = ?""",
             (seconds, imp_id),
         )
+        if cursor.rowcount == 0:
+            conn.close()
+            return jsonify({"ok": False, "error": "impression not found"}), 404
         conn.commit()
         conn.close()
     except Exception as e:

--- a/tests/test_feed_attribution.py
+++ b/tests/test_feed_attribution.py
@@ -1,0 +1,63 @@
+import sqlite3
+import time
+
+
+def test_feed_click_returns_404_for_unknown_impression(client):
+    response = client.post(
+        "/api/feed/click",
+        json={"impression_id": "imp_deadbeef"},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "ok": False,
+        "error": "impression not found",
+    }
+
+
+def test_feed_watch_returns_404_for_unknown_impression(client):
+    response = client.post(
+        "/api/feed/watch",
+        json={"impression_id": "imp_deadbeef", "seconds": 10},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "ok": False,
+        "error": "impression not found",
+    }
+
+
+def test_feed_click_remains_idempotent_for_existing_clicked_impression(app, client):
+    import bottube_server
+
+    bottube_server._feed_imp_ensure_schema()
+    conn = sqlite3.connect(str(bottube_server.DB_PATH))
+    try:
+        conn.execute(
+            """INSERT INTO feed_impressions
+               (impression_id, visitor_id, surface, bucket, video_id, position,
+                created_at, clicked_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "imp_12345678",
+                "visitor",
+                "feed_api",
+                "latest",
+                "video-1",
+                0,
+                time.time(),
+                time.time(),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client.post(
+        "/api/feed/click",
+        json={"impression_id": "imp_12345678"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True}


### PR DESCRIPTION
## Summary
- Return a client-visible 404 when `/api/feed/click` receives a well-formed but unknown impression id.
- Return the same 404 for `/api/feed/watch` when no impression row matches.
- Keep click tracking idempotent for an impression that already has `clicked_at` set.

Fixes #1021.

## Validation
- `python3 -m py_compile bottube-1021/bottube_server.py bottube-1021/tests/test_feed_attribution.py` -> passed

Focused pytest note: I attempted `PYTHONPATH=bottube-1021:/tmp/rustchain-testdeps python3 -B -m pytest -q bottube-1021/tests/test_feed_attribution.py --confcutdir=bottube-1021` in the slim local workspace, but that workspace only contains the touched server/test files and import failed before the route tests with `ModuleNotFoundError: No module named 'analytics_blueprint'`. The submitted test uses the repository's existing Flask `client` fixture and should run in a full checkout.

## Bounty
Claiming under Scottcjn/Rustchain#305 / BoTTube bug bounty for issue #1021.
