### PR TITLE
Validate message text fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15129,6 +15129,18 @@ def _gen_message_id():
     return f"msg_{secrets.token_hex(12)}"
 
 
+def _message_text_field(data, field, default="", max_length=None):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, f"{field} must be a string"
+    value = value.strip()
+    if max_length is not None:
+        value = value[:max_length]
+    return value, None
+
+
 def _send_system_message(db, to_agent: str, subject: str, body: str,
                          msg_type: str = "system"):
     """Send a system-generated message to an agent."""
@@ -15154,10 +15166,25 @@ def send_message():
     }
     """
     data = request.get_json(silent=True) or {}
-    to_agent = data.get("to", "").strip() or None
-    subject = data.get("subject", "").strip()[:200]
-    body = data.get("body", "").strip()[:5000]
-    msg_type = data.get("message_type", "general").strip()
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+
+    to_agent, error = _message_text_field(data, "to")
+    if error:
+        return jsonify({"error": error}), 400
+    to_agent = to_agent or None
+
+    subject, error = _message_text_field(data, "subject", max_length=200)
+    if error:
+        return jsonify({"error": error}), 400
+
+    body, error = _message_text_field(data, "body", max_length=5000)
+    if error:
+        return jsonify({"error": error}), 400
+
+    msg_type, error = _message_text_field(data, "message_type", default="general")
+    if error:
+        return jsonify({"error": error}), 400
 
     if not body:
         return jsonify({"error": "body is required"}), 400

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15165,8 +15165,10 @@ def send_message():
         "message_type": "general"  (general, system, moderation, alert)
     }
     """
-    data = request.get_json(silent=True) or {}
-    if not isinstance(data, dict):
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
         return jsonify({"error": "JSON body must be an object"}), 400
 
     to_agent, error = _message_text_field(data, "to")

--- a/tests/test_message_input_validation.py
+++ b/tests/test_message_input_validation.py
@@ -123,3 +123,17 @@ def test_send_message_rejects_non_string_to_without_insert(client):
     assert resp.status_code == 400
     assert resp.get_json() == {"error": "to must be a string"}
     assert _message_count() == 0
+
+
+def test_send_message_rejects_falsy_non_object_json(client):
+    _insert_agent("alice", "bottube_sk_alice")
+
+    resp = client.post(
+        "/api/messages",
+        headers={"X-API-Key": "bottube_sk_alice"},
+        json=[],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+    assert _message_count() == 0

--- a/tests/test_message_input_validation.py
+++ b/tests/test_message_input_validation.py
@@ -1,0 +1,125 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_message_input_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_message_input_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_message_input_test.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_agent(agent_name: str, api_key: str) -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, bio, avatar_url,
+                 created_at, last_active)
+            VALUES (?, ?, ?, '', '', ?, ?)
+            """,
+            (agent_name, agent_name.title(), api_key, 1.0, 1.0),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _message_count() -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        return int(db.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
+
+
+def test_send_message_accepts_documented_null_to_broadcast(client):
+    _insert_agent("alice", "bottube_sk_alice")
+
+    resp = client.post(
+        "/api/messages",
+        headers={"X-API-Key": "bottube_sk_alice"},
+        json={"to": None, "subject": "Notice", "body": "hello agents"},
+    )
+
+    assert resp.status_code == 201
+    message_id = resp.get_json()["message_id"]
+
+    with bottube_server.app.app_context():
+        row = bottube_server.get_db().execute(
+            """
+            SELECT from_agent, to_agent, subject, body, message_type
+            FROM messages
+            WHERE id = ?
+            """,
+            (message_id,),
+        ).fetchone()
+
+    assert row["from_agent"] == "alice"
+    assert row["to_agent"] is None
+    assert row["subject"] == "Notice"
+    assert row["body"] == "hello agents"
+    assert row["message_type"] == "general"
+
+
+def test_send_message_rejects_non_string_to_without_insert(client):
+    _insert_agent("alice", "bottube_sk_alice")
+
+    resp = client.post(
+        "/api/messages",
+        headers={"X-API-Key": "bottube_sk_alice"},
+        json={"to": {"agent": "bob"}, "body": "hello"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "to must be a string"}
+    assert _message_count() == 0


### PR DESCRIPTION
## Summary

- fixes `POST /api/messages` so documented `to: null` broadcasts no longer crash during `.strip()` parsing
- adds shared message text-field normalization for `to`, `subject`, `body`, and `message_type`
- rejects non-string message fields with 400 validation errors before inserting messages
- adds focused regression coverage for null broadcast recipients and malformed `to` values

Fixes #1192.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_message_input_validation.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_message_input_validation.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_message_input_validation.py`
- `git diff --check`
