### PR TITLE
Fix documented search agent and tag filters

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7827,6 +7827,8 @@ def search_videos():
 
     Optional filters (issue #188):
       category  - comma-separated category IDs (e.g. "retro,science-tech")
+      agent     - comma-separated agent names
+      tag       - comma-separated exact tag names
       after     - ISO date or Unix timestamp lower bound
       before    - ISO date or Unix timestamp upper bound
       min_views - minimum view count (engagement threshold)
@@ -7875,6 +7877,29 @@ def search_videos():
             placeholders = ",".join("?" for _ in cats)
             conditions.append(f"v.category IN ({placeholders})")
             params.extend(cats)
+
+    agent_param = request.args.get("agent", "").strip()
+    if agent_param:
+        agents = [a.strip() for a in agent_param.split(",") if a.strip()]
+        if agents:
+            placeholders = ",".join("?" for _ in agents)
+            conditions.append(f"a.agent_name IN ({placeholders})")
+            params.extend(agents)
+
+    tag_param = request.args.get("tag", "").strip()
+    if tag_param:
+        tags = [t.strip().lower() for t in tag_param.split(",") if t.strip()]
+        if tags:
+            tag_clauses = []
+            for tag in tags:
+                tag_clauses.append(
+                    "EXISTS ("
+                    "SELECT 1 FROM json_each(v.tags) "
+                    "WHERE LOWER(json_each.value) = ?"
+                    ")"
+                )
+                params.append(tag)
+            conditions.append(f"({' OR '.join(tag_clauses)})")
 
     # Date range filters
     def _parse_ts(val):
@@ -7952,6 +7977,8 @@ def search_videos():
         "pages": math.ceil(total / per_page) if total else 0,
         "filters": {
             "category": cat_param or None,
+            "agent": agent_param or None,
+            "tag": tag_param or None,
             "after": after_ts,
             "before": before_ts,
             "min_views": min_views if min_views > 0 else None,

--- a/tests/test_discoverability.py
+++ b/tests/test_discoverability.py
@@ -46,6 +46,39 @@ def _insert_video_for_trending(client, registered_agent, video_id, title, catego
         db.commit()
 
 
+def _insert_search_video(
+    client, agent_name, video_id, title, *, tags, category="other",
+):
+    import bottube_server
+
+    with client.application.app_context():
+        db = bottube_server.get_db()
+        agent = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?",
+            (agent_name,),
+        ).fetchone()
+        assert agent is not None
+        db.execute(
+            """INSERT INTO videos
+               (video_id, agent_id, title, description, filename, category,
+                tags, views, likes, created_at, is_removed)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)""",
+            (
+                video_id,
+                agent["id"],
+                title,
+                f"{title} description",
+                f"{video_id}.mp4",
+                category,
+                json.dumps(tags),
+                0,
+                0,
+                time.time(),
+            ),
+        )
+        db.commit()
+
+
 class TestSearchEnhancements:
     """Test search API enhancements (issue #425)."""
 
@@ -84,35 +117,95 @@ class TestSearchEnhancements:
 
     def test_search_agent_filter(self, client, registered_agent):
         """Test search with agent filter."""
-        # Upload video
-        client.post("/api/upload", json={
-            "title": "Test Video",
-            "description": "Description",
-            "tags": "test",
-            "category": "other",
-        }, headers={"X-API-Key": registered_agent["api_key"]})
+        other = client.post("/api/register", json={
+            "agent_name": "other_search_bot",
+            "display_name": "Other Search Bot",
+            "bio": "Another bot for testing search filters",
+        }).get_json()
+
+        _insert_search_video(
+            client, registered_agent["agent_name"], "shared-filter-primary",
+            "Shared Filter Topic", tags=["test"],
+        )
+        _insert_search_video(
+            client, other["agent_name"], "shared-filter-other",
+            "Shared Filter Topic", tags=["test"],
+        )
 
         # Search with agent filter
-        resp = client.get(f"/api/search?q=Test&agent={registered_agent['agent_name']}")
+        resp = client.get(
+            f"/api/search?q=Shared&agent={registered_agent['agent_name']}"
+        )
         assert resp.status_code == 200
         data = resp.get_json()
-        assert len(data["videos"]) >= 1
-        assert data["videos"][0]["agent_name"] == registered_agent["agent_name"]
+        assert data["filters"]["agent"] == registered_agent["agent_name"]
+        assert len(data["videos"]) == 1
+        assert {video["agent_name"] for video in data["videos"]} == {
+            registered_agent["agent_name"],
+        }
+
+        resp = client.get("/api/search?q=Shared&agent=missing_search_bot")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["filters"]["agent"] == "missing_search_bot"
+        assert data["videos"] == []
 
     def test_search_tag_filter(self, client, registered_agent):
         """Test search with tag filter."""
-        client.post("/api/upload", json={
-            "title": "AI Art Video",
-            "description": "Generated art",
-            "tags": "ai,art,creative",
-            "category": "ai-art",
-        }, headers={"X-API-Key": registered_agent["api_key"]})
+        _insert_search_video(
+            client, registered_agent["agent_name"], "filtered-art-ai",
+            "Filtered Art Video",
+            tags=["ai", "art", "creative"],
+            category="ai-art",
+        )
+        _insert_search_video(
+            client, registered_agent["agent_name"], "filtered-art-nonai",
+            "Filtered Art Video", tags=["art", "nonai"], category="ai-art",
+        )
 
         # Search with tag filter
-        resp = client.get("/api/search?q=art&tag=ai")
+        resp = client.get("/api/search?q=Filtered&tag=ai")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert len(data["videos"]) >= 1
+        assert data["filters"]["tag"] == "ai"
+        assert len(data["videos"]) == 1
+        assert all("ai" in video["tags"] for video in data["videos"])
+
+        resp = client.get("/api/search?q=Filtered&tag=missing-tag")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["filters"]["tag"] == "missing-tag"
+        assert data["videos"] == []
+
+    def test_search_tag_filter_treats_like_wildcards_as_literals(
+            self, client, registered_agent):
+        """Test tag filters treat SQL LIKE wildcard characters literally."""
+        _insert_search_video(
+            client, registered_agent["agent_name"], "wildcard-percent",
+            "Wildcard Tag Video", tags=["a%b"], category="ai-art",
+        )
+        _insert_search_video(
+            client, registered_agent["agent_name"], "wildcard-underscore",
+            "Wildcard Tag Video", tags=["a_b"], category="ai-art",
+        )
+        _insert_search_video(
+            client, registered_agent["agent_name"], "wildcard-ordinary",
+            "Wildcard Tag Video", tags=["axb"], category="ai-art",
+        )
+
+        resp = client.get("/api/search?q=Wildcard&tag=a%25b")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert [video["video_id"] for video in data["videos"]] == [
+            "wildcard-percent"
+        ]
+
+        resp = client.get("/api/search?q=Wildcard&tag=a_b")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert [video["video_id"] for video in data["videos"]] == [
+            "wildcard-underscore"
+        ]
 
     def test_search_suggestions(self, client, registered_agent):
         """Test search suggestions API."""


### PR DESCRIPTION
## Summary

Fixes the public `/api/search` route so documented `agent` and `tag` filters are actually applied instead of silently ignored.

Related bug report: #1208
Related bounty claim: Scottcjn/rustchain-bounties#1102

## What changed

- Parse comma-separated `agent` query values and filter by exact `a.agent_name`.
- Parse comma-separated `tag` query values and filter against JSON tag entries using exact quoted tag matching.
- Include `agent` and `tag` in the response `filters` object so API clients can confirm applied filters.
- Strengthen regression tests so they fail when the filters are ignored.

## Validation

```bash
PYTHONDONTWRITEBYTECODE=1 uv run --no-project --with pytest --with flask --with werkzeug --with requests --with markupsafe python -m pytest -p no:cacheprovider tests/test_discoverability.py::TestSearchEnhancements::test_search_agent_filter tests/test_discoverability.py::TestSearchEnhancements::test_search_tag_filter -q
# 2 passed

PYTHONDONTWRITEBYTECODE=1 uv run --no-project --with flask --with werkzeug --with requests --with markupsafe python -m py_compile bottube_server.py tests/test_discoverability.py

git diff --check
```

Note: I also ran the full `tests/test_discoverability.py` file. It still has pre-existing failures unrelated to this patch: several tests rely on routes that return 404 in this checkout or on upload-based fixture setup that does not create rows in the current isolated test path. The new focused regressions pass.
