### PR TITLE
Validate profile JSON fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9582,9 +9582,15 @@ def update_profile():
     """Update your agent profile (bio, display_name, avatar_url)."""
     data = request.get_json(silent=True) or {}
     ALLOWED = {"display_name", "bio", "avatar_url", "banner_url", "accent_color", "pinned_video_id"}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
     # Fields that contain user-visible text and need script tag sanitization
     _TEXT_FIELDS = {"display_name", "bio"}
-    updates = {k: v for k, v in data.items() if k in ALLOWED and isinstance(v, str)}
+    invalid_fields = [k for k, v in data.items() if k in ALLOWED and not isinstance(v, str)]
+    if invalid_fields:
+        field = sorted(invalid_fields)[0]
+        return jsonify({"error": f"{field} must be a string"}), 400
+    updates = {k: v for k, v in data.items() if k in ALLOWED}
     if not updates:
         return jsonify({"error": "Provide at least one field: display_name, bio, avatar_url"}), 400
     for field in _TEXT_FIELDS:

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9580,7 +9580,9 @@ def platform_stats():
 @require_api_key
 def update_profile():
     """Update your agent profile (bio, display_name, avatar_url)."""
-    data = request.get_json(silent=True) or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
     ALLOWED = {"display_name", "bio", "avatar_url", "banner_url", "accent_color", "pinned_video_id"}
     if not isinstance(data, dict):
         return jsonify({"error": "JSON body must be an object"}), 400

--- a/tests/test_profile_input_validation.py
+++ b/tests/test_profile_input_validation.py
@@ -1,0 +1,139 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_profile_input_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_profile_input_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_profile_input_test.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_agent(agent_name: str, api_key: str) -> int:
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """
+            INSERT INTO agents
+                (agent_name, display_name, api_key, bio, avatar_url,
+                 created_at, last_active)
+            VALUES (?, ?, ?, '', '', ?, ?)
+            """,
+            (agent_name, agent_name.title(), api_key, 1.0, 1.0),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _profile_row(agent_name: str):
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        return db.execute(
+            """
+            SELECT display_name, bio, avatar_url
+            FROM agents
+            WHERE agent_name = ?
+            """,
+            (agent_name,),
+        ).fetchone()
+
+
+def test_profile_update_rejects_non_object_json(client):
+    _insert_agent("profilebot", "bottube_sk_profile")
+
+    resp = client.patch(
+        "/api/agents/me/profile",
+        headers={"X-API-Key": "bottube_sk_profile"},
+        json=["not", "an", "object"],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+
+
+def test_profile_update_rejects_non_string_allowed_field(client):
+    _insert_agent("profilebot", "bottube_sk_profile")
+
+    resp = client.patch(
+        "/api/agents/me/profile",
+        headers={"X-API-Key": "bottube_sk_profile"},
+        json={"display_name": ["bad"], "bio": "clean bio"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "display_name must be a string"}
+    row = _profile_row("profilebot")
+    assert row["bio"] == ""
+
+
+def test_profile_update_still_accepts_valid_text_fields(client):
+    _insert_agent("profilebot", "bottube_sk_profile")
+
+    resp = client.patch(
+        "/api/agents/me/profile",
+        headers={"X-API-Key": "bottube_sk_profile"},
+        json={
+            "display_name": "Profile Bot",
+            "bio": "Clean bio",
+            "avatar_url": "https://example.com/avatar.png",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body["updated_fields"]) == {"display_name", "bio", "avatar_url"}
+    row = _profile_row("profilebot")
+    assert row["display_name"] == "Profile Bot"
+    assert row["bio"] == "Clean bio"
+    assert row["avatar_url"] == "https://example.com/avatar.png"

--- a/tests/test_profile_input_validation.py
+++ b/tests/test_profile_input_validation.py
@@ -102,6 +102,19 @@ def test_profile_update_rejects_non_object_json(client):
     assert resp.get_json() == {"error": "JSON body must be an object"}
 
 
+def test_profile_update_rejects_falsy_non_object_json(client):
+    _insert_agent("profilebot", "bottube_sk_profile")
+
+    resp = client.patch(
+        "/api/agents/me/profile",
+        headers={"X-API-Key": "bottube_sk_profile"},
+        json=[],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+
+
 def test_profile_update_rejects_non_string_allowed_field(client):
     _insert_agent("profilebot", "bottube_sk_profile")
 


### PR DESCRIPTION
## Summary

- fixes `/api/agents/me/profile` so non-object JSON payloads return 400 instead of crashing on `data.items()`
- rejects non-string values for allowed profile fields with deterministic 400 responses
- avoids partial profile updates when an allowed field is malformed
- preserves valid text/avatar profile updates and existing quest refresh behavior
- adds focused regression coverage for malformed and valid profile updates

Fixes #1200.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_profile_input_validation.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_quests.py::test_quests_endpoint_unlocks_onboarding_flow -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_profile_input_validation.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_profile_input_validation.py`
- `git diff --check`
