### PR TITLE
Add platform snapshot SDK example

### DIFF
--- a/examples/platform-snapshot/README.md
+++ b/examples/platform-snapshot/README.md
@@ -1,0 +1,63 @@
+# BoTTube Platform Snapshot
+
+Generate a Markdown or JSON snapshot of public BoTTube platform counters with the local `@bottube/sdk` package.
+
+The example is useful for agents, dashboards, release notes, or scheduled jobs that need a quick status card without scraping HTML. It reads only public endpoints and does not need a BoTTube API key.
+
+## What It Fetches
+
+- API health from `client.health()`
+- platform counters from `client.getFooterCounters()`
+- BoTTube GitHub stats from `client.getGithubStats()`
+
+## Setup
+
+```bash
+cd examples/platform-snapshot
+npm install --no-package-lock
+```
+
+The package uses the SDK from `../../js-sdk`:
+
+```json
+"@bottube/sdk": "file:../../js-sdk"
+```
+
+## Usage
+
+Render a live Markdown report:
+
+```bash
+node index.js
+```
+
+Write a JSON snapshot:
+
+```bash
+node index.js --format json --output /tmp/bottube-platform-snapshot.json
+```
+
+Render from the included fixture without network access:
+
+```bash
+node index.js --fixture test/fixture.json
+```
+
+Use another BoTTube deployment:
+
+```bash
+node index.js --base-url https://bottube.ai --timeout-ms 10000
+```
+
+## Validation
+
+```bash
+npm test
+npm run check
+node index.js --fixture test/fixture.json --output /tmp/bottube-platform-snapshot.md
+node index.js --format json --output /tmp/bottube-platform-snapshot-live.json
+```
+
+## Safety
+
+This example does not upload videos, send comments, vote, update profiles, read secrets, move wallet funds, or use private credentials. It only reads public BoTTube status and counter endpoints through the SDK.

--- a/examples/platform-snapshot/index.js
+++ b/examples/platform-snapshot/index.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { writeFile } from "node:fs/promises";
+import { BoTTubeClient } from "@bottube/sdk";
+import {
+  buildSnapshot,
+  createFetcher,
+  loadFixture,
+  parseArgs,
+  renderJson,
+  renderMarkdown,
+} from "./src/snapshot.js";
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const client = new BoTTubeClient({
+    baseUrl: options.baseUrl,
+    timeout: options.timeoutMs,
+  });
+
+  const source = options.fixture
+    ? await loadFixture(options.fixture)
+    : await buildSnapshot(createFetcher(client));
+
+  const output = options.format === "json" ? renderJson(source) : renderMarkdown(source);
+
+  if (options.output) {
+    await writeFile(options.output, output, "utf8");
+  } else {
+    process.stdout.write(output);
+    if (!output.endsWith("\n")) process.stdout.write("\n");
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`bottube-platform-snapshot: ${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/examples/platform-snapshot/package.json
+++ b/examples/platform-snapshot/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bottube-platform-snapshot",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Generate Markdown or JSON BoTTube platform snapshots with the BoTTube JavaScript SDK.",
+  "scripts": {
+    "check": "node --check index.js && node --check src/snapshot.js && node --check test/snapshot.test.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "devDependencies": {}
+}

--- a/examples/platform-snapshot/src/snapshot.js
+++ b/examples/platform-snapshot/src/snapshot.js
@@ -1,0 +1,210 @@
+import { readFile } from "node:fs/promises";
+
+const DEFAULT_BASE_URL = "https://bottube.ai";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export function parseArgs(argv) {
+  const options = {
+    baseUrl: DEFAULT_BASE_URL,
+    fixture: "",
+    format: "markdown",
+    output: "",
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      index += 1;
+      if (index >= argv.length || argv[index].startsWith("--")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      return argv[index];
+    };
+
+    if (arg === "--base-url") {
+      options.baseUrl = normalizeBaseUrl(next());
+    } else if (arg === "--fixture") {
+      options.fixture = next();
+    } else if (arg === "--format") {
+      const format = next();
+      if (!["markdown", "json"].includes(format)) {
+        throw new Error("--format must be markdown or json");
+      }
+      options.format = format;
+    } else if (arg === "--output") {
+      options.output = next();
+    } else if (arg === "--timeout-ms") {
+      options.timeoutMs = parsePositiveInteger(next(), "--timeout-ms");
+    } else if (arg === "--help" || arg === "-h") {
+      process.stdout.write(helpText());
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export function createFetcher(client) {
+  return async function fetchSnapshotParts() {
+    const [health, footerCounters, githubStats] = await Promise.all([
+      client.health(),
+      client.getFooterCounters(),
+      client.getGithubStats(),
+    ]);
+    return { health, footerCounters, githubStats };
+  };
+}
+
+export async function buildSnapshot(fetchSnapshotParts) {
+  const parts = await fetchSnapshotParts();
+  return normalizeSnapshot(parts);
+}
+
+export async function loadFixture(path) {
+  const raw = await readFile(path, "utf8");
+  return normalizeSnapshot(JSON.parse(raw));
+}
+
+export function normalizeSnapshot({ health = {}, footerCounters = {}, githubStats = {} }) {
+  const stats = asObject(footerCounters.stats);
+  const bottube = asObject(footerCounters.bottube);
+  const clawrtc = asObject(footerCounters.clawrtc);
+  const grazer = asObject(footerCounters.grazer);
+
+  return {
+    generatedAt: new Date(numberOr(footerCounters.ts, githubStats.ts, Date.now() / 1000) * 1000).toISOString(),
+    health: {
+      ok: Boolean(health.ok ?? health.status === "ok"),
+      service: stringOr(health.service, "bottube"),
+      version: stringOr(health.version, "unknown"),
+      uptimeSeconds: numberOr(health.uptime_s, 0),
+    },
+    platform: {
+      agents: numberOr(stats.agents, health.agents, 0),
+      humans: numberOr(stats.humans, health.humans, 0),
+      videos: numberOr(stats.videos, health.videos, 0),
+    },
+    projects: [
+      projectSummary("BoTTube", bottube),
+      projectSummary("ClawRTC", clawrtc),
+      projectSummary("Grazer", grazer),
+    ],
+    github: {
+      stars: numberOr(githubStats.stars, asObject(bottube.github).stars, 0),
+      forks: numberOr(githubStats.forks, asObject(bottube.github).forks, 0),
+      clones: numberOr(githubStats.clones, asObject(bottube.github).clones, 0),
+    },
+  };
+}
+
+export function renderMarkdown(snapshot) {
+  const rows = snapshot.projects
+    .map(
+      (project) =>
+        `| ${escapeCell(project.name)} | ${formatNumber(project.stars)} | ${formatNumber(project.forks)} | ${formatNumber(project.npmDownloads)} | ${formatNumber(project.pypiDownloads)} | ${formatNumber(project.clawhubDownloads)} |`,
+    )
+    .join("\n");
+
+  return [
+    "# BoTTube Platform Snapshot",
+    "",
+    `Generated: ${snapshot.generatedAt}`,
+    "",
+    "## Health",
+    "",
+    `- Service: ${snapshot.health.service}`,
+    `- Version: ${snapshot.health.version}`,
+    `- API OK: ${snapshot.health.ok ? "yes" : "no"}`,
+    `- Uptime: ${formatNumber(snapshot.health.uptimeSeconds)} seconds`,
+    "",
+    "## Platform",
+    "",
+    `- Agents: ${formatNumber(snapshot.platform.agents)}`,
+    `- Humans: ${formatNumber(snapshot.platform.humans)}`,
+    `- Videos: ${formatNumber(snapshot.platform.videos)}`,
+    "",
+    "## Project Counters",
+    "",
+    "| Project | Stars | Forks | npm downloads | PyPI downloads | ClawHub downloads |",
+    "| --- | ---: | ---: | ---: | ---: | ---: |",
+    rows,
+    "",
+    "## BoTTube GitHub",
+    "",
+    `- Stars: ${formatNumber(snapshot.github.stars)}`,
+    `- Forks: ${formatNumber(snapshot.github.forks)}`,
+    `- Clones: ${formatNumber(snapshot.github.clones)}`,
+    "",
+  ].join("\n");
+}
+
+export function renderJson(snapshot) {
+  return `${JSON.stringify(snapshot, null, 2)}\n`;
+}
+
+function projectSummary(name, project) {
+  const github = asObject(project.github);
+  const downloads = asObject(project.downloads);
+  return {
+    name,
+    stars: numberOr(github.stars, 0),
+    forks: numberOr(github.forks, 0),
+    npmDownloads: numberOr(downloads.npm, 0),
+    pypiDownloads: numberOr(downloads.pypi, 0),
+    clawhubDownloads: numberOr(downloads.clawhub, 0),
+  };
+}
+
+function normalizeBaseUrl(value) {
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:"].includes(url.protocol)) {
+      throw new Error("invalid protocol");
+    }
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    throw new Error("--base-url must be a valid http(s) URL");
+  }
+}
+
+function parsePositiveInteger(value, label) {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function asObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function numberOr(...values) {
+  for (const value of values) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return 0;
+}
+
+function stringOr(value, fallback) {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+}
+
+function escapeCell(value) {
+  return String(value).replace(/\|/g, "\\|");
+}
+
+function helpText() {
+  return `Usage: node index.js [options]\n\nOptions:\n  --base-url <url>      BoTTube base URL (default: ${DEFAULT_BASE_URL})\n  --fixture <path>      Render from a fixture JSON file instead of live API calls\n  --format <type>       markdown or json (default: markdown)\n  --output <path>       Write output to a file instead of stdout\n  --timeout-ms <ms>     SDK request timeout (default: ${DEFAULT_TIMEOUT_MS})\n  -h, --help            Show this help text\n`;
+}

--- a/examples/platform-snapshot/test/fixture.json
+++ b/examples/platform-snapshot/test/fixture.json
@@ -1,0 +1,33 @@
+{
+  "health": {
+    "agents": 249,
+    "humans": 81,
+    "ok": true,
+    "service": "bottube",
+    "uptime_s": 1635765,
+    "version": "1.2.0",
+    "videos": 1556
+  },
+  "footerCounters": {
+    "bottube": {
+      "downloads": { "clawhub": 890, "npm": 439, "pypi": 6668 },
+      "github": { "clones": 399, "forks": 160, "stars": 244 }
+    },
+    "clawrtc": {
+      "downloads": { "clawhub": 878, "npm": 1516, "pypi": 8083 },
+      "github": { "forks": 390, "stars": 338 }
+    },
+    "grazer": {
+      "downloads": { "clawhub": 17, "npm": 224, "pypi": 5485 },
+      "github": { "forks": 42, "stars": 147 }
+    },
+    "stats": { "agents": 249, "humans": 81, "videos": 1556 },
+    "ts": 1779486062
+  },
+  "githubStats": {
+    "clones": 399,
+    "forks": 160,
+    "stars": 244,
+    "ts": 1779486062.7780893
+  }
+}

--- a/examples/platform-snapshot/test/snapshot.test.js
+++ b/examples/platform-snapshot/test/snapshot.test.js
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildSnapshot,
+  parseArgs,
+  renderJson,
+  renderMarkdown,
+} from "../src/snapshot.js";
+
+test("buildSnapshot normalizes public BoTTube counters", async () => {
+  const snapshot = await buildSnapshot(async () => ({
+    health: { ok: true, service: "bottube", version: "1.2.0", uptime_s: 42 },
+    footerCounters: {
+      stats: { agents: 12, humans: 3, videos: 99 },
+      bottube: {
+        github: { stars: 7, forks: 2 },
+        downloads: { npm: 5, pypi: 6, clawhub: 1 },
+      },
+      clawrtc: {
+        github: { stars: 8, forks: 4 },
+        downloads: { npm: 15, pypi: 16, clawhub: 11 },
+      },
+      ts: 1779486062,
+    },
+    githubStats: { stars: 10, forks: 4, clones: 20 },
+  }));
+
+  assert.equal(snapshot.health.ok, true);
+  assert.equal(snapshot.platform.agents, 12);
+  assert.equal(snapshot.platform.videos, 99);
+  assert.equal(snapshot.projects[0].name, "BoTTube");
+  assert.equal(snapshot.projects[0].npmDownloads, 5);
+  assert.equal(snapshot.github.stars, 10);
+});
+
+test("renderMarkdown includes the health and project table", async () => {
+  const snapshot = await buildSnapshot(async () => ({
+    health: { ok: true, service: "bottube", version: "1.2.0" },
+    footerCounters: {
+      stats: { agents: 12, humans: 3, videos: 99 },
+      bottube: { github: { stars: 7, forks: 2 }, downloads: { npm: 5 } },
+      ts: 1779486062,
+    },
+    githubStats: { stars: 10, forks: 4, clones: 20 },
+  }));
+
+  const markdown = renderMarkdown(snapshot);
+  assert.match(markdown, /# BoTTube Platform Snapshot/);
+  assert.match(markdown, /API OK: yes/);
+  assert.match(markdown, /\| BoTTube \| 7 \| 2 \| 5 \| 0 \| 0 \|/);
+  assert.match(markdown, /Stars: 10/);
+});
+
+test("renderJson emits parseable JSON", async () => {
+  const snapshot = await buildSnapshot(async () => ({
+    health: { ok: true },
+    footerCounters: { stats: { agents: 1 }, ts: 1779486062 },
+    githubStats: {},
+  }));
+
+  assert.equal(JSON.parse(renderJson(snapshot)).platform.agents, 1);
+});
+
+test("parseArgs rejects malformed timeout and format values", () => {
+  assert.throws(() => parseArgs(["--timeout-ms", "2abc"]), /positive integer/);
+  assert.throws(() => parseArgs(["--format", "xml"]), /markdown or json/);
+});


### PR DESCRIPTION
## Summary
- add `examples/platform-snapshot`, a Node.js example that uses the local `@bottube/sdk` package
- fetch public health, footer counter, and GitHub-stat endpoints through the SDK
- render Markdown or JSON platform snapshots for agents, dashboards, release notes, or scheduled reports
- include fixture/no-network mode, CLI validation, README setup instructions, and node:test coverage

## Validation
- `npm install --no-package-lock` from `examples/platform-snapshot` -> added 1 package, 0 vulnerabilities
- `npm test` from `examples/platform-snapshot` -> 4 passed
- `npm run check` from `examples/platform-snapshot` -> passed
- `node index.js --fixture test/fixture.json --output /tmp/bottube-platform-snapshot.md` -> rendered fixture Markdown
- `node index.js --format json --output /tmp/bottube-platform-snapshot-live.json` -> reached live public BoTTube API through the SDK and wrote JSON with `ok: true`, `agents: 249`, `videos: 1556`, `stars: 244`
- `git diff --check -- examples/platform-snapshot` -> passed

/claim #2143

Safety: no BoTTube API key, private token, wallet secret, upload, comment, vote, profile edit, withdrawal, transfer, or fund movement was used.