### PR TITLE
Guard watch analytics and Cast CSP

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1498,7 +1498,7 @@ def set_security_headers(response):
         # mitigated by safe_jsonld() / jsonld_safe which escape </ sequences.
         csp = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://stats.g.doubleclick.net https://cdn.jsdelivr.net https://unpkg.com; "
+            "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://stats.g.doubleclick.net https://cdn.jsdelivr.net https://unpkg.com https://www.gstatic.com; "
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self' data: https:; "
             "media-src 'self'; "

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -28,7 +28,7 @@
     <meta name="google-site-verification" content="bkfaNyLjJZI8b35iZYe3I5dqr2ymoreq__ZfU3UgaYM" />
 
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pagead2.googlesyndication.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.bottube.ai https://bottube.ai; frame-src 'self' https://www.youtube.com https://player.vimeo.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pagead2.googlesyndication.com https://www.googletagmanager.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.bottube.ai https://bottube.ai; frame-src 'self' https://www.youtube.com https://player.vimeo.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';">
 
     <!-- DNS Prefetch / Preconnect Hints -->
     <link rel="preconnect" href="https://dofollow.tools" crossorigin>

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2937,6 +2937,16 @@ var uploaderAgent = "{{ video.agent_name }}";
 var loggedIn = {{ 'true' if current_user else 'false' }};
 var WATCH_THEME_STORAGE_KEY = 'bottube_watch_theme';
 
+function trackWatchEvent(name, data) {
+    try {
+        if (typeof window.btTrack === 'function') {
+            window.btTrack(name, data);
+        }
+    } catch (e) {
+        // Analytics must not break video playback or page initialization.
+    }
+}
+
 function getStoredWatchTheme() {
     try {
         return localStorage.getItem(WATCH_THEME_STORAGE_KEY) === 'light' ? 'light' : 'dark';
@@ -4032,10 +4042,10 @@ function seekTo(seconds) {
         adsManager.addEventListener(google.ima.AdEvent.Type.CONTENT_RESUME_REQUESTED, function() {
             adContainer.style.display = 'none';
             videoEl.play();
-            btTrack('ad_complete', {video_id: videoId});
+            trackWatchEvent('ad_complete', {video_id: videoId});
         });
         adsManager.addEventListener(google.ima.AdEvent.Type.STARTED, function() {
-            btTrack('ad_impression', {video_id: videoId});
+            trackWatchEvent('ad_impression', {video_id: videoId});
         });
         try {
             adContainer.style.display = 'block';
@@ -4063,17 +4073,17 @@ function seekTo(seconds) {
     if (!vid) return;
     var tracked25 = false, tracked50 = false, tracked75 = false, trackedComplete = false;
     vid.addEventListener('play', function() {
-        btTrack('video_play', {video_id: videoId, creator: uploaderAgent});
+        trackWatchEvent('video_play', {video_id: videoId, creator: uploaderAgent});
     });
     vid.addEventListener('timeupdate', function() {
         if (!vid.duration) return;
         var pct = vid.currentTime / vid.duration;
-        if (pct >= 0.25 && !tracked25) { tracked25 = true; btTrack('video_progress', {video_id: videoId, milestone: '25%'}); }
-        if (pct >= 0.50 && !tracked50) { tracked50 = true; btTrack('video_progress', {video_id: videoId, milestone: '50%'}); }
-        if (pct >= 0.75 && !tracked75) { tracked75 = true; btTrack('video_progress', {video_id: videoId, milestone: '75%'}); }
+        if (pct >= 0.25 && !tracked25) { tracked25 = true; trackWatchEvent('video_progress', {video_id: videoId, milestone: '25%'}); }
+        if (pct >= 0.50 && !tracked50) { tracked50 = true; trackWatchEvent('video_progress', {video_id: videoId, milestone: '50%'}); }
+        if (pct >= 0.75 && !tracked75) { tracked75 = true; trackWatchEvent('video_progress', {video_id: videoId, milestone: '75%'}); }
     });
     vid.addEventListener('ended', function() {
-        if (!trackedComplete) { trackedComplete = true; btTrack('video_complete', {video_id: videoId, creator: uploaderAgent}); }
+        if (!trackedComplete) { trackedComplete = true; trackWatchEvent('video_complete', {video_id: videoId, creator: uploaderAgent}); }
     });
 })();
 </script>
@@ -4105,7 +4115,7 @@ function seekTo(seconds) {
                         {% endif %}
                         var request = new chrome.cast.media.LoadRequest(mediaInfo);
                         session.loadMedia(request);
-                        btTrack('cast_started', {video_id: videoId});
+                        trackWatchEvent('cast_started', {video_id: videoId});
                     }
                 }
             }

--- a/tests/test_watch_tracking_and_csp.py
+++ b/tests/test_watch_tracking_and_csp.py
@@ -1,0 +1,33 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_watch_template_uses_safe_tracking_wrapper():
+    template = (ROOT / "bottube_templates" / "watch.html").read_text()
+
+    assert "function trackWatchEvent(name, data)" in template
+    assert "window.btTrack(name, data)" in template
+    assert re.search(r"(?<!window\.)\bbtTrack\s*\(", template) is None
+
+    for event_name in [
+        "ad_complete",
+        "ad_impression",
+        "video_play",
+        "video_progress",
+        "video_complete",
+        "cast_started",
+    ]:
+        assert f"trackWatchEvent('{event_name}'" in template
+
+
+def test_google_cast_script_is_allowed_by_csp_definitions():
+    base_template = (ROOT / "bottube_templates" / "base.html").read_text()
+    server_source = (ROOT / "bottube_server.py").read_text()
+    watch_template = (ROOT / "bottube_templates" / "watch.html").read_text()
+
+    assert "https://www.gstatic.com/cv/js/sender/v1/cast_sender.js" in watch_template
+    assert "https://www.gstatic.com" in base_template
+    assert "https://www.gstatic.com" in server_source


### PR DESCRIPTION
## Summary
- add a local `trackWatchEvent` wrapper so watch-page analytics never throws when deferred global bootstrap has not initialized `window.btTrack` yet
- route watch-page video, ad, and Cast analytics through the safe wrapper
- allow the Google Cast sender SDK host in both CSP definitions so the existing Cast script is not blocked

Fixes #1148.

RustChain bounty reference: Scottcjn/rustchain-bounties#1102
Wallet/miner ID for any bounty assessment: `kebanks2`

## Validation
- `.venv/bin/python -m pytest tests/test_watch_tracking_and_csp.py -q` -> 2 passed
- `python3 -m py_compile bottube_server.py` -> passed
- `git diff --check` -> passed