### PR TITLE
Use embed route in embed guide

### DIFF
--- a/bottube_templates/embed_guide.html
+++ b/bottube_templates/embed_guide.html
@@ -259,7 +259,7 @@
         <p>Copy and paste this HTML to embed a video. Replace <code>VIDEO_ID</code> with any BoTTube video ID.</p>
 
         <div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy basic embed HTML code">Copy</button>&lt;iframe
-  src="https://bottube.ai/watch/VIDEO_ID"
+  src="https://bottube.ai/embed/VIDEO_ID"
   width="560"
   height="315"
   frameborder="0"
@@ -293,7 +293,7 @@
 
         <div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy responsive embed HTML code">Copy</button>&lt;div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;"&gt;
   &lt;iframe
-    src="https://bottube.ai/watch/VIDEO_ID"
+    src="https://bottube.ai/embed/VIDEO_ID"
     style="position:absolute;top:0;left:0;width:100%;height:100%;"
     frameborder="0"
     allowfullscreen
@@ -354,10 +354,10 @@ function setVideo(videoId, btn) {
     btn.classList.add("active");
 
     var iframe = document.getElementById("embed-iframe");
-    iframe.src = "https://bottube.ai/watch/" + videoId;
+    iframe.src = "https://bottube.ai/embed/" + videoId;
     document.getElementById("embed-demo").style.display = "block";
 
-    var codeText = '&lt;iframe src="https://bottube.ai/watch/' + videoId + '" width="560" height="315" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;';
+    var codeText = '&lt;iframe src="https://bottube.ai/embed/' + videoId + '" width="560" height="315" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;';
     document.getElementById("embed-code-text").innerHTML = codeText;
     document.getElementById("embed-code-output").style.display = "block";
 }

--- a/tests/test_embed_guide_links.py
+++ b/tests/test_embed_guide_links.py
@@ -1,0 +1,48 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("BOTTUBE_DB_PATH", "/tmp/bottube_test_embed_guide.db")
+os.environ.setdefault("BOTTUBE_DB", "/tmp/bottube_test_embed_guide.db")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_embed_guide.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def test_iframe_embed_examples_use_iframe_safe_embed_route(client):
+    response = client.get("/embed-guide")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'src="https://bottube.ai/embed/VIDEO_ID"' in html
+    assert 'iframe.src = "https://bottube.ai/embed/" + videoId' in html
+    assert 'iframe src="https://bottube.ai/watch/' not in html


### PR DESCRIPTION
## Summary

- update `/embed-guide` iframe snippets, preview iframe, and generated embed code to use `/embed/<video_id>` instead of frame-blocked `/watch/<video_id>`
- keep `/watch/VIDEO_ID` documented for direct links/oEmbed discovery and Markdown backlinks
- add regression coverage for the iframe snippets

Fixes #1167.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_embed_guide_links.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_embed_guide_links.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_embed_guide_links.py`
- `git diff --check`