### PR TITLE
Validate comment parent ids

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7228,6 +7228,8 @@ def _parse_optional_comment_parent_id(raw_parent_id):
             return None, None
     if isinstance(raw_parent_id, bool):
         return None, "parent_id must be an integer"
+    if isinstance(raw_parent_id, float) and not raw_parent_id.is_integer():
+        return None, "parent_id must be an integer"
     try:
         parent_id = int(raw_parent_id)
     except (TypeError, ValueError):

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7152,7 +7152,9 @@ def add_comment(video_id):
     if len(content) > 5000:
         return jsonify({"error": "Comment too long (max 5000 chars)"}), 400
 
-    parent_id = data.get("parent_id")
+    parent_id, parent_error = _parse_optional_comment_parent_id(data.get("parent_id"))
+    if parent_error:
+        return jsonify({"error": parent_error}), 400
     if parent_id is not None:
         parent = db.execute(
             "SELECT id FROM comments WHERE id = ? AND video_id = ?",
@@ -7217,6 +7219,24 @@ def add_comment(video_id):
     }), 201
 
 
+def _parse_optional_comment_parent_id(raw_parent_id):
+    if raw_parent_id is None:
+        return None, None
+    if isinstance(raw_parent_id, str):
+        raw_parent_id = raw_parent_id.strip()
+        if not raw_parent_id:
+            return None, None
+    if isinstance(raw_parent_id, bool):
+        return None, "parent_id must be an integer"
+    try:
+        parent_id = int(raw_parent_id)
+    except (TypeError, ValueError):
+        return None, "parent_id must be an integer"
+    if parent_id < 1:
+        return None, "parent_id must be a positive integer"
+    return parent_id, None
+
+
 @app.route("/api/videos/<video_id>/web-comment", methods=["POST"])
 def web_add_comment(video_id):
     """Add a comment from the web UI (requires login session)."""
@@ -7250,9 +7270,10 @@ def web_add_comment(video_id):
     if existing:
         return jsonify({"error": "Duplicate comment"}), 409
 
-    parent_id = data.get("parent_id")
+    parent_id, parent_error = _parse_optional_comment_parent_id(data.get("parent_id"))
+    if parent_error:
+        return jsonify({"error": parent_error}), 400
     if parent_id is not None:
-        parent_id = int(parent_id)
         parent = db.execute(
             "SELECT id FROM comments WHERE id = ? AND video_id = ?", (parent_id, video_id)
         ).fetchone()

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -334,6 +334,66 @@ def test_web_comment_rejects_malformed_parent_id(client):
     assert comment_count == 0
 
 
+def test_api_comment_rejects_fractional_parent_id(client):
+    commenter_id = _insert_agent("replyapi", "bottube_sk_replyapi")
+    owner_id = _insert_agent("replyowner", "bottube_sk_replyowner")
+    _insert_video(owner_id, "replyvideo02A")
+
+    resp = client.post(
+        "/api/videos/replyvideo02A/comment",
+        headers={"X-API-Key": "bottube_sk_replyapi"},
+        json={
+            "content": "Fractional parents should not be truncated",
+            "parent_id": 1.9,
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "parent_id must be an integer"
+
+    conn = sqlite3.connect(bottube_server.DB_PATH)
+    try:
+        comment_count = conn.execute(
+            "SELECT COUNT(*) FROM comments WHERE video_id = 'replyvideo02A'",
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert comment_count == 0
+
+
+def test_web_comment_rejects_fractional_parent_id(client):
+    commenter_id = _insert_agent("replyweb", "bottube_sk_replyweb")
+    owner_id = _insert_agent("replytarget", "bottube_sk_replytarget")
+    _insert_video(owner_id, "replyvideo03A")
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = commenter_id
+        sess["csrf_token"] = "test-csrf"
+
+    resp = client.post(
+        "/api/videos/replyvideo03A/web-comment",
+        headers={"X-CSRF-Token": "test-csrf"},
+        json={
+            "content": "Fractional parents should not be truncated",
+            "parent_id": 1.9,
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "parent_id must be an integer"
+
+    conn = sqlite3.connect(bottube_server.DB_PATH)
+    try:
+        comment_count = conn.execute(
+            "SELECT COUNT(*) FROM comments WHERE video_id = 'replyvideo03A'",
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert comment_count == 0
+
+
 def test_admin_ban_defaults_to_coaching_hold_instead_of_ban(client):
     agent_id = _insert_agent("coachme", "bottube_sk_coachme")
 

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -302,6 +302,38 @@ def test_suspicious_comment_reward_is_held_for_review(client):
     assert comment_earnings == 0
 
 
+def test_web_comment_rejects_malformed_parent_id(client):
+    commenter_id = _insert_agent("replyalice", "bottube_sk_replyalice")
+    owner_id = _insert_agent("replybob", "bottube_sk_replybob")
+    _insert_video(owner_id, "replyvideo01A")
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = commenter_id
+        sess["csrf_token"] = "test-csrf"
+
+    resp = client.post(
+        "/api/videos/replyvideo01A/web-comment",
+        headers={"X-CSRF-Token": "test-csrf"},
+        json={
+            "content": "This should stay a validation error",
+            "parent_id": "not-an-id",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "parent_id must be an integer"
+
+    conn = sqlite3.connect(bottube_server.DB_PATH)
+    try:
+        comment_count = conn.execute(
+            "SELECT COUNT(*) FROM comments WHERE video_id = 'replyvideo01A'",
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert comment_count == 0
+
+
 def test_admin_ban_defaults_to_coaching_hold_instead_of_ban(client):
     agent_id = _insert_agent("coachme", "bottube_sk_coachme")
 


### PR DESCRIPTION
## Summary
- add shared parsing for optional comment `parent_id` values
- return 400 for malformed or non-positive parent ids before comment insertion
- cover the logged-in web comment malformed-parent case with a regression test

Closes #1190

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_quests.py::test_web_comment_rejects_malformed_parent_id -q` -> 1 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_quests.py::test_suspicious_comment_reward_is_held_for_review -q` -> 1 passed, 1 existing utcfromtimestamp warning
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_quests.py` -> passed
- `git diff --check` -> passed