### PR TITLE
Hide moderated videos from public direct routes

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -4186,6 +4186,11 @@ def video_to_dict(row):
     return d
 
 
+def _public_video_filter_sql() -> str:
+    """SQL predicate for public video surfaces."""
+    return "COALESCE(v.is_removed, 0) = 0 AND COALESCE(a.is_banned, 0) = 0"
+
+
 def agent_to_dict(row, include_private=False, *, badges=None):
     """Convert agent row to public-safe dict (allowlist only).
 
@@ -6649,9 +6654,9 @@ def get_video(video_id):
     """Get video metadata."""
     db = get_db()
     row = db.execute(
-        """SELECT v.*, a.agent_name, a.display_name, a.avatar_url
+        f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.video_id = ?""",
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
         (video_id,),
     ).fetchone()
 
@@ -6664,9 +6669,9 @@ def get_video(video_id):
     d["avatar_url"] = row["avatar_url"]
     if "revision_of" in row.keys() and row["revision_of"]:
         original = db.execute(
-            """SELECT v.video_id, v.title, a.agent_name, a.display_name
+            f"""SELECT v.video_id, v.title, a.agent_name, a.display_name
                FROM videos v JOIN agents a ON v.agent_id = a.id
-               WHERE v.video_id = ?""",
+               WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
             (row["revision_of"],),
         ).fetchone()
         if original:
@@ -6677,9 +6682,9 @@ def get_video(video_id):
                 "display_name": original["display_name"],
             }
     revisions = db.execute(
-        """SELECT v.video_id, v.title, v.created_at, a.agent_name, a.display_name
+        f"""SELECT v.video_id, v.title, v.created_at, a.agent_name, a.display_name
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.revision_of = ?
+           WHERE v.revision_of = ? AND {_public_video_filter_sql()}
            ORDER BY v.created_at DESC LIMIT 10""",
         (video_id,),
     ).fetchall()
@@ -6696,9 +6701,9 @@ def get_video(video_id):
     # Response video handling (Issue #2282 - Agent Collab System)
     if "response_to_video_id" in row.keys() and row["response_to_video_id"]:
         original_video = db.execute(
-            """SELECT v.video_id, v.title, v.views, v.created_at, a.agent_name, a.display_name, a.avatar_url
+            f"""SELECT v.video_id, v.title, v.views, v.created_at, a.agent_name, a.display_name, a.avatar_url
                FROM videos v JOIN agents a ON v.agent_id = a.id
-               WHERE v.video_id = ?""",
+               WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
             (row["response_to_video_id"],),
         ).fetchone()
         if original_video:
@@ -6713,9 +6718,9 @@ def get_video(video_id):
             }
     # Get response videos to this video
     response_videos = db.execute(
-        """SELECT v.video_id, v.title, v.views, v.created_at, a.agent_name, a.display_name, a.avatar_url
+        f"""SELECT v.video_id, v.title, v.views, v.created_at, a.agent_name, a.display_name, a.avatar_url
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.response_to_video_id = ? AND v.is_removed = 0
+           WHERE v.response_to_video_id = ? AND {_public_video_filter_sql()}
            ORDER BY v.created_at DESC LIMIT 10""",
         (video_id,),
     ).fetchall()
@@ -6923,7 +6928,12 @@ def get_mood_history(agent_name):
 def stream_video(video_id):
     """Stream video file with range request support."""
     db = get_db()
-    row = db.execute("SELECT filename FROM videos WHERE video_id = ?", (video_id,)).fetchone()
+    row = db.execute(
+        f"""SELECT v.filename
+           FROM videos v JOIN agents a ON v.agent_id = a.id
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
+        (video_id,),
+    ).fetchone()
     if not row:
         abort(404)
 
@@ -6994,9 +7004,9 @@ def record_view(video_id):
     """Record a view and return video metadata."""
     db = get_db()
     row = db.execute(
-        """SELECT v.*, a.agent_name, a.display_name, a.avatar_url
+        f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.video_id = ?""",
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
         (video_id,),
     ).fetchone()
 
@@ -7071,9 +7081,9 @@ def describe_video(video_id):
     agent needs to understand and engage with the content."""
     db = get_db()
     row = db.execute(
-        """SELECT v.*, a.agent_name, a.display_name
+        f"""SELECT v.*, a.agent_name, a.display_name
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.video_id = ?""",
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
         (video_id,),
     ).fetchone()
 
@@ -7360,13 +7370,20 @@ def _compute_agent_interaction_context(db, video_agent_id, commenting_agent_id):
 def get_comments(video_id):
     """Get comments for a video with agent interaction context."""
     db = get_db()
-    v = db.execute("SELECT 1 FROM videos WHERE video_id = ?", (video_id,)).fetchone()
+    v = db.execute(
+        f"""SELECT 1
+           FROM videos v JOIN agents a ON v.agent_id = a.id
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
+        (video_id,),
+    ).fetchone()
     if not v:
         return jsonify({"error": "Video not found"}), 404
     
     # Get video owner info for interaction context
     video_owner = db.execute(
-        "SELECT agent_id FROM videos WHERE video_id = ?",
+        f"""SELECT v.agent_id
+           FROM videos v JOIN agents a ON v.agent_id = a.id
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
         (video_id,),
     ).fetchone()
     if not video_owner:
@@ -11491,11 +11508,11 @@ def watch(video_id):
     """Video player page."""
     db = get_db()
     video = db.execute(
-        """SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human,
+        f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human,
                   a.rtc_address, a.rtc_wallet, a.btc_address, a.eth_address,
                   a.sol_address, a.ltc_address, a.erg_address, a.paypal_email
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.video_id = ?""",
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
         (video_id,),
     ).fetchone()
 
@@ -11566,16 +11583,16 @@ def watch(video_id):
     revision_of = None
     if "revision_of" in video.keys() and video["revision_of"]:
         revision_of = db.execute(
-            """SELECT v.video_id, v.title, a.agent_name, a.display_name
+            f"""SELECT v.video_id, v.title, a.agent_name, a.display_name
                FROM videos v JOIN agents a ON v.agent_id = a.id
-               WHERE v.video_id = ?""",
+               WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
             (video["revision_of"],),
         ).fetchone()
 
     revisions = db.execute(
-        """SELECT v.video_id, v.title, v.created_at, a.agent_name, a.display_name
+        f"""SELECT v.video_id, v.title, v.created_at, a.agent_name, a.display_name
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.revision_of = ?
+           WHERE v.revision_of = ? AND {_public_video_filter_sql()}
            ORDER BY v.created_at DESC LIMIT 8""",
         (video_id,),
     ).fetchall()
@@ -11585,17 +11602,17 @@ def watch(video_id):
     response_to_video = None
     if "response_to_video_id" in video.keys() and video["response_to_video_id"]:
         response_to_video = db.execute(
-            """SELECT v.video_id, v.title, v.views, v.created_at, a.agent_name, a.display_name, a.avatar_url
+            f"""SELECT v.video_id, v.title, v.views, v.created_at, a.agent_name, a.display_name, a.avatar_url
                FROM videos v JOIN agents a ON v.agent_id = a.id
-               WHERE v.video_id = ?""",
+               WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
             (video["response_to_video_id"],),
         ).fetchone()
 
     # Get all response videos to this video
     response_videos = db.execute(
-        """SELECT v.video_id, v.title, v.views, v.created_at, a.agent_name, a.display_name, a.avatar_url
+        f"""SELECT v.video_id, v.title, v.views, v.created_at, a.agent_name, a.display_name, a.avatar_url
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.response_to_video_id = ? AND v.is_removed = 0
+           WHERE v.response_to_video_id = ? AND {_public_video_filter_sql()}
            ORDER BY v.created_at DESC LIMIT 10""",
         (video_id,),
     ).fetchall()
@@ -11625,9 +11642,9 @@ def watch(video_id):
     _cur_cat = video["category"] or "other"
 
     _candidates = db.execute(
-        """SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human
+        f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.video_id != ? AND v.is_removed = 0
+           WHERE v.video_id != ? AND {_public_video_filter_sql()}
            ORDER BY v.views DESC
            LIMIT 100""",
         (video_id,),
@@ -11792,7 +11809,9 @@ def embed(video_id):
     """Branded embed player for iframes and Twitter player cards."""
     db = get_db()
     video = db.execute(
-        "SELECT v.*, a.agent_name, a.display_name FROM videos v JOIN agents a ON v.agent_id = a.id WHERE v.video_id = ?",
+        f"""SELECT v.*, a.agent_name, a.display_name
+           FROM videos v JOIN agents a ON v.agent_id = a.id
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
         (video_id,),
     ).fetchone()
     if not video:
@@ -11859,7 +11878,9 @@ def oembed():
     video_id = match.group(1)
     db = get_db()
     video = db.execute(
-        "SELECT v.*, a.agent_name, a.display_name FROM videos v JOIN agents a ON v.agent_id = a.id WHERE v.video_id = ?",
+        f"""SELECT v.*, a.agent_name, a.display_name
+           FROM videos v JOIN agents a ON v.agent_id = a.id
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
         (video_id,),
     ).fetchone()
 
@@ -15392,7 +15413,10 @@ def api_related_videos(video_id):
     """Get related videos for a given video ID."""
     db = get_db()
     video = db.execute(
-        "SELECT * FROM videos WHERE video_id = ?", (video_id,)
+        f"""SELECT v.*
+           FROM videos v JOIN agents a ON v.agent_id = a.id
+           WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
+        (video_id,),
     ).fetchone()
     if not video:
         return jsonify({"error": "Video not found"}), 404
@@ -15405,9 +15429,9 @@ def api_related_videos(video_id):
     cur_cat = video["category"] or "other"
 
     candidates = db.execute(
-        """SELECT v.*, a.agent_name, a.display_name, a.avatar_url
+        f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.video_id != ? AND v.is_removed = 0
+           WHERE v.video_id != ? AND {_public_video_filter_sql()}
            ORDER BY v.views DESC
            LIMIT 100""",
         (video_id,),

--- a/tests/test_public_video_visibility.py
+++ b/tests/test_public_video_visibility.py
@@ -1,0 +1,172 @@
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+TEST_BASE_DIR = "/tmp/bottube_test_public_video_visibility"
+os.environ.setdefault("BOTTUBE_BASE_DIR", TEST_BASE_DIR)
+os.environ.setdefault("BOTTUBE_DB_PATH", f"{TEST_BASE_DIR}/bottube.db")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_public_video_visibility.db"
+    video_dir = tmp_path / "videos"
+    video_dir.mkdir()
+
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(bottube_server, "VIDEO_DIR", video_dir, raising=False)
+    monkeypatch.setattr(
+        bottube_server,
+        "render_template",
+        lambda *args, **kwargs: "rendered",
+    )
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server._ctr_tracker = None
+    bottube_server._ab_manager = None
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_agent(agent_name: str, *, is_banned: int = 0) -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, password_hash, bio,
+                 avatar_url, is_human, is_banned, created_at, last_active)
+            VALUES (?, ?, ?, '', '', '', 0, ?, ?, ?)
+            """,
+            (
+                agent_name,
+                agent_name.replace("_", " ").title(),
+                f"bottube_sk_{agent_name}",
+                is_banned,
+                time.time(),
+                time.time(),
+            ),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _insert_video(
+    video_id: str,
+    agent_id: int,
+    *,
+    is_removed: int = 0,
+) -> None:
+    video_file = bottube_server.VIDEO_DIR / f"{video_id}.mp4"
+    video_file.write_bytes(b"fake video bytes")
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, description, filename, tags,
+                 category, created_at, is_removed, width, height)
+            VALUES (?, ?, ?, ?, ?, '[]', 'other', ?, ?, 640, 360)
+            """,
+            (
+                video_id,
+                agent_id,
+                f"{video_id} title",
+                "moderation visibility fixture",
+                f"{video_id}.mp4",
+                time.time(),
+                is_removed,
+            ),
+        )
+        db.execute(
+            """
+            INSERT INTO comments (video_id, agent_id, content, created_at)
+            VALUES (?, ?, 'hidden context', ?)
+            """,
+            (video_id, agent_id, time.time()),
+        )
+        db.commit()
+
+
+def test_public_routes_hide_removed_videos(client):
+    agent_id = _insert_agent("visible_agent")
+    _insert_video("removed-clip", agent_id, is_removed=1)
+
+    hidden_paths = [
+        "/api/videos/removed-clip",
+        "/api/videos/removed-clip/view",
+        "/api/videos/removed-clip/describe",
+        "/api/videos/removed-clip/comments",
+        "/api/videos/removed-clip/related",
+        "/api/videos/removed-clip/stream",
+        "/watch/removed-clip",
+        "/embed/removed-clip",
+        "/oembed?url=https://bottube.ai/watch/removed-clip",
+    ]
+
+    for path in hidden_paths:
+        assert client.get(path).status_code == 404, path
+
+
+def test_public_routes_hide_videos_from_banned_agents(client):
+    agent_id = _insert_agent("banned_agent", is_banned=1)
+    _insert_video("banned-clip", agent_id)
+
+    hidden_paths = [
+        "/api/videos/banned-clip",
+        "/api/videos/banned-clip/view",
+        "/api/videos/banned-clip/describe",
+        "/api/videos/banned-clip/comments",
+        "/api/videos/banned-clip/related",
+        "/api/videos/banned-clip/stream",
+        "/watch/banned-clip",
+        "/embed/banned-clip",
+        "/oembed?url=https://bottube.ai/watch/banned-clip",
+    ]
+
+    for path in hidden_paths:
+        assert client.get(path).status_code == 404, path
+
+
+def test_public_routes_still_return_visible_videos(client):
+    agent_id = _insert_agent("visible_agent")
+    _insert_video("visible-clip", agent_id)
+
+    expected_ok_paths = [
+        "/api/videos/visible-clip",
+        "/api/videos/visible-clip/view",
+        "/api/videos/visible-clip/describe",
+        "/api/videos/visible-clip/comments",
+        "/api/videos/visible-clip/related",
+        "/api/videos/visible-clip/stream",
+        "/watch/visible-clip",
+        "/embed/visible-clip",
+        "/oembed?url=https://bottube.ai/watch/visible-clip",
+    ]
+
+    for path in expected_ok_paths:
+        assert client.get(path).status_code == 200, path


### PR DESCRIPTION
## Summary
- add a shared public-video visibility predicate for removed videos and videos owned by banned agents
- apply it to direct public video routes, including metadata, view, describe, comments, related, stream, watch, embed, and oEmbed lookups
- keep revision/response/related-video sidebars from re-exposing hidden videos
- add regression coverage for removed videos, banned-agent videos, and still-visible normal videos

Fixes #1172.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_public_video_visibility.py -q` -> 3 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_public_video_visibility.py tests/test_video_public_id_routes.py -q` -> 5 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_public_video_visibility.py` -> passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_public_video_visibility.py` -> passed
- `git diff --check` -> passed

No secrets, tokens, hidden context, payout details, or private runtime data are included.