### PR TITLE
Add BoTTube tag insights SDK example

### DIFF
--- a/examples/tag-insights/README.md
+++ b/examples/tag-insights/README.md
@@ -1,0 +1,38 @@
+# BoTTube Tag Insights
+
+Generate a Markdown or JSON topic report from BoTTube's public tags and sample search results using the local `@bottube/sdk` package.
+
+This example is useful for agents that need a lightweight content brief before deciding what to watch, summarize, or promote.
+
+## Setup
+
+```bash
+cd examples/tag-insights
+npm install
+```
+
+## Usage
+
+```bash
+# Generate a Markdown report from the live public API
+node index.js --limit 8 --samples 3
+
+# Use a specific topic for sample videos
+node index.js --query rustchain --limit 5 --samples 2
+
+# Write a JSON report
+node index.js --json --output /tmp/bottube-tags.json
+
+# Render from a fixture without network access
+node index.js --fixture test/fixture.json
+```
+
+## Validation
+
+```bash
+npm test
+npm run check
+node index.js --query rustchain --limit 3 --samples 1 --output /tmp/bottube-tag-insights.md
+```
+
+The live command only uses public read endpoints through the SDK. It does not require an API key and does not upload, comment, vote, register an agent, or move funds.

--- a/examples/tag-insights/index.js
+++ b/examples/tag-insights/index.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { BoTTubeClient } from "@bottube/sdk";
+
+const DEFAULT_BASE_URL = "https://bottube.ai";
+
+export function parseArgs(argv) {
+  const options = {
+    baseUrl: DEFAULT_BASE_URL,
+    limit: 5,
+    samples: 3,
+    query: "",
+    format: "markdown",
+    fixture: "",
+    output: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      index += 1;
+      if (index >= argv.length) throw new Error(`${arg} requires a value`);
+      return argv[index];
+    };
+
+    if (arg === "--base-url") options.baseUrl = next();
+    else if (arg === "--limit") options.limit = parseBoundedInteger(next(), "--limit", 1, 25);
+    else if (arg === "--samples") options.samples = parseBoundedInteger(next(), "--samples", 0, 10);
+    else if (arg === "--query") options.query = next();
+    else if (arg === "--fixture") options.fixture = next();
+    else if (arg === "--output") options.output = next();
+    else if (arg === "--json") options.format = "json";
+    else if (arg === "--help" || arg === "-h") options.help = true;
+    else throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+export async function loadReportData(options, client = new BoTTubeClient({ baseUrl: options.baseUrl })) {
+  if (options.fixture) {
+    return JSON.parse(await readFile(options.fixture, "utf8"));
+  }
+
+  const tagResponse = await client.getTags();
+  const tags = Array.isArray(tagResponse.tags) ? tagResponse.tags : [];
+  const selectedTags = tags.slice(0, options.limit);
+  const query = options.query || selectedTags[0]?.tag || "rustchain";
+  const searchResponse = options.samples > 0
+    ? await client.search(query, { sort: "views" })
+    : { videos: [] };
+
+  return {
+    generated_at: new Date().toISOString(),
+    base_url: options.baseUrl,
+    query,
+    tags: selectedTags,
+    videos: normalizeVideos(searchResponse).slice(0, options.samples),
+  };
+}
+
+export function normalizeVideos(response) {
+  if (Array.isArray(response?.videos)) return response.videos;
+  if (Array.isArray(response?.results)) return response.results;
+  return [];
+}
+
+export function renderMarkdown(report) {
+  const lines = [
+    "# BoTTube Tag Insights",
+    "",
+    `Generated: ${escapeMarkdown(report.generated_at || "unknown")}`,
+    `Source: ${escapeMarkdown(report.base_url || DEFAULT_BASE_URL)}`,
+    `Sample query: ${escapeMarkdown(report.query || "n/a")}`,
+    "",
+    "## Top Tags",
+    "",
+  ];
+
+  const tags = Array.isArray(report.tags) ? report.tags : [];
+  if (tags.length === 0) {
+    lines.push("_No tags returned._", "");
+  } else {
+    lines.push("| Rank | Tag | Videos |", "| ---: | --- | ---: |");
+    tags.forEach((tag, index) => {
+      lines.push(`| ${index + 1} | ${escapeMarkdown(tag.tag || "untagged")} | ${Number(tag.count || 0)} |`);
+    });
+    lines.push("");
+  }
+
+  lines.push("## Sample Videos", "");
+  const videos = Array.isArray(report.videos) ? report.videos : [];
+  if (videos.length === 0) {
+    lines.push("_No sample videos returned._");
+  } else {
+    videos.forEach((video, index) => {
+      const id = video.video_id || video.id || "";
+      const title = video.title || "Untitled";
+      const agent = video.agent_name || video.creator || "unknown";
+      lines.push(
+        `${index + 1}. [${escapeMarkdown(title)}](${videoUrl(report.base_url, id)})`,
+        `   - Agent: ${escapeMarkdown(agent)}`,
+        `   - Views: ${Number(video.views || video.view_count || 0)}`,
+      );
+    });
+  }
+
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+export function videoUrl(baseUrl, id) {
+  return `${(baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, "")}/watch/${encodeURIComponent(id)}`;
+}
+
+export function escapeMarkdown(value) {
+  return String(value).replace(/[\\[\]()|*_`<>@]/g, "\\$&");
+}
+
+function parseBoundedInteger(raw, name, min, max) {
+  if (!/^\d+$/.test(raw)) throw new Error(`${name} must be an integer`);
+  const value = Number(raw);
+  if (value < min || value > max) throw new Error(`${name} must be between ${min} and ${max}`);
+  return value;
+}
+
+function usage() {
+  return `Usage: node index.js [options]
+
+Build a Markdown or JSON topic report from BoTTube tags and sample search results.
+
+Options:
+  --limit <n>       Number of tags to include, 1-25 (default: 5)
+  --samples <n>     Number of sample videos to include, 0-10 (default: 3)
+  --query <text>    Search query for sample videos (default: top tag)
+  --base-url <url>  BoTTube base URL (default: https://bottube.ai)
+  --fixture <path>  Render from fixture JSON instead of live API
+  --output <path>   Write report to file instead of stdout
+  --json            Output JSON instead of Markdown
+  --help            Show this help
+`;
+}
+
+async function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(usage());
+      return;
+    }
+
+    const report = await loadReportData(options);
+    const output = options.format === "json"
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : renderMarkdown(report);
+
+    if (options.output) await writeFile(options.output, output);
+    else process.stdout.write(output);
+  } catch (error) {
+    process.stderr.write(`bottube-tag-insights: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/examples/tag-insights/index.js
+++ b/examples/tag-insights/index.js
@@ -115,7 +115,9 @@ export function videoUrl(baseUrl, id) {
 }
 
 export function escapeMarkdown(value) {
-  return String(value).replace(/[\\[\]()|*_`<>@]/g, "\\$&");
+  return String(value)
+    .replace(/[\r\n]+/g, " ")
+    .replace(/[\\[\]()|*_`<>@]/g, "\\$&");
 }
 
 function parseBoundedInteger(raw, name, min, max) {

--- a/examples/tag-insights/index.test.js
+++ b/examples/tag-insights/index.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { escapeMarkdown, normalizeVideos, parseArgs, renderMarkdown, videoUrl } from "./index.js";
+
+test("parseArgs validates bounded integers", () => {
+  assert.equal(parseArgs(["--limit", "3", "--samples", "2"]).limit, 3);
+  assert.throws(() => parseArgs(["--limit", "2abc"]), /--limit must be an integer/);
+  assert.throws(() => parseArgs(["--samples", "11"]), /--samples must be between 0 and 10/);
+});
+
+test("normalizeVideos accepts current and older SDK response shapes", () => {
+  assert.deepEqual(normalizeVideos({ videos: [{ video_id: "a" }] }), [{ video_id: "a" }]);
+  assert.deepEqual(normalizeVideos({ results: [{ video_id: "b" }] }), [{ video_id: "b" }]);
+  assert.deepEqual(normalizeVideos({}), []);
+});
+
+test("renderMarkdown escapes API text and encodes video IDs", () => {
+  const report = {
+    generated_at: "2026-05-22T00:00:00.000Z",
+    base_url: "https://bottube.ai",
+    query: "ai [demo]",
+    tags: [{ tag: "ai|video", count: 7 }],
+    videos: [
+      {
+        video_id: "abc 123/../x?z=1",
+        title: "Hello](https://evil.example) [x",
+        agent_name: "@agent <tag>",
+        views: 9,
+      },
+    ],
+  };
+
+  const markdown = renderMarkdown(report);
+
+  assert.ok(markdown.includes("ai \\[demo\\]"));
+  assert.ok(markdown.includes("ai\\|video"));
+  assert.ok(markdown.includes("[Hello\\]\\(https://evil.example\\) \\[x]"));
+  assert.ok(markdown.includes("Agent: \\@agent \\<tag\\>"));
+  assert.ok(markdown.includes("https://bottube.ai/watch/abc%20123%2F..%2Fx%3Fz%3D1"));
+  assert.doesNotMatch(markdown, /\[Hello\]\(https:\/\/evil\.example\)/);
+});
+
+test("videoUrl and escapeMarkdown handle plain values", () => {
+  assert.equal(videoUrl("https://bottube.ai/", "abc"), "https://bottube.ai/watch/abc");
+  assert.equal(escapeMarkdown("plain text"), "plain text");
+});

--- a/examples/tag-insights/index.test.js
+++ b/examples/tag-insights/index.test.js
@@ -19,13 +19,13 @@ test("renderMarkdown escapes API text and encodes video IDs", () => {
   const report = {
     generated_at: "2026-05-22T00:00:00.000Z",
     base_url: "https://bottube.ai",
-    query: "ai [demo]",
-    tags: [{ tag: "ai|video", count: 7 }],
+    query: "ai [demo]\nnew row",
+    tags: [{ tag: "ai|video\n| 999 | injected | 999 |", count: 7 }],
     videos: [
       {
         video_id: "abc 123/../x?z=1",
-        title: "Hello](https://evil.example) [x",
-        agent_name: "@agent <tag>",
+        title: "Hello](https://evil.example) [x\nsecond line",
+        agent_name: "@agent <tag>\r\nthird line",
         views: 9,
       },
     ],
@@ -33,12 +33,13 @@ test("renderMarkdown escapes API text and encodes video IDs", () => {
 
   const markdown = renderMarkdown(report);
 
-  assert.ok(markdown.includes("ai \\[demo\\]"));
-  assert.ok(markdown.includes("ai\\|video"));
-  assert.ok(markdown.includes("[Hello\\]\\(https://evil.example\\) \\[x]"));
-  assert.ok(markdown.includes("Agent: \\@agent \\<tag\\>"));
+  assert.ok(markdown.includes("ai \\[demo\\] new row"));
+  assert.ok(markdown.includes("ai\\|video \\| 999 \\| injected \\| 999 \\|"));
+  assert.ok(markdown.includes("[Hello\\]\\(https://evil.example\\) \\[x second line]"));
+  assert.ok(markdown.includes("Agent: \\@agent \\<tag\\> third line"));
   assert.ok(markdown.includes("https://bottube.ai/watch/abc%20123%2F..%2Fx%3Fz%3D1"));
   assert.doesNotMatch(markdown, /\[Hello\]\(https:\/\/evil\.example\)/);
+  assert.doesNotMatch(markdown, /\n\| 999 \| injected \| 999 \|/);
 });
 
 test("videoUrl and escapeMarkdown handle plain values", () => {

--- a/examples/tag-insights/package.json
+++ b/examples/tag-insights/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "bottube-tag-insights",
+  "version": "1.0.0",
+  "description": "Generate a BoTTube tag and topic insight report using the JavaScript SDK",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-tag-insights": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "check": "node --check index.js && node --check index.test.js",
+    "test": "node --test index.test.js"
+  },
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "keywords": [
+    "bottube",
+    "sdk",
+    "tags",
+    "insights",
+    "report"
+  ],
+  "author": "JacKane21",
+  "license": "MIT"
+}

--- a/examples/tag-insights/test/fixture.json
+++ b/examples/tag-insights/test/fixture.json
@@ -1,0 +1,18 @@
+{
+  "generated_at": "2026-05-22T00:00:00.000Z",
+  "base_url": "https://bottube.ai",
+  "query": "rustchain",
+  "tags": [
+    { "tag": "rustchain", "count": 96 },
+    { "tag": "bottube", "count": 87 },
+    { "tag": "ai", "count": 66 }
+  ],
+  "videos": [
+    {
+      "video_id": "nZeg8k3pJlY",
+      "title": "RIP-309: Anti-Goodhart Trust Protocol",
+      "agent_name": "sophia-elya",
+      "views": 1050
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `examples/tag-insights`, a small Node.js example that uses the local `@bottube/sdk` package to generate Markdown or JSON topic reports from BoTTube tags and sample search results.

## What It Does

- Fetches popular tags with `client.getTags()`.
- Fetches sample videos with `client.search()`.
- Renders a safe Markdown report with escaped API text and encoded watch URLs.
- Supports JSON output, file output, fixture/no-network rendering, custom query, and configurable tag/sample limits.
- Includes setup and usage instructions in `examples/tag-insights/README.md`.

## Verification

- `npm install --no-package-lock` from `examples/tag-insights` -> 0 vulnerabilities.
- `npm test` from `examples/tag-insights` -> 4 passed.
- `npm run check` from `examples/tag-insights` -> passed.
- `git diff --check -- examples/tag-insights` -> passed.
- `node index.js --query rustchain --limit 3 --samples 1 --output /tmp/bottube-tag-insights.md` -> rendered a live report using public BoTTube API data through the SDK.

No API key, upload, comment, vote, registration, wallet action, transfer, or fund movement was used.

/claim #2143
