### PR TITLE
Validate report JSON fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15453,6 +15453,19 @@ def api_related_videos(video_id):
 
 REPORT_REASONS = {"spam", "inappropriate", "copyright", "harassment", "misleading", "other"}
 
+
+def _report_text_field(data, field, default="", max_length=None):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, f"{field} must be a string"
+    value = value.strip()
+    if max_length is not None:
+        value = value[:max_length]
+    return value, None
+
+
 def _get_reporter_id():
     """Get reporter agent ID from either API key auth or browser session."""
     # API key auth (check header directly since @require_api_key may not be applied)
@@ -15483,8 +15496,16 @@ def report_video(video_id):
         return jsonify({"error": "Video not found"}), 404
 
     data = request.get_json(silent=True) or {}
-    reason = data.get("reason", "").strip().lower()
-    details = data.get("details", "").strip()[:1000]
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+
+    reason, error = _report_text_field(data, "reason")
+    if error:
+        return jsonify({"error": error}), 400
+    reason = reason.lower()
+    details, error = _report_text_field(data, "details", max_length=1000)
+    if error:
+        return jsonify({"error": error}), 400
 
     if reason not in REPORT_REASONS:
         return jsonify({"error": f"Invalid reason. Must be one of: {', '.join(sorted(REPORT_REASONS))}"}), 400
@@ -15552,8 +15573,16 @@ def report_comment(comment_id):
         return jsonify({"error": "Comment not found"}), 404
 
     data = request.get_json(silent=True) or {}
-    reason = data.get("reason", "").strip().lower()
-    details = data.get("details", "").strip()[:1000]
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+
+    reason, error = _report_text_field(data, "reason")
+    if error:
+        return jsonify({"error": error}), 400
+    reason = reason.lower()
+    details, error = _report_text_field(data, "details", max_length=1000)
+    if error:
+        return jsonify({"error": error}), 400
 
     if reason not in REPORT_REASONS:
         return jsonify({"error": f"Invalid reason. Must be one of: {', '.join(sorted(REPORT_REASONS))}"}), 400

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15495,8 +15495,10 @@ def report_video(video_id):
     if not video:
         return jsonify({"error": "Video not found"}), 404
 
-    data = request.get_json(silent=True) or {}
-    if not isinstance(data, dict):
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
         return jsonify({"error": "JSON body must be an object"}), 400
 
     reason, error = _report_text_field(data, "reason")
@@ -15572,8 +15574,10 @@ def report_comment(comment_id):
     if not comment:
         return jsonify({"error": "Comment not found"}), 404
 
-    data = request.get_json(silent=True) or {}
-    if not isinstance(data, dict):
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
         return jsonify({"error": "JSON body must be an object"}), 400
 
     reason, error = _report_text_field(data, "reason")

--- a/tests/test_report_input_validation.py
+++ b/tests/test_report_input_validation.py
@@ -176,6 +176,39 @@ def test_comment_report_rejects_non_object_json(client):
     assert _report_count() == 0
 
 
+def test_video_report_rejects_falsy_non_object_json(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("reporter", "bottube_sk_reporter")
+    _insert_video(owner_id, "ownervideo02A")
+
+    resp = client.post(
+        "/api/videos/ownervideo02A/report",
+        headers={"X-API-Key": "bottube_sk_reporter"},
+        json=[],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+    assert _report_count() == 0
+
+
+def test_comment_report_rejects_falsy_non_object_json(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("reporter", "bottube_sk_reporter")
+    _insert_video(owner_id, "ownervideo03A")
+    comment_id = _insert_comment(owner_id, "ownervideo03A", "spammy")
+
+    resp = client.post(
+        f"/api/comments/{comment_id}/report",
+        headers={"X-API-Key": "bottube_sk_reporter"},
+        json=[],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+    assert _report_count() == 0
+
+
 def test_video_report_accepts_null_details_as_empty(client):
     owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
     _insert_agent("reporter", "bottube_sk_reporter")

--- a/tests/test_report_input_validation.py
+++ b/tests/test_report_input_validation.py
@@ -1,0 +1,192 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_report_input_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_report_input_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_report_input_test.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_agent(agent_name: str, api_key: str) -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, bio, avatar_url,
+                 created_at, last_active)
+            VALUES (?, ?, ?, '', '', ?, ?)
+            """,
+            (agent_name, agent_name.title(), api_key, 1.0, 1.0),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _insert_video(agent_id: int, video_id: str) -> None:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO videos
+                (video_id, agent_id, title, filename, created_at, is_removed)
+            VALUES (?, ?, ?, ?, ?, 0)
+            """,
+            (video_id, agent_id, f"Video {video_id}", f"{video_id}.mp4", 2.0),
+        )
+        db.commit()
+
+
+def _insert_comment(agent_id: int, video_id: str, content: str) -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO comments (video_id, agent_id, content, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (video_id, agent_id, content, 3.0),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _report_count() -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        return int(db.execute("SELECT COUNT(*) FROM reports").fetchone()[0])
+
+
+def test_video_report_null_reason_uses_existing_invalid_reason_error(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("reporter", "bottube_sk_reporter")
+    _insert_video(owner_id, "ownervideo01A")
+
+    resp = client.post(
+        "/api/videos/ownervideo01A/report",
+        headers={"X-API-Key": "bottube_sk_reporter"},
+        json={"reason": None},
+    )
+
+    assert resp.status_code == 400
+    assert "Invalid reason" in resp.get_json()["error"]
+    assert _report_count() == 0
+
+
+def test_video_report_rejects_non_string_details_without_insert(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("reporter", "bottube_sk_reporter")
+    _insert_video(owner_id, "ownervideo01A")
+
+    resp = client.post(
+        "/api/videos/ownervideo01A/report",
+        headers={"X-API-Key": "bottube_sk_reporter"},
+        json={"reason": "spam", "details": {"text": "bad"}},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "details must be a string"}
+    assert _report_count() == 0
+
+
+def test_comment_report_rejects_non_string_reason_without_insert(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("reporter", "bottube_sk_reporter")
+    _insert_video(owner_id, "ownervideo01A")
+    comment_id = _insert_comment(owner_id, "ownervideo01A", "spammy")
+
+    resp = client.post(
+        f"/api/comments/{comment_id}/report",
+        headers={"X-API-Key": "bottube_sk_reporter"},
+        json={"reason": ["spam"], "details": "bad comment"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "reason must be a string"}
+    assert _report_count() == 0
+
+
+def test_comment_report_rejects_non_object_json(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("reporter", "bottube_sk_reporter")
+    _insert_video(owner_id, "ownervideo01A")
+    comment_id = _insert_comment(owner_id, "ownervideo01A", "spammy")
+
+    resp = client.post(
+        f"/api/comments/{comment_id}/report",
+        headers={"X-API-Key": "bottube_sk_reporter"},
+        json=["not", "an", "object"],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+    assert _report_count() == 0
+
+
+def test_video_report_accepts_null_details_as_empty(client):
+    owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
+    _insert_agent("reporter", "bottube_sk_reporter")
+    _insert_video(owner_id, "ownervideo01A")
+
+    resp = client.post(
+        "/api/videos/ownervideo01A/report",
+        headers={"X-API-Key": "bottube_sk_reporter"},
+        json={"reason": "spam", "details": None},
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+    assert _report_count() == 1


### PR DESCRIPTION
## Summary

- fixes video and comment report routes so malformed-but-valid JSON fields do not crash before validation
- rejects non-object report JSON payloads with 400
- keeps null/missing `details` on the existing empty-string behavior
- rejects non-string `reason` and `details` with deterministic 400 responses
- adds focused regression coverage for video and comment report input validation

Fixes #1198.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_report_input_validation.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_report_input_validation.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_report_input_validation.py`
- `git diff --check`
