### PR TITLE
Clamp video list pagination

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -6596,7 +6596,6 @@ def list_videos():
     per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
     sort = request.args.get("sort", "newest")
     agent_name = request.args.get("agent", "")
-    offset = (page - 1) * per_page
 
     sort_map = {
         "newest": "v.created_at DESC",
@@ -6619,6 +6618,12 @@ def list_videos():
         f"SELECT COUNT(*) FROM videos v JOIN agents a ON v.agent_id = a.id {where}",
         params,
     ).fetchone()[0]
+    pages = math.ceil(total / per_page) if total else 0
+    if pages:
+        page = min(page, pages)
+    else:
+        page = 1
+    offset = (page - 1) * per_page
 
     rows = db.execute(
         f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url
@@ -6640,7 +6645,7 @@ def list_videos():
         "page": page,
         "per_page": per_page,
         "total": total,
-        "pages": math.ceil(total / per_page) if total else 0,
+        "pages": pages,
     })
 
 

--- a/tests/test_video_list_pagination.py
+++ b/tests/test_video_list_pagination.py
@@ -1,0 +1,68 @@
+import time
+
+
+def _insert_videos(count=3):
+    import bottube_server
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        agent = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, password_hash, bio,
+                 avatar_url, is_human, created_at, last_active)
+            VALUES (?, ?, ?, '', '', '', 0, ?, ?)
+            """,
+            (
+                "pagination_bot",
+                "Pagination Bot",
+                "bottube_sk_pagination",
+                time.time(),
+                time.time(),
+            ),
+        )
+        agent_id = int(agent.lastrowid)
+        for idx in range(count):
+            video_id = f"pagevid{idx:02d}"
+            db.execute(
+                """
+                INSERT INTO videos
+                    (video_id, agent_id, title, filename, created_at,
+                     is_removed)
+                VALUES (?, ?, ?, ?, ?, 0)
+                """,
+                (
+                    video_id,
+                    agent_id,
+                    f"Pagination Video {idx}",
+                    f"{video_id}.mp4",
+                    time.time() + idx,
+                ),
+            )
+        db.commit()
+
+
+def test_video_list_clamps_out_of_range_page(client):
+    _insert_videos(count=3)
+
+    response = client.get("/api/videos?page=9999&per_page=2")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["page"] == 2
+    assert data["pages"] == 2
+    assert data["total"] == 3
+    assert len(data["videos"]) == 1
+
+
+def test_video_list_empty_result_keeps_page_one(client):
+    response = client.get(
+        "/api/videos?agent=no_such_agent&page=9999&per_page=2"
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["page"] == 1
+    assert data["pages"] == 0
+    assert data["total"] == 0
+    assert data["videos"] == []


### PR DESCRIPTION
## Summary
- clamp `/api/videos` out-of-range pages to the last available page before querying rows
- normalize empty result sets to `page: 1` with `pages: 0`
- add regression coverage for both non-empty out-of-range pagination and empty filtered results

Fixes #1161.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest tests/test_video_list_pagination.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_video_list_pagination.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_video_list_pagination.py`
- `git diff --check`
