### PR TITLE
docs: expand contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,134 @@
 # Contributing to BoTTube
 
-First off, thanks for taking the time to contribute! 🎉
+Thanks for helping improve BoTTube. This guide covers the normal workflow for
+documentation, bug fixes, API work, SDK changes, and bounty-related pull
+requests.
 
-## Getting Started
+## Before You Start
 
-1. **Fork** the repository
-2. **Clone** your fork: `git clone https://github.com/YOUR_USERNAME/bottube.git`
-3. **Create a branch**: `git checkout -b my-feature`
-4. **Make changes** and commit: `git commit -m "Add my feature"`
-5. **Push**: `git push origin my-feature`
-6. **Open a Pull Request**
+1. Check the issue tracker for an existing report or bounty.
+2. Keep the change focused on one behavior, bug, or document.
+3. Avoid mixing unrelated cleanup, dependency updates, and feature work in the
+   same pull request.
+4. If you are claiming a bounty, keep public proof in GitHub: issue link, pull
+   request link, tests run, and your public RTC wallet address.
 
-## Development Setup
+## Local Setup
 
-### Python SDK
+Use a virtual environment for Python work:
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m pip install -r tests/requirements.txt
+```
+
+On Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m pip install -r tests/requirements.txt
+```
+
+For SDK-specific work, also check the package directory you are touching:
 
 ```bash
 cd python-sdk
-pip install -e ".[dev]"
-python -m pytest tests/
+python -m pip install -e ".[dev]"
 ```
-
-### Running Tests from Repo Root
 
 ```bash
-pip install pytest
-python -m pytest
+cd js-sdk
+npm install
 ```
+
+## Running Tests
+
+Run the smallest focused test that covers your change first:
+
+```bash
+python -m pytest tests/test_upload_api.py -q
+```
+
+Then run broader tests when the change touches shared behavior:
+
+```bash
+python -m pytest -q
+```
+
+For syntax-only or documentation-adjacent Python changes:
+
+```bash
+python -m py_compile path/to/file.py
+git diff --check
+```
+
+If a full test run is blocked by optional local dependencies, say exactly what
+failed and include the focused tests that did run.
 
 ## Code Style
 
-- Python: Follow [PEP 8](https://peps.python.org/pep-0008/)
-- Use type hints where possible
-- Write docstrings for public functions and classes
+- Follow the style of the surrounding file.
+- Keep API responses stable unless the issue asks for a contract change.
+- Add tests for user-visible behavior, security checks, migrations, and SDK
+  request paths.
+- Do not expose secrets, API keys, private paths, or raw exception text in
+  client-facing responses.
+- Prefer small helpers over repeated parsing or validation logic when multiple
+  routes share the same behavior.
 
-## Pull Request Guidelines
+## Pull Request Checklist
 
-- Keep PRs focused on a single change
-- Include tests for new features
-- Update documentation as needed
-- Ensure all tests pass before submitting
+Before opening a pull request, confirm:
+
+- The title describes the user-visible change.
+- The body links the issue, for example `Fixes #123`.
+- The body lists validation commands and results.
+- New files include any required license header used by nearby files.
+- Tests cover the bug or feature rather than only checking imports.
+- The diff does not include generated caches, local databases, screenshots, or
+  unrelated formatting churn.
 
 ## Reporting Bugs
 
-1. Check if the issue already exists
-2. Open a new issue with:
-   - Clear description of the problem
-   - Steps to reproduce
-   - Expected vs actual behavior
-   - Your environment (OS, Python version, etc.)
+Open a new issue with:
+
+- A short summary of the affected route, page, script, or SDK method.
+- Steps to reproduce.
+- Expected behavior and actual behavior.
+- Environment details when relevant: OS, Python version, browser, API endpoint,
+  or command line.
+- Logs or screenshots only when they do not contain secrets.
 
 ## Feature Requests
 
-Open an issue with the `[Feature]` label and describe:
-- The problem you're trying to solve
-- Your proposed solution
-- Any alternatives you've considered
+For feature requests, describe:
+
+- The workflow or user problem.
+- The proposed behavior.
+- Any compatibility concerns.
+- The smallest useful first version.
+
+## Bounty Notes
+
+BoTTube and RustChain bounty claims are reviewed by maintainers. A pull request,
+issue comment, or review is not a guaranteed payout until accepted. Claims are
+stronger when they include:
+
+- A public RTC wallet address.
+- A link to the merged or reviewed work.
+- The exact commands used for validation.
+- A short explanation of why the change satisfies the bounty.
+
+Never paste private keys, BoTTube API secrets, session cookies, or personal
+identity documents into a public issue or pull request.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the
+MIT License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,6 @@ python -m venv .venv
 . .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
-python -m pip install -r tests/requirements.txt
 ```
 
 On Windows PowerShell:
@@ -32,7 +31,6 @@ python -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
-python -m pip install -r tests/requirements.txt
 ```
 
 For SDK-specific work, also check the package directory you are touching:


### PR DESCRIPTION
Fixes #964.

## Summary
- Expand `CONTRIBUTING.md` from a minimal checklist into a project-specific contributor guide.
- Add setup notes for Python, Windows PowerShell, Python SDK, and JS SDK work.
- Add focused testing guidance, PR checklist, bug report guidance, and bounty safety notes.
- Remove the broken emoji/mojibake from the intro line.

## Validation
- `git diff --check` passed locally for the documentation change.

RTC wallet for accepted bounty payout:
`RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7`
