### PR TITLE
Label header search input for accessibility

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -814,7 +814,8 @@
         </div>
 
         <form class="search-bar" action="{{ P }}/search" method="get" role="search" aria-label="{{ _('nav.search') }}">
-            <input type="text" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}">
+            <label for="site-search-input" class="sr-only">{{ _('nav.search') }}</label>
+            <input id="site-search-input" type="text" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}" aria-label="{{ _('nav.search') }}">
             <button type="submit" aria-label="{{ _('nav.search') }}">{{ _('nav.search') }}</button>
         </form>
 

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -88,6 +88,18 @@ class TestAccessibilityAttributes(unittest.TestCase):
                       "Search form should have role='search'")
         self.assertIn('aria-label', match.group(0),
                       "Search form missing aria-label")
+
+    def test_header_search_input_has_accessible_name(self):
+        """Test that the header search input is labelled for screen readers."""
+        content = self.read_file(self.TEMPLATE_DIR / 'base.html')
+        label = re.search(r'<label[^>]*for="site-search-input"[^>]*>', content)
+        self.assertIsNotNone(label, "Header search input missing associated label")
+        self.assertIn('class="sr-only"', label.group(0),
+                      "Header search label should use sr-only utility")
+        field = re.search(r'<input[^>]*id="site-search-input"[^>]*>', content)
+        self.assertIsNotNone(field, "Header search input not found")
+        self.assertIn('aria-label', field.group(0),
+                      "Header search input missing aria-label fallback")
     
     def test_skip_link_present(self):
         """Test that skip link for keyboard navigation is present."""


### PR DESCRIPTION
## Summary

- Adds an associated `sr-only` label to the shared header search input.
- Adds an `id` and `aria-label` fallback so the input itself has an accessible name, not only the surrounding search form.
- Adds regression coverage for the header search input accessible name.

Fixes #1217.

Bounty context: candidate accessibility fix/report for Scottcjn/rustchain-bounties#1618 and Scottcjn/rustchain-bounties#2139.

/claim Scottcjn/rustchain-bounties#2139

## Validation

- `uv run --no-project --with pytest python -m pytest -p no:cacheprovider tests/test_accessibility.py -q` -> 18 passed
- `git diff --check` -> passed
- Parsed `bottube_templates/base.html` with BeautifulSoup and confirmed `#site-search-input` has both an associated label and `aria-label`.

## Payout boundary

This is a public bounty claim for maintainer assessment only; no RTC award, payout approval, wallet transfer, wallet credit, bank transfer, exchange movement, or payment receipt is asserted here.
