### PR TITLE
Hide moderated agents from public profile surfaces

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7969,7 +7969,8 @@ def get_agent(agent_name):
     """Get agent profile and their videos."""
     db = get_db()
     agent = db.execute(
-        "SELECT * FROM agents WHERE agent_name = ?", (agent_name,)
+        "SELECT * FROM agents WHERE agent_name = ? AND COALESCE(is_banned, 0) = 0",
+        (agent_name,),
     ).fetchone()
     if not agent:
         return jsonify({"error": "Agent not found"}), 404
@@ -7977,7 +7978,7 @@ def get_agent(agent_name):
     videos = db.execute(
         """SELECT v.*, a.agent_name, a.display_name, a.avatar_url
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.agent_id = ?
+           WHERE v.agent_id = ? AND COALESCE(v.is_removed, 0) = 0
            ORDER BY v.created_at DESC""",
         (agent["id"],),
     ).fetchall()
@@ -8002,6 +8003,8 @@ def get_agent(agent_name):
            FROM comments c JOIN videos v ON c.video_id = v.video_id
            JOIN agents a2 ON c.agent_id = a2.id
            WHERE v.agent_id = ? AND c.agent_id != ?
+             AND COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(a2.is_banned, 0) = 0
            GROUP BY a2.id ORDER BY cnt DESC LIMIT 8""",
         (aid, aid)).fetchall()
     interaction_likers = db.execute(
@@ -8009,20 +8012,22 @@ def get_agent(agent_name):
            FROM votes vt JOIN videos v ON vt.video_id = v.video_id
            JOIN agents a2 ON vt.agent_id = a2.id
            WHERE v.agent_id = ? AND vt.vote = 1 AND vt.agent_id != ?
+             AND COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(a2.is_banned, 0) = 0
            GROUP BY a2.id ORDER BY cnt DESC LIMIT 8""",
         (aid, aid)).fetchall()
     interaction_outgoing = db.execute(
         """SELECT a2.agent_name, a2.display_name, a2.avatar_url,
                (SELECT COUNT(*) FROM comments c2 JOIN videos v2 ON c2.video_id=v2.video_id
-                WHERE c2.agent_id=? AND v2.agent_id=a2.id) AS comments_given,
+                WHERE c2.agent_id=? AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) AS comments_given,
                (SELECT COUNT(*) FROM votes vt2 JOIN videos v2 ON vt2.video_id=v2.video_id
-                WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id) AS likes_given
+                WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) AS likes_given
            FROM agents a2
-           WHERE a2.id != ? AND (
+           WHERE a2.id != ? AND COALESCE(a2.is_banned, 0) = 0 AND (
                (SELECT COUNT(*) FROM comments c2 JOIN videos v2 ON c2.video_id=v2.video_id
-                WHERE c2.agent_id=? AND v2.agent_id=a2.id) > 0
+                WHERE c2.agent_id=? AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) > 0
                OR (SELECT COUNT(*) FROM votes vt2 JOIN videos v2 ON vt2.video_id=v2.video_id
-                   WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id) > 0)
+                   WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) > 0)
            ORDER BY comments_given + likes_given DESC LIMIT 8""",
         (aid, aid, aid, aid, aid)).fetchall()
     return jsonify({
@@ -11912,7 +11917,10 @@ def agents_page():
     agents = db.execute(
         """SELECT a.*, COUNT(v.id) as video_count,
                   COALESCE(SUM(v.views), 0) as total_views
-           FROM agents a LEFT JOIN videos v ON a.id = v.agent_id
+           FROM agents a
+           LEFT JOIN videos v
+             ON a.id = v.agent_id AND COALESCE(v.is_removed, 0) = 0
+           WHERE COALESCE(a.is_banned, 0) = 0
            GROUP BY a.id
            ORDER BY total_views DESC""",
     ).fetchall()
@@ -11933,7 +11941,8 @@ def channel(agent_name):
     """Agent channel page."""
     db = get_db()
     agent = db.execute(
-        "SELECT * FROM agents WHERE agent_name = ?", (agent_name,)
+        "SELECT * FROM agents WHERE agent_name = ? AND COALESCE(is_banned, 0) = 0",
+        (agent_name,),
     ).fetchone()
     if not agent:
         abort(404)
@@ -11941,13 +11950,14 @@ def channel(agent_name):
     videos = db.execute(
         """SELECT v.*, a.agent_name, a.display_name, a.avatar_url
            FROM videos v JOIN agents a ON v.agent_id = a.id
-           WHERE v.agent_id = ?
+           WHERE v.agent_id = ? AND COALESCE(v.is_removed, 0) = 0
            ORDER BY v.created_at DESC""",
         (agent["id"],),
     ).fetchall()
 
     total_views = db.execute(
-        "SELECT COALESCE(SUM(views), 0) FROM videos WHERE agent_id = ?",
+        """SELECT COALESCE(SUM(views), 0) FROM videos
+           WHERE agent_id = ? AND COALESCE(is_removed, 0) = 0""",
         (agent["id"],),
     ).fetchone()[0]
 
@@ -12006,6 +12016,8 @@ def channel(agent_name):
            FROM comments c JOIN videos v ON c.video_id = v.video_id
            JOIN agents a2 ON c.agent_id = a2.id
            WHERE v.agent_id = ? AND c.agent_id != ?
+             AND COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(a2.is_banned, 0) = 0
            GROUP BY a2.id ORDER BY cnt DESC LIMIT 8""",
         (aid, aid)).fetchall()
     interaction_likers = db.execute(
@@ -12013,20 +12025,22 @@ def channel(agent_name):
            FROM votes vt JOIN videos v ON vt.video_id = v.video_id
            JOIN agents a2 ON vt.agent_id = a2.id
            WHERE v.agent_id = ? AND vt.vote = 1 AND vt.agent_id != ?
+             AND COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(a2.is_banned, 0) = 0
            GROUP BY a2.id ORDER BY cnt DESC LIMIT 8""",
         (aid, aid)).fetchall()
     interaction_outgoing = db.execute(
         """SELECT a2.agent_name, a2.display_name, a2.avatar_url,
                (SELECT COUNT(*) FROM comments c2 JOIN videos v2 ON c2.video_id=v2.video_id
-                WHERE c2.agent_id=? AND v2.agent_id=a2.id) AS comments_given,
+                WHERE c2.agent_id=? AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) AS comments_given,
                (SELECT COUNT(*) FROM votes vt2 JOIN videos v2 ON vt2.video_id=v2.video_id
-                WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id) AS likes_given
+                WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) AS likes_given
            FROM agents a2
-           WHERE a2.id != ? AND (
+           WHERE a2.id != ? AND COALESCE(a2.is_banned, 0) = 0 AND (
                (SELECT COUNT(*) FROM comments c2 JOIN videos v2 ON c2.video_id=v2.video_id
-                WHERE c2.agent_id=? AND v2.agent_id=a2.id) > 0
+                WHERE c2.agent_id=? AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) > 0
                OR (SELECT COUNT(*) FROM votes vt2 JOIN videos v2 ON vt2.video_id=v2.video_id
-                   WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id) > 0)
+                   WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) > 0)
            ORDER BY comments_given + likes_given DESC LIMIT 8""",
         (aid, aid, aid, aid, aid)).fetchall()
 
@@ -13617,13 +13631,18 @@ def _cdata_safe(s: str) -> str:
 def agent_rss(agent_name):
     """RSS 2.0 feed for a channel's videos."""
     db = get_db()
-    agent = db.execute("SELECT * FROM agents WHERE agent_name = ?", (agent_name,)).fetchone()
+    agent = db.execute(
+        "SELECT * FROM agents WHERE agent_name = ? AND COALESCE(is_banned, 0) = 0",
+        (agent_name,),
+    ).fetchone()
     if not agent:
         abort(404)
 
     videos = db.execute(
         """SELECT video_id, title, description, created_at, duration_sec, thumbnail, views
-           FROM videos WHERE agent_id = ? ORDER BY created_at DESC LIMIT 50""",
+           FROM videos
+           WHERE agent_id = ? AND COALESCE(is_removed, 0) = 0
+           ORDER BY created_at DESC LIMIT 50""",
         (agent["id"],),
     ).fetchall()
 
@@ -13678,6 +13697,8 @@ def global_rss():
         """SELECT v.video_id, v.title, v.description, v.created_at, v.thumbnail,
                   a.agent_name, a.display_name
            FROM videos v JOIN agents a ON v.agent_id = a.id
+           WHERE COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(a.is_banned, 0) = 0
            ORDER BY v.created_at DESC LIMIT 50""",
     ).fetchall()
 

--- a/tests/test_agent_public_visibility.py
+++ b/tests/test_agent_public_visibility.py
@@ -1,0 +1,220 @@
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+TEST_BASE_DIR = "/tmp/bottube_test_agent_public_visibility"
+os.environ.setdefault("BOTTUBE_BASE_DIR", TEST_BASE_DIR)
+os.environ.setdefault("BOTTUBE_DB_PATH", f"{TEST_BASE_DIR}/bottube.db")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_agent_public_visibility.db"
+    rendered = []
+
+    def fake_render_template(template, **context):
+        rendered.append((template, context))
+        return "rendered"
+
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(
+        bottube_server,
+        "render_template",
+        fake_render_template,
+    )
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server._ctr_tracker = None
+    bottube_server._ab_manager = None
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client(), rendered
+
+
+def _insert_agent(agent_name: str, *, is_banned: int = 0) -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, password_hash, bio,
+                 avatar_url, is_human, is_banned, created_at, last_active)
+            VALUES (?, ?, ?, '', '', '', 0, ?, ?, ?)
+            """,
+            (
+                agent_name,
+                agent_name.replace("_", " ").title(),
+                f"bottube_sk_{agent_name}",
+                is_banned,
+                time.time(),
+                time.time(),
+            ),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _insert_video(
+    video_id: str,
+    agent_id: int,
+    *,
+    title: str,
+    views: int = 0,
+    is_removed: int = 0,
+) -> None:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, description, filename, tags,
+                 category, created_at, is_removed, views)
+            VALUES (?, ?, ?, ?, ?, '[]', 'other', ?, ?, ?)
+            """,
+            (
+                video_id,
+                agent_id,
+                title,
+                f"{title} description",
+                f"{video_id}.mp4",
+                time.time(),
+                is_removed,
+                views,
+            ),
+        )
+        db.commit()
+
+
+def _render_context(rendered, template):
+    matches = [context for name, context in rendered if name == template]
+    assert matches
+    return matches[-1]
+
+
+def test_agents_page_hides_banned_agents_and_removed_video_counts(client):
+    http, rendered = client
+    visible_agent = _insert_agent("visible_agent")
+    banned_agent = _insert_agent("banned_agent", is_banned=1)
+    _insert_video("visible-clip", visible_agent, title="Visible Clip", views=7)
+    _insert_video(
+        "removed-clip",
+        visible_agent,
+        title="Removed Clip",
+        views=90,
+        is_removed=1,
+    )
+    _insert_video("banned-clip", banned_agent, title="Banned Clip", views=100)
+
+    resp = http.get("/agents")
+
+    assert resp.status_code == 200
+    agents = _render_context(rendered, "agents.html")["agents"]
+    assert [row["agent_name"] for row in agents] == ["visible_agent"]
+    assert agents[0]["video_count"] == 1
+    assert agents[0]["total_views"] == 7
+
+
+def test_agent_profile_api_hides_banned_agents_and_removed_videos(client):
+    http, _rendered = client
+    visible_agent = _insert_agent("visible_agent")
+    banned_agent = _insert_agent("banned_agent", is_banned=1)
+    _insert_video("visible-clip", visible_agent, title="Visible Clip")
+    _insert_video(
+        "removed-clip",
+        visible_agent,
+        title="Removed Clip",
+        is_removed=1,
+    )
+    _insert_video("banned-clip", banned_agent, title="Banned Clip")
+
+    visible_resp = http.get("/api/agents/visible_agent")
+    banned_resp = http.get("/api/agents/banned_agent")
+
+    assert visible_resp.status_code == 200
+    payload = visible_resp.get_json()
+    assert payload["video_count"] == 1
+    assert [
+        video["video_id"] for video in payload["videos"]
+    ] == ["visible-clip"]
+    assert banned_resp.status_code == 404
+
+
+def test_agent_channel_page_hides_banned_agents_and_removed_videos(client):
+    http, rendered = client
+    visible_agent = _insert_agent("visible_agent")
+    banned_agent = _insert_agent("banned_agent", is_banned=1)
+    _insert_video(
+        "visible-clip",
+        visible_agent,
+        title="Visible Clip",
+        views=11,
+    )
+    _insert_video(
+        "removed-clip",
+        visible_agent,
+        title="Removed Clip",
+        views=80,
+        is_removed=1,
+    )
+    _insert_video("banned-clip", banned_agent, title="Banned Clip")
+
+    visible_resp = http.get("/agent/visible_agent")
+    banned_resp = http.get("/agent/banned_agent")
+
+    assert visible_resp.status_code == 200
+    context = _render_context(rendered, "channel.html")
+    assert [
+        video["video_id"] for video in context["videos"]
+    ] == ["visible-clip"]
+    assert context["total_views"] == 11
+    assert banned_resp.status_code == 404
+
+
+def test_agent_and_global_rss_hide_banned_agents_and_removed_videos(client):
+    http, _rendered = client
+    visible_agent = _insert_agent("visible_agent")
+    banned_agent = _insert_agent("banned_agent", is_banned=1)
+    _insert_video("visible-clip", visible_agent, title="Visible Clip")
+    _insert_video(
+        "removed-clip",
+        visible_agent,
+        title="Removed Clip",
+        is_removed=1,
+    )
+    _insert_video("banned-clip", banned_agent, title="Banned Clip")
+
+    agent_rss = http.get("/agent/visible_agent/rss")
+    banned_rss = http.get("/agent/banned_agent/rss")
+    global_rss = http.get("/rss")
+
+    assert agent_rss.status_code == 200
+    assert "Visible Clip" in agent_rss.text
+    assert "Removed Clip" not in agent_rss.text
+    assert banned_rss.status_code == 404
+    assert global_rss.status_code == 200
+    assert "Visible Clip" in global_rss.text
+    assert "Removed Clip" not in global_rss.text
+    assert "Banned Clip" not in global_rss.text


### PR DESCRIPTION
## Summary
- hide banned agents from the public agent directory, agent profile API, channel page, and agent RSS feed
- count/list only non-removed videos on public agent/profile/RSS surfaces
- keep global RSS from syndicating removed videos or videos owned by banned agents
- filter removed-video and banned-agent interaction sidebars on public agent responses
- add focused regression coverage for banned agents, removed videos, RSS output, and normal visible content

Fixes #1174.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_agent_public_visibility.py -q` -> 4 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_agent_public_visibility.py` -> passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_agent_public_visibility.py` -> passed
- `git diff --check` -> passed

Note: I also tried the broader `tests/test_agent_interaction_visibility.py` sweep, but this checkout currently fails unrelated tests on missing templates/routes such as `watch.html`, `404.html`, `/api/activity/feed`, and `/api/conversations/...`; those failures are not introduced by this patch.

No secrets, tokens, hidden context, payout details, or private runtime data are included.