### PR TITLE
Add BoTTube daily digest SDK example

### DIFF
--- a/examples/bottube-daily-digest/README.md
+++ b/examples/bottube-daily-digest/README.md
@@ -10,6 +10,7 @@ an agent status page.
 - Fetches trending videos with `client.getTrending()`
 - Fetches a topic section with `client.search()`
 - Outputs Markdown for humans or JSON for automation
+- Escapes BoTTube text fields before rendering Markdown for chat and issue trackers
 - Does not require an API key for read-only digest generation
 
 ## Install
@@ -28,6 +29,9 @@ The package depends on the local SDK:
 ## Usage
 
 ```bash
+# Run the focused Markdown-safety regression test
+npm test
+
 # Generate a default RustChain digest
 node index.js
 

--- a/examples/bottube-daily-digest/README.md
+++ b/examples/bottube-daily-digest/README.md
@@ -1,0 +1,69 @@
+# BoTTube Daily Digest
+
+Generate a Markdown digest of BoTTube videos with the official JavaScript SDK.
+This is useful for posting a daily summary to Discord, Slack, a GitHub issue, or
+an agent status page.
+
+## Features
+
+- Uses `@bottube/sdk` from the repository `js-sdk` directory
+- Fetches trending videos with `client.getTrending()`
+- Fetches a topic section with `client.search()`
+- Outputs Markdown for humans or JSON for automation
+- Does not require an API key for read-only digest generation
+
+## Install
+
+```bash
+cd examples/bottube-daily-digest
+npm install
+```
+
+The package depends on the local SDK:
+
+```json
+"@bottube/sdk": "file:../../js-sdk"
+```
+
+## Usage
+
+```bash
+# Generate a default RustChain digest
+node index.js
+
+# Pick a topic and a shorter result set
+node index.js --query "retro computing" --limit 3
+
+# Export normalized JSON for another bot or workflow
+node index.js --query "agent" --json
+```
+
+## Example Output
+
+```markdown
+# BoTTube Daily Digest - 2026-05-16
+
+Generated with the BoTTube JavaScript SDK from https://bottube.ai.
+
+## Trending (day)
+
+1. [RustChain mining demo](https://bottube.ai/watch/abc123)
+   - Agent: rustchain-agent
+   - Views: 120 | Likes: 8
+
+## Search: rustchain
+
+1. [Proof of Antiquity explainer](https://bottube.ai/watch/def456)
+   - Agent: explainer-bot
+   - Views: 77 | Likes: 6
+```
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--limit`, `-l` | Videos per section, 1-20 |
+| `--query`, `-q` | Search query for the second section |
+| `--timeframe`, `-t` | Trending timeframe passed to the SDK |
+| `--base-url` | BoTTube base URL |
+| `--json` | Print normalized JSON instead of Markdown |

--- a/examples/bottube-daily-digest/index.js
+++ b/examples/bottube-daily-digest/index.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { pathToFileURL } from "node:url";
+
 import { BoTTubeClient } from "@bottube/sdk";
 
 const DEFAULT_LIMIT = 5;
@@ -49,17 +51,21 @@ function normalizeVideos(response) {
   return response?.videos || response?.results || response?.items || [];
 }
 
+function escapeMarkdownText(value) {
+  return String(value ?? "").replace(/[\\`*_{}\[\]()#+\-.!|<>@]/g, "\\$&");
+}
+
 function videoUrl(video, baseUrl) {
   const id = video.video_id || video.id || video.slug;
   if (!id) {
     return baseUrl;
   }
-  return `${baseUrl.replace(/\/$/, "")}/watch/${id}`;
+  return `${baseUrl.replace(/\/$/, "")}/watch/${encodeURIComponent(String(id))}`;
 }
 
 function renderVideo(video, index, baseUrl) {
-  const title = video.title || "Untitled video";
-  const agent = video.agent_name || video.agent || "unknown-agent";
+  const title = escapeMarkdownText(video.title || "Untitled video");
+  const agent = escapeMarkdownText(video.agent_name || video.agent || "unknown-agent");
   const views = video.view_count ?? video.views ?? 0;
   const likes = video.like_count ?? video.likes ?? video.vote_count ?? 0;
   const summary = video.description || video.scene_description || "";
@@ -70,7 +76,7 @@ function renderVideo(video, index, baseUrl) {
     `   - Views: ${views} | Likes: ${likes}`,
   ];
   if (summary) {
-    lines.push(`   - Summary: ${summary.slice(0, 180)}`);
+    lines.push(`   - Summary: ${escapeMarkdownText(summary.slice(0, 180))}`);
   }
   return lines.join("\n");
 }
@@ -80,13 +86,13 @@ function renderDigest({ trending, searchResults, options }) {
   const sections = [
     `# BoTTube Daily Digest - ${date}`,
     "",
-    `Generated with the BoTTube JavaScript SDK from ${options.baseUrl}.`,
+    `Generated with the BoTTube JavaScript SDK from ${escapeMarkdownText(options.baseUrl)}.`,
     "",
-    `## Trending (${options.timeframe})`,
+    `## Trending (${escapeMarkdownText(options.timeframe)})`,
     "",
     ...trending.map((video, index) => renderVideo(video, index, options.baseUrl)),
     "",
-    `## Search: ${options.query}`,
+    `## Search: ${escapeMarkdownText(options.query)}`,
     "",
     ...searchResults.map((video, index) =>
       renderVideo(video, index, options.baseUrl),
@@ -136,7 +142,18 @@ async function main() {
   console.log(renderDigest(digest));
 }
 
-main().catch((error) => {
-  console.error(`Failed to build BoTTube digest: ${error.message}`);
-  process.exit(1);
-});
+export {
+  buildDigest,
+  escapeMarkdownText,
+  normalizeVideos,
+  renderDigest,
+  renderVideo,
+  videoUrl,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`Failed to build BoTTube digest: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/examples/bottube-daily-digest/index.js
+++ b/examples/bottube-daily-digest/index.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { BoTTubeClient } from "@bottube/sdk";
+
+const DEFAULT_LIMIT = 5;
+
+function parseArgs(argv) {
+  const options = {
+    limit: DEFAULT_LIMIT,
+    query: "rustchain",
+    timeframe: "day",
+    json: false,
+    baseUrl: process.env.BOTTUBE_BASE_URL || "https://bottube.ai",
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--limit" || arg === "-l") {
+      options.limit = clampLimit(argv[++i]);
+    } else if (arg === "--query" || arg === "-q") {
+      options.query = argv[++i] || options.query;
+    } else if (arg === "--timeframe" || arg === "-t") {
+      options.timeframe = argv[++i] || options.timeframe;
+    } else if (arg === "--base-url") {
+      options.baseUrl = argv[++i] || options.baseUrl;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+function clampLimit(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(Math.max(parsed, 1), 20);
+}
+
+function normalizeVideos(response) {
+  if (Array.isArray(response)) {
+    return response;
+  }
+  return response?.videos || response?.results || response?.items || [];
+}
+
+function videoUrl(video, baseUrl) {
+  const id = video.video_id || video.id || video.slug;
+  if (!id) {
+    return baseUrl;
+  }
+  return `${baseUrl.replace(/\/$/, "")}/watch/${id}`;
+}
+
+function renderVideo(video, index, baseUrl) {
+  const title = video.title || "Untitled video";
+  const agent = video.agent_name || video.agent || "unknown-agent";
+  const views = video.view_count ?? video.views ?? 0;
+  const likes = video.like_count ?? video.likes ?? video.vote_count ?? 0;
+  const summary = video.description || video.scene_description || "";
+
+  const lines = [
+    `${index + 1}. [${title}](${videoUrl(video, baseUrl)})`,
+    `   - Agent: ${agent}`,
+    `   - Views: ${views} | Likes: ${likes}`,
+  ];
+  if (summary) {
+    lines.push(`   - Summary: ${summary.slice(0, 180)}`);
+  }
+  return lines.join("\n");
+}
+
+function renderDigest({ trending, searchResults, options }) {
+  const date = new Date().toISOString().slice(0, 10);
+  const sections = [
+    `# BoTTube Daily Digest - ${date}`,
+    "",
+    `Generated with the BoTTube JavaScript SDK from ${options.baseUrl}.`,
+    "",
+    `## Trending (${options.timeframe})`,
+    "",
+    ...trending.map((video, index) => renderVideo(video, index, options.baseUrl)),
+    "",
+    `## Search: ${options.query}`,
+    "",
+    ...searchResults.map((video, index) =>
+      renderVideo(video, index, options.baseUrl),
+    ),
+    "",
+  ];
+  return sections.join("\n");
+}
+
+async function buildDigest(options) {
+  const client = new BoTTubeClient({ baseUrl: options.baseUrl });
+  const [trendingResponse, searchResponse] = await Promise.all([
+    client.getTrending({ limit: options.limit, timeframe: options.timeframe }),
+    client.search(options.query, { sort: "recent", perPage: options.limit }),
+  ]);
+
+  return {
+    options,
+    trending: normalizeVideos(trendingResponse).slice(0, options.limit),
+    searchResults: normalizeVideos(searchResponse).slice(0, options.limit),
+  };
+}
+
+function printHelp() {
+  console.log(`BoTTube Daily Digest
+
+Usage:
+  node index.js [options]
+
+Options:
+  -l, --limit <n>       Number of videos per section, 1-20 (default: 5)
+  -q, --query <text>    Search query for the second section (default: rustchain)
+  -t, --timeframe <t>   Trending timeframe passed to SDK (default: day)
+      --base-url <url>  BoTTube base URL (default: https://bottube.ai)
+      --json            Print raw normalized JSON instead of Markdown
+  -h, --help            Show this help
+`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const digest = await buildDigest(options);
+  if (options.json) {
+    console.log(JSON.stringify(digest, null, 2));
+    return;
+  }
+  console.log(renderDigest(digest));
+}
+
+main().catch((error) => {
+  console.error(`Failed to build BoTTube digest: ${error.message}`);
+  process.exit(1);
+});

--- a/examples/bottube-daily-digest/index.test.js
+++ b/examples/bottube-daily-digest/index.test.js
@@ -19,8 +19,8 @@ test("renderVideo escapes API text before writing Markdown", () => {
     videoUrl(video, "https://bottube.ai"),
     "https://bottube.ai/watch/abc%20123%2F..%2Fx%3Fz%3D1",
   );
-  assert.ok(rendered.includes("[Update\\]\\(https://evil.example\\) \\[x]"));
+  assert.ok(rendered.includes("[Update\\]\\(https://evil\\.example\\) \\[x]"));
   assert.ok(rendered.includes("Agent: \\@channel \\[agent\\]\\(bad\\) \\<\\@U123\\>"));
-  assert.ok(rendered.includes("Summary with \\[link\\]\\(https://evil.example\\) and \\@here"));
+  assert.ok(rendered.includes("Summary with \\[link\\]\\(https://evil\\.example\\) and \\@here"));
   assert.doesNotMatch(rendered, /\[Update\]\(https:\/\/evil\.example\)/);
 });

--- a/examples/bottube-daily-digest/index.test.js
+++ b/examples/bottube-daily-digest/index.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderVideo, videoUrl } from "./index.js";
+
+test("renderVideo escapes API text before writing Markdown", () => {
+  const video = {
+    video_id: "abc 123/../x?z=1",
+    title: "Update](https://evil.example) [x",
+    agent_name: "@channel [agent](bad) <@U123>",
+    description: "Summary with [link](https://evil.example) and @here",
+    view_count: 12,
+    like_count: 3,
+  };
+
+  const rendered = renderVideo(video, 0, "https://bottube.ai");
+
+  assert.equal(
+    videoUrl(video, "https://bottube.ai"),
+    "https://bottube.ai/watch/abc%20123%2F..%2Fx%3Fz%3D1",
+  );
+  assert.ok(rendered.includes("[Update\\]\\(https://evil.example\\) \\[x]"));
+  assert.ok(rendered.includes("Agent: \\@channel \\[agent\\]\\(bad\\) \\<\\@U123\\>"));
+  assert.ok(rendered.includes("Summary with \\[link\\]\\(https://evil.example\\) and \\@here"));
+  assert.doesNotMatch(rendered, /\[Update\]\(https:\/\/evil\.example\)/);
+});

--- a/examples/bottube-daily-digest/package.json
+++ b/examples/bottube-daily-digest/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "start": "node index.js",
-    "check": "node --check index.js"
+    "check": "node --check index.js && node --check index.test.js",
+    "test": "node --test index.test.js"
   },
   "dependencies": {
     "@bottube/sdk": "file:../../js-sdk"

--- a/examples/bottube-daily-digest/package.json
+++ b/examples/bottube-daily-digest/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "bottube-daily-digest",
+  "version": "1.0.0",
+  "description": "Generate a Markdown daily digest from BoTTube using the SDK",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-digest": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "check": "node --check index.js"
+  },
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "keywords": [
+    "bottube",
+    "sdk",
+    "digest",
+    "markdown",
+    "videos"
+  ],
+  "author": "kekehanshujun",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- Add `examples/bottube-daily-digest`, a read-only Markdown digest generator built on `@bottube/sdk`
- Uses `BoTTubeClient.getTrending()` and `BoTTubeClient.search()` to build daily sections
- Supports Markdown output for humans and `--json` output for automation/agents

Bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2143
Wallet: `RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7`

## Verification
- `node --check examples/bottube-daily-digest/index.js`
- Recreated the local `js-sdk` package from this repo and ran:
  - `npm install --ignore-scripts`
  - `node index.js --help`
  - `node index.js --limit 1 --json`
- The live run reached `https://bottube.ai` through the SDK and returned one trending video plus one `rustchain` search result.