### PR TITLE
feat: add BoTTube embed widget SDK example

### DIFF
--- a/examples/embed-widget/README.md
+++ b/examples/embed-widget/README.md
@@ -1,0 +1,63 @@
+# BoTTube Embed Widget Example
+
+Generate a standalone HTML video widget with the BoTTube JavaScript SDK.
+
+This example is useful for blogs, documentation pages, dashboards, and agent
+reports that need to embed a small set of BoTTube videos without building a full
+frontend app. It can render trending videos, search results, the chronological
+feed, or a local fixture for offline validation.
+
+## Setup
+
+```bash
+cd examples/embed-widget
+npm install
+```
+
+## Usage
+
+Render trending videos to stdout:
+
+```bash
+node index.js --limit 4
+```
+
+Render search results into a page:
+
+```bash
+node index.js --query rustchain --limit 6 --output rustchain-widget.html
+```
+
+Render from the included fixture without network access:
+
+```bash
+node index.js --fixture test/fixtures/videos.json --output fixture-widget.html
+```
+
+Customize the copy:
+
+```bash
+node index.js \
+  --query "physical ai" \
+  --title "Physical AI watchlist" \
+  --subtitle "Fresh BoTTube videos for agents and builders" \
+  --output physical-ai.html
+```
+
+Open the generated HTML file in a browser or paste the body into a docs page.
+The widget links each card to the public BoTTube watch page.
+
+## Verification
+
+```bash
+npm test
+node --check index.js
+node index.js --fixture test/fixtures/videos.json --output /tmp/bottube-widget.html
+```
+
+## Notes
+
+- Uses `@bottube/sdk` from the repository's `js-sdk` directory.
+- Does not require a BoTTube API key for public search, trending, feed, or
+  fixture rendering.
+- Escapes titles, descriptions, tags, and agent names before rendering HTML.

--- a/examples/embed-widget/index.js
+++ b/examples/embed-widget/index.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { BoTTubeClient } from '@bottube/sdk';
+
+import { renderWidgetHtml } from './src/widget.js';
+
+const args = parseArgs(process.argv.slice(2));
+
+try {
+  const videos = args.fixture
+    ? JSON.parse(await readFile(args.fixture, 'utf8'))
+    : await fetchVideos(args);
+  const html = renderWidgetHtml(videos, {
+    title: args.title,
+    subtitle: args.subtitle,
+    baseUrl: args.baseUrl,
+  });
+
+  if (args.output) {
+    await writeFile(args.output, html);
+    console.log(`Wrote BoTTube widget to ${args.output}`);
+  } else {
+    console.log(html);
+  }
+} catch (error) {
+  console.error(`bottube-embed-widget: ${error.message}`);
+  process.exit(1);
+}
+
+async function fetchVideos(options) {
+  const client = new BoTTubeClient({ baseUrl: options.baseUrl });
+  if (options.query) {
+    const result = await client.search(options.query, { sort: options.sort });
+    return (result.results || result.videos || []).slice(0, options.limit);
+  }
+  if (options.feed) {
+    const result = await client.getFeed({ page: 1, per_page: options.limit });
+    return (result.videos || []).slice(0, options.limit);
+  }
+  const result = await client.getTrending({ limit: options.limit, timeframe: options.timeframe });
+  return (result.videos || []).slice(0, options.limit);
+}
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: 'https://bottube.ai',
+    limit: 6,
+    sort: 'relevance',
+    timeframe: 'day',
+    title: 'BoTTube video picks',
+    subtitle: 'Generated with the BoTTube JavaScript SDK',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+
+    if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else if (arg === '--query') {
+      options.query = next();
+    } else if (arg === '--feed') {
+      options.feed = true;
+    } else if (arg === '--limit') {
+      options.limit = clampInteger(next(), 1, 24, '--limit');
+    } else if (arg === '--timeframe') {
+      options.timeframe = next();
+    } else if (arg === '--sort') {
+      options.sort = next();
+    } else if (arg === '--base-url') {
+      options.baseUrl = next().replace(/\/+$/, '');
+    } else if (arg === '--title') {
+      options.title = next();
+    } else if (arg === '--subtitle') {
+      options.subtitle = next();
+    } else if (arg === '--fixture') {
+      options.fixture = next();
+    } else if (arg === '--output') {
+      options.output = next();
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function clampInteger(value, min, max, name) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${name} must be an integer from ${min} to ${max}`);
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`BoTTube embed widget
+
+Generate a standalone HTML widget from BoTTube videos.
+
+Usage:
+  node index.js [options]
+
+Options:
+  --query <text>       Search BoTTube and render matching videos
+  --feed               Render the chronological feed instead of trending
+  --limit <n>          Number of cards to render, 1-24 (default: 6)
+  --timeframe <name>   Trending timeframe: hour, day, week, month
+  --sort <name>        Search sort: relevance, recent, views
+  --fixture <file>     Render from a local JSON fixture instead of the network
+  --output <file>      Write HTML to a file instead of stdout
+  --title <text>       Widget title
+  --subtitle <text>    Widget subtitle
+  --base-url <url>     BoTTube instance URL (default: https://bottube.ai)
+`);
+}

--- a/examples/embed-widget/index.js
+++ b/examples/embed-widget/index.js
@@ -5,9 +5,8 @@ import { BoTTubeClient } from '@bottube/sdk';
 
 import { renderWidgetHtml } from './src/widget.js';
 
-const args = parseArgs(process.argv.slice(2));
-
 try {
+  const args = parseArgs(process.argv.slice(2));
   const videos = args.fixture
     ? JSON.parse(await readFile(args.fixture, 'utf8'))
     : await fetchVideos(args);
@@ -93,7 +92,7 @@ function parseArgs(argv) {
 }
 
 function clampInteger(value, min, max, name) {
-  const parsed = Number.parseInt(value, 10);
+  const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
     throw new Error(`${name} must be an integer from ${min} to ${max}`);
   }

--- a/examples/embed-widget/package.json
+++ b/examples/embed-widget/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bottube-embed-widget-example",
+  "version": "1.0.0",
+  "description": "Generate an embeddable BoTTube video widget with the JavaScript SDK",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-embed-widget": "./index.js"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/examples/embed-widget/src/widget.js
+++ b/examples/embed-widget/src/widget.js
@@ -1,0 +1,147 @@
+const DEFAULT_BASE_URL = 'https://bottube.ai';
+
+export function normalizeVideos(videos, options = {}) {
+  const baseUrl = (options.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
+  return videos
+    .map((video) => {
+      const id = text(video.video_id || video.videoId || video.id);
+      if (!id) return null;
+      return {
+        id,
+        title: text(video.title) || 'Untitled BoTTube video',
+        description: text(video.description),
+        agent: text(video.agent || video.agent_name || video.agentName || video.creator) || 'unknown',
+        views: number(video.views ?? video.view_count ?? video.viewCount),
+        likes: number(video.likes ?? video.vote_count ?? video.voteCount),
+        thumbnailUrl: text(video.thumbnail_url || video.thumbnailUrl || video.thumbnail),
+        streamUrl: text(video.stream_url || video.streamUrl),
+        tags: Array.isArray(video.tags) ? video.tags.map(text).filter(Boolean) : [],
+        watchUrl: `${baseUrl}/watch/${encodeURIComponent(id)}`,
+      };
+    })
+    .filter(Boolean);
+}
+
+export function renderWidgetHtml(videos, options = {}) {
+  const title = options.title || 'BoTTube video picks';
+  const subtitle = options.subtitle || 'Generated with the BoTTube JavaScript SDK';
+  const normalized = normalizeVideos(videos, options);
+  const cards = normalized.length
+    ? normalized.map(renderCard).join('\n')
+    : '<p class="empty">No videos matched this widget yet.</p>';
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <style>
+    :root { color-scheme: light dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; padding: 24px; background: #f7f7f3; color: #1b1c1d; }
+    .bt-widget { max-width: 1120px; margin: 0 auto; }
+    .bt-header { display: flex; justify-content: space-between; gap: 16px; align-items: end; margin-bottom: 18px; }
+    h1 { font-size: 26px; line-height: 1.2; margin: 0; }
+    .subtitle { margin: 6px 0 0; color: #555f68; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 14px; }
+    .card { display: flex; flex-direction: column; min-height: 100%; border: 1px solid #d9ddd6; border-radius: 8px; background: #ffffff; overflow: hidden; text-decoration: none; color: inherit; }
+    .thumb { aspect-ratio: 16 / 9; background: linear-gradient(135deg, #17202a, #2d6a6a); display: grid; place-items: center; color: #ffffff; font-weight: 700; }
+    .thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .body { padding: 14px; display: flex; flex-direction: column; gap: 8px; }
+    .title { font-weight: 700; line-height: 1.25; }
+    .desc { color: #53606a; font-size: 14px; line-height: 1.45; }
+    .meta { display: flex; flex-wrap: wrap; gap: 8px; color: #687681; font-size: 13px; }
+    .tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 2px; }
+    .tag { border: 1px solid #d8ded7; border-radius: 999px; padding: 2px 7px; font-size: 12px; color: #36545a; }
+    .empty { border: 1px dashed #aeb8ad; border-radius: 8px; padding: 18px; color: #53606a; background: #fff; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #101412; color: #f2f4f1; }
+      .card, .empty { background: #171d1a; border-color: #303a35; }
+      .subtitle, .desc, .meta { color: #aab5ae; }
+      .tag { border-color: #38443d; color: #bdd8cd; }
+    }
+  </style>
+</head>
+<body>
+  <section class="bt-widget" aria-label="BoTTube video widget">
+    <header class="bt-header">
+      <div>
+        <h1>${escapeHtml(title)}</h1>
+        <p class="subtitle">${escapeHtml(subtitle)}</p>
+      </div>
+      <a href="${DEFAULT_BASE_URL}" rel="noopener">Open BoTTube</a>
+    </header>
+    <div class="grid">
+${cards}
+    </div>
+  </section>
+</body>
+</html>`;
+}
+
+function renderCard(video) {
+  const description = video.description
+    ? `<p class="desc">${escapeHtml(truncate(video.description, 150))}</p>`
+    : '';
+  const thumb = video.thumbnailUrl
+    ? `<img src="${escapeAttribute(video.thumbnailUrl)}" alt="">`
+    : `<span>${escapeHtml(initials(video.title))}</span>`;
+  const tags = video.tags.length
+    ? `<div class="tags">${video.tags.slice(0, 4).map((tag) => `<span class="tag">#${escapeHtml(tag)}</span>`).join('')}</div>`
+    : '';
+
+  return `      <a class="card" href="${escapeAttribute(video.watchUrl)}" rel="noopener">
+        <div class="thumb">${thumb}</div>
+        <div class="body">
+          <div class="title">${escapeHtml(video.title)}</div>
+          ${description}
+          <div class="meta">
+            <span>@${escapeHtml(video.agent)}</span>
+            <span>${formatCount(video.views)} views</span>
+            <span>${formatCount(video.likes)} likes</span>
+          </div>
+          ${tags}
+        </div>
+      </a>`;
+}
+
+function text(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function number(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function truncate(value, max) {
+  return value.length > max ? `${value.slice(0, max - 1)}...` : value;
+}
+
+function initials(title) {
+  return title
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0].toUpperCase())
+    .join('') || 'BT';
+}
+
+function formatCount(value) {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value).replaceAll('`', '&#96;');
+}

--- a/examples/embed-widget/test/fixtures/videos.json
+++ b/examples/embed-widget/test/fixtures/videos.json
@@ -1,0 +1,21 @@
+[
+  {
+    "video_id": "rustchain-demo",
+    "title": "RustChain miner walkthrough",
+    "description": "A public overview of Proof-of-Antiquity mining on older hardware.",
+    "agent_name": "antiquity-lab",
+    "views": 1820,
+    "likes": 64,
+    "thumbnail_url": "https://bottube.ai/static/example-rustchain.jpg",
+    "tags": ["rustchain", "miner", "depin"]
+  },
+  {
+    "video_id": "agent-video",
+    "title": "Agent-native video curation",
+    "description": "How agents can discover and share useful BoTTube content.",
+    "agent_name": "media-agent",
+    "views": 937,
+    "likes": 21,
+    "tags": ["agents", "video"]
+  }
+]

--- a/examples/embed-widget/test/widget.test.js
+++ b/examples/embed-widget/test/widget.test.js
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  normalizeVideos,
+  renderWidgetHtml,
+} from '../src/widget.js';
+
+test('normalizes SDK video shapes into public watch cards', () => {
+  const videos = normalizeVideos([
+    {
+      video_id: 'abc123',
+      title: 'RustChain demo',
+      description: 'Proof of antiquity walkthrough',
+      agent_name: 'miner-bot',
+      views: 1532,
+      likes: 42,
+      thumbnail_url: 'https://cdn.example/thumb.jpg',
+      tags: ['rustchain', 'demo'],
+    },
+    {
+      id: 'legacy-7',
+      title: '',
+      agentName: 'agent-two',
+      view_count: 7,
+      vote_count: 2,
+      stream_url: 'https://cdn.example/video.mp4',
+    },
+  ]);
+
+  assert.deepEqual(videos, [
+    {
+      id: 'abc123',
+      title: 'RustChain demo',
+      description: 'Proof of antiquity walkthrough',
+      agent: 'miner-bot',
+      views: 1532,
+      likes: 42,
+      thumbnailUrl: 'https://cdn.example/thumb.jpg',
+      streamUrl: '',
+      tags: ['rustchain', 'demo'],
+      watchUrl: 'https://bottube.ai/watch/abc123',
+    },
+    {
+      id: 'legacy-7',
+      title: 'Untitled BoTTube video',
+      description: '',
+      agent: 'agent-two',
+      views: 7,
+      likes: 2,
+      thumbnailUrl: '',
+      streamUrl: 'https://cdn.example/video.mp4',
+      tags: [],
+      watchUrl: 'https://bottube.ai/watch/legacy-7',
+    },
+  ]);
+});
+
+test('renders escaped standalone widget HTML', () => {
+  const html = renderWidgetHtml([
+    {
+      id: 'xss-1',
+      title: '<script>alert(1)</script>',
+      description: 'An <b>unsafe</b> description',
+      agent: 'agent<one>',
+      views: 1200,
+      likes: 5,
+      thumbnailUrl: 'https://cdn.example/thumb.jpg',
+      streamUrl: '',
+      tags: ['ai', '<tag>'],
+      watchUrl: 'https://bottube.ai/watch/xss-1',
+    },
+  ], {
+    title: 'BoTTube picks',
+    subtitle: 'Fresh videos for agents',
+  });
+
+  assert.match(html, /^<!doctype html>/);
+  assert.match(html, /BoTTube picks/);
+  assert.match(html, /Fresh videos for agents/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html, /An &lt;b&gt;unsafe&lt;\/b&gt; description/);
+  assert.match(html, /agent&lt;one&gt;/);
+  assert.match(html, /1\.2K views/);
+  assert.match(html, /#&lt;tag&gt;/);
+  assert.doesNotMatch(html, /<script>alert/);
+});

--- a/examples/embed-widget/test/widget.test.js
+++ b/examples/embed-widget/test/widget.test.js
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   normalizeVideos,
   renderWidgetHtml,
 } from '../src/widget.js';
+
+const exampleRoot = dirname(fileURLToPath(new URL('../index.js', import.meta.url)));
 
 test('normalizes SDK video shapes into public watch cards', () => {
   const videos = normalizeVideos([
@@ -84,4 +89,20 @@ test('renders escaped standalone widget HTML', () => {
   assert.match(html, /1\.2K views/);
   assert.match(html, /#&lt;tag&gt;/);
   assert.doesNotMatch(html, /<script>alert/);
+});
+
+test('CLI rejects malformed limit values instead of parsing numeric prefixes', () => {
+  const result = spawnSync(process.execPath, [
+    join(exampleRoot, 'index.js'),
+    '--fixture',
+    join(exampleRoot, 'test/fixtures/videos.json'),
+    '--limit',
+    '2abc',
+  ], {
+    encoding: 'utf8',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--limit must be an integer from 1 to 24/);
+  assert.doesNotMatch(result.stderr, /at clampInteger|Node\.js/);
 });


### PR DESCRIPTION
## Summary
- add `examples/embed-widget`, a standalone HTML video-widget generator built with `@bottube/sdk`
- support public search, trending, feed, fixture/no-network rendering, and file output
- include README setup/usage instructions and node:test coverage for video normalization and HTML escaping

## Validation
- RED: `npm test --prefix examples/embed-widget` initially failed with `ERR_MODULE_NOT_FOUND` for missing `src/widget.js`
- `npm test --prefix examples/embed-widget` -> 2 passed
- `node --check examples/embed-widget/index.js && node --check examples/embed-widget/src/widget.js && node --check examples/embed-widget/test/widget.test.js`
- `node examples/embed-widget/index.js --fixture examples/embed-widget/test/fixtures/videos.json --output /tmp/bottube-embed-widget.html`
- `node examples/embed-widget/index.js --query rustchain --limit 1 --output /tmp/bottube-embed-widget-live.html`
- `git diff --check -- examples/embed-widget`

Bounty route: Scottcjn/rustchain-bounties#2143. No BoTTube API key, private token, withdrawal, transfer, or fund movement was used.