### PR TITLE
Validate beef arc JSON inputs

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -412,12 +412,24 @@ def start_arc():
       relationship_id  int
       arc_template     str  (must be one of DRAMA_ARC_TEMPLATES keys)
     """
-    data = request.get_json(silent=True) or {}
-    rel_id = data.get("relationship_id")
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
+
+    rel_id, error = _parse_positive_int(
+        data.get("relationship_id"), "relationship_id"
+    )
+    if error:
+        return jsonify({"error": error}), 400
     template = data.get("arc_template")
 
-    if not rel_id or not template:
-        return jsonify({"error": "relationship_id and arc_template required"}), 400
+    if not isinstance(template, str):
+        return jsonify({"error": "arc_template must be a string"}), 400
+    template = template.strip()
+    if not template:
+        return jsonify({"error": "arc_template required"}), 400
     if template not in DRAMA_ARC_TEMPLATES:
         return jsonify({"error": f"unknown template '{template}'"}), 400
 
@@ -450,8 +462,16 @@ def start_arc():
 @beef_bp.route("/arcs/<int:arc_id>/resolve", methods=["POST"])
 def resolve_arc(arc_id: int):
     """Mark an arc as resolved."""
-    data = request.get_json(silent=True) or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
     note = data.get("resolution_note", "")
+    if note is None:
+        note = ""
+    if not isinstance(note, str):
+        return jsonify({"error": "resolution_note must be a string"}), 400
     db = get_db()
     db.execute(
         "UPDATE drama_arcs SET status='resolved', resolved_at=?, resolution_note=? WHERE id=?",

--- a/tests/test_beef_system.py
+++ b/tests/test_beef_system.py
@@ -286,6 +286,35 @@ def test_start_drama_arc(client):
     assert arc["status"] == "active"
 
 
+def test_start_drama_arc_rejects_non_object_json(client):
+    resp = client.post("/api/beef/arcs", json=["not", "an", "object"])
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+@pytest.mark.parametrize(
+    "payload, error",
+    [
+        (
+            {"relationship_id": ["1"], "arc_template": "hot_take_beef"},
+            "relationship_id must be a positive integer",
+        ),
+        (
+            {"relationship_id": 1, "arc_template": ["hot_take_beef"]},
+            "arc_template must be a string",
+        ),
+        (
+            {"relationship_id": 1, "arc_template": "   "},
+            "arc_template required",
+        ),
+    ],
+)
+def test_start_drama_arc_rejects_malformed_fields(client, payload, error):
+    resp = client.post("/api/beef/arcs", json=payload)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == error
+
+
 def test_list_active_arcs(client):
     _post_event(client, 15, 16, "callout", 70)
     rels = client.get("/api/beef/relationships").get_json()
@@ -306,11 +335,45 @@ def test_resolve_drama_arc(client):
     _post_event(client, 17, 18, "disagree", 70)
     rels = client.get("/api/beef/relationships").get_json()
     rel_id = next(r["id"] for r in rels if r["agent_a_id"] == 17)
-    arc = client.post("/api/beef/arcs", json={"relationship_id": rel_id, "arc_template": "redemption_arc"}).get_json()
+    arc = client.post(
+        "/api/beef/arcs",
+        json={"relationship_id": rel_id, "arc_template": "redemption_arc"},
+    ).get_json()
 
     resp = client.post(f"/api/beef/arcs/{arc['id']}/resolve", json={"resolution_note": "peace achieved"})
     assert resp.status_code == 200
     assert resp.get_json()["status"] == "resolved"
+
+
+def test_resolve_drama_arc_rejects_non_object_json(client):
+    _post_event(client, 23, 24, "disagree", 70)
+    rels = client.get("/api/beef/relationships").get_json()
+    rel_id = next(r["id"] for r in rels if r["agent_a_id"] == 23)
+    arc = client.post(
+        "/api/beef/arcs",
+        json={"relationship_id": rel_id, "arc_template": "redemption_arc"},
+    ).get_json()
+
+    resp = client.post(f"/api/beef/arcs/{arc['id']}/resolve", json=["done"])
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_resolve_drama_arc_rejects_non_string_note(client):
+    _post_event(client, 25, 26, "disagree", 70)
+    rels = client.get("/api/beef/relationships").get_json()
+    rel_id = next(r["id"] for r in rels if r["agent_a_id"] == 25)
+    arc = client.post(
+        "/api/beef/arcs",
+        json={"relationship_id": rel_id, "arc_template": "redemption_arc"},
+    ).get_json()
+
+    resp = client.post(
+        f"/api/beef/arcs/{arc['id']}/resolve",
+        json={"resolution_note": {"text": "done"}},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "resolution_note must be a string"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- fixes `/api/beef/arcs` so non-object JSON bodies return 400 instead of crashing on `.get()`
- validates `relationship_id` through the existing positive-integer parser before DB lookup
- rejects non-string or blank `arc_template` values with deterministic 400 responses
- fixes `/api/beef/arcs/<arc_id>/resolve` so non-object JSON and non-string `resolution_note` values return 400 instead of reaching DB binding
- adds focused regression coverage for malformed arc start/resolve inputs

Fixes #1210.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m pytest -p no:cacheprovider tests/test_beef_system.py -q`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-oembed-venv/bin/python -m py_compile agent_relationships.py tests/test_beef_system.py`
- `git diff --check`