### PR TITLE
Validate oEmbed provider URLs

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11851,12 +11851,10 @@ def oembed():
     if fmt not in ("json", "xml"):
         return jsonify({"error": "Unsupported format. Use json or xml."}), 501
 
-    # Extract video_id from URL
-    match = re.search(r"/watch/([A-Za-z0-9_-]{5,20})", url)
-    if not match:
+    video_id = _extract_oembed_video_id(url)
+    if not video_id:
         return jsonify({"error": "Invalid URL"}), 404
 
-    video_id = match.group(1)
     db = get_db()
     video = db.execute(
         "SELECT v.*, a.agent_name, a.display_name FROM videos v JOIN agents a ON v.agent_id = a.id WHERE v.video_id = ?",
@@ -11903,6 +11901,20 @@ def oembed():
         return Response("\n".join(xml_parts), mimetype="text/xml")
 
     return jsonify(data)
+
+
+def _extract_oembed_video_id(url):
+    """Return a BoTTube video id only for canonical watch URLs."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    host = (parsed.hostname or "").lower()
+    if host not in {"bottube.ai", "www.bottube.ai"}:
+        return None
+    match = re.fullmatch(r"/watch/([A-Za-z0-9_-]{5,20})/?", parsed.path)
+    if not match:
+        return None
+    return match.group(1)
 
 
 @app.route("/agents")

--- a/tests/test_oembed_domain_validation.py
+++ b/tests/test_oembed_domain_validation.py
@@ -1,0 +1,80 @@
+import time
+
+
+def _insert_video(video_id="oembedtest"):
+    import bottube_server
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        agent = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, password_hash, bio,
+                 avatar_url, is_human, created_at, last_active)
+            VALUES (?, ?, ?, '', '', '', 0, ?, ?)
+            """,
+            (
+                "oembed_bot",
+                "oEmbed Bot",
+                "bottube_sk_oembed",
+                time.time(),
+                time.time(),
+            ),
+        )
+        db.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, filename, width, height,
+                 created_at, is_removed)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+            """,
+            (
+                video_id,
+                int(agent.lastrowid),
+                "oEmbed domain validation",
+                f"{video_id}.mp4",
+                640,
+                360,
+                time.time(),
+            ),
+        )
+        db.commit()
+    return video_id
+
+
+def test_oembed_accepts_canonical_bottube_watch_url(client):
+    video_id = _insert_video()
+
+    response = client.get(
+        f"/oembed?url=https://bottube.ai/watch/{video_id}",
+        base_url="https://bottube.ai",
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["provider_url"] == "https://bottube.ai"
+    assert f"https://bottube.ai/embed/{video_id}" in data["html"]
+
+
+def test_oembed_rejects_off_domain_watch_url(client):
+    video_id = _insert_video()
+
+    response = client.get(
+        f"/oembed?url=https://evil.example/watch/{video_id}",
+        base_url="https://bottube.ai",
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Invalid URL"}
+
+
+def test_oembed_rejects_spoofed_bottube_host_suffix(client):
+    video_id = _insert_video()
+
+    response = client.get(
+        f"/oembed?url=https://bottube.ai.evil.example/watch/{video_id}",
+        base_url="https://bottube.ai",
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Invalid URL"}


### PR DESCRIPTION
## Summary
- validate `/oembed` URLs by scheme, hostname, and full `/watch/<video_id>` path before returning embed metadata
- allow canonical `bottube.ai` and `www.bottube.ai` watch URLs
- reject off-domain and host-suffix spoofed watch URLs with the existing invalid URL response

Fixes #1153.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest tests/test_oembed_domain_validation.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_oembed_domain_validation.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_oembed_domain_validation.py`
- `git diff --check`
