### PR TITLE
fix: label bridge and verifier form fields

### DIFF
--- a/bottube_templates/bridge.html
+++ b/bottube_templates/bridge.html
@@ -369,7 +369,7 @@
                 </div>
             </div>
             <div class="field-group">
-                <label>Transaction Signature (Solana)</label>
+                <label for="wrtc-deposit-tx">Transaction Signature (Solana)</label>
                 <input type="text" id="wrtc-deposit-tx" placeholder="5X... (Base58 signature)">
             </div>
             <button class="btn-primary" id="wrtc-deposit-btn" onclick="submitWrtcDeposit()" aria-label="Verify wRTC deposit transaction">Verify Transaction</button>
@@ -392,11 +392,11 @@
                 <span class="label">Your Balance</span>
             </div>
             <div class="field-group">
-                <label>Destination Wallet (Solana)</label>
+                <label for="wrtc-withdraw-addr">Destination Wallet (Solana)</label>
                 <input type="text" id="wrtc-withdraw-addr" placeholder="Your Solana public key" value="{{ user_sol_address or '' }}">
             </div>
             <div class="field-group">
-                <label>Amount to Withdraw (wRTC)</label>
+                <label for="wrtc-withdraw-amount">Amount to Withdraw (wRTC)</label>
                 <input type="number" id="wrtc-withdraw-amount" placeholder="10.0" min="10" step="0.1">
             </div>
             <button class="btn-primary" id="wrtc-withdraw-btn" onclick="submitWrtcWithdraw()" aria-label="Queue vault withdrawal for wRTC">Queue Vault Withdrawal</button>
@@ -472,7 +472,7 @@
                 </div>
             </div>
             <div class="field-group">
-                <label>Ergo Transaction ID</label>
+                <label for="ergo-deposit-tx">Ergo Transaction ID</label>
                 <input type="text" id="ergo-deposit-tx" placeholder="Paste your Ergo transaction ID...">
             </div>
             <button class="btn-primary btn-ergo" id="ergo-deposit-btn" onclick="submitErgoDeposit()" aria-label="Verify ERG deposit and credit account">Verify &amp; Credit</button>
@@ -492,11 +492,11 @@
                 <span class="label">Your Balance</span>
             </div>
             <div class="field-group">
-                <label>Ergo Wallet Address</label>
+                <label for="ergo-withdraw-addr">Ergo Wallet Address</label>
                 <input type="text" id="ergo-withdraw-addr" placeholder="Your Ergo address (starts with 9)...">
             </div>
             <div class="field-group">
-                <label>Amount (RTC to convert)</label>
+                <label for="ergo-withdraw-amount">Amount (RTC to convert)</label>
                 <input type="number" id="ergo-withdraw-amount" placeholder="16.0" min="8" step="0.1">
             </div>
             <button class="btn-primary btn-ergo" id="ergo-withdraw-btn" onclick="submitErgoWithdraw()" aria-label="Request ERG withdrawal">Request Withdrawal</button>

--- a/bottube_templates/verify.html
+++ b/bottube_templates/verify.html
@@ -78,7 +78,8 @@
   </p>
 
   <form id="vrf-form" class="vrf-form" onsubmit="event.preventDefault(); runVerify();">
-    <input type="text" id="vrf-vid" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus>
+    <label class="sr-only" for="vrf-vid">Video ID to verify</label>
+    <input type="text" id="vrf-vid" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus aria-label="Video ID to verify">
     <button type="submit" id="vrf-btn" aria-label="Verify video provenance">Verify</button>
     <button type="button" id="vrf-asset-btn" style="background:#999;color:#000" title="Stream the canonical asset bytes and re-hash" onclick="runVerify(true)">+ check asset bytes</button>
   </form>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -88,6 +88,30 @@ class TestAccessibilityAttributes(unittest.TestCase):
                       "Search form should have role='search'")
         self.assertIn('aria-label', match.group(0),
                       "Search form missing aria-label")
+
+    def test_bridge_inputs_have_associated_labels(self):
+        """Test that bridge wallet and transaction inputs have labels."""
+        content = self.read_file(self.TEMPLATE_DIR / 'bridge.html')
+        for input_id in (
+            'wrtc-deposit-tx',
+            'wrtc-withdraw-addr',
+            'wrtc-withdraw-amount',
+            'ergo-deposit-tx',
+            'ergo-withdraw-addr',
+            'ergo-withdraw-amount',
+        ):
+            self.assertIn(f'for="{input_id}"', content,
+                          f"Bridge input #{input_id} missing associated label")
+
+    def test_verify_video_id_input_has_accessible_name(self):
+        """Test that the provenance verifier video ID input is named."""
+        content = self.read_file(self.TEMPLATE_DIR / 'verify.html')
+        self.assertIn('for="vrf-vid"', content,
+                      "Verifier video ID input missing associated label")
+        match = re.search(r'<input[^>]*id="vrf-vid"[^>]*>', content)
+        self.assertIsNotNone(match, "Verifier video ID input not found")
+        self.assertIn('aria-label="Video ID to verify"', match.group(0),
+                      "Verifier video ID input missing aria-label fallback")
     
     def test_skip_link_present(self):
         """Test that skip link for keyboard navigation is present."""


### PR DESCRIPTION
## Summary

Fixes accessibility issue #1223 by giving bridge wallet/transaction fields and the provenance verifier video-id field stable accessible names.

## Changes

- Associates existing wRTC and ERG bridge labels with their inputs via `for` attributes.
- Adds an `sr-only` label and `aria-label` fallback for the provenance verifier `#vrf-vid` field.
- Adds regression coverage for the bridge/verifier fields in `tests/test_accessibility.py`.

## Validation

- `uv run --no-project --with pytest python -m pytest -p no:cacheprovider tests/test_accessibility.py -q` -> 19 passed
- `git diff --check` -> passed

## Bounty

Fixes https://github.com/Scottcjn/bottube/issues/1223
Related accessibility bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2139

RTC wallet: `RTC21cb705df64c81dcea3286a153453351b64aadae`
