### PR TITLE
Fix trending category filters

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8389,7 +8389,12 @@ def social_graph():
 # Trending / Feed
 # ---------------------------------------------------------------------------
 
-def _get_trending_videos(db, limit=20):
+def _normalize_category_filter(category):
+    category = (category or "").strip().lower()
+    return category if category in CATEGORY_MAP else None
+
+
+def _get_trending_videos(db, limit=20, category=None):
     """Compute trending videos with improved scoring.
 
     Score = (recent_views_24h * 2) + (likes * 3) + (recent_comments_24h * 4)
@@ -8401,9 +8406,27 @@ def _get_trending_videos(db, limit=20):
     cutoff_24h = now - 86400
     cutoff_6h = now - 21600
     query_limit = max(limit * 3, limit)
+    category = _normalize_category_filter(category)
+    category_clause = "AND v.category = ?" if category else ""
+    params = [
+        cutoff_6h,
+        cutoff_24h,
+        cutoff_24h,
+        cutoff_24h,
+    ]
+    if category:
+        params.append(category)
+    params.extend([
+        cutoff_6h,
+        cutoff_24h,
+        NOVELTY_WEIGHT,
+        TRENDING_PENALTY_HIGH_SIMILARITY,
+        TRENDING_PENALTY_LOW_INFO,
+        query_limit,
+    ])
 
     rows = db.execute(
-        """SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human,
+        f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human,
                   COALESCE(rv.recent_views, 0) AS recent_views,
                   COALESCE(rc.recent_comments, 0) AS recent_comments,
                   CASE
@@ -8424,6 +8447,7 @@ def _get_trending_videos(db, limit=20):
                GROUP BY video_id
            ) rc ON rc.video_id = v.video_id
            WHERE v.is_removed = 0 AND COALESCE(a.is_banned, 0) = 0
+             {category_clause}
            ORDER BY (
                COALESCE(rv.recent_views, 0) * 2
                + v.likes * 3
@@ -8444,18 +8468,7 @@ def _get_trending_videos(db, limit=20):
                END
            ) DESC, v.created_at DESC
            LIMIT ?""",
-        (
-            cutoff_6h,
-            cutoff_24h,
-            cutoff_24h,
-            cutoff_24h,
-            cutoff_6h,
-            cutoff_24h,
-            NOVELTY_WEIGHT,
-            TRENDING_PENALTY_HIGH_SIMILARITY,
-            TRENDING_PENALTY_LOW_INFO,
-            query_limit,
-        ),
+        params,
     ).fetchall()
     if TRENDING_AGENT_CAP <= 0:
         return rows[:limit]
@@ -8477,7 +8490,8 @@ def _get_trending_videos(db, limit=20):
 def trending():
     """Get trending videos (weighted by recent views, likes, comments, recency)."""
     db = get_db()
-    rows = _get_trending_videos(db, limit=20)
+    category = _normalize_category_filter(request.args.get("category"))
+    rows = _get_trending_videos(db, limit=20, category=category)
 
     videos = []
     for row in rows:
@@ -8489,7 +8503,7 @@ def trending():
         d["recent_comments"] = row["recent_comments"]
         videos.append(d)
 
-    return jsonify({"videos": videos})
+    return jsonify({"videos": videos, "category": category})
 
 
 # --- Phase 7: bucketed feed (latest / heuristic / hybrid-v1) -------------
@@ -12638,8 +12652,14 @@ def search_page():
 def trending_page():
     """Dedicated trending page with top 50 videos."""
     db = get_db()
-    rows = _get_trending_videos(db, limit=50)
-    return render_template("trending.html", videos=rows)
+    category = _normalize_category_filter(request.args.get("category"))
+    rows = _get_trending_videos(db, limit=50, category=category)
+    return render_template(
+        "trending.html",
+        videos=rows,
+        categories=VIDEO_CATEGORIES,
+        current_category=category,
+    )
 
 
 @app.route("/categories")
@@ -13780,7 +13800,8 @@ app.register_blueprint(wrtc_bp)
 # wRTC Bridge Integration (Base L2 / Ethereum)
 from base_wrtc_bridge_blueprint import base_wrtc_bp, init_base_wrtc_tables
 import sqlite3 as _base_wrtc_sqlite3
-_base_wrtc_db = _base_wrtc_sqlite3.connect('/root/bottube/bottube.db')
+_base_wrtc_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
+_base_wrtc_db = _base_wrtc_sqlite3.connect(_base_wrtc_db_path)
 init_base_wrtc_tables(_base_wrtc_db)
 _base_wrtc_db.close()
 app.register_blueprint(base_wrtc_bp)

--- a/tests/test_discoverability.py
+++ b/tests/test_discoverability.py
@@ -15,7 +15,35 @@ import json
 import time
 import pytest
 
-from bottube_server import VIDEO_CATEGORIES
+
+def _insert_video_for_trending(client, registered_agent, video_id, title, category, *, views=0, likes=0):
+    import bottube_server
+
+    with client.application.app_context():
+        db = bottube_server.get_db()
+        agent = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?",
+            (registered_agent["agent_name"],),
+        ).fetchone()
+        assert agent is not None
+        db.execute(
+            """INSERT INTO videos
+               (video_id, agent_id, title, description, filename, category,
+                views, likes, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                video_id,
+                agent["id"],
+                title,
+                f"{title} description",
+                f"{video_id}.mp4",
+                category,
+                views,
+                likes,
+                time.time(),
+            ),
+        )
+        db.commit()
 
 
 class TestSearchEnhancements:
@@ -120,26 +148,20 @@ class TestTrendingEnhancements:
 
     def test_trending_category_filter(self, client, registered_agent):
         """Test trending with category filter."""
-        # Upload videos in different categories
-        client.post("/api/upload", json={
-            "title": "Music Video",
-            "description": "A music video",
-            "tags": "music",
-            "category": "music",
-        }, headers={"X-API-Key": registered_agent["api_key"]})
-
-        client.post("/api/upload", json={
-            "title": "Tech Demo",
-            "description": "Technology demonstration",
-            "tags": "tech",
-            "category": "science-tech",
-        }, headers={"X-API-Key": registered_agent["api_key"]})
+        _insert_video_for_trending(
+            client, registered_agent, "music-trending", "Music Video", "music", views=3, likes=2,
+        )
+        _insert_video_for_trending(
+            client, registered_agent, "tech-trending", "Tech Demo", "science-tech", views=50, likes=20,
+        )
 
         # Get trending for music category
         resp = client.get("/api/trending?category=music")
         assert resp.status_code == 200
         data = resp.get_json()
         assert "videos" in data
+        assert data["category"] == "music"
+        assert [video["title"] for video in data["videos"]] == ["Music Video"]
         # All videos should be in music category
         for video in data["videos"]:
             assert video["category"] == "music"
@@ -273,13 +295,23 @@ class TestSearchPageUI:
 class TestTrendingPageUI:
     """Test trending page UI enhancements (issue #425)."""
 
-    def test_trending_page_category_filter(self, client):
+    def test_trending_page_category_filter(self, client, registered_agent):
         """Test trending page has category filter."""
-        resp = client.get("/trending")
+        _insert_video_for_trending(
+            client, registered_agent, "music-page-trending", "Music Page Video", "music", views=3, likes=2,
+        )
+        _insert_video_for_trending(
+            client, registered_agent, "tech-page-trending", "Tech Page Video", "science-tech", views=50, likes=20,
+        )
+
+        resp = client.get("/trending?category=music")
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
         # Check for category filter elements
         assert "category-filter" in html or "category" in html
+        assert "Music Page Video" in html
+        assert "Tech Page Video" not in html
+        assert 'category=music" class="category-filter-chip active"' in html
 
     def test_trending_page_rising_section(self, client, registered_agent):
         """Test trending page has rising section."""


### PR DESCRIPTION
## Summary
- honor `category` on `/api/trending` and `/trending` using the existing category whitelist
- pass category metadata into the trending template so the active chip reflects the selected filter
- make Base wRTC table initialization respect `BOTTUBE_DB_PATH`/`DB_PATH` instead of hard-coding `/root/bottube/bottube.db`, matching the adjacent payment integrations and allowing Flask tests to import in isolated DBs

## Root cause
Homepage category chips linked to `/trending?category=...`, but the trending route ignored that query param and always called `_get_trending_videos()` without a category. The API endpoint had the same issue, so all categories returned the same ranked list.

## Validation
- `python3 -m py_compile bottube_server.py`
- `/tmp/bottube-test-venv/bin/python -m pytest tests/test_discoverability.py::TestTrendingEnhancements::test_trending_category_filter tests/test_discoverability.py::TestTrendingPageUI::test_trending_page_category_filter -q`

Related: Scottcjn/rustchain-bounties#1102