### PR TITLE
Validate comment JSON fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7129,6 +7129,15 @@ def describe_video(video_id):
 # Comments
 # ---------------------------------------------------------------------------
 
+def _comment_text_field(data, field, default=""):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, f"{field} must be a string"
+    return value.strip(), None
+
+
 @app.route("/api/videos/<video_id>/comment", methods=["POST"])
 @require_api_key
 def add_comment(video_id):
@@ -7143,8 +7152,16 @@ def add_comment(video_id):
         return jsonify({"error": "Video not found"}), 404
 
     data = request.get_json(silent=True) or {}
-    content = data.get("content", "").strip()
-    comment_type = (data.get("comment_type") or "comment").strip().lower()
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+
+    content, error = _comment_text_field(data, "content")
+    if error:
+        return jsonify({"error": error}), 400
+    comment_type, error = _comment_text_field(data, "comment_type", default="comment")
+    if error:
+        return jsonify({"error": error}), 400
+    comment_type = comment_type.lower()
     if not content:
         return jsonify({"error": "content is required"}), 400
     if comment_type not in COMMENT_TYPES:
@@ -7233,8 +7250,16 @@ def web_add_comment(video_id):
         return jsonify({"error": "Video not found"}), 404
 
     data = request.get_json(silent=True) or {}
-    content = data.get("content", "").strip()
-    comment_type = (data.get("comment_type") or "comment").strip().lower()
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+
+    content, error = _comment_text_field(data, "content")
+    if error:
+        return jsonify({"error": error}), 400
+    comment_type, error = _comment_text_field(data, "comment_type", default="comment")
+    if error:
+        return jsonify({"error": error}), 400
+    comment_type = comment_type.lower()
     if not content:
         return jsonify({"error": "content is required"}), 400
     if comment_type not in COMMENT_TYPES:

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7151,8 +7151,10 @@ def add_comment(video_id):
     if not video:
         return jsonify({"error": "Video not found"}), 404
 
-    data = request.get_json(silent=True) or {}
-    if not isinstance(data, dict):
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
         return jsonify({"error": "JSON body must be an object"}), 400
 
     content, error = _comment_text_field(data, "content")
@@ -7249,8 +7251,10 @@ def web_add_comment(video_id):
     if not video:
         return jsonify({"error": "Video not found"}), 404
 
-    data = request.get_json(silent=True) or {}
-    if not isinstance(data, dict):
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
         return jsonify({"error": "JSON body must be an object"}), 400
 
     content, error = _comment_text_field(data, "content")

--- a/tests/test_comment_input_validation.py
+++ b/tests/test_comment_input_validation.py
@@ -1,0 +1,161 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_comment_input_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_comment_input_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_comment_input_test.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_agent(agent_name: str, api_key: str) -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, bio, avatar_url,
+                 created_at, last_active)
+            VALUES (?, ?, ?, '', '', ?, ?)
+            """,
+            (agent_name, agent_name.title(), api_key, 1.0, 1.0),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _insert_video(agent_id: int, video_id: str) -> None:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, filename, created_at, is_removed)
+            VALUES (?, ?, ?, ?, ?, 0)
+            """,
+            (video_id, agent_id, f"Video {video_id}", f"{video_id}.mp4", 2.0),
+        )
+        db.commit()
+
+
+def _comment_count() -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        return int(db.execute("SELECT COUNT(*) FROM comments").fetchone()[0])
+
+
+def test_api_comment_null_content_returns_validation_error(client):
+    commenter_id = _insert_agent("alice", "bottube_sk_alice")
+    _insert_video(commenter_id, "alicevideo01A")
+
+    resp = client.post(
+        "/api/videos/alicevideo01A/comment",
+        headers={"X-API-Key": "bottube_sk_alice"},
+        json={"content": None},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "content is required"}
+    assert _comment_count() == 0
+
+
+def test_api_comment_rejects_non_string_comment_type_without_insert(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("alice", "bottube_sk_alice")
+    _insert_video(owner_id, "ownervideo01A")
+
+    resp = client.post(
+        "/api/videos/ownervideo01A/comment",
+        headers={"X-API-Key": "bottube_sk_alice"},
+        json={"content": "good video", "comment_type": ["review"]},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "comment_type must be a string"}
+    assert _comment_count() == 0
+
+
+def test_api_comment_accepts_null_comment_type_as_default(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("alice", "bottube_sk_alice")
+    _insert_video(owner_id, "ownervideo01A")
+
+    resp = client.post(
+        "/api/videos/ownervideo01A/comment",
+        headers={"X-API-Key": "bottube_sk_alice"},
+        json={"content": "good video", "comment_type": None},
+    )
+
+    assert resp.status_code == 201
+    assert resp.get_json()["comment_type"] == "comment"
+
+
+def test_web_comment_rejects_non_object_json(client):
+    user_id = _insert_agent("webalice", "bottube_sk_webalice")
+    _insert_video(user_id, "webvideo01A")
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+        sess["csrf_token"] = "test-csrf"
+
+    resp = client.post(
+        "/api/videos/webvideo01A/web-comment",
+        headers={"X-CSRF-Token": "test-csrf"},
+        json=["not", "an", "object"],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+    assert _comment_count() == 0

--- a/tests/test_comment_input_validation.py
+++ b/tests/test_comment_input_validation.py
@@ -142,6 +142,22 @@ def test_api_comment_accepts_null_comment_type_as_default(client):
     assert resp.get_json()["comment_type"] == "comment"
 
 
+def test_api_comment_rejects_falsy_non_object_json(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("alice", "bottube_sk_alice")
+    _insert_video(owner_id, "ownervideo02A")
+
+    resp = client.post(
+        "/api/videos/ownervideo02A/comment",
+        headers={"X-API-Key": "bottube_sk_alice"},
+        json=[],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+    assert _comment_count() == 0
+
+
 def test_web_comment_rejects_non_object_json(client):
     user_id = _insert_agent("webalice", "bottube_sk_webalice")
     _insert_video(user_id, "webvideo01A")
@@ -154,6 +170,25 @@ def test_web_comment_rejects_non_object_json(client):
         "/api/videos/webvideo01A/web-comment",
         headers={"X-CSRF-Token": "test-csrf"},
         json=["not", "an", "object"],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+    assert _comment_count() == 0
+
+
+def test_web_comment_rejects_falsy_non_object_json(client):
+    user_id = _insert_agent("webbob", "bottube_sk_webbob")
+    _insert_video(user_id, "webvideo02A")
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+        sess["csrf_token"] = "test-csrf"
+
+    resp = client.post(
+        "/api/videos/webvideo02A/web-comment",
+        headers={"X-CSRF-Token": "test-csrf"},
+        json=[],
     )
 
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary

- fixes API and web comment routes so malformed-but-valid JSON text/type fields do not crash before validation
- requires parsed comment JSON bodies to be objects
- keeps null/missing `comment_type` on the existing `comment` default
- rejects non-string `content` and `comment_type` with deterministic 400 responses
- adds focused regression coverage for API and web comment input validation

Fixes #1196.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_comment_input_validation.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_quests.py::test_suspicious_comment_reward_is_held_for_review -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_comment_input_validation.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_comment_input_validation.py`
- `git diff --check`
