### PR TITLE
fix: validate BAN transfer amounts

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -11,6 +11,7 @@ Custodial model: platform seed derives per-user accounts by index.
 from flask import Blueprint, request, jsonify, g, session
 import json
 import logging
+import math
 import os
 import sqlite3
 import time
@@ -69,6 +70,26 @@ def get_db():
         g.db = sqlite3.connect(db_path)
         g.db.row_factory = sqlite3.Row
     return g.db
+
+
+def _request_json_object():
+    data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _parse_positive_ban_amount(data):
+    raw_amount = data.get("amount", 0)
+    if isinstance(raw_amount, bool):
+        return None, (jsonify({"error": "amount must be a finite positive number"}), 400)
+    try:
+        amount = float(raw_amount)
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": "amount must be a finite positive number"}), 400)
+    if not math.isfinite(amount) or amount <= 0:
+        return None, (jsonify({"error": "amount must be a finite positive number"}), 400)
+    return amount, None
 
 
 def init_ban_tables(db=None):
@@ -431,13 +452,17 @@ def ban_tip():
     if not user_id:
         return jsonify({"error": "Authentication required"}), 401
 
-    data = request.get_json() or {}
-    to_agent = data.get("to_agent", "").strip()
-    amount = float(data.get("amount", 0))
-    video_id = data.get("video_id", "")
-
-    if not to_agent or amount <= 0:
+    data, error = _request_json_object()
+    if error:
+        return error
+    to_agent_raw = data.get("to_agent", "")
+    to_agent = to_agent_raw.strip() if isinstance(to_agent_raw, str) else ""
+    if not to_agent:
         return jsonify({"error": "to_agent and positive amount required"}), 400
+    amount, error = _parse_positive_ban_amount(data)
+    if error:
+        return error
+    video_id = data.get("video_id", "")
 
     if amount > 1000:
         return jsonify({"error": "Maximum tip is 1000 BAN"}), 400
@@ -487,12 +512,16 @@ def ban_withdraw():
     if not user_id:
         return jsonify({"error": "Authentication required"}), 401
 
-    data = request.get_json() or {}
-    to_address = data.get("address", "").strip()
-    amount = float(data.get("amount", 0))
-
-    if not to_address or amount <= 0:
+    data, error = _request_json_object()
+    if error:
+        return error
+    to_address_raw = data.get("address", "")
+    to_address = to_address_raw.strip() if isinstance(to_address_raw, str) else ""
+    if not to_address:
         return jsonify({"error": "address and positive amount required"}), 400
+    amount, error = _parse_positive_ban_amount(data)
+    if error:
+        return error
 
     if not to_address.startswith("ban_") or len(to_address) != 64:
         return jsonify({"error": "Invalid Banano address format"}), 400

--- a/tests/test_banano_amount_validation.py
+++ b/tests/test_banano_amount_validation.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+import time
+
+import pytest
+from flask import Flask, g
+
+import banano_blueprint
+
+
+@pytest.fixture
+def ban_client(tmp_path):
+    db_path = tmp_path / "bottube.db"
+    app = Flask(__name__)
+    app.secret_key = "test-secret-key"
+    app.config["TESTING"] = True
+    app.register_blueprint(banano_blueprint.ban_bp)
+
+    @app.before_request
+    def before_request():
+        g.db = sqlite3.connect(db_path)
+        g.db.row_factory = sqlite3.Row
+
+    @app.teardown_request
+    def teardown_request(_exc):
+        db = getattr(g, "db", None)
+        if db is not None:
+            db.close()
+
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            "CREATE TABLE agents (id INTEGER PRIMARY KEY, agent_name TEXT UNIQUE NOT NULL)"
+        )
+        banano_blueprint.init_ban_tables(db)
+        now = time.time()
+        db.executemany(
+            "INSERT INTO agents (id, agent_name) VALUES (?, ?)",
+            [(1, "alice"), (2, "bob")],
+        )
+        db.execute(
+            """
+            INSERT INTO ban_transactions
+            (agent_id, tx_type, amount_ban, reason, status, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (1, "reward", 10.0, "seed_balance", "credited", now),
+        )
+        db.commit()
+
+    client = app.test_client()
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+    client.db_path = db_path
+    return client
+
+
+def _ban_transaction_count(db_path):
+    with sqlite3.connect(db_path) as db:
+        return db.execute("SELECT COUNT(*) FROM ban_transactions").fetchone()[0]
+
+
+@pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True, 0, -1])
+def test_ban_tip_rejects_invalid_amounts_without_writes(ban_client, amount):
+    before = _ban_transaction_count(ban_client.db_path)
+
+    response = ban_client.post("/ban/tip", json={"to_agent": "bob", "amount": amount})
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "amount must be a finite positive number"
+    assert _ban_transaction_count(ban_client.db_path) == before
+
+
+@pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True, 0, -1])
+def test_ban_withdraw_rejects_invalid_amounts_without_writes(ban_client, amount):
+    before = _ban_transaction_count(ban_client.db_path)
+
+    response = ban_client.post(
+        "/ban/withdraw",
+        json={"address": "ban_" + "a" * 60, "amount": amount},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "amount must be a finite positive number"
+    assert _ban_transaction_count(ban_client.db_path) == before
+
+
+def test_ban_tip_rejects_non_object_json_body(ban_client):
+    before = _ban_transaction_count(ban_client.db_path)
+
+    response = ban_client.post("/ban/tip", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+    assert _ban_transaction_count(ban_client.db_path) == before
+
+
+def test_valid_ban_tip_still_records_sender_and_recipient_rows(ban_client):
+    response = ban_client.post("/ban/tip", json={"to_agent": "bob", "amount": "1.25"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "amount_ban": 1.25, "to": "bob"}
+
+    with sqlite3.connect(ban_client.db_path) as db:
+        rows = db.execute(
+            """
+            SELECT agent_id, tx_type, amount_ban, status
+            FROM ban_transactions
+            ORDER BY id
+            """
+        ).fetchall()
+
+    assert rows == [
+        (1, "reward", 10.0, "credited"),
+        (1, "tip_sent", 1.25, "credited"),
+        (2, "tip_received", 1.25, "credited"),
+    ]


### PR DESCRIPTION
Fixes #1133.

This PR keeps the BAN payment endpoints on the client-error path when request shape or amount values are malformed. The changed surface is intentionally limited to `banano_blueprint.py` and a focused regression file, because the bug happens before any external Banano RPC call.

| Area | Change | Evidence |
| --- | --- | --- |
| BAN request parsing | Reject non-object JSON bodies before field access | New `/ban/tip` regression covers array payloads returning 400 without writes |
| BAN amount parsing | Reject booleans, non-numeric strings, `NaN`, `Infinity`, zero, and negative amounts before balance or insert logic | New tip/withdraw parameterized regressions cover both endpoints and assert no transaction rows are added |
| Happy path | Preserve a valid tip recording sender and recipient rows | New valid-tip regression still records `tip_sent` and `tip_received` rows |

Validation was run locally:

```text
uv run --no-project --with flask --with pytest python -m pytest tests/test_banano_amount_validation.py -q
14 passed in 0.47s

python -m py_compile banano_blueprint.py tests/test_banano_amount_validation.py
git diff --check -- banano_blueprint.py tests/test_banano_amount_validation.py
```

The PR deliberately leaves balance accounting, maximum-tip enforcement, Banano address format validation, and external withdrawal processing untouched.


CI note: the `auto-label` job is failing with `Resource not accessible by integration` because this PR comes from a fork and that job only has read permissions. The code-bearing jobs on the same run (`lint`, `security`, and `test`) passed.
