### PR TITLE
fix: validate Base bridge request fields

### DIFF
--- a/base_wrtc_bridge_blueprint.py
+++ b/base_wrtc_bridge_blueprint.py
@@ -18,6 +18,7 @@ import re
 import secrets
 import sqlite3
 import time
+from math import isfinite
 
 import requests as http_requests
 from flask import Blueprint, g, jsonify, render_template, request
@@ -120,6 +121,39 @@ def init_base_wrtc_tables(db):
         """
     )
     db.commit()
+
+
+def _json_object_body():
+    """Return request JSON when it is an object, or a 400 response tuple."""
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _string_field(data, field_name):
+    """Return a stripped string field, rejecting arrays/objects before .strip()."""
+    value = data.get(field_name)
+    if value is None:
+        return "", None
+    if not isinstance(value, str):
+        return None, f"{field_name} must be a string"
+    return value.strip(), None
+
+
+def _finite_amount(value):
+    """Parse a positive finite bridge amount without accepting booleans/NaN/inf."""
+    if isinstance(value, bool):
+        return None
+    try:
+        amount = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(amount):
+        return None
+    return amount
 
 
 # ─── On-Chain Verification ────────────────────────────────────
@@ -276,8 +310,13 @@ def base_bridge_deposit():
     if not agent:
         return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
 
-    data = request.get_json(silent=True) or {}
-    tx_hash = (data.get("tx_hash") or "").strip().lower()
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
+    tx_hash, field_error = _string_field(data, "tx_hash")
+    if field_error:
+        return jsonify({"error": field_error}), 400
+    tx_hash = tx_hash.lower()
     if not _ETH_TX_RE.match(tx_hash):
         return jsonify({"error": "tx_hash required (0x-prefixed, 66 chars)"}), 400
 
@@ -379,12 +418,15 @@ def base_bridge_withdraw():
     if not agent:
         return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
 
-    data = request.get_json(silent=True) or {}
-    to_address = (data.get("to_address") or "").strip()
-    try:
-        amount = float(data.get("amount", 0))
-    except (TypeError, ValueError):
-        amount = 0.0
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
+    to_address, field_error = _string_field(data, "to_address")
+    if field_error:
+        return jsonify({"error": field_error}), 400
+    amount = _finite_amount(data.get("amount", 0))
+    if amount is None:
+        return jsonify({"error": "amount must be a finite number"}), 400
 
     if not _ETH_ADDR_RE.match(to_address):
         return jsonify({"error": "Valid Base/Ethereum destination address required (0x + 40 hex)"}), 400

--- a/tests/test_base_wrtc_bridge_validation.py
+++ b/tests/test_base_wrtc_bridge_validation.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: MIT
+"""Validation tests for Base wRTC bridge request parsing."""
+
+import sqlite3
+
+import pytest
+from flask import Flask, g
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    import base_wrtc_bridge_blueprint as bridge
+
+    db_path = tmp_path / "base_bridge.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            api_key TEXT NOT NULL,
+            eth_address TEXT,
+            rtc_balance REAL DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO agents (agent_name, api_key, eth_address, rtc_balance)
+        VALUES (?, ?, ?, ?)
+        """,
+        (
+            "bridgeuser",
+            "bottube_sk_bridgeuser",
+            "0x1111111111111111111111111111111111111111",
+            1000.0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.register_blueprint(bridge.base_wrtc_bp)
+
+    def _test_get_db():
+        if "test_db" in g:
+            return g.test_db
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        g.test_db = db
+        return db
+
+    monkeypatch.setattr(bridge, "get_db", _test_get_db)
+
+    yield flask_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _auth_headers():
+    return {"X-API-Key": "bottube_sk_bridgeuser"}
+
+
+def _withdraw(client, payload):
+    return client.post(
+        "/api/base-bridge/withdraw",
+        json=payload,
+        headers=_auth_headers(),
+    )
+
+
+def test_base_bridge_deposit_rejects_non_object_json(client):
+    resp = client.post(
+        "/api/base-bridge/deposit",
+        json=["not", "an", "object"],
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_base_bridge_deposit_rejects_non_string_tx_hash(client):
+    resp = client.post(
+        "/api/base-bridge/deposit",
+        json={"tx_hash": ["0xabc"]},
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "tx_hash must be a string"
+
+
+def test_base_bridge_withdraw_rejects_non_object_json(client):
+    resp = _withdraw(client, [{"to_address": "0x2222222222222222222222222222222222222222"}])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_base_bridge_withdraw_rejects_non_string_to_address(client):
+    resp = _withdraw(
+        client,
+        {"to_address": ["0x2222222222222222222222222222222222222222"], "amount": 10},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "to_address must be a string"
+
+
+@pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True])
+def test_base_bridge_withdraw_rejects_non_finite_amounts(client, amount):
+    resp = _withdraw(
+        client,
+        {"to_address": "0x2222222222222222222222222222222222222222", "amount": amount},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "amount must be a finite number"
+
+
+def test_rejected_base_bridge_withdrawal_does_not_queue_or_debit(client):
+    resp = _withdraw(
+        client,
+        {"to_address": "0x2222222222222222222222222222222222222222", "amount": "NaN"},
+    )
+    assert resp.status_code == 400
+
+    with client.application.app_context():
+        import base_wrtc_bridge_blueprint as bridge
+
+        db = bridge.get_db()
+        bridge.init_base_wrtc_tables(db)
+        queued = db.execute("SELECT COUNT(*) FROM base_wrtc_withdrawals").fetchone()[0]
+        balance = db.execute(
+            "SELECT rtc_balance FROM agents WHERE api_key = ?",
+            ("bottube_sk_bridgeuser",),
+        ).fetchone()[0]
+
+    assert queued == 0
+    assert balance == 1000.0


### PR DESCRIPTION
This PR fixes malformed-input handling for the Base wRTC bridge write endpoints. The changed surface is intentionally limited to `base_wrtc_bridge_blueprint.py` and focused bridge request-validation tests.

Fixes #1141

| Area | Change | Evidence |
| --- | --- | --- |
| JSON body shape | Rejects non-object JSON before `.get(...)` field access | regression coverage for deposit and withdraw array JSON bodies |
| String fields | Rejects non-string `tx_hash` / `to_address` before `.strip()` | regression coverage for array-shaped fields |
| Withdrawal amount | Rejects non-numeric, boolean, `NaN`, and infinite amounts before queue/balance logic | regression coverage confirms no queued withdrawal and no balance debit for `NaN` |

Validation was run locally:

```text
uv run --no-project --with flask --with pytest --with requests python -m pytest tests/test_base_wrtc_bridge_validation.py -q
9 passed in 0.41s

python -m py_compile base_wrtc_bridge_blueprint.py tests/test_base_wrtc_bridge_validation.py
passed

git diff --check -- base_wrtc_bridge_blueprint.py tests/test_base_wrtc_bridge_validation.py
passed
```

The PR deliberately leaves on-chain transaction verification, reserve-wallet checks, cooldown behavior, and withdrawal processing unchanged.

Hosted CI note after PR creation:

```text
auto-label  fail  (fork permission / Resource not accessible by integration)
lint        pass
security    pass
test        pass
```

The failing auto-label job is the fork-label permission path; the code-bearing jobs passed.
