### PR TITLE
docs: add BoTTube RSS feed SDK example

### DIFF
--- a/examples/rss-feed/README.md
+++ b/examples/rss-feed/README.md
@@ -1,0 +1,62 @@
+# BoTTube RSS Feed Example
+
+Generate RSS XML from BoTTube trending, search, or chronological feed results with the JavaScript SDK.
+
+## Setup
+
+```bash
+cd examples/rss-feed
+npm install
+```
+
+The example depends on the local SDK package:
+
+```json
+"@bottube/sdk": "file:../../js-sdk"
+```
+
+## Usage
+
+Write a trending feed to `bottube.xml`:
+
+```bash
+node index.js --mode trending --limit 10 --out bottube.xml
+```
+
+Generate a search feed:
+
+```bash
+node index.js --query "rustchain miner" --limit 15 --title "RustChain on BoTTube"
+```
+
+Generate the latest chronological feed:
+
+```bash
+node index.js --mode feed --limit 20 --feed-url https://example.com/bottube.xml
+```
+
+Use a saved SDK-style fixture without making a network request:
+
+```bash
+node index.js --fixture test/fixtures/videos.json --out fixture.xml
+```
+
+## Options
+
+- `--mode trending|search|feed` selects the SDK method.
+- `--query` searches videos and implies `search` mode.
+- `--limit` caps the number of videos at 50.
+- `--base-url` overrides the API base URL. It defaults to `https://bottube.ai`.
+- `--site-url` controls generated watch links.
+- `--feed-url` adds an RSS self link.
+- `--title` and `--description` customize channel metadata.
+- `--fixture` renders a saved JSON response for tests or dry runs.
+- `--out` writes RSS XML to a file instead of stdout.
+
+## Validation
+
+```bash
+npm test
+node --check index.js
+node index.js --fixture test/fixtures/videos.json --out /tmp/bottube-rss.xml
+```

--- a/examples/rss-feed/index.js
+++ b/examples/rss-feed/index.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { extractVideos, generateRss, normalizeLimit } from './src/rss.js';
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const baseUrl = options.baseUrl || process.env.BOTTUBE_BASE_URL || 'https://bottube.ai';
+  const siteUrl = options.siteUrl || baseUrl;
+  const limit = normalizeLimit(options.limit || 10);
+  const response = options.fixture
+    ? JSON.parse(await readFile(options.fixture, 'utf8'))
+    : await fetchWithSdk(options, baseUrl, limit);
+
+  const videos = extractVideos(response, limit);
+  const xml = generateRss({
+    title: options.title || defaultTitle(options),
+    description: options.description,
+    siteUrl,
+    feedUrl: options.feedUrl,
+    videos
+  });
+
+  if (options.out) {
+    await writeFile(options.out, xml, 'utf8');
+    console.log(`Wrote ${videos.length} videos to ${options.out}`);
+  } else {
+    process.stdout.write(xml);
+  }
+}
+
+async function fetchWithSdk(options, baseUrl, limit) {
+  const { BoTTubeClient } = await import('@bottube/sdk');
+  const client = new BoTTubeClient({
+    baseUrl,
+    timeout: Number.parseInt(String(options.timeout || 30000), 10)
+  });
+  const mode = options.mode || (options.query ? 'search' : 'trending');
+
+  if (mode === 'search') {
+    if (!options.query) {
+      throw new Error('Search mode requires --query "search terms".');
+    }
+    return client.search(options.query, { sort: options.sort });
+  }
+
+  if (mode === 'feed') {
+    return client.getFeed({ per_page: limit });
+  }
+
+  if (mode === 'trending') {
+    return client.getTrending({
+      limit,
+      timeframe: options.timeframe
+    });
+  }
+
+  throw new Error(`Unknown mode "${mode}". Use trending, search, or feed.`);
+}
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    const [name, inlineValue] = arg.startsWith('--') ? arg.split('=', 2) : [arg, undefined];
+    const value = inlineValue ?? argv[i + 1];
+
+    switch (name) {
+      case '--mode':
+        options.mode = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--query':
+        options.query = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--limit':
+        options.limit = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--timeframe':
+        options.timeframe = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--sort':
+        options.sort = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--base-url':
+        options.baseUrl = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--site-url':
+        options.siteUrl = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--feed-url':
+        options.feedUrl = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--title':
+        options.title = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--description':
+        options.description = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--fixture':
+        options.fixture = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--out':
+        options.out = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--timeout':
+        options.timeout = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function requireValue(name, value) {
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a value.`);
+  }
+  return value;
+}
+
+function defaultTitle(options) {
+  if (options.mode === 'feed') return 'Latest BoTTube videos';
+  if (options.query) return `BoTTube search: ${options.query}`;
+  return 'Trending BoTTube videos';
+}
+
+function printHelp() {
+  console.log(`BoTTube RSS feed example
+
+Usage:
+  node index.js [options]
+
+Options:
+  --mode trending|search|feed   SDK source to use. Defaults to trending.
+  --query "agent ai"            Search query. Implies search mode.
+  --limit 10                    Number of videos, capped at 50.
+  --timeframe week              Trending timeframe forwarded to the SDK.
+  --base-url https://...        BoTTube API base URL.
+  --site-url https://...        Public site URL for generated watch links.
+  --feed-url https://...        Optional canonical URL for this RSS feed.
+  --title "Feed title"          RSS channel title.
+  --description "Text"          RSS channel description.
+  --fixture file.json           Render from a saved SDK-style JSON response.
+  --out feed.xml                Write XML to a file instead of stdout.
+  --timeout 30000               SDK request timeout in milliseconds.
+`);
+}
+
+main().catch((error) => {
+  console.error(`bottube-rss: ${error.message}`);
+  process.exit(1);
+});

--- a/examples/rss-feed/package.json
+++ b/examples/rss-feed/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "bottube-rss-feed-example",
+  "version": "1.0.0",
+  "description": "Generate RSS feeds from BoTTube trending, search, or chronological SDK results.",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-rss": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "test": "node --test test/*.test.js"
+  },
+  "keywords": [
+    "bottube",
+    "rss",
+    "feed",
+    "sdk",
+    "video"
+  ],
+  "author": "iamdinhthuan",
+  "license": "MIT",
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/examples/rss-feed/src/rss.js
+++ b/examples/rss-feed/src/rss.js
@@ -1,0 +1,132 @@
+const DEFAULT_SITE_URL = 'https://bottube.ai';
+
+export function escapeXml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+export function extractVideos(response, limit = 20) {
+  const source = Array.isArray(response)
+    ? response
+    : response?.videos ?? response?.results ?? response?.items ?? response?.data ?? [];
+
+  if (!Array.isArray(source)) return [];
+  return source
+    .filter((video) => video && typeof video === 'object')
+    .slice(0, normalizeLimit(limit));
+}
+
+export function normalizeLimit(limit) {
+  const parsed = Number.parseInt(String(limit), 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return 20;
+  return Math.min(parsed, 50);
+}
+
+export function generateRss(options) {
+  const siteUrl = trimTrailingSlash(options.siteUrl || DEFAULT_SITE_URL);
+  const title = options.title || 'BoTTube Videos';
+  const description = options.description || 'A generated RSS feed powered by the BoTTube JavaScript SDK.';
+  const feedUrl = options.feedUrl;
+  const videos = Array.isArray(options.videos) ? options.videos : [];
+  const now = new Date().toUTCString();
+
+  const atomSelf = feedUrl
+    ? `    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml"/>\n`
+    : '';
+
+  const items = videos.map((video) => renderItem(video, siteUrl)).join('');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    `    <title>${escapeXml(title)}</title>`,
+    `    <link>${escapeXml(siteUrl)}</link>`,
+    `    <description>${escapeXml(description)}</description>`,
+    atomSelf.trimEnd(),
+    `    <lastBuildDate>${now}</lastBuildDate>`,
+    '    <generator>BoTTube RSS feed example</generator>',
+    items.trimEnd(),
+    '  </channel>',
+    '</rss>',
+    ''
+  ].filter(Boolean).join('\n');
+}
+
+function renderItem(video, siteUrl) {
+  const link = getVideoUrl(video, siteUrl);
+  const title = getFirst(video, ['title', 'name'], 'Untitled BoTTube video');
+  const description = getDescription(video);
+  const pubDate = getPubDate(video);
+
+  return [
+    '    <item>',
+    `      <title>${escapeXml(title)}</title>`,
+    `      <link>${escapeXml(link)}</link>`,
+    `      <guid isPermaLink="true">${escapeXml(link)}</guid>`,
+    `      <description><![CDATA[${escapeCdata(description)}]]></description>`,
+    pubDate ? `      <pubDate>${pubDate}</pubDate>` : '',
+    '    </item>',
+    ''
+  ].filter(Boolean).join('\n');
+}
+
+function getDescription(video) {
+  const description = getFirst(video, ['description', 'summary', 'caption'], '');
+  if (description) return description;
+
+  const creator = getFirst(video, ['creator', 'agent_name', 'author', 'uploader'], '');
+  const views = getFirst(video, ['view_count', 'views'], '');
+  const parts = [];
+  if (creator) parts.push(`Creator: ${creator}`);
+  if (views !== '') parts.push(`Views: ${views}`);
+  return parts.length ? parts.join(' | ') : 'Watch this video on BoTTube.';
+}
+
+function getVideoUrl(video, siteUrl) {
+  const absoluteUrl = getFirst(video, ['url', 'watch_url', 'link'], '');
+  if (absoluteUrl && /^https?:\/\//i.test(absoluteUrl)) return absoluteUrl;
+
+  const relativeUrl = getFirst(video, ['watch_url', 'link'], '');
+  if (relativeUrl && String(relativeUrl).startsWith('/')) return `${siteUrl}${relativeUrl}`;
+
+  const id = getFirst(video, ['video_id', 'public_id', 'id', 'slug'], '');
+  if (!id) return siteUrl;
+  return `${siteUrl}/watch/${encodeURIComponent(String(id))}`;
+}
+
+function getPubDate(video) {
+  const raw = getFirst(video, ['created_at', 'createdAt', 'uploaded_at', 'upload_date', 'timestamp'], '');
+  if (!raw) return '';
+  const date = new Date(normalizeDateValue(raw));
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toUTCString();
+}
+
+function normalizeDateValue(value) {
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (Number.isFinite(numeric)) {
+    return Math.abs(numeric) < 100000000000 ? numeric * 1000 : numeric;
+  }
+  return value;
+}
+
+function escapeCdata(value) {
+  return String(value ?? '').replaceAll(']]>', ']]]]><![CDATA[>');
+}
+
+function getFirst(video, keys, fallback) {
+  for (const key of keys) {
+    const value = video[key];
+    if (value !== undefined && value !== null && value !== '') return value;
+  }
+  return fallback;
+}
+
+function trimTrailingSlash(value) {
+  return String(value).replace(/\/+$/, '');
+}

--- a/examples/rss-feed/test/fixtures/videos.json
+++ b/examples/rss-feed/test/fixtures/videos.json
@@ -1,0 +1,18 @@
+{
+  "videos": [
+    {
+      "video_id": "antique-gpu-tour",
+      "title": "Antique GPU Miner Tour",
+      "description": "A short tour of a revived mining workstation.",
+      "creator": "sophia",
+      "created_at": "2026-05-17T08:00:00Z"
+    },
+    {
+      "id": "sdk-demo",
+      "title": "BoTTube SDK Demo",
+      "description": "Using the JavaScript SDK to build syndication tools.",
+      "agent_name": "demo-agent",
+      "created_at": "2026-05-17T09:00:00Z"
+    }
+  ]
+}

--- a/examples/rss-feed/test/rss.test.js
+++ b/examples/rss-feed/test/rss.test.js
@@ -3,11 +3,24 @@ import { execFile } from 'node:child_process';
 import { readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { extractVideos, generateRss } from '../src/rss.js';
 
 const execFileAsync = promisify(execFile);
-const root = new URL('..', import.meta.url).pathname;
+
+function exampleRootFromMetaUrl(metaUrl) {
+  return fileURLToPath(new URL('..', metaUrl));
+}
+
+const root = exampleRootFromMetaUrl(import.meta.url);
+
+test('exampleRootFromMetaUrl decodes file URLs for child process cwd', () => {
+  const decodedRoot = exampleRootFromMetaUrl('file:///tmp/bottube%20rss/examples/rss-feed/test/rss.test.js');
+
+  assert.equal(decodedRoot.includes('%20'), false);
+  assert.match(decodedRoot, /bottube rss/);
+});
 
 test('generateRss escapes XML and emits watch links', () => {
   const xml = generateRss({
@@ -70,7 +83,7 @@ test('CLI renders fixture data and writes an RSS file', async () => {
   const outFile = join(root, 'test', 'tmp-feed.xml');
   await rm(outFile, { force: true });
 
-  const { stdout } = await execFileAsync('node', [
+  const { stdout } = await execFileAsync(process.execPath, [
     'index.js',
     '--fixture',
     'test/fixtures/videos.json',

--- a/examples/rss-feed/test/rss.test.js
+++ b/examples/rss-feed/test/rss.test.js
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { extractVideos, generateRss } from '../src/rss.js';
 
@@ -16,7 +17,10 @@ function exampleRootFromMetaUrl(metaUrl) {
 const root = exampleRootFromMetaUrl(import.meta.url);
 
 test('exampleRootFromMetaUrl decodes file URLs for child process cwd', () => {
-  const decodedRoot = exampleRootFromMetaUrl('file:///tmp/bottube%20rss/examples/rss-feed/test/rss.test.js');
+  const encodedMetaUrl = pathToFileURL(
+    join(tmpdir(), 'bottube rss', 'examples', 'rss-feed', 'test', 'rss.test.js')
+  ).href;
+  const decodedRoot = exampleRootFromMetaUrl(encodedMetaUrl);
 
   assert.equal(decodedRoot.includes('%20'), false);
   assert.match(decodedRoot, /bottube rss/);

--- a/examples/rss-feed/test/rss.test.js
+++ b/examples/rss-feed/test/rss.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import test from 'node:test';
+import { promisify } from 'node:util';
+import { extractVideos, generateRss } from '../src/rss.js';
+
+const execFileAsync = promisify(execFile);
+const root = new URL('..', import.meta.url).pathname;
+
+test('generateRss escapes XML and emits watch links', () => {
+  const xml = generateRss({
+    title: 'BoTTube <Trending>',
+    description: 'AI & agent videos',
+    siteUrl: 'https://bottube.ai',
+    feedUrl: 'https://example.com/bottube.xml',
+    videos: [
+      {
+        id: 'video-1',
+        title: 'RustChain & "Agents"',
+        description: 'Preserve <old> machines ]]> safely',
+        creator: 'alice',
+        created_at: '2026-05-17T10:00:00Z'
+      }
+    ]
+  });
+
+  assert.match(xml, /^<\?xml version="1.0" encoding="UTF-8"\?>/);
+  assert.match(xml, /<title>BoTTube &lt;Trending&gt;<\/title>/);
+  assert.match(xml, /<title>RustChain &amp; &quot;Agents&quot;<\/title>/);
+  assert.match(xml, /<description><!\[CDATA\[Preserve <old> machines \]\]\]\]><!\[CDATA\[> safely\]\]><\/description>/);
+  assert.match(xml, /<link>https:\/\/bottube\.ai\/watch\/video-1<\/link>/);
+  assert.match(xml, /<guid isPermaLink="true">https:\/\/bottube\.ai\/watch\/video-1<\/guid>/);
+});
+
+test('extractVideos accepts SDK response shapes and respects limit', () => {
+  assert.deepEqual(
+    extractVideos({ videos: [{ id: 1 }, { id: 2 }, { id: 3 }] }, 2).map((video) => video.id),
+    [1, 2]
+  );
+  assert.deepEqual(
+    extractVideos({ results: [{ id: 'a' }] }, 10).map((video) => video.id),
+    ['a']
+  );
+  assert.deepEqual(
+    extractVideos([{ id: 'direct' }], 10).map((video) => video.id),
+    ['direct']
+  );
+});
+
+test('generateRss treats numeric timestamps as Unix seconds', () => {
+  const xml = generateRss({
+    siteUrl: 'https://bottube.ai',
+    videos: [
+      {
+        video_id: 'GRMIiChn-UM',
+        watch_url: '/watch/GRMIiChn-UM',
+        title: 'SDK timestamp sample',
+        created_at: 1778940440.082385
+      }
+    ]
+  });
+
+  assert.match(xml, /<link>https:\/\/bottube\.ai\/watch\/GRMIiChn-UM<\/link>/);
+  assert.match(xml, /<pubDate>Sat, 16 May 2026 14:07:20 GMT<\/pubDate>/);
+});
+
+test('CLI renders fixture data and writes an RSS file', async () => {
+  const outFile = join(root, 'test', 'tmp-feed.xml');
+  await rm(outFile, { force: true });
+
+  const { stdout } = await execFileAsync('node', [
+    'index.js',
+    '--fixture',
+    'test/fixtures/videos.json',
+    '--out',
+    outFile,
+    '--title',
+    'Fixture Feed'
+  ], { cwd: root });
+
+  assert.match(stdout, /Wrote 2 videos to/);
+  const xml = await readFile(outFile, 'utf8');
+  assert.match(xml, /<title>Fixture Feed<\/title>/);
+  assert.match(xml, /<title>Antique GPU Miner Tour<\/title>/);
+  assert.match(xml, /<title>BoTTube SDK Demo<\/title>/);
+  await rm(outFile, { force: true });
+});


### PR DESCRIPTION
## Summary
- add `examples/rss-feed`, a Node.js RSS 2.0 generator built on the local `@bottube/sdk` package
- support trending, search, and chronological feed sources plus fixture/no-network mode
- include setup docs, CLI options, fixture data, and Node test coverage

Refs Scottcjn/rustchain-bounties#2143.

## Validation
- `npm test`
- `node --check index.js`
- `git diff --check -- examples/rss-feed`
- `npm install --no-package-lock`
- `node index.js --mode trending --limit 1 --out /tmp/bottube-rss-live.xml`
- `node index.js --query rustchain --limit 1 --out /tmp/bottube-rss-search.xml`
- `node index.js --mode feed --limit 1 --out /tmp/bottube-rss-feed.xml`

No private tokens, API keys, uploads, account writes, wallet operations, withdrawals, transfers, or payout actions were used.