### PR TITLE
Return missing video for similar lookup

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -19262,11 +19262,23 @@ def api_videos_similar(video_id):
         k = max(1, min(50, int(request.args.get("k", 10))))
     except Exception:
         k = 10
+    db = get_db()
+    video = db.execute(
+        """SELECT 1 FROM videos
+           WHERE video_id = ? AND COALESCE(is_removed, 0) = 0""",
+        (video_id,),
+    ).fetchone()
+    if not video:
+        return jsonify({
+            "ok": False,
+            "error": "video not found",
+            "video_id": video_id,
+        }), 404
+
     pairs = _ue_top_k_for_video(video_id, k=k, exclude_self=True)
     if not pairs:
         return jsonify({"ok": False, "error": "no_embeddings_yet", "video_id": video_id}), 404
 
-    db = get_db()
     placeholders = ",".join("?" for _ in pairs)
     rows = db.execute(
         f"""SELECT v.video_id, v.title, v.thumbnail, v.duration_sec, v.views,

--- a/tests/test_similar_missing_video.py
+++ b/tests/test_similar_missing_video.py
@@ -1,0 +1,79 @@
+import time
+
+
+def _insert_video(video_id="similar01"):
+    import bottube_server
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        agent = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, password_hash, bio,
+                 avatar_url, is_human, created_at, last_active)
+            VALUES (?, ?, ?, '', '', '', 0, ?, ?)
+            """,
+            (
+                "similar_bot",
+                "Similar Bot",
+                "bottube_sk_similar",
+                time.time(),
+                time.time(),
+            ),
+        )
+        db.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, filename, created_at, is_removed)
+            VALUES (?, ?, ?, ?, ?, 0)
+            """,
+            (
+                video_id,
+                int(agent.lastrowid),
+                "Similar route validation",
+                f"{video_id}.mp4",
+                time.time(),
+            ),
+        )
+        db.commit()
+    return video_id
+
+
+def test_similar_rejects_missing_video_before_embedding_lookup(
+    client, monkeypatch
+):
+    import bottube_server
+
+    def fail_lookup(*args, **kwargs):
+        raise AssertionError("embedding lookup should not run")
+
+    monkeypatch.setattr(bottube_server, "_ue_top_k_for_video", fail_lookup)
+
+    response = client.get("/api/videos/missing-similar/similar")
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "ok": False,
+        "error": "video not found",
+        "video_id": "missing-similar",
+    }
+
+
+def test_similar_preserves_no_embeddings_for_existing_video(
+    client, monkeypatch
+):
+    import bottube_server
+
+    video_id = _insert_video()
+    monkeypatch.setattr(
+        bottube_server, "_ue_top_k_for_video", lambda *args, **kwargs: []
+    )
+
+    response = client.get(f"/api/videos/{video_id}/similar")
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "ok": False,
+        "error": "no_embeddings_yet",
+        "video_id": video_id,
+    }


### PR DESCRIPTION
## Summary
- validate that the requested public video exists before running similar-video embedding lookup
- return a missing-video 404 for nonexistent or removed videos
- preserve `no_embeddings_yet` for existing videos without embedding results

Fixes #1159.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest tests/test_similar_missing_video.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_similar_missing_video.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_similar_missing_video.py`
- `git diff --check`
