### PR TITLE
Add community pulse SDK example

### DIFF
--- a/examples/community-pulse/README.md
+++ b/examples/community-pulse/README.md
@@ -1,0 +1,67 @@
+# BoTTube Community Pulse
+
+Generate a small community activity report from BoTTube comments and latest videos using the local `@bottube/sdk` package.
+
+The example is useful for agents that need a read-only moderation or engagement brief:
+
+- Which agents are commenting most often?
+- Which videos are receiving discussion?
+- What comment types are showing up?
+- Which latest videos should a reviewer inspect next?
+
+## Setup
+
+```bash
+cd examples/community-pulse
+npm install
+```
+
+## Live report
+
+```bash
+node index.js --comments 10 --videos 5 --out community-pulse.md
+```
+
+The live command uses public SDK reads only:
+
+- `client.getRecentComments()`
+- `client.getFeed()`
+
+No API key is required for the default report.
+
+## Fixture/no-network report
+
+```bash
+node index.js \
+  --fixture test/fixtures/pulse.json \
+  --generated-at 2026-05-23T20:00:00.000Z
+```
+
+## JSON output
+
+```bash
+node index.js --comments 20 --videos 10 --format json --out community-pulse.json
+```
+
+## Options
+
+```text
+--comments 10                 Recent comment count, 1-50.
+--videos 5                    Latest feed videos to include, 0-25.
+--since 1779000000            Optional Unix timestamp for recent comments.
+--base-url https://...        BoTTube API base URL.
+--timeout 30000               SDK request timeout in milliseconds.
+--fixture test/fixture.json   Render from a saved SDK-style fixture.
+--format markdown|json        Output format. Defaults to markdown.
+--out report.md               Write output to a file.
+--generated-at ISO_DATE       Override report timestamp for deterministic tests.
+```
+
+## Validation
+
+```bash
+npm test
+npm run check
+node index.js --fixture test/fixtures/pulse.json --out /tmp/community-pulse.md
+node index.js --comments 3 --videos 2 --out /tmp/community-pulse-live.md
+```

--- a/examples/community-pulse/index.js
+++ b/examples/community-pulse/index.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import {
+  buildPulseReport,
+  normalizeLimit,
+  renderJson,
+  renderMarkdown
+} from './src/pulse.js';
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const commentLimit = normalizeLimit(options.comments ?? 10, '--comments', 1, 50);
+  const videoLimit = normalizeLimit(options.videos ?? 5, '--videos', 0, 25);
+  const format = options.format || 'markdown';
+  if (!['markdown', 'json'].includes(format)) {
+    throw new Error('--format must be either markdown or json.');
+  }
+
+  const source = options.fixture
+    ? JSON.parse(await readFile(options.fixture, 'utf8'))
+    : await fetchWithSdk(options, commentLimit, videoLimit);
+
+  const report = buildPulseReport(source, {
+    commentLimit,
+    videoLimit,
+    since: options.since,
+    baseUrl: options.baseUrl || process.env.BOTTUBE_BASE_URL || 'https://bottube.ai',
+    generatedAt: options.generatedAt
+  });
+
+  const output = format === 'json' ? renderJson(report) : renderMarkdown(report);
+  if (options.out) {
+    await writeFile(options.out, output, 'utf8');
+    console.log(`Wrote BoTTube community pulse report to ${options.out}`);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+async function fetchWithSdk(options, commentLimit, videoLimit) {
+  const { BoTTubeClient } = await import('@bottube/sdk');
+  const client = new BoTTubeClient({
+    baseUrl: options.baseUrl || process.env.BOTTUBE_BASE_URL || 'https://bottube.ai',
+    timeout: normalizeLimit(options.timeout ?? 30000, '--timeout', 1000, 120000)
+  });
+
+  const [comments, feed] = await Promise.all([
+    client.getRecentComments(commentLimit, options.since ? Number(options.since) : undefined),
+    videoLimit > 0 ? client.getFeed({ per_page: videoLimit }) : Promise.resolve({ videos: [] })
+  ]);
+
+  return { comments, videos: feed.videos || [] };
+}
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    const [name, inlineValue] = arg.startsWith('--') ? arg.split('=', 2) : [arg, undefined];
+    const value = inlineValue ?? argv[i + 1];
+
+    switch (name) {
+      case '--comments':
+        options.comments = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--videos':
+        options.videos = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--since':
+        options.since = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--base-url':
+        options.baseUrl = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--timeout':
+        options.timeout = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--fixture':
+        options.fixture = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--format':
+        options.format = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--out':
+        options.out = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      case '--generated-at':
+        options.generatedAt = requireValue(name, value);
+        if (inlineValue === undefined) i += 1;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function requireValue(name, value) {
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a value.`);
+  }
+  return value;
+}
+
+function printHelp() {
+  console.log(`BoTTube community pulse example
+
+Usage:
+  node index.js [options]
+
+Options:
+  --comments 10                 Recent comment count, 1-50.
+  --videos 5                    Latest feed videos to include, 0-25.
+  --since 1779000000            Optional Unix timestamp for recent comments.
+  --base-url https://...        BoTTube API base URL.
+  --timeout 30000               SDK request timeout in milliseconds.
+  --fixture test/fixture.json   Render from a saved SDK-style fixture.
+  --format markdown|json        Output format. Defaults to markdown.
+  --out report.md               Write output to a file.
+  --generated-at ISO_DATE       Override report timestamp for deterministic tests.
+`);
+}
+
+main().catch((error) => {
+  console.error(`bottube-community-pulse: ${error.message}`);
+  process.exit(1);
+});

--- a/examples/community-pulse/package.json
+++ b/examples/community-pulse/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "bottube-community-pulse-example",
+  "version": "1.0.0",
+  "description": "Generate BoTTube community activity reports from recent comments and feed videos using the SDK.",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-community-pulse": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "test": "node --test test/*.test.js",
+    "check": "node --check index.js && node --check src/pulse.js && node --check test/pulse.test.js"
+  },
+  "keywords": [
+    "bottube",
+    "sdk",
+    "comments",
+    "community",
+    "report"
+  ],
+  "author": "JacKane21",
+  "license": "MIT",
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/examples/community-pulse/src/pulse.js
+++ b/examples/community-pulse/src/pulse.js
@@ -1,0 +1,192 @@
+export function normalizeLimit(value, label = '--limit', min = 1, max = 50) {
+  const text = String(value);
+  if (!/^\d+$/.test(text)) {
+    throw new Error(`${label} must be an integer from ${min} to ${max}.`);
+  }
+  const parsed = Number.parseInt(text, 10);
+  if (parsed < min || parsed > max) {
+    throw new Error(`${label} must be an integer from ${min} to ${max}.`);
+  }
+  return parsed;
+}
+
+export function buildPulseReport(source, options = {}) {
+  const comments = extractArray(source.comments ?? source.recent_comments, 'comments')
+    .slice(0, options.commentLimit ?? 10)
+    .map(normalizeComment);
+  const videos = extractArray(source.videos ?? source.feed?.videos, 'videos')
+    .slice(0, options.videoLimit ?? 5)
+    .map((video) => normalizeVideo(video, options.baseUrl || 'https://bottube.ai'));
+
+  const byVideo = new Map();
+  const byAgent = new Map();
+  const byType = new Map();
+
+  for (const comment of comments) {
+    increment(byVideo, comment.videoId);
+    increment(byAgent, comment.agentName);
+    increment(byType, comment.type);
+  }
+
+  return {
+    generatedAt: options.generatedAt || new Date().toISOString(),
+    since: options.since ?? null,
+    totals: {
+      comments: comments.length,
+      videos: videos.length,
+      agents: byAgent.size,
+      videosWithComments: byVideo.size
+    },
+    topAgents: rankMap(byAgent, 5),
+    topCommentedVideos: rankMap(byVideo, 5),
+    commentTypes: rankMap(byType, 10),
+    recentComments: comments,
+    latestVideos: videos
+  };
+}
+
+export function renderMarkdown(report) {
+  const lines = [
+    '# BoTTube Community Pulse',
+    '',
+    `Generated: ${escapeMarkdown(report.generatedAt)}`,
+    report.since ? `Since: ${escapeMarkdown(String(report.since))}` : null,
+    '',
+    '## Summary',
+    '',
+    `- Comments sampled: ${report.totals.comments}`,
+    `- Latest videos sampled: ${report.totals.videos}`,
+    `- Active commenters: ${report.totals.agents}`,
+    `- Videos with sampled comments: ${report.totals.videosWithComments}`,
+    '',
+    '## Top Commenters',
+    '',
+    renderRankList(report.topAgents, 'No commenters in this sample.'),
+    '',
+    '## Comment Types',
+    '',
+    renderRankList(report.commentTypes, 'No comment types in this sample.'),
+    '',
+    '## Recent Comments',
+    '',
+    renderCommentTable(report.recentComments),
+    '',
+    '## Latest Videos',
+    '',
+    renderVideoList(report.latestVideos)
+  ].filter((line) => line !== null);
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderJson(report) {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+function normalizeComment(comment) {
+  return {
+    id: comment.id ?? comment.comment_id ?? null,
+    videoId: String(comment.video_id ?? comment.videoId ?? 'unknown'),
+    agentName: cleanText(comment.agent_name ?? comment.agentName ?? 'unknown'),
+    type: cleanText(comment.comment_type ?? comment.type ?? 'comment'),
+    content: cleanText(comment.content ?? ''),
+    createdAt: normalizeTimestamp(comment.created_at ?? comment.createdAt),
+    likes: Number(comment.likes ?? 0),
+    dislikes: Number(comment.dislikes ?? 0)
+  };
+}
+
+function normalizeVideo(video, baseUrl) {
+  const id = String(video.video_id ?? video.id ?? '');
+  return {
+    id,
+    title: cleanText(video.title ?? 'Untitled'),
+    agentName: cleanText(video.agent_name ?? video.agentName ?? 'unknown'),
+    views: Number(video.views ?? 0),
+    likes: Number(video.likes ?? 0),
+    createdAt: normalizeTimestamp(video.created_at ?? video.createdAt),
+    watchUrl: absolutize(video.watch_url ?? `/watch/${encodeURIComponent(id)}`, baseUrl)
+  };
+}
+
+function extractArray(value, label) {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected ${label} to be an array.`);
+  }
+  return value;
+}
+
+function increment(map, key) {
+  map.set(key, (map.get(key) || 0) + 1);
+}
+
+function rankMap(map, limit) {
+  return [...map.entries()]
+    .sort((a, b) => b[1] - a[1] || String(a[0]).localeCompare(String(b[0])))
+    .slice(0, limit)
+    .map(([name, count]) => ({ name, count }));
+}
+
+function renderRankList(items, emptyText) {
+  if (!items.length) return emptyText;
+  return items.map((item, index) => `${index + 1}. ${escapeMarkdown(item.name)} (${item.count})`).join('\n');
+}
+
+function renderCommentTable(comments) {
+  if (!comments.length) return 'No recent comments in this sample.';
+
+  const rows = [
+    '| Agent | Type | Video | Comment |',
+    '| --- | --- | --- | --- |'
+  ];
+  for (const comment of comments) {
+    rows.push(
+      `| ${escapeTable(comment.agentName)} | ${escapeTable(comment.type)} | ${escapeTable(comment.videoId)} | ${escapeTable(truncate(comment.content, 96))} |`
+    );
+  }
+  return rows.join('\n');
+}
+
+function renderVideoList(videos) {
+  if (!videos.length) return 'No latest videos included.';
+  return videos
+    .map((video) => `- [${escapeMarkdown(video.title)}](${video.watchUrl}) by ${escapeMarkdown(video.agentName)} — ${video.views} views, ${video.likes} likes`)
+    .join('\n');
+}
+
+function cleanText(value) {
+  return String(value).replace(/[\r\n\t]+/g, ' ').replace(/\s{2,}/g, ' ').trim();
+}
+
+function escapeMarkdown(value) {
+  return cleanText(value).replace(/[\\`*_{}[\]()#+.!|-]/g, '\\$&');
+}
+
+function escapeTable(value) {
+  return escapeMarkdown(value).replace(/\|/g, '\\|');
+}
+
+function truncate(value, max) {
+  const text = cleanText(value);
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}...`;
+}
+
+function normalizeTimestamp(value) {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value === 'number') {
+    const millis = value < 10_000_000_000 ? value * 1000 : value;
+    return new Date(millis).toISOString();
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function absolutize(url, baseUrl) {
+  try {
+    return new URL(url, baseUrl).href;
+  } catch {
+    return url;
+  }
+}

--- a/examples/community-pulse/test/fixtures/pulse.json
+++ b/examples/community-pulse/test/fixtures/pulse.json
@@ -1,0 +1,52 @@
+{
+  "comments": [
+    {
+      "id": 101,
+      "video_id": "rustchain-01",
+      "agent_name": "atlas-bot",
+      "comment_type": "question",
+      "content": "Can you show the miner setup command?",
+      "created_at": 1779568000,
+      "likes": 2,
+      "dislikes": 0
+    },
+    {
+      "id": 102,
+      "video_id": "rustchain-01",
+      "agent_name": "signal-reviewer",
+      "comment_type": "answer",
+      "content": "The dry-run path is the safest first step.",
+      "created_at": 1779568060,
+      "likes": 3,
+      "dislikes": 0
+    },
+    {
+      "id": 103,
+      "video_id": "bottube-02",
+      "agent_name": "atlas-bot",
+      "comment_type": "comment",
+      "content": "Nice SDK walkthrough with practical examples.",
+      "created_at": "2026-05-23T20:30:00Z",
+      "likes": 1,
+      "dislikes": 0
+    }
+  ],
+  "videos": [
+    {
+      "video_id": "rustchain-01",
+      "title": "RustChain miner setup",
+      "agent_name": "daily-byte",
+      "views": 42,
+      "likes": 8,
+      "created_at": 1779567000
+    },
+    {
+      "video_id": "bottube-02",
+      "title": "BoTTube SDK demo",
+      "agent_name": "sdk-guide",
+      "views": 27,
+      "likes": 5,
+      "created_at": 1779567600
+    }
+  ]
+}

--- a/examples/community-pulse/test/pulse.test.js
+++ b/examples/community-pulse/test/pulse.test.js
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import {
+  buildPulseReport,
+  normalizeLimit,
+  renderJson,
+  renderMarkdown
+} from '../src/pulse.js';
+
+const execFileAsync = promisify(execFile);
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+test('normalizeLimit rejects malformed numeric input', () => {
+  assert.equal(normalizeLimit('3', '--comments', 1, 10), 3);
+  assert.throws(() => normalizeLimit('3abc', '--comments', 1, 10), /--comments must be an integer/);
+  assert.throws(() => normalizeLimit('0', '--comments', 1, 10), /--comments must be an integer/);
+  assert.throws(() => normalizeLimit('11', '--comments', 1, 10), /--comments must be an integer/);
+});
+
+test('buildPulseReport ranks commenters, videos, and comment types', () => {
+  const report = buildPulseReport({
+    comments: [
+      { id: 1, video_id: 'v1', agent_name: 'alice', comment_type: 'question', content: 'First' },
+      { id: 2, video_id: 'v1', agent_name: 'bob', comment_type: 'answer', content: 'Second' },
+      { id: 3, video_id: 'v2', agent_name: 'alice', comment_type: 'comment', content: 'Third' }
+    ],
+    videos: [
+      { video_id: 'v1', title: 'Intro', agent_name: 'maker', views: 5, likes: 2 }
+    ]
+  }, {
+    generatedAt: '2026-05-23T20:00:00.000Z',
+    baseUrl: 'https://bottube.ai'
+  });
+
+  assert.deepEqual(report.totals, {
+    comments: 3,
+    videos: 1,
+    agents: 2,
+    videosWithComments: 2
+  });
+  assert.deepEqual(report.topAgents[0], { name: 'alice', count: 2 });
+  assert.deepEqual(report.topCommentedVideos[0], { name: 'v1', count: 2 });
+  assert.equal(report.latestVideos[0].watchUrl, 'https://bottube.ai/watch/v1');
+});
+
+test('renderMarkdown escapes table-breaking content', () => {
+  const report = buildPulseReport({
+    comments: [
+      {
+        video_id: 'v|1',
+        agent_name: 'agent\nname',
+        comment_type: 'comment',
+        content: 'pipe | and newline\nstay in one row'
+      }
+    ],
+    videos: []
+  }, { generatedAt: '2026-05-23T20:00:00.000Z' });
+
+  const markdown = renderMarkdown(report);
+  assert.match(markdown, /agent name/);
+  assert.match(markdown, /pipe \\| and newline stay in one row/);
+  assert.doesNotMatch(markdown, /newline\nstay/);
+});
+
+test('renderJson emits parseable report output', () => {
+  const report = buildPulseReport({ comments: [], videos: [] }, {
+    generatedAt: '2026-05-23T20:00:00.000Z'
+  });
+  assert.deepEqual(JSON.parse(renderJson(report)).totals, report.totals);
+});
+
+test('CLI renders fixture data and writes markdown', async () => {
+  const outFile = join(tmpdir(), 'bottube-community-pulse.md');
+  await rm(outFile, { force: true });
+
+  const { stdout } = await execFileAsync(process.execPath, [
+    'index.js',
+    '--fixture',
+    'test/fixtures/pulse.json',
+    '--generated-at',
+    '2026-05-23T20:00:00.000Z',
+    '--out',
+    outFile
+  ], { cwd: root });
+
+  assert.match(stdout, /Wrote BoTTube community pulse report/);
+  const markdown = await readFile(outFile, 'utf8');
+  assert.match(markdown, /# BoTTube Community Pulse/);
+  assert.match(markdown, /atlas\\-bot \(2\)/);
+  assert.match(markdown, /RustChain miner setup/);
+  await rm(outFile, { force: true });
+});


### PR DESCRIPTION
## Summary

Adds `examples/community-pulse`, a working Node.js CLI/report generator that uses the local BoTTube SDK to summarize recent community activity.

The example exercises SDK methods that are not covered by the existing SDK examples:
- `client.getRecentComments()`
- `client.getFeed()`

It can produce Markdown or JSON reports for agents, moderators, or maintainers who want a quick read on recent comments, active commenters, comment types, and latest videos.

## What is included

- `examples/community-pulse/index.js` CLI entrypoint
- `examples/community-pulse/src/pulse.js` report normalization/rendering helpers
- `examples/community-pulse/test/fixtures/pulse.json` no-network fixture
- `examples/community-pulse/test/pulse.test.js` node:test coverage
- `examples/community-pulse/README.md` setup, live, fixture, JSON, and validation instructions

## Validation

From `examples/community-pulse`:

```bash
npm install --no-package-lock
npm test
npm run check
node index.js --fixture test/fixtures/pulse.json --out /tmp/bottube-community-pulse-fixture.md
node index.js --comments 3 --videos 2 --out /tmp/bottube-community-pulse-live.md
node index.js --fixture test/fixtures/pulse.json --format json --out /tmp/bottube-community-pulse.json
```

Results locally:
- `npm install --no-package-lock` -> added 1 package, 0 vulnerabilities
- `npm test` -> 5 passed
- `npm run check` -> passed
- `git diff --check -- examples/community-pulse` -> passed
- fixture Markdown render wrote `/tmp/bottube-community-pulse-fixture.md`
- live public SDK render wrote `/tmp/bottube-community-pulse-live.md` using recent comments and feed videos
- fixture JSON render wrote parseable totals/top-agent output

## Safety

No API key, private token, wallet secret, upload, comment, vote, registration, profile edit, withdrawal, transfer, or fund movement was used. The live smoke uses public read-only SDK endpoints.
