### PR TITLE
Validate chat REST JSON bodies

### DIFF
--- a/chat_handlers.py
+++ b/chat_handlers.py
@@ -10,6 +10,43 @@ import uuid as _uuid
 
 chat_bp = Blueprint("chat", __name__)
 
+
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _int_field(data, field_name, default=0):
+    value = data.get(field_name, default)
+    if isinstance(value, bool):
+        return None, (jsonify({"error": f"{field_name} must be an integer"}), 400)
+    try:
+        return int(value), None
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": f"{field_name} must be an integer"}), 400)
+
+
+def _float_field(data, field_name, default=0):
+    value = data.get(field_name, default)
+    if isinstance(value, bool):
+        return None, (jsonify({"error": f"{field_name} must be a number"}), 400)
+    try:
+        return float(value), None
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": f"{field_name} must be a number"}), 400)
+
+
+def _string_field(data, field_name, default=""):
+    value = data.get(field_name, default)
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"{field_name} must be a string"}), 400)
+    return value, None
+
+
 # ── Database helpers ────────────────────────────────────────────
 def get_db():
     """Return the app-wide SQLite connection (set in bottube_server.py)."""
@@ -90,9 +127,19 @@ def send_message(video_id):
     """REST fallback for sending a chat message (non-WebSocket clients)."""
     db = get_db()
     init_chat_tables(db)
-    data = request.get_json(force=True)
-    username = session.get("username", data.get("username", "Anonymous"))
-    msg_text = (data.get("message") or "").strip()
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
+
+    username_value, error_response = _string_field(data, "username", "Anonymous")
+    if error_response:
+        return error_response
+    message_value, error_response = _string_field(data, "message", "")
+    if error_response:
+        return error_response
+
+    username = session.get("username", username_value)
+    msg_text = message_value.strip()
     if not msg_text or len(msg_text) > 500:
         return jsonify({"error": "Message must be 1-500 chars"}), 400
 
@@ -106,8 +153,12 @@ def send_message(video_id):
         return jsonify({"error": "You are banned from this chat"}), 403
 
     msg_id = str(_uuid.uuid4())
-    is_super = int(data.get("is_super", 0))
-    tip = float(data.get("tip_amount", 0))
+    is_super, error_response = _int_field(data, "is_super", 0)
+    if error_response:
+        return error_response
+    tip, error_response = _float_field(data, "tip_amount", 0)
+    if error_response:
+        return error_response
 
     db.execute(
         "INSERT INTO chat_messages (id, video_id, user_id, username, message, is_super, tip_amount, created_at)"
@@ -123,16 +174,32 @@ def ban_user(video_id):
     """Moderator: ban a user from chat."""
     if not session.get("is_mod"):
         return jsonify({"error": "Moderator only"}), 403
-    data = request.get_json(force=True)
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
     db = get_db()
     init_chat_tables(db)
+
+    user_id, error_response = _string_field(data, "user_id", "")
+    if error_response:
+        return error_response
+    if not user_id.strip():
+        return jsonify({"error": "user_id is required"}), 400
+    reason, error_response = _string_field(data, "reason", "")
+    if error_response:
+        return error_response
+
     duration = data.get("duration")  # seconds, None = permanent
+    if duration is not None:
+        duration, error_response = _float_field(data, "duration", 0)
+        if error_response:
+            return error_response
     expires = time.time() + duration if duration else None
     db.execute(
         "INSERT INTO chat_bans (id, video_id, user_id, banned_by, reason, expires_at, created_at)"
         " VALUES (?,?,?,?,?,?,?)",
-        (str(_uuid.uuid4()), video_id, data["user_id"], session.get("username", "mod"),
-         data.get("reason", ""), expires, time.time()),
+        (str(_uuid.uuid4()), video_id, user_id.strip(), session.get("username", "mod"),
+         reason, expires, time.time()),
     )
     db.commit()
     return jsonify({"status": "banned"})
@@ -146,12 +213,25 @@ def chat_settings(video_id):
     if request.method == "POST":
         if not session.get("is_mod"):
             return jsonify({"error": "Moderator only"}), 403
-        data = request.get_json(force=True)
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        slow_mode, error_response = _int_field(data, "slow_mode", 0)
+        if error_response:
+            return error_response
+        sub_only, error_response = _int_field(data, "sub_only", 0)
+        if error_response:
+            return error_response
+        premiere, error_response = _int_field(data, "premiere", 0)
+        if error_response:
+            return error_response
+        premiere_at = data.get("premiere_at")
+        if premiere_at is not None and not isinstance(premiere_at, str):
+            return jsonify({"error": "premiere_at must be a string"}), 400
         db.execute(
             "INSERT OR REPLACE INTO chat_settings (video_id, slow_mode, sub_only, premiere, premiere_at)"
             " VALUES (?,?,?,?,?)",
-            (video_id, int(data.get("slow_mode", 0)), int(data.get("sub_only", 0)),
-             int(data.get("premiere", 0)), data.get("premiere_at")),
+            (video_id, slow_mode, sub_only, premiere, premiere_at),
         )
         db.commit()
         return jsonify({"status": "updated"})

--- a/tests/test_chat_handlers.py
+++ b/tests/test_chat_handlers.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+
+from flask import Flask
+
+from chat_handlers import chat_bp
+
+
+def create_app(tmp_path):
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["DATABASE"] = str(tmp_path / "chat.sqlite3")
+    app.register_blueprint(chat_bp)
+    return app
+
+
+def set_moderator(client):
+    with client.session_transaction() as session:
+        session["is_mod"] = True
+        session["username"] = "mod"
+
+
+def test_send_message_rejects_non_object_json(tmp_path):
+    client = create_app(tmp_path).test_client()
+
+    response = client.post("/api/chat/demo/send", json="not-object")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_send_message_rejects_non_string_message(tmp_path):
+    client = create_app(tmp_path).test_client()
+
+    response = client.post("/api/chat/demo/send", json={"message": ["hello"]})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "message must be a string"}
+
+
+def test_send_message_rejects_invalid_tip_amount(tmp_path):
+    client = create_app(tmp_path).test_client()
+
+    response = client.post(
+        "/api/chat/demo/send",
+        json={"message": "hello", "tip_amount": "many"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "tip_amount must be a number"}
+
+
+def test_send_message_rejects_boolean_numeric_fields(tmp_path):
+    client = create_app(tmp_path).test_client()
+
+    response = client.post(
+        "/api/chat/demo/send",
+        json={"message": "hello", "is_super": True},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "is_super must be an integer"}
+
+    response = client.post(
+        "/api/chat/demo/send",
+        json={"message": "hello", "tip_amount": False},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "tip_amount must be a number"}
+
+
+def test_ban_user_rejects_non_object_json(tmp_path):
+    client = create_app(tmp_path).test_client()
+    set_moderator(client)
+
+    response = client.post("/api/chat/demo/ban", json=["not-object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_ban_user_rejects_missing_user_id(tmp_path):
+    client = create_app(tmp_path).test_client()
+    set_moderator(client)
+
+    response = client.post("/api/chat/demo/ban", json={"reason": "spam"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "user_id is required"}
+
+
+def test_ban_user_rejects_invalid_duration(tmp_path):
+    client = create_app(tmp_path).test_client()
+    set_moderator(client)
+
+    response = client.post(
+        "/api/chat/demo/ban",
+        json={"user_id": "alice", "duration": "forever"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "duration must be a number"}
+
+
+def test_chat_settings_rejects_non_object_json(tmp_path):
+    client = create_app(tmp_path).test_client()
+    set_moderator(client)
+
+    response = client.post("/api/chat/demo/settings", json="not-object")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_chat_settings_rejects_invalid_numeric_fields(tmp_path):
+    client = create_app(tmp_path).test_client()
+    set_moderator(client)
+
+    response = client.post("/api/chat/demo/settings", json={"slow_mode": "fast"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "slow_mode must be an integer"}
+
+
+def test_chat_settings_rejects_boolean_numeric_fields(tmp_path):
+    client = create_app(tmp_path).test_client()
+    set_moderator(client)
+
+    response = client.post("/api/chat/demo/settings", json={"slow_mode": True})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "slow_mode must be an integer"}
+
+
+def test_chat_settings_rejects_non_string_premiere_at(tmp_path):
+    client = create_app(tmp_path).test_client()
+    set_moderator(client)
+
+    response = client.post("/api/chat/demo/settings", json={"premiere_at": ["soon"]})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "premiere_at must be a string"}


### PR DESCRIPTION
## Summary
- add shared JSON-object parsing for the live-chat REST fallback routes
- reject non-object chat JSON bodies before `.get()` access
- validate chat message, ban, and settings field types so malformed inputs return 400s instead of 500s
- add focused regression coverage for chat send, moderator ban, and moderator settings failures

Fixes #1228.

## Validation
- `uv run --no-project --with flask --with pytest python -B -m pytest -q tests/test_chat_handlers.py --tb=short`
- `python3 -B -m py_compile chat_handlers.py tests/test_chat_handlers.py`
- `git diff --check`

/claim #1102
