### PR TITLE
fix: validate beef relationship events

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -14,6 +14,7 @@ Features:
 import sqlite3
 import time
 from datetime import datetime, timedelta
+from math import isfinite
 from pathlib import Path
 
 from flask import Blueprint, g, jsonify, request
@@ -147,6 +148,41 @@ def init_beef_tables(db_path: str | None = None) -> None:
 def _canonical_pair(a: int, b: int) -> tuple[int, int]:
     """Return (min, max) so agent_a_id < agent_b_id always."""
     return (min(a, b), max(a, b))
+
+
+def _parse_positive_int(value, field_name: str) -> tuple[int | None, str | None]:
+    """Parse a required positive integer without accepting booleans or floats."""
+    if isinstance(value, bool) or value is None:
+        return None, f"{field_name} must be a positive integer"
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None, f"{field_name} must be a positive integer"
+        try:
+            parsed = int(stripped, 10)
+        except ValueError:
+            return None, f"{field_name} must be a positive integer"
+    else:
+        return None, f"{field_name} must be a positive integer"
+
+    if parsed <= 0:
+        return None, f"{field_name} must be a positive integer"
+    return parsed, None
+
+
+def _parse_finite_float(value, field_name: str) -> tuple[float | None, str | None]:
+    """Parse a finite float field without accepting booleans, NaN, or infinity."""
+    if isinstance(value, bool):
+        return None, f"{field_name} must be a finite number"
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None, f"{field_name} must be a finite number"
+    if not isfinite(parsed):
+        return None, f"{field_name} must be a finite number"
+    return parsed, None
 
 
 def _transition_state(tension: float, current_state: str, beef_started_at: float | None) -> str:
@@ -287,15 +323,30 @@ def create_or_update_relationship():
       delta        float  tension change (+/-)
       description  str  optional
     """
-    data = request.get_json(silent=True) or {}
-    a_id = data.get("agent_a_id")
-    b_id = data.get("agent_b_id")
-    event_type = data.get("event_type", "generic")
-    delta = float(data.get("delta", 0))
-    description = data.get("description", "")
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
 
-    if not a_id or not b_id:
-        return jsonify({"error": "agent_a_id and agent_b_id required"}), 400
+    a_id, error = _parse_positive_int(data.get("agent_a_id"), "agent_a_id")
+    if error:
+        return jsonify({"error": error}), 400
+    b_id, error = _parse_positive_int(data.get("agent_b_id"), "agent_b_id")
+    if error:
+        return jsonify({"error": error}), 400
+    delta, error = _parse_finite_float(data.get("delta", 0), "delta")
+    if error:
+        return jsonify({"error": error}), 400
+
+    event_type = data.get("event_type", "generic")
+    if not isinstance(event_type, str):
+        event_type = "generic"
+    event_type = event_type.strip() or "generic"
+    description = data.get("description", "")
+    if not isinstance(description, str):
+        description = ""
+
     if a_id == b_id:
         return jsonify({"error": "agents must be different"}), 400
 

--- a/tests/test_beef_system.py
+++ b/tests/test_beef_system.py
@@ -342,6 +342,43 @@ def test_same_agent_returns_400(client):
     assert resp.status_code == 400
 
 
+def test_relationship_event_rejects_non_object_json(client):
+    resp = client.post("/api/beef/relationships", json=[{"agent_a_id": 1}])
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+@pytest.mark.parametrize(
+    "payload, error",
+    [
+        (
+            {"agent_a_id": "alice", "agent_b_id": 2, "event_type": "test", "delta": 1},
+            "agent_a_id must be a positive integer",
+        ),
+        (
+            {"agent_a_id": 1, "agent_b_id": 2.5, "event_type": "test", "delta": 1},
+            "agent_b_id must be a positive integer",
+        ),
+        (
+            {"agent_a_id": True, "agent_b_id": 2, "event_type": "test", "delta": 1},
+            "agent_a_id must be a positive integer",
+        ),
+        (
+            {"agent_a_id": 1, "agent_b_id": 2, "event_type": "test", "delta": "abc"},
+            "delta must be a finite number",
+        ),
+        (
+            {"agent_a_id": 1, "agent_b_id": 2, "event_type": "test", "delta": "NaN"},
+            "delta must be a finite number",
+        ),
+    ],
+)
+def test_relationship_event_rejects_malformed_fields(client, payload, error):
+    resp = client.post("/api/beef/relationships", json=payload)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == error
+
+
 # ---------------------------------------------------------------------------
 # 15. check_beef_expirations utility
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes malformed-input handling for `POST /api/beef/relationships`. The changed surface is intentionally limited to the beef relationship endpoint and its existing test file.

Fixes #1139

| Area | Change | Evidence |
| --- | --- | --- |
| Relationship event parsing | Requires a JSON object before field access | regression coverage for non-object JSON |
| Agent IDs | Accepts only positive integer `agent_a_id` / `agent_b_id` values and rejects booleans/floats/text | regression coverage for string, float, and boolean IDs |
| Delta parsing | Rejects non-numeric and non-finite `delta` values before lookup/update | regression coverage for `abc` and `NaN` deltas |

Validation was run locally:

```text
uv run --no-project --with flask --with pytest python -m pytest tests/test_beef_system.py -q
30 passed in 0.60s

python -m py_compile agent_relationships.py tests/test_beef_system.py
passed

git diff --check -- agent_relationships.py tests/test_beef_system.py
passed
```

The PR deliberately leaves the rest of the beef/drama arc API unchanged.

Hosted CI note after PR creation:

```text
auto-label  fail  (fork permission / Resource not accessible by integration)
lint        pass
security    pass
test        pass
```

The failing auto-label job is the fork-label permission path; the code-bearing jobs passed.
