### PR TITLE
Validate agent wallet JSON bodies

### DIFF
--- a/agent_discovery.py
+++ b/agent_discovery.py
@@ -22,6 +22,15 @@ from flask import Blueprint, Response, current_app, jsonify, request
 discovery_bp = Blueprint("agent_discovery", __name__)
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
 # ═══════════════════════════════════════════════════════════════
 # GOOGLE A2A — Agent Card
 # Spec: https://google.github.io/A2A
@@ -822,7 +831,9 @@ def beacon_verify():
     POST {"agent_name": "...", "beacon_id": "bcn_..."}
     Returns whether the claimed beacon matches.
     """
-    data = request.get_json(silent=True) or {}
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
     agent_name = data.get("agent_name", "")
     claimed_id = data.get("beacon_id", "")
 

--- a/bottube_x402.py
+++ b/bottube_x402.py
@@ -160,6 +160,14 @@ def init_app(app, db_path):
     # Wallet Endpoints
     # ------------------------------------------------------------------
 
+    def _json_object_body():
+        data = request.get_json(silent=True)
+        if data is None:
+            return {}, None
+        if not isinstance(data, dict):
+            return None, (_jsonify({"error": "JSON object required"}), 400)
+        return data, None
+
     @app.route("/api/agents/me/coinbase-wallet", methods=["GET"])
     def x402_get_agent_wallet():
         """Get agent's Coinbase wallet info."""
@@ -193,7 +201,10 @@ def init_app(app, db_path):
         if not api_key:
             return _jsonify({"error": "API key required"}), 401
 
-        data = request.get_json(silent=True) or {}
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        has_manual_address = "coinbase_address" in data
         manual_address = data.get("coinbase_address")
 
         db = _get_db()
@@ -205,8 +216,12 @@ def init_app(app, db_path):
             if not agent:
                 return _jsonify({"error": "Invalid API key"}), 401
 
-            if manual_address:
+            if has_manual_address and manual_address is not None:
                 # Basic validation: 0x + 40 hex chars
+                if not isinstance(manual_address, str):
+                    return _jsonify({"error": "coinbase_address must be a string"}), 400
+                if not manual_address:
+                    return _jsonify({"error": "Invalid Ethereum address format"}), 400
                 if not (manual_address.startswith("0x") and len(manual_address) == 42):
                     return _jsonify({"error": "Invalid Ethereum address format"}), 400
                 db.execute(

--- a/tests/test_agent_wallet_json_validation.py
+++ b/tests/test_agent_wallet_json_validation.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+
+from flask import Flask
+
+from agent_discovery import discovery_bp
+from bottube_x402 import init_app as init_x402_app
+
+
+def test_beacon_verify_rejects_non_object_json():
+    app = Flask(__name__)
+    app.register_blueprint(discovery_bp)
+    client = app.test_client()
+
+    response = client.post("/api/beacon/verify", json="not-object")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def create_x402_app(tmp_path):
+    db_path = tmp_path / "bottube.sqlite3"
+    db = sqlite3.connect(db_path)
+    db.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY,
+            agent_name TEXT,
+            display_name TEXT,
+            api_key TEXT,
+            coinbase_address TEXT,
+            coinbase_wallet_created INTEGER DEFAULT 0
+        )
+        """
+    )
+    db.execute(
+        "INSERT INTO agents (id, agent_name, display_name, api_key) VALUES (?, ?, ?, ?)",
+        (1, "alice", "Alice", "secret"),
+    )
+    db.commit()
+    db.close()
+
+    app = Flask(__name__)
+    init_x402_app(app, db_path)
+    return app
+
+
+def test_coinbase_wallet_rejects_non_object_json(tmp_path):
+    client = create_x402_app(tmp_path).test_client()
+
+    response = client.post(
+        "/api/agents/me/coinbase-wallet",
+        json="not-object",
+        headers={"Authorization": "Bearer secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_coinbase_wallet_rejects_non_string_manual_address(tmp_path):
+    client = create_x402_app(tmp_path).test_client()
+
+    response = client.post(
+        "/api/agents/me/coinbase-wallet",
+        json={"coinbase_address": ["0x123"]},
+        headers={"Authorization": "Bearer secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "coinbase_address must be a string"}
+
+
+def test_coinbase_wallet_rejects_falsy_non_string_manual_address(tmp_path):
+    client = create_x402_app(tmp_path).test_client()
+
+    response = client.post(
+        "/api/agents/me/coinbase-wallet",
+        json={"coinbase_address": 0},
+        headers={"Authorization": "Bearer secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "coinbase_address must be a string"}


### PR DESCRIPTION
## Summary
- reject non-object JSON in `POST /api/beacon/verify` before reading Beacon fields
- reject non-object JSON in `POST /api/agents/me/coinbase-wallet` before wallet-linking logic
- validate manual `coinbase_address` type before calling string methods
- add focused regression coverage for Beacon verify and x402 wallet malformed JSON bodies

Fixes #1230.

## Validation
- `uv run --no-project --with flask --with pytest python -B -m pytest -q tests/test_agent_wallet_json_validation.py --tb=short`
- `python3 -B -m py_compile agent_discovery.py bottube_x402.py tests/test_agent_wallet_json_validation.py`
- `git diff --check`

/claim #1102
