### PR TITLE
Hide moderated edges from public social graph

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8209,7 +8209,9 @@ def get_agent_interactions(agent_name):
     """Who interacted with this agent and how (comments, likes, subscriptions)."""
     db = get_db()
     agent = db.execute(
-        "SELECT id, agent_name, display_name FROM agents WHERE agent_name = ?",
+        """SELECT id, agent_name, display_name
+           FROM agents
+           WHERE agent_name = ? AND COALESCE(is_banned, 0) = 0""",
         (agent_name,),
     ).fetchone()
     if not agent:
@@ -8227,6 +8229,8 @@ def get_agent_interactions(agent_name):
            JOIN videos v ON c.video_id = v.video_id
            JOIN agents a2 ON c.agent_id = a2.id
            WHERE v.agent_id = ? AND c.agent_id != ?
+             AND COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(a2.is_banned, 0) = 0
            GROUP BY a2.id ORDER BY comment_count DESC LIMIT ?""",
         (aid, aid, limit),
     ).fetchall()
@@ -8240,6 +8244,8 @@ def get_agent_interactions(agent_name):
            JOIN videos v ON vt.video_id = v.video_id
            JOIN agents a2 ON vt.agent_id = a2.id
            WHERE v.agent_id = ? AND vt.vote = 1 AND vt.agent_id != ?
+             AND COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(a2.is_banned, 0) = 0
            GROUP BY a2.id ORDER BY like_count DESC LIMIT ?""",
         (aid, aid, limit),
     ).fetchall()
@@ -8251,6 +8257,7 @@ def get_agent_interactions(agent_name):
            FROM subscriptions s
            JOIN agents a2 ON s.follower_id = a2.id
            WHERE s.following_id = ?
+            AND COALESCE(a2.is_banned, 0) = 0
            ORDER BY s.created_at DESC LIMIT ?""",
         (aid, limit),
     ).fetchall()
@@ -8265,16 +8272,23 @@ def get_agent_interactions(agent_name):
            LEFT JOIN (
                SELECT v.agent_id AS target, COUNT(*) AS cnt
                FROM comments c JOIN videos v ON c.video_id = v.video_id
+               JOIN agents target_agent ON v.agent_id = target_agent.id
                WHERE c.agent_id = ? AND v.agent_id != ?
+                 AND COALESCE(v.is_removed, 0) = 0
+                 AND COALESCE(target_agent.is_banned, 0) = 0
                GROUP BY v.agent_id
            ) cm ON a2.id = cm.target
            LEFT JOIN (
                SELECT v.agent_id AS target, COUNT(*) AS cnt
                FROM votes vt JOIN videos v ON vt.video_id = v.video_id
+               JOIN agents target_agent ON v.agent_id = target_agent.id
                WHERE vt.agent_id = ? AND vt.vote = 1 AND v.agent_id != ?
+                 AND COALESCE(v.is_removed, 0) = 0
+                 AND COALESCE(target_agent.is_banned, 0) = 0
                GROUP BY v.agent_id
            ) lk ON a2.id = lk.target
            WHERE COALESCE(cm.cnt, 0) + COALESCE(lk.cnt, 0) > 0
+             AND COALESCE(a2.is_banned, 0) = 0
            ORDER BY total DESC LIMIT ?""",
         (aid, aid, aid, aid, limit),
     ).fetchall()
@@ -8317,13 +8331,23 @@ def social_graph():
            FROM (
                SELECT c.agent_id AS src, v.agent_id AS dst, COUNT(*) AS cnt
                FROM comments c JOIN videos v ON c.video_id = v.video_id
+               JOIN agents src_agent ON c.agent_id = src_agent.id
+               JOIN agents dst_agent ON v.agent_id = dst_agent.id
                WHERE c.agent_id != v.agent_id
+                 AND COALESCE(v.is_removed, 0) = 0
+                 AND COALESCE(src_agent.is_banned, 0) = 0
+                 AND COALESCE(dst_agent.is_banned, 0) = 0
                GROUP BY c.agent_id, v.agent_id
            ) cm
            LEFT JOIN (
                SELECT vt.agent_id AS src, v.agent_id AS dst, COUNT(*) AS cnt
                FROM votes vt JOIN videos v ON vt.video_id = v.video_id
+               JOIN agents src_agent ON vt.agent_id = src_agent.id
+               JOIN agents dst_agent ON v.agent_id = dst_agent.id
                WHERE vt.agent_id != v.agent_id AND vt.vote = 1
+                 AND COALESCE(v.is_removed, 0) = 0
+                 AND COALESCE(src_agent.is_banned, 0) = 0
+                 AND COALESCE(dst_agent.is_banned, 0) = 0
                GROUP BY vt.agent_id, v.agent_id
            ) lk ON cm.src = lk.src AND cm.dst = lk.dst
            JOIN agents a1 ON cm.src = a1.id
@@ -8333,13 +8357,37 @@ def social_graph():
     ).fetchall()
 
     # Network stats
-    total_agents = db.execute("SELECT COUNT(*) FROM agents").fetchone()[0]
-    total_subs = db.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0]
+    total_agents = db.execute(
+        "SELECT COUNT(*) FROM agents WHERE COALESCE(is_banned, 0) = 0"
+    ).fetchone()[0]
+    total_subs = db.execute(
+        """SELECT COUNT(*)
+           FROM subscriptions s
+           JOIN agents follower ON s.follower_id = follower.id
+           JOIN agents following ON s.following_id = following.id
+           WHERE COALESCE(follower.is_banned, 0) = 0
+             AND COALESCE(following.is_banned, 0) = 0"""
+    ).fetchone()[0]
     active_commenters = db.execute(
-        "SELECT COUNT(DISTINCT agent_id) FROM comments"
+        """SELECT COUNT(DISTINCT c.agent_id)
+           FROM comments c
+           JOIN videos v ON c.video_id = v.video_id
+           JOIN agents commenter ON c.agent_id = commenter.id
+           JOIN agents owner ON v.agent_id = owner.id
+           WHERE COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(commenter.is_banned, 0) = 0
+             AND COALESCE(owner.is_banned, 0) = 0"""
     ).fetchone()[0]
     active_likers = db.execute(
-        "SELECT COUNT(DISTINCT agent_id) FROM votes WHERE vote = 1"
+        """SELECT COUNT(DISTINCT vt.agent_id)
+           FROM votes vt
+           JOIN videos v ON vt.video_id = v.video_id
+           JOIN agents liker ON vt.agent_id = liker.id
+           JOIN agents owner ON v.agent_id = owner.id
+           WHERE vt.vote = 1
+             AND COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(liker.is_banned, 0) = 0
+             AND COALESCE(owner.is_banned, 0) = 0"""
     ).fetchone()[0]
 
     # Most connected agents (by unique interaction partners)
@@ -8349,17 +8397,38 @@ def social_graph():
            FROM (
                SELECT c.agent_id AS self, v.agent_id AS partner
                FROM comments c JOIN videos v ON c.video_id = v.video_id
+               JOIN agents self_agent ON c.agent_id = self_agent.id
+               JOIN agents partner_agent ON v.agent_id = partner_agent.id
                WHERE c.agent_id != v.agent_id
+                 AND COALESCE(v.is_removed, 0) = 0
+                 AND COALESCE(self_agent.is_banned, 0) = 0
+                 AND COALESCE(partner_agent.is_banned, 0) = 0
                UNION
                SELECT v.agent_id AS self, c.agent_id AS partner
                FROM comments c JOIN videos v ON c.video_id = v.video_id
+               JOIN agents self_agent ON v.agent_id = self_agent.id
+               JOIN agents partner_agent ON c.agent_id = partner_agent.id
                WHERE c.agent_id != v.agent_id
+                 AND COALESCE(v.is_removed, 0) = 0
+                 AND COALESCE(self_agent.is_banned, 0) = 0
+                 AND COALESCE(partner_agent.is_banned, 0) = 0
                UNION
-               SELECT follower_id AS self, following_id AS partner FROM subscriptions
+               SELECT follower_id AS self, following_id AS partner
+               FROM subscriptions s
+               JOIN agents follower ON s.follower_id = follower.id
+               JOIN agents following ON s.following_id = following.id
+               WHERE COALESCE(follower.is_banned, 0) = 0
+                 AND COALESCE(following.is_banned, 0) = 0
                UNION
-               SELECT following_id AS self, follower_id AS partner FROM subscriptions
+               SELECT following_id AS self, follower_id AS partner
+               FROM subscriptions s
+               JOIN agents follower ON s.follower_id = follower.id
+               JOIN agents following ON s.following_id = following.id
+               WHERE COALESCE(follower.is_banned, 0) = 0
+                 AND COALESCE(following.is_banned, 0) = 0
            ) edges
            JOIN agents a ON edges.self = a.id
+           WHERE COALESCE(a.is_banned, 0) = 0
            GROUP BY a.id ORDER BY connections DESC LIMIT 10""",
     ).fetchall()
 

--- a/tests/test_public_interaction_visibility.py
+++ b/tests/test_public_interaction_visibility.py
@@ -1,0 +1,229 @@
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+TEST_BASE_DIR = "/tmp/bottube_test_public_interaction_visibility"
+os.environ.setdefault("BOTTUBE_BASE_DIR", TEST_BASE_DIR)
+os.environ.setdefault("BOTTUBE_DB_PATH", f"{TEST_BASE_DIR}/bottube.db")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_public_interaction_visibility.db"
+
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server._ctr_tracker = None
+    bottube_server._ab_manager = None
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_agent(agent_name: str, *, is_banned: int = 0) -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, password_hash, bio,
+                 avatar_url, is_human, is_banned, created_at, last_active)
+            VALUES (?, ?, ?, '', '', '', 0, ?, ?, ?)
+            """,
+            (
+                agent_name,
+                agent_name.title(),
+                f"bottube_sk_{agent_name}",
+                is_banned,
+                time.time(),
+                time.time(),
+            ),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _insert_video(
+    video_id: str,
+    agent_id: int,
+    *,
+    is_removed: int = 0,
+) -> None:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, filename, created_at, is_removed)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                video_id,
+                agent_id,
+                f"Video {video_id}",
+                f"{video_id}.mp4",
+                time.time(),
+                is_removed,
+            ),
+        )
+        db.commit()
+
+
+def _insert_comment(video_id: str, agent_id: int) -> None:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO comments (video_id, agent_id, content, created_at)
+            VALUES (?, ?, 'interaction fixture comment', ?)
+            """,
+            (video_id, agent_id, time.time()),
+        )
+        db.commit()
+
+
+def _insert_vote(video_id: str, agent_id: int, vote: int = 1) -> None:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO votes (agent_id, video_id, vote, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (agent_id, video_id, vote, time.time()),
+        )
+        db.commit()
+
+
+def _insert_subscription(follower_id: int, following_id: int) -> None:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO subscriptions (follower_id, following_id, created_at)
+            VALUES (?, ?, ?)
+            """,
+            (follower_id, following_id, time.time()),
+        )
+        db.commit()
+
+
+def test_agent_interactions_hide_banned_agents_and_removed_videos(client):
+    alice = _insert_agent("alice")
+    bob = _insert_agent("bob")
+    banned = _insert_agent("banned", is_banned=1)
+    carol = _insert_agent("carol")
+
+    _insert_video("alice-visible", alice)
+    _insert_video("alice-removed", alice, is_removed=1)
+    _insert_video("bob-visible", bob)
+    _insert_video("banned-visible", banned)
+
+    _insert_comment("alice-visible", bob)
+    _insert_vote("alice-visible", bob)
+    _insert_subscription(bob, alice)
+
+    _insert_comment("alice-visible", banned)
+    _insert_vote("alice-visible", banned)
+    _insert_subscription(banned, alice)
+
+    _insert_comment("alice-removed", carol)
+    _insert_vote("alice-removed", carol)
+
+    _insert_comment("bob-visible", alice)
+    _insert_vote("bob-visible", alice)
+    _insert_comment("banned-visible", alice)
+    _insert_vote("banned-visible", alice)
+
+    resp = client.get("/api/agents/alice/interactions")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    incoming = data["incoming"]
+    assert [row["agent_name"] for row in incoming["commenters"]] == ["bob"]
+    assert [row["agent_name"] for row in incoming["likers"]] == ["bob"]
+    assert [row["agent_name"] for row in incoming["followers"]] == ["bob"]
+    assert [row["agent_name"] for row in data["outgoing"]] == ["bob"]
+
+
+def test_agent_interactions_hide_banned_target_agent(client):
+    banned = _insert_agent("banned", is_banned=1)
+    bob = _insert_agent("bob")
+    _insert_video("banned-visible", banned)
+    _insert_comment("banned-visible", bob)
+
+    resp = client.get("/api/agents/banned/interactions")
+
+    assert resp.status_code == 404
+
+
+def test_social_graph_excludes_banned_agents_and_removed_video_edges(client):
+    alice = _insert_agent("alice")
+    bob = _insert_agent("bob")
+    banned = _insert_agent("banned", is_banned=1)
+    carol = _insert_agent("carol")
+
+    _insert_video("alice-visible", alice)
+    _insert_video("alice-removed", alice, is_removed=1)
+    _insert_video("bob-visible", bob)
+    _insert_video("banned-visible", banned)
+
+    _insert_comment("alice-visible", bob)
+    _insert_vote("alice-visible", bob)
+    _insert_subscription(bob, alice)
+
+    _insert_comment("alice-visible", banned)
+    _insert_vote("alice-visible", banned)
+    _insert_subscription(banned, alice)
+    _insert_subscription(alice, banned)
+
+    _insert_comment("alice-removed", carol)
+    _insert_vote("alice-removed", carol)
+    _insert_comment("banned-visible", alice)
+    _insert_vote("banned-visible", alice)
+
+    resp = client.get("/api/social/graph?limit=10")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["network"]["total_agents"] == 3
+    assert data["network"]["total_subscriptions"] == 1
+    assert data["network"]["active_commenters"] == 1
+    assert data["network"]["active_likers"] == 1
+    assert data["top_pairs"] == [
+        {
+            "from": "bob",
+            "from_display": "Bob",
+            "to": "alice",
+            "to_display": "Alice",
+            "comments": 1,
+            "likes": 1,
+            "strength": 2,
+        }
+    ]
+    connected_names = {row["agent_name"] for row in data["most_connected"]}
+    assert connected_names <= {"alice", "bob"}


### PR DESCRIPTION
## Summary
- hide banned target agents from public interaction summaries
- exclude banned counterpart agents from commenters, likers, followers, outgoing interaction targets, graph pairs, and connected-agent lists
- exclude comments/votes on removed videos from public agent interactions and social graph metrics
- keep normal visible interactions working and covered by existing social graph tests

Fixes #1178.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_public_interaction_visibility.py tests/test_social_graph.py -q` -> 5 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_public_interaction_visibility.py` -> passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_public_interaction_visibility.py` -> passed
- `git diff --check` -> passed

No secrets, tokens, hidden context, payout details, or private runtime data are included.