### PR TITLE
Validate register JSON fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -4629,8 +4629,10 @@ def register_agent():
     if not _rate_limit(f"register:{ip}", 5, 3600):
         return jsonify({"error": "Too many registrations. Try again later."}), 429
 
-    data = request.get_json(silent=True) or {}
-    if not isinstance(data, dict):
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
         return jsonify({"error": "JSON body must be an object"}), 400
 
     agent_name, error = _register_text_field(data, "agent_name")

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -4611,6 +4611,16 @@ def api_docs_swagger_ui():
     # Self-hosted Swagger UI assets (no CDN dependency).
     return render_template("api_swagger.html")
 
+
+def _register_text_field(data, field, default=""):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, f"{field} must be a string"
+    return value.strip(), None
+
+
 @app.route("/api/register", methods=["POST"])
 def register_agent():
     """Register a new agent and return API key."""
@@ -4620,9 +4630,22 @@ def register_agent():
         return jsonify({"error": "Too many registrations. Try again later."}), 429
 
     data = request.get_json(silent=True) or {}
-    agent_name = data.get("agent_name", "").strip().lower()
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+
+    agent_name, error = _register_text_field(data, "agent_name")
+    if error:
+        return jsonify({"error": error}), 400
+    agent_name = agent_name.lower()
+
+    ref_code_raw, error = _register_text_field(data, "ref_code")
+    if error:
+        return jsonify({"error": error}), 400
+    ref_raw, error = _register_text_field(data, "ref")
+    if error:
+        return jsonify({"error": error}), 400
     ref_code = _normalize_ref_code(
-        data.get("ref_code", "") or data.get("ref", "") or request.args.get("ref", "")
+        ref_code_raw or ref_raw or request.args.get("ref", "")
     )
 
     if not agent_name:
@@ -4641,10 +4664,24 @@ def register_agent():
                 "allowed_track": _normalize_referral_track(ref["allowed_track"], "both"),
             }), 400
 
-    display_name = _strip_script_tags(data.get("display_name", agent_name).strip()[:MAX_DISPLAY_NAME_LENGTH])
-    bio = _strip_script_tags(data.get("bio", "").strip()[:MAX_BIO_LENGTH])
-    avatar_url = data.get("avatar_url", "").strip()
-    x_handle = data.get("x_handle", "").strip().lstrip("@")[:32]
+    display_name, error = _register_text_field(
+        data, "display_name", default=agent_name
+    )
+    if error:
+        return jsonify({"error": error}), 400
+    bio, error = _register_text_field(data, "bio")
+    if error:
+        return jsonify({"error": error}), 400
+    avatar_url, error = _register_text_field(data, "avatar_url")
+    if error:
+        return jsonify({"error": error}), 400
+    x_handle, error = _register_text_field(data, "x_handle")
+    if error:
+        return jsonify({"error": error}), 400
+
+    display_name = _strip_script_tags(display_name[:MAX_DISPLAY_NAME_LENGTH])
+    bio = _strip_script_tags(bio[:MAX_BIO_LENGTH])
+    x_handle = x_handle.lstrip("@")[:32]
 
     # Validate avatar_url if provided
     if avatar_url:

--- a/tests/test_register_input_validation.py
+++ b/tests/test_register_input_validation.py
@@ -39,3 +39,10 @@ def test_register_rejects_non_object_json(client):
 
     assert resp.status_code == 400
     assert resp.get_json() == {"error": "JSON body must be an object"}
+
+
+def test_register_rejects_falsy_non_object_json(client):
+    resp = client.post("/api/register", json=[])
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}

--- a/tests/test_register_input_validation.py
+++ b/tests/test_register_input_validation.py
@@ -1,0 +1,41 @@
+def test_register_null_agent_name_returns_validation_error(client):
+    resp = client.post("/api/register", json={"agent_name": None})
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "agent_name is required"}
+
+
+def test_register_rejects_non_string_optional_fields_without_insert(client):
+    resp = client.post(
+        "/api/register",
+        json={"agent_name": "typed_bot", "display_name": ["bad"]},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "display_name must be a string"}
+
+    retry = client.post("/api/register", json={"agent_name": "typed_bot"})
+    assert retry.status_code == 201
+
+
+def test_register_accepts_null_optional_fields_as_defaults(client):
+    resp = client.post(
+        "/api/register",
+        json={
+            "agent_name": "null_optional_bot",
+            "display_name": None,
+            "bio": None,
+            "avatar_url": None,
+            "x_handle": None,
+        },
+    )
+
+    assert resp.status_code == 201
+    assert resp.get_json()["agent_name"] == "null_optional_bot"
+
+
+def test_register_rejects_non_object_json(client):
+    resp = client.post("/api/register", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}


### PR DESCRIPTION
## Summary

- fixes `/api/register` so malformed-but-valid JSON does not crash before validation
- normalizes registration text fields before trimming/lowercasing
- keeps null optional fields on their existing defaults and rejects non-string text fields with 400
- rejects non-object JSON payloads with 400
- adds focused regression coverage and keeps the existing registration flow tests passing

Fixes #1194.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_register_input_validation.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_upload_api.py::TestRegistrationFlow -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_register_input_validation.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_register_input_validation.py`
- `git diff --check`
