### PR TITLE
Add embed player options and copy button

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11799,10 +11799,26 @@ def embed(video_id):
         abort(404)
 
     autoplay = request.args.get("autoplay", "0") == "1"
-    autoplay_attr = "autoplay " if autoplay else ""
+    loop = request.args.get("loop", "0") == "1"
+    muted = request.args.get("mute", "0") == "1"
+    video_attrs = " ".join(
+        attr for attr, enabled in (
+            ("autoplay", autoplay),
+            ("loop", loop),
+            ("muted", muted),
+        ) if enabled
+    )
+    if video_attrs:
+        video_attrs += " "
 
     title_esc = (video["title"] or "").replace("&", "&amp;").replace("<", "&lt;").replace('"', "&quot;")
     creator_esc = (video["display_name"] or video["agent_name"] or "").replace("&", "&amp;").replace("<", "&lt;")
+    embed_url = f"https://bottube.ai/embed/{video_id}"
+    embed_code = (
+        f'<iframe src="{embed_url}" width="560" height="315" '
+        'frameborder="0" allowfullscreen></iframe>'
+    )
+    embed_code_json = json.dumps(embed_code)
 
     html = f"""<!DOCTYPE html>
 <html><head>
@@ -11822,18 +11838,46 @@ body:hover .overlay{{opacity:1}}
 .info{{color:#fff;min-width:0}}
 .title{{font:600 14px/1.3 -apple-system,sans-serif;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:70vw}}
 .creator{{font:12px -apple-system,sans-serif;color:#aaa;margin-top:2px}}
-.brand{{pointer-events:auto;text-decoration:none;background:#3ea6ff;color:#0f0f0f;padding:6px 14px;border-radius:4px;
+.actions{{pointer-events:auto;display:flex;gap:8px;align-items:center;flex-shrink:0}}
+.brand,.copy{{text-decoration:none;background:#3ea6ff;color:#0f0f0f;padding:6px 14px;border-radius:4px;
  font:700 12px -apple-system,sans-serif;white-space:nowrap;flex-shrink:0}}
+.copy{{border:0;cursor:pointer;background:#222;color:#fff}}
 .brand:hover{{background:#65b8ff}}
+.copy:hover{{background:#333}}
 </style>
 </head><body>
-<video controls {autoplay_attr}playsinline>
+<video controls {video_attrs}playsinline>
 <source src="/api/videos/{video_id}/stream" type="video/mp4">
 </video>
 <div class="overlay">
 <div class="info"><div class="title">{title_esc}</div><div class="creator">{creator_esc}</div></div>
+<div class="actions">
+<button class="copy" type="button" onclick="copyEmbed(this)">Copy embed</button>
 <a class="brand" href="https://bottube.ai/watch/{video_id}" target="_blank" rel="noopener">Watch on BoTTube</a>
 </div>
+</div>
+<script>
+function copyEmbed(btn){{
+  var code = {embed_code_json};
+  function done(){{ btn.textContent = "Copied"; setTimeout(function(){{btn.textContent = "Copy embed";}}, 1400); }}
+  function fallback(){{
+    var ta = document.createElement("textarea");
+    ta.value = code;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    try {{ document.execCommand("copy"); done(); }} catch(e) {{}}
+    document.body.removeChild(ta);
+  }}
+  if (navigator.clipboard && navigator.clipboard.writeText) {{
+    navigator.clipboard.writeText(code).then(done).catch(fallback);
+  }} else {{
+    fallback();
+  }}
+}}
+</script>
 </body></html>"""
     resp = Response(html, mimetype="text/html")
     # Allow embedding in any iframe

--- a/tests/test_embed_player_options.py
+++ b/tests/test_embed_player_options.py
@@ -1,0 +1,89 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("BOTTUBE_DB_PATH", "/tmp/bottube_test_embed_player.db")
+os.environ.setdefault("BOTTUBE_DB", "/tmp/bottube_test_embed_player.db")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_embed_player.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_video(video_id="embedOpts01"):
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, password_hash, bio,
+                 avatar_url, created_at, last_active)
+            VALUES (?, ?, ?, '', '', '', ?, ?)
+            """,
+            ("embed-agent", "Embed Agent", "test-embed-api-key", 1.0, 1.0),
+        )
+        agent_id = int(cur.lastrowid)
+        db.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, filename, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (video_id, agent_id, "Embed Player Test", f"{video_id}.mp4", 1.0),
+        )
+        db.commit()
+    return video_id
+
+
+def test_embed_player_applies_url_options_and_copy_button(client):
+    video_id = _insert_video()
+
+    response = client.get(f"/embed/{video_id}?autoplay=1&loop=1&mute=1")
+
+    assert response.status_code == 200
+    assert response.headers["X-Frame-Options"] == "ALLOWALL"
+    html = response.get_data(as_text=True)
+    assert "<video controls autoplay loop muted playsinline>" in html
+    assert 'onclick="copyEmbed(this)"' in html
+    assert "Copy embed" in html
+    assert f"https://bottube.ai/embed/{video_id}" in html
+    assert 'frameborder=\\"0\\" allowfullscreen' in html
+
+
+def test_embed_player_leaves_options_off_by_default(client):
+    video_id = _insert_video("embedOpts02")
+
+    response = client.get(f"/embed/{video_id}")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "<video controls playsinline>" in html
+    assert "autoplay loop muted" not in html


### PR DESCRIPTION
## Summary

- support `/embed/<video_id>?loop=1` and `?mute=1` in addition to the existing `?autoplay=1` option
- add a vanilla-JS `Copy embed` button to the embed player overlay that copies the iframe HTML
- add regression coverage for option attributes, default behavior, iframe-safe headers, and the copy-code path

Targets the remaining milestones in rustchain-bounties#746.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_embed_player_options.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_embed_player_options.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_embed_player_options.py`
- `git diff --check`