### PR TITLE
Validate comment JSON fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1521,7 +1521,7 @@ def _verify_csrf():
     )
     if not token:
         data = request.get_json(silent=True) or {}
-        token = data.get("csrf_token", "")
+        token = data.get("csrf_token", "") if isinstance(data, dict) else ""
     expected = session.get("csrf_token", "")
     if not expected or not token or not secrets.compare_digest(token, expected):
         # Return JSON for AJAX/API requests so JS can handle the error
@@ -7129,6 +7129,41 @@ def describe_video(video_id):
 # Comments
 # ---------------------------------------------------------------------------
 
+def _normalized_comment_payload():
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return None, "", "", (jsonify({"error": "JSON body must be an object"}), 400)
+
+    raw_content = data.get("content", "")
+    if raw_content is None:
+        content = ""
+    elif not isinstance(raw_content, str):
+        return None, "", "", (jsonify({"error": "content must be a string"}), 400)
+    else:
+        content = raw_content.strip()
+
+    raw_comment_type = data.get("comment_type")
+    if raw_comment_type is None:
+        comment_type = "comment"
+    elif not isinstance(raw_comment_type, str):
+        return None, "", "", (jsonify({"error": "comment_type must be a string"}), 400)
+    else:
+        comment_type = raw_comment_type.strip().lower()
+
+    if not content:
+        return None, "", "", (jsonify({"error": "content is required"}), 400)
+    if comment_type not in COMMENT_TYPES:
+        return None, "", "", (
+            jsonify({"error": f"comment_type must be one of {sorted(COMMENT_TYPES)}"}),
+            400,
+        )
+    if len(content) > 5000:
+        return None, "", "", (jsonify({"error": "Comment too long (max 5000 chars)"}), 400)
+    return data, content, comment_type, None
+
+
 @app.route("/api/videos/<video_id>/comment", methods=["POST"])
 @require_api_key
 def add_comment(video_id):
@@ -7142,15 +7177,9 @@ def add_comment(video_id):
     if not video:
         return jsonify({"error": "Video not found"}), 404
 
-    data = request.get_json(silent=True) or {}
-    content = data.get("content", "").strip()
-    comment_type = (data.get("comment_type") or "comment").strip().lower()
-    if not content:
-        return jsonify({"error": "content is required"}), 400
-    if comment_type not in COMMENT_TYPES:
-        return jsonify({"error": f"comment_type must be one of {sorted(COMMENT_TYPES)}"}), 400
-    if len(content) > 5000:
-        return jsonify({"error": "Comment too long (max 5000 chars)"}), 400
+    data, content, comment_type, error_response = _normalized_comment_payload()
+    if error_response:
+        return error_response
 
     parent_id = data.get("parent_id")
     if parent_id is not None:
@@ -7232,15 +7261,9 @@ def web_add_comment(video_id):
     if not video:
         return jsonify({"error": "Video not found"}), 404
 
-    data = request.get_json(silent=True) or {}
-    content = data.get("content", "").strip()
-    comment_type = (data.get("comment_type") or "comment").strip().lower()
-    if not content:
-        return jsonify({"error": "content is required"}), 400
-    if comment_type not in COMMENT_TYPES:
-        return jsonify({"error": f"comment_type must be one of {sorted(COMMENT_TYPES)}"}), 400
-    if len(content) > 5000:
-        return jsonify({"error": "Comment too long (max 5000 chars)"}), 400
+    data, content, comment_type, error_response = _normalized_comment_payload()
+    if error_response:
+        return error_response
 
     # Duplicate check: reject if same user posted identical content on this video
     existing = db.execute(

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -302,6 +302,72 @@ def test_suspicious_comment_reward_is_held_for_review(client):
     assert comment_earnings == 0
 
 
+def test_api_comment_rejects_malformed_text_fields_without_insert(client):
+    commenter_id = _insert_agent("typealice", "bottube_sk_typealice")
+    target_id = _insert_agent("typebob", "bottube_sk_typebob")
+    _insert_video(target_id, "typevideo01A")
+
+    cases = [
+        ({"content": None}, "content is required"),
+        ({"content": ["hello"]}, "content must be a string"),
+        ({"content": "good video", "comment_type": ["review"]}, "comment_type must be a string"),
+        (["not-an-object"], "JSON body must be an object"),
+    ]
+    for payload, expected_error in cases:
+        resp = client.post(
+            "/api/videos/typevideo01A/comment",
+            headers={"X-API-Key": "bottube_sk_typealice"},
+            json=payload,
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == expected_error
+
+    conn = sqlite3.connect(bottube_server.DB_PATH)
+    try:
+        comment_count = conn.execute(
+            "SELECT COUNT(*) FROM comments WHERE agent_id = ? AND video_id = 'typevideo01A'",
+            (commenter_id,),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert comment_count == 0
+
+
+def test_web_comment_rejects_malformed_text_fields_after_csrf(client):
+    commenter_id = _insert_agent("webtypealice", "bottube_sk_webtypealice")
+    target_id = _insert_agent("webtypebob", "bottube_sk_webtypebob")
+    _insert_video(target_id, "webtype01A")
+    csrf_token = "test-csrf-token"
+    with client.session_transaction() as sess:
+        sess["user_id"] = commenter_id
+        sess["csrf_token"] = csrf_token
+
+    cases = [
+        ({"content": 123}, "content must be a string"),
+        ({"content": "good video", "comment_type": {"kind": "critique"}}, "comment_type must be a string"),
+        (["not-an-object"], "JSON body must be an object"),
+    ]
+    for payload, expected_error in cases:
+        resp = client.post(
+            "/api/videos/webtype01A/web-comment",
+            headers={"X-CSRF-Token": csrf_token},
+            json=payload,
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == expected_error
+
+    resp = client.post(
+        "/api/videos/webtype01A/web-comment",
+        headers={"X-CSRF-Token": csrf_token},
+        json={"content": "  Clear and useful  ", "comment_type": None},
+    )
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body["content"] == "Clear and useful"
+    assert body["comment_type"] == "comment"
+
+
 def test_admin_ban_defaults_to_coaching_hold_instead_of_ban(client):
     agent_id = _insert_agent("coachme", "bottube_sk_coachme")
 


### PR DESCRIPTION
Fixes #1196.

## Summary
- validate comment JSON bodies are objects before field access
- return deterministic 400 errors for non-string content/comment_type while preserving null content -> content is required and null comment_type -> comment default
- share the validation between API and web comment routes, and avoid CSRF token lookup crashes on non-object JSON

## Verification
- uv run --no-project --with pytest --with flask --with pynacl --with requests --with werkzeug --with markupsafe pytest tests/test_quests.py -q -> 15 passed
- uv run --no-project --with flask --with pynacl --with requests python -m py_compile bottube_server.py tests/test_quests.py
- git diff --check
- uv run --no-project --with flake8 flake8 tests/test_quests.py --select E9,F821,F811,F841

Note: whole-file flake8 on bottube_server.py still reports pre-existing F841 warnings outside this patch.