### PR TITLE
fix: avoid duplicate watch page main landmarks

### DIFF
--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2158,10 +2158,7 @@
 {% endblock %}
 
 {% block content %}
-<!-- Skip link for screen readers -->
-<a href="#main-content" class="sr-only" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to main content</a>
-
-<div class="watch-layout" role="main" id="main-content" aria-label="Video page">
+<div class="watch-layout" id="watch-layout" role="region" aria-label="Video page">
     <div class="player-section" id="player-region" role="region" aria-label="Video player">
         <div class="video-player" id="video-player-region" role="region" aria-label="Video player for {{ video.title }}" aria-describedby="video-description-summary">
             <!-- IMA SDK pre-roll ad container -->

--- a/tests/test_watch_template_accessibility.py
+++ b/tests/test_watch_template_accessibility.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_watch_template_does_not_duplicate_main_landmark():
+    template = Path(__file__).resolve().parents[1] / "bottube_templates" / "watch.html"
+    html = template.read_text(encoding="utf-8")
+
+    assert 'id="main-content"' not in html
+    assert 'role="main"' not in html
+    assert 'href="#main-content"' not in html
+    assert 'id="watch-layout" role="region" aria-label="Video page"' in html


### PR DESCRIPTION
## Summary
- Remove the watch template's duplicate skip link that points at `#main-content`.
- Keep the page-level `main-content` landmark from `base.html` as the single main landmark.
- Change the inner watch layout to a unique `watch-layout` region and add a static regression test.

Fixes #999.

## Validation
- `python3 -m py_compile bottube-999/tests/test_watch_template_accessibility.py` -> passed
- Direct test function invocation -> passed
- `rg` check confirms `base.html` keeps one `href="#main-content"` and one `<main id="main-content" role="main">`, while `watch.html` now uses `id="watch-layout" role="region"`.

## Bounty
Claiming under Scottcjn/RustChain#305 / BoTTube bug bounty for issue #999.