### PR TITLE
Validate public report JSON fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -18371,6 +18371,15 @@ def agent_accept_terms():
 
 # --- Public report endpoint -----------------------------------------------
 
+def _public_report_text_field(data, field, max_length):
+    value = data.get(field, "")
+    if value is None:
+        value = ""
+    if not isinstance(value, str):
+        return None, f"{field} must be a string"
+    return value.strip()[:max_length], None
+
+
 @app.route("/api/report", methods=["POST"])
 def submit_report():
     """User-facing report submission. Anonymous accepted, rate-limited per IP."""
@@ -18380,10 +18389,22 @@ def submit_report():
         return jsonify({"ok": False, "error": "Too many reports from this IP. Try again later."}), 429
 
     data = request.get_json(silent=True) or {}
-    category = (data.get("category") or "").strip().lower()[:32]
-    target = (data.get("target") or "").strip()[:512]
-    detail = (data.get("detail") or "").strip()[:4000]
-    email = (data.get("email") or "").strip()[:200]
+    if not isinstance(data, dict):
+        return jsonify({"ok": False, "error": "JSON body must be an object"}), 400
+
+    category, error = _public_report_text_field(data, "category", 32)
+    if error:
+        return jsonify({"ok": False, "error": error}), 400
+    category = category.lower()
+    target, error = _public_report_text_field(data, "target", 512)
+    if error:
+        return jsonify({"ok": False, "error": error}), 400
+    detail, error = _public_report_text_field(data, "detail", 4000)
+    if error:
+        return jsonify({"ok": False, "error": error}), 400
+    email, error = _public_report_text_field(data, "email", 200)
+    if error:
+        return jsonify({"ok": False, "error": error}), 400
 
     valid_cats = {"csam", "illegal", "ncii", "ip", "harassment",
                   "impersonation", "malware", "spam", "minor", "other"}

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -18388,8 +18388,10 @@ def submit_report():
     if not _rate_limit(f"report:{ip}", 10, 3600):
         return jsonify({"ok": False, "error": "Too many reports from this IP. Try again later."}), 429
 
-    data = request.get_json(silent=True) or {}
-    if not isinstance(data, dict):
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
         return jsonify({"ok": False, "error": "JSON body must be an object"}), 400
 
     category, error = _public_report_text_field(data, "category", 32)

--- a/tests/test_public_report_input_validation.py
+++ b/tests/test_public_report_input_validation.py
@@ -1,0 +1,143 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_public_report_input_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_public_report_input_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_public_report_input_test.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+    bottube_server._TS_SCHEMA_READY = False
+    bottube_server.init_db()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _report_count() -> int:
+    with bottube_server.app.app_context():
+        bottube_server._ensure_ts_schema()
+        db = bottube_server.get_db()
+        row = db.execute("SELECT COUNT(*) FROM moderation_reports").fetchone()
+        return int(row[0])
+
+
+def test_public_report_rejects_non_object_json(client):
+    resp = client.post("/api/report", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "JSON body must be an object",
+    }
+    assert _report_count() == 0
+
+
+def test_public_report_rejects_non_string_category_without_insert(client):
+    resp = client.post(
+        "/api/report",
+        json={
+            "category": ["spam"],
+            "target": "https://bottube.ai/watch/abc123",
+            "detail": "This report has enough detail.",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "category must be a string",
+    }
+    assert _report_count() == 0
+
+
+def test_public_report_rejects_non_string_email_without_insert(client):
+    resp = client.post(
+        "/api/report",
+        json={
+            "category": "spam",
+            "target": "https://bottube.ai/watch/abc123",
+            "detail": "This report has enough detail.",
+            "email": {"address": "reporter@example.com"},
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"ok": False, "error": "email must be a string"}
+    assert _report_count() == 0
+
+
+def test_public_report_null_fields_use_existing_required_validations(client):
+    resp = client.post(
+        "/api/report",
+        json={"category": None, "target": None, "detail": None, "email": None},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"ok": False, "error": "invalid category"}
+    assert _report_count() == 0
+
+
+def test_public_report_still_accepts_valid_report(client):
+    resp = client.post(
+        "/api/report",
+        json={
+            "category": "spam",
+            "target": "https://bottube.ai/watch/abc123",
+            "detail": "This report has enough detail for review.",
+            "email": "reporter@example.com",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["severity"] == "normal"
+    assert _report_count() == 1

--- a/tests/test_public_report_input_validation.py
+++ b/tests/test_public_report_input_validation.py
@@ -80,6 +80,17 @@ def test_public_report_rejects_non_object_json(client):
     assert _report_count() == 0
 
 
+def test_public_report_rejects_falsy_non_object_json(client):
+    resp = client.post("/api/report", json=[])
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "JSON body must be an object",
+    }
+    assert _report_count() == 0
+
+
 def test_public_report_rejects_non_string_category_without_insert(client):
     resp = client.post(
         "/api/report",


### PR DESCRIPTION
## Summary

- fixes `/api/report` so non-object JSON payloads return 400 instead of crashing on `.get()`
- rejects non-string `category`, `target`, `detail`, and `email` values with deterministic 400 responses
- keeps null/missing fields on the existing required/invalid validation paths
- preserves valid anonymous public report insertion
- adds focused regression coverage for malformed and valid public report inputs

Fixes #1204.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_public_report_input_validation.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m flake8 tests/test_public_report_input_validation.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile bottube_server.py tests/test_public_report_input_validation.py`
- `git diff --check`
