### PR TITLE
fix: validate USDC payment amounts

### DIFF
--- a/tests/test_usdc_amount_validation.py
+++ b/tests/test_usdc_amount_validation.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+import time
+
+import pytest
+from flask import Flask, g
+
+import usdc_blueprint
+
+
+@pytest.fixture
+def usdc_client(tmp_path):
+    db_path = tmp_path / "bottube.db"
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(usdc_blueprint.usdc_bp)
+
+    @app.before_request
+    def before_request():
+        g.db = sqlite3.connect(db_path)
+        g.db.row_factory = sqlite3.Row
+
+    @app.teardown_request
+    def teardown_request(_exc):
+        db = getattr(g, "db", None)
+        if db is not None:
+            db.close()
+
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            "CREATE TABLE agents (name TEXT PRIMARY KEY, api_key TEXT UNIQUE NOT NULL)"
+        )
+        usdc_blueprint.init_usdc_tables(db)
+        now = time.time()
+        db.executemany(
+            "INSERT INTO agents (name, api_key) VALUES (?, ?)",
+            [("alice", "key-alice"), ("bob", "key-bob")],
+        )
+        db.execute(
+            """
+            INSERT INTO usdc_balances
+            (agent_name, balance_usdc, total_deposited, total_spent, total_earned, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("alice", 10.0, 10.0, 0.0, 0.0, now),
+        )
+        db.commit()
+
+    client = app.test_client()
+    client.db_path = db_path
+    client.auth_headers = {"X-API-Key": "key-alice"}
+    return client
+
+
+def _table_count(db_path, table):
+    with sqlite3.connect(db_path) as db:
+        return db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+
+def _balance(db_path, agent_name):
+    with sqlite3.connect(db_path) as db:
+        row = db.execute(
+            "SELECT balance_usdc, total_spent FROM usdc_balances WHERE agent_name = ?",
+            (agent_name,),
+        ).fetchone()
+    return row
+
+
+@pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True])
+def test_usdc_tip_rejects_malformed_amounts_without_writes(usdc_client, amount):
+    before_tips = _table_count(usdc_client.db_path, "usdc_tips")
+    before_alice = _balance(usdc_client.db_path, "alice")
+
+    response = usdc_client.post(
+        "/api/usdc/tip",
+        json={"to_agent": "bob", "amount_usdc": amount},
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "amount_usdc must be a finite number"
+    assert _table_count(usdc_client.db_path, "usdc_tips") == before_tips
+    assert _balance(usdc_client.db_path, "alice") == before_alice
+
+
+@pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True])
+def test_usdc_payout_rejects_malformed_amounts_without_writes(usdc_client, amount):
+    before_payouts = _table_count(usdc_client.db_path, "usdc_payouts")
+    before_alice = _balance(usdc_client.db_path, "alice")
+
+    response = usdc_client.post(
+        "/api/usdc/payout",
+        json={"to_address": "0x" + "a" * 40, "amount_usdc": amount},
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "amount_usdc must be a finite number"
+    assert _table_count(usdc_client.db_path, "usdc_payouts") == before_payouts
+    assert _balance(usdc_client.db_path, "alice") == before_alice
+
+
+def test_usdc_tip_rejects_non_object_json_body(usdc_client):
+    before_tips = _table_count(usdc_client.db_path, "usdc_tips")
+
+    response = usdc_client.post(
+        "/api/usdc/tip",
+        json=["not", "an", "object"],
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+    assert _table_count(usdc_client.db_path, "usdc_tips") == before_tips
+
+
+def test_valid_usdc_tip_still_debits_sender_and_credits_creator(usdc_client):
+    response = usdc_client.post(
+        "/api/usdc/tip",
+        json={"to_agent": "bob", "amount_usdc": "2.00"},
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["tip"]["creator_receives"] == 1.7
+    assert body["tip"]["platform_fee"] == 0.3
+
+    alice = _balance(usdc_client.db_path, "alice")
+    bob = _balance(usdc_client.db_path, "bob")
+    assert alice == (8.0, 2.0)
+    assert bob == (1.7, 0.0)
+    assert _table_count(usdc_client.db_path, "usdc_tips") == 1
+
+
+def test_valid_usdc_payout_still_creates_pending_request(usdc_client):
+    response = usdc_client.post(
+        "/api/usdc/payout",
+        json={"to_address": "0x" + "b" * 40, "amount_usdc": "1.25"},
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["payout"]["status"] == "pending"
+    assert body["payout"]["amount_usdc"] == 1.25
+    assert _balance(usdc_client.db_path, "alice") == (8.75, 1.25)
+    assert _table_count(usdc_client.db_path, "usdc_payouts") == 1

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -4,6 +4,7 @@ Flask Blueprint for USDC deposits, tips, and premium API access.
 """
 
 from flask import Blueprint, request, jsonify, g
+import math
 import sqlite3
 import time
 import hashlib
@@ -47,6 +48,28 @@ def get_db():
         g.db = sqlite3.connect(db_path)
         g.db.row_factory = sqlite3.Row
     return g.db
+
+
+def _request_json_object():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _parse_finite_usdc_amount(data):
+    raw_amount = data.get("amount_usdc", 0)
+    if isinstance(raw_amount, bool):
+        return None, (jsonify({"error": "amount_usdc must be a finite number"}), 400)
+    try:
+        amount = float(raw_amount)
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": "amount_usdc must be a finite number"}), 400)
+    if not math.isfinite(amount):
+        return None, (jsonify({"error": "amount_usdc must be a finite number"}), 400)
+    return amount, None
 
 
 def init_usdc_tables(db):
@@ -316,13 +339,18 @@ def usdc_tip():
     if not agent_name:
         return jsonify({"error": "Authentication required"}), 401
 
-    data = request.get_json() or {}
+    data, error = _request_json_object()
+    if error:
+        return error
     video_id = data.get("video_id")
     to_agent = data.get("to_agent")
-    amount = float(data.get("amount_usdc", 0))
 
     if not video_id and not to_agent:
         return jsonify({"error": "video_id or to_agent required"}), 400
+
+    amount, error = _parse_finite_usdc_amount(data)
+    if error:
+        return error
     if amount <= 0:
         return jsonify({"error": "amount_usdc must be positive"}), 400
     if amount < 0.01:
@@ -464,9 +492,14 @@ def usdc_payout():
     if not agent_name:
         return jsonify({"error": "Authentication required"}), 401
 
-    data = request.get_json() or {}
-    amount = float(data.get("amount_usdc", 0))
-    to_address = data.get("to_address", "").strip()
+    data, error = _request_json_object()
+    if error:
+        return error
+    amount, error = _parse_finite_usdc_amount(data)
+    if error:
+        return error
+    to_address_raw = data.get("to_address", "")
+    to_address = to_address_raw.strip() if isinstance(to_address_raw, str) else ""
 
     if amount < 1.0:
         return jsonify({"error": "Minimum payout is 1.00 USDC"}), 400


### PR DESCRIPTION
Fixes #1137.

This PR keeps the USDC balance-backed payment endpoints on the client-error path for malformed request bodies and non-finite amounts. The changed surface is intentionally limited to `usdc_blueprint.py` and focused endpoint regressions.

| Area | Change | Evidence |
| --- | --- | --- |
| Request body shape | Reject non-object JSON before field access | New `/api/usdc/tip` regression covers array payloads returning 400 without writes |
| USDC amount parsing | Reject booleans, non-numeric strings, `NaN`, and `Infinity` before balance mutation or insert logic | New tip/payout parameterized regressions assert no tips, payouts, or balance changes are written |
| Existing valid flows | Preserve valid tip debit/creator credit and valid payout request creation | New happy-path regressions cover both endpoints |

Validation was run locally:

```text
uv run --no-project --with flask --with pytest --with requests python -m pytest tests/test_usdc_amount_validation.py -q
11 passed in 0.66s

python -m py_compile usdc_blueprint.py tests/test_usdc_amount_validation.py
git diff --check -- usdc_blueprint.py tests/test_usdc_amount_validation.py
```

The PR deliberately leaves deposit verification, premium purchases, balance accounting formulas, and Base address format validation untouched.


CI note: the `auto-label` job is failing with `Resource not accessible by integration` because this PR comes from a fork and that job only has read permissions. The code-bearing jobs on the same run (`lint`, `security`, and `test`) passed.
