### PR TITLE
Validate USDC API JSON bodies

### DIFF
--- a/tests/test_usdc_json_validation.py
+++ b/tests/test_usdc_json_validation.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+
+from flask import Flask
+
+from usdc_blueprint import usdc_bp
+
+
+def create_app(tmp_path, monkeypatch):
+    db_path = tmp_path / "bottube.sqlite3"
+    db = sqlite3.connect(db_path)
+    db.execute("CREATE TABLE agents (name TEXT, api_key TEXT)")
+    db.execute(
+        "INSERT INTO agents (name, api_key) VALUES (?, ?)",
+        ("alice", "secret"),
+    )
+    db.commit()
+    db.close()
+
+    monkeypatch.setenv("BOTTUBE_DB", str(db_path))
+    app = Flask(__name__)
+    app.register_blueprint(usdc_bp)
+    return app
+
+
+def auth_headers():
+    return {"X-API-Key": "secret"}
+
+
+def test_usdc_deposit_rejects_non_object_json(tmp_path, monkeypatch):
+    client = create_app(tmp_path, monkeypatch).test_client()
+
+    response = client.post(
+        "/api/usdc/deposit",
+        json="not-object",
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_usdc_deposit_rejects_non_string_tx_hash(tmp_path, monkeypatch):
+    client = create_app(tmp_path, monkeypatch).test_client()
+
+    response = client.post(
+        "/api/usdc/deposit",
+        json={"tx_hash": ["0x123"]},
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "tx_hash must be a string"}
+
+
+def test_usdc_premium_rejects_non_object_json(tmp_path, monkeypatch):
+    client = create_app(tmp_path, monkeypatch).test_client()
+
+    response = client.post(
+        "/api/usdc/premium",
+        json="not-object",
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_usdc_premium_rejects_non_string_tier(tmp_path, monkeypatch):
+    client = create_app(tmp_path, monkeypatch).test_client()
+
+    response = client.post(
+        "/api/usdc/premium",
+        json={"tier": ["basic"]},
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "tier must be a string"}
+
+
+def test_verify_payment_rejects_non_object_json():
+    app = Flask(__name__)
+    app.register_blueprint(usdc_bp)
+    client = app.test_client()
+
+    response = client.post("/api/usdc/verify-payment", json="not-object")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_verify_payment_rejects_non_string_tx_hash():
+    app = Flask(__name__)
+    app.register_blueprint(usdc_bp)
+    client = app.test_client()
+
+    response = client.post("/api/usdc/verify-payment", json={"tx_hash": ["0x123"]})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "tx_hash must be a string"}

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -72,6 +72,13 @@ def _parse_finite_usdc_amount(data):
     return amount, None
 
 
+def _string_field(data, field_name, default=""):
+    value = data.get(field_name, default)
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"{field_name} must be a string"}), 400)
+    return value, None
+
+
 def init_usdc_tables(db):
     """Create USDC-related tables if they don't exist."""
     db.executescript("""
@@ -246,8 +253,13 @@ def usdc_deposit():
     if not agent_name:
         return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
 
-    data = request.get_json() or {}
-    tx_hash = data.get("tx_hash", "").strip()
+    data, error = _request_json_object()
+    if error:
+        return error
+    tx_hash_raw, error = _string_field(data, "tx_hash", "")
+    if error:
+        return error
+    tx_hash = tx_hash_raw.strip()
     if not tx_hash or not tx_hash.startswith("0x"):
         return jsonify({"error": "tx_hash required (0x-prefixed Base chain transaction hash)"}), 400
 
@@ -430,8 +442,12 @@ def usdc_premium():
     if not agent_name:
         return jsonify({"error": "Authentication required"}), 401
 
-    data = request.get_json() or {}
-    tier = data.get("tier", "basic")
+    data, error = _request_json_object()
+    if error:
+        return error
+    tier, error = _string_field(data, "tier", "basic")
+    if error:
+        return error
 
     if tier not in PREMIUM_TIERS:
         return jsonify({
@@ -603,8 +619,13 @@ def usdc_stats():
 @usdc_bp.route('/api/usdc/verify-payment', methods=['POST'])
 def verify_payment():
     """Verify any USDC payment on Base chain. Returns transfer details."""
-    data = request.get_json() or {}
-    tx_hash = data.get("tx_hash", "").strip()
+    data, error = _request_json_object()
+    if error:
+        return error
+    tx_hash_raw, error = _string_field(data, "tx_hash", "")
+    if error:
+        return error
+    tx_hash = tx_hash_raw.strip()
 
     if not tx_hash or not tx_hash.startswith("0x"):
         return jsonify({"error": "tx_hash required"}), 400


### PR DESCRIPTION
## Summary
- use the existing USDC JSON-object parser in deposit, premium, and verify-payment routes
- validate string fields before calling `.strip()` or checking premium tier membership
- add focused regression coverage for malformed USDC JSON bodies and field types

Fixes #1232.

## Validation
- `uv run --no-project --with flask --with pytest --with requests python -B -m pytest -q tests/test_usdc_json_validation.py --tb=short`
- `python3 -B -m py_compile usdc_blueprint.py tests/test_usdc_json_validation.py`
- `git diff --check`

/claim #1102
