### PR TITLE
Add BoTTube Slack digest SDK example

### DIFF
--- a/examples/slack-digest/README.md
+++ b/examples/slack-digest/README.md
@@ -1,0 +1,85 @@
+# BoTTube Slack Digest
+
+Post a compact BoTTube digest to Slack using the `@bottube/sdk` JavaScript SDK.
+
+The example can send either:
+
+- Daily trending BoTTube videos.
+- Recent videos for a topic such as `rustchain`, `ai`, or an agent name.
+
+It includes a `--dry-run` mode so you can verify the Slack payload without a
+Slack webhook secret.
+
+## Requirements
+
+- Node.js 18 or newer.
+- npm.
+- A Slack incoming webhook URL for real posting.
+- Optional BoTTube API key if your target instance requires one.
+
+## Setup
+
+From the BoTTube repository root:
+
+```bash
+cd examples/slack-digest
+npm install
+```
+
+The example uses the local SDK package through `file:../../js-sdk`.
+
+## Dry Run
+
+Dry-run mode prints the exact Slack JSON payload and does not contact Slack.
+
+```bash
+node index.js --dry-run --topic rustchain --limit 3
+```
+
+Omit `--topic` to use the SDK trending endpoint:
+
+```bash
+node index.js --dry-run --limit 5
+```
+
+## Post to Slack
+
+Create an incoming webhook in Slack, then pass it with an environment variable:
+
+```bash
+export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
+node index.js --topic rustchain --limit 5
+```
+
+You can also pass the webhook URL as an argument:
+
+```bash
+node index.js --webhook-url "https://hooks.slack.com/services/..." --topic rustchain
+```
+
+## Configuration
+
+| Option | Environment | Description |
+| --- | --- | --- |
+| `--topic <query>` | | Search topic. Omit for trending videos. |
+| `--limit <number>` | | Number of videos to include, from 1 to 10. |
+| `--base-url <url>` | `BOTTUBE_API_URL` | BoTTube API base URL. Defaults to `https://bottube.ai`. |
+| `--webhook-url <url>` | `SLACK_WEBHOOK_URL` | Slack incoming webhook URL. |
+| `--dry-run` | | Print payload instead of posting to Slack. |
+| | `BOTTUBE_API_KEY` | Optional SDK API key for authenticated instances. |
+
+## Test
+
+```bash
+npm test
+node --check index.js
+```
+
+## How It Uses the SDK
+
+- Creates a `BoTTubeClient` from `@bottube/sdk`.
+- Calls `client.search(topic, { sort: "recent" })` when a topic is provided.
+- Calls `client.getTrending({ limit, timeframe: "day" })` when no topic is
+  provided.
+- Formats the returned videos into Slack Block Kit sections with BoTTube watch
+  links.

--- a/examples/slack-digest/index.js
+++ b/examples/slack-digest/index.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_BASE_URL = 'https://bottube.ai';
+
+export function buildSlackDigestPayload({ topic = 'trending', videos = [], baseUrl = DEFAULT_BASE_URL } = {}) {
+  const label = topic.trim() || 'trending';
+  const normalizedVideos = videos.map(normalizeVideo).filter((video) => video.id).slice(0, 10);
+  const videoWord = normalizedVideos.length === 1 ? 'video' : 'videos';
+
+  const blocks = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: `BoTTube digest: ${label}`,
+      },
+    },
+  ];
+
+  if (normalizedVideos.length === 0) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'No BoTTube videos matched this digest.',
+      },
+    });
+  } else {
+    for (const [index, video] of normalizedVideos.entries()) {
+      const url = `${baseUrl.replace(/\/+$/, '')}/watch/${encodeURIComponent(video.id)}`;
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          verbatim: true,
+          text: [
+            `*${index + 1}. <${url}|${escapeSlack(video.title)}>*`,
+            `${formatNumber(video.views)} views | ${formatNumber(video.likes)} likes | ${escapeSlack(video.agentName)}`,
+          ].join('\n'),
+        },
+      });
+    }
+  }
+
+  return {
+    text: `BoTTube digest for ${label}: ${normalizedVideos.length} ${videoWord}`,
+    blocks,
+  };
+}
+
+export async function collectDigestVideos({ client, topic = '', limit = 5 } = {}) {
+  const maxVideos = clampLimit(limit);
+  const query = topic.trim();
+  const response = query
+    ? await client.search(query, { sort: 'recent' })
+    : await client.getTrending({ limit: maxVideos, timeframe: 'day' });
+
+  return responseVideos(response).slice(0, maxVideos);
+}
+
+export async function createBoTTubeClient({ baseUrl = DEFAULT_BASE_URL, apiKey, timeout } = {}) {
+  const { BoTTubeClient } = await import('@bottube/sdk');
+  return new BoTTubeClient({ baseUrl, apiKey, timeout });
+}
+
+export async function postSlackDigest({ webhookUrl, payload, fetchImpl = fetch } = {}) {
+  if (!webhookUrl) {
+    throw new Error('SLACK_WEBHOOK_URL or --webhook-url is required unless --dry-run is used');
+  }
+
+  const response = await fetchImpl(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const body = typeof response.text === 'function' ? await response.text() : '';
+    throw new Error(`Slack webhook returned ${response.status}${body ? `: ${body}` : ''}`);
+  }
+}
+
+export async function runSlackDigest({
+  argv = process.argv.slice(2),
+  env = process.env,
+  client,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  fetchImpl = fetch,
+} = {}) {
+  try {
+    const options = parseArgs(argv);
+    if (options.help) {
+      stdout.write(usage());
+      return 0;
+    }
+
+    const baseUrl = options.baseUrl || env.BOTTUBE_API_URL || DEFAULT_BASE_URL;
+    const topic = options.topic || '';
+    const sdkClient = client || await createBoTTubeClient({
+      baseUrl,
+      apiKey: env.BOTTUBE_API_KEY,
+    });
+    const videos = await collectDigestVideos({ client: sdkClient, topic, limit: options.limit });
+    const payload = buildSlackDigestPayload({ topic: topic || 'trending', videos, baseUrl });
+
+    if (options.dryRun) {
+      stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+      return 0;
+    }
+
+    await postSlackDigest({
+      webhookUrl: options.webhookUrl || env.SLACK_WEBHOOK_URL,
+      payload,
+      fetchImpl,
+    });
+    stdout.write(`Posted BoTTube digest with ${videos.length} video${videos.length === 1 ? '' : 's'} to Slack.\n`);
+    return 0;
+  } catch (error) {
+    stderr.write(`Error: ${error.message}\n`);
+    return 1;
+  }
+}
+
+function normalizeVideo(video) {
+  return {
+    id: String(video.video_id ?? video.id ?? ''),
+    title: String(video.title ?? 'Untitled BoTTube video'),
+    agentName: String(video.agent_name ?? video.creator ?? video.agent ?? 'unknown agent'),
+    views: Number(video.views ?? video.view_count ?? 0),
+    likes: Number(video.likes ?? video.vote_count ?? 0),
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    topic: '',
+    limit: 5,
+    dryRun: false,
+    webhookUrl: '',
+    baseUrl: '',
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--topic' || arg === '-t') {
+      options.topic = requireValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--limit' || arg === '-l') {
+      options.limit = requireValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--webhook-url') {
+      options.webhookUrl = requireValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--base-url') {
+      options.baseUrl = requireValue(argv, index, arg);
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function usage() {
+  return [
+    'BoTTube Slack Digest',
+    '',
+    'Usage:',
+    '  node index.js --dry-run [--topic rustchain] [--limit 5]',
+    '  SLACK_WEBHOOK_URL=https://hooks.slack.com/services/... node index.js --topic rustchain',
+    '',
+    'Options:',
+    '  -t, --topic <query>       Search topic. Omit for daily trending videos.',
+    '  -l, --limit <number>      Number of videos to include, 1-10. Default: 5.',
+    '      --base-url <url>      BoTTube base URL. Default: https://bottube.ai.',
+    '      --webhook-url <url>   Slack incoming webhook URL.',
+    '      --dry-run            Print the Slack payload instead of posting it.',
+    '  -h, --help               Show this help.',
+    '',
+  ].join('\n');
+}
+
+function responseVideos(response) {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.videos)) return response.videos;
+  if (Array.isArray(response?.results)) return response.results;
+  return [];
+}
+
+function clampLimit(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return 5;
+  return Math.max(1, Math.min(parsed, 10));
+}
+
+function formatNumber(value) {
+  if (!Number.isFinite(value)) return '0';
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
+}
+
+function escapeSlack(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runSlackDigest().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/examples/slack-digest/package.json
+++ b/examples/slack-digest/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "bottube-slack-digest",
+  "version": "1.0.0",
+  "description": "Post BoTTube trending or topic digests to Slack",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-slack-digest": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "test": "node --test test/*.test.mjs"
+  },
+  "keywords": [
+    "bottube",
+    "sdk",
+    "slack",
+    "digest",
+    "webhook"
+  ],
+  "author": "iamdinhthuan",
+  "license": "MIT",
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/examples/slack-digest/test/slack-digest.test.mjs
+++ b/examples/slack-digest/test/slack-digest.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildSlackDigestPayload, collectDigestVideos, runSlackDigest } from '../index.js';
+
+test('builds a Slack Block Kit payload with BoTTube video links', () => {
+  const payload = buildSlackDigestPayload({
+    topic: 'rustchain',
+    videos: [
+      {
+        video_id: 'vid_rustchain',
+        title: 'RustChain miner walkthrough',
+        agent_name: 'miner-agent',
+        views: 1234,
+        likes: 12,
+      },
+      {
+        id: 'vid_sdk',
+        title: 'BoTTube SDK release notes',
+        agent_name: 'sdk-agent',
+        view_count: 98,
+        vote_count: 3,
+      },
+    ],
+  });
+
+  assert.equal(payload.text, 'BoTTube digest for rustchain: 2 videos');
+  assert.equal(payload.blocks[0].type, 'header');
+  assert.match(payload.blocks[0].text.text, /BoTTube digest: rustchain/);
+  assert.match(payload.blocks[1].text.text, /<https:\/\/bottube.ai\/watch\/vid_rustchain\|RustChain miner walkthrough>/);
+  assert.match(payload.blocks[1].text.text, /1.2K views/);
+  assert.match(payload.blocks[2].text.text, /<https:\/\/bottube.ai\/watch\/vid_sdk\|BoTTube SDK release notes>/);
+});
+
+test('escapes Slack mrkdwn fields and encodes watch URLs', () => {
+  const payload = buildSlackDigestPayload({
+    topic: 'security',
+    videos: [
+      {
+        video_id: 'id with spaces/and/slashes',
+        title: 'Watch <this> & ping @channel',
+        agent_name: 'agent <ops> & friends',
+      },
+    ],
+  });
+
+  assert.match(payload.blocks[1].text.text, /watch\/id%20with%20spaces%2Fand%2Fslashes/);
+  assert.match(payload.blocks[1].text.text, /Watch &lt;this&gt; &amp; ping @channel/);
+  assert.match(payload.blocks[1].text.text, /agent &lt;ops&gt; &amp; friends/);
+  assert.equal(payload.blocks[1].text.verbatim, true);
+});
+
+test('collects topic videos through the BoTTube SDK client', async () => {
+  const calls = [];
+  const client = {
+    async search(query, options) {
+      calls.push({ query, options });
+      return {
+        videos: [
+          { video_id: 'vid_1', title: 'First' },
+          { video_id: 'vid_2', title: 'Second' },
+          { video_id: 'vid_3', title: 'Third' },
+        ],
+      };
+    },
+  };
+
+  const videos = await collectDigestVideos({ client, topic: 'rustchain', limit: 2 });
+
+  assert.deepEqual(calls, [{ query: 'rustchain', options: { sort: 'recent' } }]);
+  assert.deepEqual(videos.map((video) => video.video_id), ['vid_1', 'vid_2']);
+});
+
+test('dry-run prints the Slack payload without calling a webhook', async () => {
+  const stdout = [];
+  const client = {
+    async search() {
+      return {
+        videos: [{ video_id: 'vid_1', title: 'RustChain briefing', views: 1000, likes: 4 }],
+      };
+    },
+  };
+
+  const exitCode = await runSlackDigest({
+    argv: ['--topic', 'rustchain', '--limit', '1', '--dry-run'],
+    env: {},
+    client,
+    stdout: { write: (chunk) => stdout.push(chunk) },
+    stderr: { write: () => {} },
+    fetchImpl: async () => {
+      throw new Error('webhook should not be called during dry-run');
+    },
+  });
+
+  const payload = JSON.parse(stdout.join(''));
+  assert.equal(exitCode, 0);
+  assert.equal(payload.text, 'BoTTube digest for rustchain: 1 video');
+  assert.match(payload.blocks[1].text.text, /RustChain briefing/);
+});
+
+test('posts the digest JSON to the configured Slack webhook', async () => {
+  const stdout = [];
+  const posts = [];
+  const client = {
+    async search() {
+      return {
+        videos: [{ video_id: 'vid_1', title: 'Webhook briefing', views: 12, likes: 1 }],
+      };
+    },
+  };
+
+  const exitCode = await runSlackDigest({
+    argv: ['--topic', 'rustchain', '--webhook-url', 'https://hooks.slack.test/services/demo'],
+    env: {},
+    client,
+    stdout: { write: (chunk) => stdout.push(chunk) },
+    stderr: { write: () => {} },
+    fetchImpl: async (url, init) => {
+      posts.push({ url, init });
+      return { ok: true, status: 200, text: async () => 'ok' };
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(posts.length, 1);
+  assert.equal(posts[0].url, 'https://hooks.slack.test/services/demo');
+  assert.equal(posts[0].init.method, 'POST');
+  assert.equal(posts[0].init.headers['Content-Type'], 'application/json');
+  assert.equal(JSON.parse(posts[0].init.body).text, 'BoTTube digest for rustchain: 1 video');
+  assert.match(stdout.join(''), /Posted BoTTube digest with 1 video to Slack/);
+});
+
+test('requires a Slack webhook outside dry-run mode', async () => {
+  const stderr = [];
+  const client = {
+    async search() {
+      return { videos: [{ video_id: 'vid_1', title: 'Missing webhook briefing' }] };
+    },
+  };
+
+  const exitCode = await runSlackDigest({
+    argv: ['--topic', 'rustchain'],
+    env: {},
+    client,
+    stdout: { write: () => {} },
+    stderr: { write: (chunk) => stderr.push(chunk) },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(stderr.join(''), /SLACK_WEBHOOK_URL or --webhook-url is required/);
+});


### PR DESCRIPTION
## Summary

Adds `examples/slack-digest`, a Node.js example that uses the local `@bottube/sdk` package to build Slack Block Kit digests from BoTTube videos.

The example can:
- fetch recent videos for a topic with `BoTTubeClient.search(topic, { sort: "recent" })`
- fetch daily trending videos with `BoTTubeClient.getTrending({ limit, timeframe: "day" })`
- print the Slack payload with `--dry-run` so verification does not require a Slack webhook secret
- post the same JSON payload to an incoming Slack webhook when `SLACK_WEBHOOK_URL` or `--webhook-url` is provided

## Verification

```text
cd examples/slack-digest
npm install --package-lock=false
npm test
# 6 tests passed

node --check index.js
# passed

node index.js --dry-run --topic rustchain --limit 1
# printed a Slack Block Kit payload for a live public BoTTube search result

node index.js --dry-run --limit 1
# printed a Slack Block Kit payload for live public trending results

git diff --check origin/main...HEAD -- examples/slack-digest
# passed
```

## Duplicate and safety notes

- Bounty route: Scottcjn/rustchain-bounties#2143.
- Fresh searches for same-account Slack/webhook/digest BoTTube SDK PRs and claims returned no matches before opening this PR.
- No private Slack webhook URL, API token, wallet secret, withdrawal, transfer, or fund movement was used.
