### PR TITLE
Reject non-object generation job JSON bodies

### DIFF
--- a/generation/routes.py
+++ b/generation/routes.py
@@ -42,13 +42,31 @@ def init_routes(router: GenerationRouter, publish_fn=None):
     _publish_fn = publish_fn
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _string_field(data, field_name, default=""):
+    value = data.get(field_name, default)
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"{field_name} must be a string"}), 400)
+    return value, None
+
+
 def _require_api_key(f):
     """Accept X-API-Key header or agent_api_key in JSON body."""
     @wraps(f)
     def decorated(*args, **kwargs):
         api_key = request.headers.get("X-API-Key", "")
         if not api_key:
-            data = request.get_json(silent=True) or {}
+            data, error_response = _json_object_body()
+            if error_response:
+                return error_response
             api_key = data.get("agent_api_key", "")
         if not api_key:
             return jsonify({"error": "Missing API key"}), 401
@@ -102,8 +120,13 @@ def _record_rate(api_key: str):
 @_require_api_key
 def create_generation_job():
     """Create a new video generation job."""
-    data = request.get_json(silent=True) or {}
-    prompt = (data.get("prompt") or "").strip()
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
+    prompt_value, error_response = _string_field(data, "prompt", "")
+    if error_response:
+        return error_response
+    prompt = prompt_value.strip()
     if not prompt:
         return jsonify({"error": "prompt is required"}), 400
     if len(prompt) > 500:

--- a/tests/test_generation_routes.py
+++ b/tests/test_generation_routes.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: MIT
+
+import sys
+from types import SimpleNamespace
+
+from flask import Flask
+
+from generation.routes import generation_bp
+from video_gen_blueprint import video_gen_bp
+
+
+def create_app():
+    app = Flask(__name__)
+    app.register_blueprint(generation_bp)
+    return app
+
+
+def create_legacy_app():
+    app = Flask(__name__)
+    app.register_blueprint(video_gen_bp)
+    return app
+
+
+class FakeAgentDB:
+    def __init__(self, agent_id=9, api_key="legacy-secret"):
+        self.agent_id = agent_id
+        self.api_key = api_key
+
+    def execute(self, *_args, **_kwargs):
+        return self
+
+    def fetchone(self):
+        return {"id": self.agent_id, "api_key": self.api_key, "is_banned": 0}
+
+
+def test_generation_job_rejects_non_object_json_before_auth():
+    client = create_app().test_client()
+
+    response = client.post("/api/generation/jobs", json="not-object")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_generation_job_rejects_non_object_json_after_header_auth(monkeypatch):
+    class FakeDB:
+        def execute(self, *_args, **_kwargs):
+            return self
+
+        def fetchone(self):
+            return {"id": 7, "api_key": "secret", "is_banned": 0}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "bottube_server",
+        SimpleNamespace(get_db=lambda: FakeDB()),
+    )
+    client = create_app().test_client()
+
+    response = client.post(
+        "/api/generation/jobs",
+        json="not-object",
+        headers={"X-API-Key": "secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_generation_job_rejects_non_string_prompt_after_header_auth(monkeypatch):
+    class FakeDB:
+        def execute(self, *_args, **_kwargs):
+            return self
+
+        def fetchone(self):
+            return {"id": 7, "api_key": "secret", "is_banned": 0}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "bottube_server",
+        SimpleNamespace(get_db=lambda: FakeDB()),
+    )
+    client = create_app().test_client()
+
+    response = client.post(
+        "/api/generation/jobs",
+        json={"prompt": ["make a video"]},
+        headers={"X-API-Key": "secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "prompt must be a string"}
+
+
+def test_legacy_generate_video_rejects_non_object_json_before_auth():
+    client = create_legacy_app().test_client()
+
+    response = client.post("/api/generate-video", json=["not-object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_legacy_generate_video_rejects_non_object_json_after_header_auth(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "bottube_server",
+        SimpleNamespace(
+            CATEGORY_MAP={"other": "Other"},
+            get_db=lambda: FakeAgentDB(),
+        ),
+    )
+    client = create_legacy_app().test_client()
+
+    response = client.post(
+        "/api/generate-video",
+        json="not-object",
+        headers={"X-API-Key": "legacy-secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_legacy_generate_video_rejects_non_string_prompt(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "bottube_server",
+        SimpleNamespace(CATEGORY_MAP={"other": "Other"}, get_db=lambda: FakeAgentDB()),
+    )
+    client = create_legacy_app().test_client()
+
+    response = client.post(
+        "/api/generate-video",
+        json={"prompt": ["make a video"]},
+        headers={"X-API-Key": "legacy-secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "prompt must be a string"}
+
+
+def test_legacy_generate_video_rejects_non_integer_duration(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "bottube_server",
+        SimpleNamespace(CATEGORY_MAP={"other": "Other"}, get_db=lambda: FakeAgentDB()),
+    )
+    client = create_legacy_app().test_client()
+
+    response = client.post(
+        "/api/generate-video",
+        json={"prompt": "make a video", "duration": "long"},
+        headers={"X-API-Key": "legacy-secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "duration must be an integer"}
+
+
+def test_legacy_generate_video_rejects_non_string_category(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "bottube_server",
+        SimpleNamespace(CATEGORY_MAP={"other": "Other"}, get_db=lambda: FakeAgentDB()),
+    )
+    client = create_legacy_app().test_client()
+
+    response = client.post(
+        "/api/generate-video",
+        json={"prompt": "make a video", "category": ["music"]},
+        headers={"X-API-Key": "legacy-secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "category must be a string"}
+
+
+def test_legacy_generate_video_rejects_non_string_title(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "bottube_server",
+        SimpleNamespace(CATEGORY_MAP={"other": "Other"}, get_db=lambda: FakeAgentDB()),
+    )
+    client = create_legacy_app().test_client()
+
+    response = client.post(
+        "/api/generate-video",
+        json={"prompt": "make a video", "title": ["demo"]},
+        headers={"X-API-Key": "legacy-secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "title must be a string"}

--- a/video_gen_blueprint.py
+++ b/video_gen_blueprint.py
@@ -123,13 +123,24 @@ def _category_map() -> dict:
     return CATEGORY_MAP
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
 def _require_api_key_or_json(f):
     """Accept X-API-Key header (standard) or agent_api_key in JSON body."""
     @wraps(f)
     def decorated(*args, **kwargs):
         api_key = request.headers.get("X-API-Key", "")
         if not api_key:
-            data = request.get_json(silent=True) or {}
+            data, error_response = _json_object_body()
+            if error_response:
+                return error_response
             api_key = data.get("agent_api_key", "")
         if not api_key:
             return jsonify({"error": "Missing API key (X-API-Key header or agent_api_key in body)"}), 401
@@ -896,21 +907,38 @@ def generate_video():
         title       (str, optional)  - Video title (defaults to truncated prompt)
         agent_api_key (str, optional) - API key (alternative to X-API-Key header)
     """
-    data = request.get_json(silent=True) or {}
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
 
     # --- Input validation ---
-    prompt = (data.get("prompt") or "").strip()
+    prompt_value = data.get("prompt", "")
+    if not isinstance(prompt_value, str):
+        return jsonify({"error": "prompt must be a string"}), 400
+
+    prompt = prompt_value.strip()
     if not prompt:
         return jsonify({"error": "prompt is required"}), 400
     if len(prompt) > PROMPT_MAX_LEN:
         return jsonify({"error": f"prompt exceeds {PROMPT_MAX_LEN} characters"}), 400
 
-    duration = min(MAX_DURATION, max(1, int(data.get("duration", MAX_DURATION))))
-    category = (data.get("category") or "other").strip().lower()
+    duration_value = data.get("duration", MAX_DURATION)
+    try:
+        duration = min(MAX_DURATION, max(1, int(duration_value)))
+    except (TypeError, ValueError):
+        return jsonify({"error": "duration must be an integer"}), 400
+
+    category_value = data.get("category", "other")
+    if not isinstance(category_value, str):
+        return jsonify({"error": "category must be a string"}), 400
+    category = (category_value or "other").strip().lower()
     if category not in _category_map():
         category = "other"
 
-    title = (data.get("title") or "").strip()
+    title_value = data.get("title", "")
+    if not isinstance(title_value, str):
+        return jsonify({"error": "title must be a string"}), 400
+    title = title_value.strip()
     if not title:
         title = prompt[:200]
 


### PR DESCRIPTION
## Summary
- add shared JSON-object parsing for both generation job APIs
- reject non-object JSON before reading `agent_api_key` or generation fields
- validate legacy `/api/generate-video` field types for `prompt`, `duration`, `category`, and `title` so malformed authenticated bodies return 400s instead of 500s
- cover unauthenticated/authenticated non-object bodies plus authenticated malformed field bodies

Fixes #1225.

## Validation
- `uv run --no-project --with flask --with pytest python -B -m pytest -q tests/test_generation_routes.py --tb=short`
- `python3 -B -m py_compile generation/routes.py video_gen_blueprint.py tests/test_generation_routes.py`
- `git diff --check`

/claim #1102
