### PR TITLE
fix: video tips 404 + search/agent pagination validation (Closes #1025 #1005 #1007)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -10889,6 +10889,8 @@ def tip_agent(agent_name):
 def get_video_tips(video_id):
     """Get recent tips for a video (public)."""
     db = get_db()
+    if not db.execute("SELECT 1 FROM videos WHERE video_id = ?", (video_id,)).fetchone():
+        return jsonify({"error": "Video not found"}), 404
     _sync_pending_tips(db)
     page = max(1, request.args.get("page", 1, type=int))
     per_page = min(50, max(1, request.args.get("per_page", 10, type=int)))

--- a/search_blueprint.py
+++ b/search_blueprint.py
@@ -51,8 +51,11 @@ def api_search():
     query = request.args.get('q', '').strip()
     category = request.args.get('category', '').strip()
     sort = request.args.get('sort', 'relevance')
-    limit = min(int(request.args.get('limit', 20)), 50)
-    offset = int(request.args.get('offset', 0))
+    try:
+        limit = min(int(request.args.get('limit', 20)), 50)
+        offset = int(request.args.get('offset', 0))
+    except (ValueError, TypeError):
+        return jsonify({'error': 'Invalid pagination parameters'}), 400
     
     if not query and not category:
         return jsonify({"error": "Query or category required"}), 400
@@ -493,7 +496,10 @@ def api_agent_directory():
     - limit: max results (default: 20)
     """
     sort = request.args.get('sort', 'subscribers')
-    limit = min(int(request.args.get('limit', 20)), 50)
+    try:
+        limit = min(int(request.args.get('limit', 20)), 50)
+    except (ValueError, TypeError):
+        return jsonify({'error': 'Invalid pagination parameters'}), 400
     
     db = get_db()
     


### PR DESCRIPTION
## Batch Fix\n\n### #1025: Returns 404 for nonexistent video in tips endpoint\n- Added  check before querying tips\n\n### #1005: Discover API malformed params return 500\n- Added try/except for limit/offset parsing in search_blueprint.py\n\n### #1007: Agent directory malformed params return 500\n- Added try/except for limit parsing in agent directory route