### PR TITLE
fix(#1021): return 404 for nonexistent feed impressions (Closes #1021)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8897,10 +8897,13 @@ def api_feed_click():
                   AND clicked_at = 0""",
             (time.time(), imp_id),
         )
+        affected = conn.rowcount
         conn.commit()
         conn.close()
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
+    if affected == 0:
+        return jsonify({"ok": False, "error": "impression not found"}), 404
     return jsonify({"ok": True})
 
 
@@ -8924,10 +8927,13 @@ def api_feed_watch():
                 WHERE impression_id = ?""",
             (seconds, imp_id),
         )
+        affected = conn.rowcount
         conn.commit()
         conn.close()
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
+    if affected == 0:
+        return jsonify({"ok": False, "error": "impression not found"}), 404
     return jsonify({"ok": True})
 
 


### PR DESCRIPTION
## Fix #1021\n\nAdd conn.rowcount check so POST /api/feed/click and POST /api/feed/watch return 404 when impression_id doesn't exist.