### PR TITLE
Track broadcast message reads per recipient

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -2427,6 +2427,16 @@ def init_db():
     """)
     conn.execute("CREATE INDEX IF NOT EXISTS idx_messages_to ON messages(to_agent)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_messages_created ON messages(created_at DESC)")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS message_reads (
+            message_id TEXT NOT NULL,
+            agent_name TEXT NOT NULL,
+            read_at TEXT DEFAULT (datetime('now')),
+            PRIMARY KEY (message_id, agent_name),
+            FOREIGN KEY (message_id) REFERENCES messages(id)
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_message_reads_agent ON message_reads(agent_name)")
 
     # Migration: watch_history table (Phase 6)
     conn.execute("""
@@ -15201,17 +15211,29 @@ def message_inbox():
     db = get_db()
     agent_name = g.agent["agent_name"]
 
+    read_join = (
+        "LEFT JOIN message_reads mr "
+        "ON m.id = mr.message_id AND mr.agent_name = ?"
+    )
     where = "WHERE (m.to_agent = ? OR m.to_agent IS NULL)"
-    params = [agent_name]
+    params = [agent_name, agent_name]
     if unread_only:
-        where += " AND m.read_at IS NULL"
+        where += (
+            " AND ((m.to_agent IS NULL AND mr.read_at IS NULL) "
+            "OR (m.to_agent IS NOT NULL AND m.read_at IS NULL))"
+        )
 
     total = db.execute(
-        f"SELECT COUNT(*) FROM messages m {where}", params
+        f"SELECT COUNT(*) FROM messages m {read_join} {where}", params
     ).fetchone()[0]
 
     rows = db.execute(
-        f"""SELECT m.* FROM messages m {where}
+        f"""SELECT m.*,
+                   CASE
+                     WHEN m.to_agent IS NULL THEN mr.read_at
+                     ELSE m.read_at
+                   END AS effective_read_at
+            FROM messages m {read_join} {where}
             ORDER BY m.created_at DESC LIMIT ? OFFSET ?""",
         params + [per_page, offset],
     ).fetchall()
@@ -15225,7 +15247,7 @@ def message_inbox():
             "subject": r["subject"],
             "body": r["body"],
             "message_type": r["message_type"],
-            "read_at": r["read_at"],
+            "read_at": r["effective_read_at"],
             "created_at": r["created_at"],
         })
 
@@ -15255,10 +15277,19 @@ def mark_message_read(msg_id):
     if msg["to_agent"] and msg["to_agent"] != agent_name:
         return jsonify({"error": "Not your message"}), 403
 
-    db.execute(
-        "UPDATE messages SET read_at = datetime('now') WHERE id = ? AND read_at IS NULL",
-        (msg_id,),
-    )
+    if msg["to_agent"] is None:
+        db.execute(
+            """INSERT INTO message_reads (message_id, agent_name, read_at)
+               VALUES (?, ?, datetime('now'))
+               ON CONFLICT(message_id, agent_name)
+               DO UPDATE SET read_at = excluded.read_at""",
+            (msg_id, agent_name),
+        )
+    else:
+        db.execute(
+            "UPDATE messages SET read_at = datetime('now') WHERE id = ? AND read_at IS NULL",
+            (msg_id,),
+        )
     db.commit()
     return jsonify({"ok": True})
 
@@ -15271,10 +15302,14 @@ def message_unread_count():
     agent_name = g.agent["agent_name"]
 
     count = db.execute(
-        """SELECT COUNT(*) FROM messages
-           WHERE (to_agent = ? OR to_agent IS NULL)
-           AND read_at IS NULL""",
-        (agent_name,),
+        """SELECT COUNT(*)
+           FROM messages m
+           LEFT JOIN message_reads mr
+             ON m.id = mr.message_id AND mr.agent_name = ?
+           WHERE (m.to_agent = ? OR m.to_agent IS NULL)
+             AND ((m.to_agent IS NULL AND mr.read_at IS NULL)
+                  OR (m.to_agent IS NOT NULL AND m.read_at IS NULL))""",
+        (agent_name, agent_name),
     ).fetchone()[0]
 
     return jsonify({"ok": True, "unread": count})

--- a/tests/test_message_reads.py
+++ b/tests/test_message_reads.py
@@ -1,0 +1,157 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_message_reads_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_message_reads_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_message_reads_test.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_agent(agent_name: str, created_at: float) -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, bio, avatar_url,
+                 created_at, last_active)
+            VALUES (?, ?, ?, '', '', ?, ?)
+            """,
+            (
+                agent_name,
+                agent_name.replace("-", " ").title(),
+                f"bottube_sk_{agent_name}",
+                created_at,
+                created_at,
+            ),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _headers(agent_name: str) -> dict[str, str]:
+    return {"X-API-Key": f"bottube_sk_{agent_name}"}
+
+
+def _unread_count(client, agent_name: str) -> int:
+    resp = client.get(
+        "/api/messages/unread-count",
+        headers=_headers(agent_name),
+    )
+    assert resp.status_code == 200
+    return int(resp.get_json()["unread"])
+
+
+def test_broadcast_read_state_is_per_recipient(client):
+    _insert_agent("sender", 1000.0)
+    _insert_agent("alice", 1001.0)
+    _insert_agent("bob", 1002.0)
+    create_resp = client.post(
+        "/api/messages",
+        headers=_headers("sender"),
+        json={"subject": "Notice", "body": "Broadcast update"},
+    )
+    assert create_resp.status_code == 201
+    message_id = create_resp.get_json()["message_id"]
+    assert _unread_count(client, "alice") == 1
+    assert _unread_count(client, "bob") == 1
+
+    read_resp = client.post(
+        f"/api/messages/{message_id}/read",
+        headers=_headers("alice"),
+    )
+
+    assert read_resp.status_code == 200
+    assert _unread_count(client, "alice") == 0
+    assert _unread_count(client, "bob") == 1
+
+    alice_inbox = client.get("/api/messages/inbox", headers=_headers("alice"))
+    bob_unread = client.get(
+        "/api/messages/inbox?unread_only=1",
+        headers=_headers("bob"),
+    )
+    assert alice_inbox.status_code == 200
+    assert bob_unread.status_code == 200
+    assert alice_inbox.get_json()["messages"][0]["read_at"]
+    assert [m["id"] for m in bob_unread.get_json()["messages"]] == [message_id]
+
+
+def test_direct_message_read_state_still_uses_recipient_only(client):
+    _insert_agent("sender", 1000.0)
+    _insert_agent("alice", 1001.0)
+    _insert_agent("bob", 1002.0)
+    create_resp = client.post(
+        "/api/messages",
+        headers=_headers("sender"),
+        json={"to": "bob", "subject": "Direct", "body": "For Bob"},
+    )
+    assert create_resp.status_code == 201
+    message_id = create_resp.get_json()["message_id"]
+
+    forbidden = client.post(
+        f"/api/messages/{message_id}/read",
+        headers=_headers("alice"),
+    )
+    assert forbidden.status_code == 403
+    assert _unread_count(client, "bob") == 1
+
+    read_resp = client.post(
+        f"/api/messages/{message_id}/read",
+        headers=_headers("bob"),
+    )
+
+    assert read_resp.status_code == 200
+    assert _unread_count(client, "bob") == 0


### PR DESCRIPTION
## Summary

- Add per-recipient read state for broadcast messages via `message_reads`.
- Keep direct-message reads on the existing `messages.read_at` field.
- Update inbox and unread-count queries so broadcast reads only apply to the current agent.
- Add regression coverage for broadcast reads across two recipients and direct-message recipient checks.

Closes #1186.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_message_reads.py -q` -> 2 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_message_reads.py` -> passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_message_reads.py` -> passed
- `git diff --check` -> passed
