### PR TITLE
Fix verified badge watch links

### DIFF
--- a/bottube_templates/badges.html
+++ b/bottube_templates/badges.html
@@ -351,8 +351,8 @@
                 <button class="code-tab active" onclick="showTab(this, 'vrf-md')">Markdown</button>
                 <button class="code-tab" onclick="showTab(this, 'vrf-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="vrf-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification Markdown badge code">Copy</button>[![Verified on RustChain](https://bottube.ai/badge/verified/VIDEO_ID.svg)](https://bottube.ai/v/VIDEO_ID)</div></div>
-            <div class="code-panel" id="vrf-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification HTML badge code">Copy</button>&lt;a href="https://bottube.ai/v/VIDEO_ID"&gt;&lt;img src="https://bottube.ai/badge/verified/VIDEO_ID.svg" alt="Verified on RustChain"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="vrf-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification Markdown badge code">Copy</button>[![Verified on RustChain](https://bottube.ai/badge/verified/VIDEO_ID.svg)](https://bottube.ai/watch/VIDEO_ID)</div></div>
+            <div class="code-panel" id="vrf-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification HTML badge code">Copy</button>&lt;a href="https://bottube.ai/watch/VIDEO_ID"&gt;&lt;img src="https://bottube.ai/badge/verified/VIDEO_ID.svg" alt="Verified on RustChain"&gt;&lt;/a&gt;</div></div>
         </div>
 
         <!-- 2. iframe widget -->

--- a/tests/test_badges_page_links.py
+++ b/tests/test_badges_page_links.py
@@ -1,0 +1,47 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("BOTTUBE_DB_PATH", "/tmp/bottube_test_badges_links.db")
+os.environ.setdefault("BOTTUBE_DB", "/tmp/bottube_test_badges_links.db")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_badges_links.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def test_verified_badge_copy_snippets_link_to_watch_page(client):
+    response = client.get("/badges")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "https://bottube.ai/watch/VIDEO_ID" in html
+    assert "https://bottube.ai/v/VIDEO_ID" not in html


### PR DESCRIPTION
## Summary

- update the `/badges` verified badge Markdown and HTML snippets to link to `/watch/VIDEO_ID` instead of the dead `/v/VIDEO_ID` path
- add regression coverage for the badges page copy snippets

Fixes #1165.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_badges_page_links.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_badges_page_links.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_badges_page_links.py`
- `git diff --check`