### PR TITLE
Validate USDC payment JSON bodies

### DIFF
--- a/tests/test_usdc_amount_validation.py
+++ b/tests/test_usdc_amount_validation.py
@@ -114,6 +114,115 @@ def test_usdc_tip_rejects_non_object_json_body(usdc_client):
     assert _table_count(usdc_client.db_path, "usdc_tips") == before_tips
 
 
+def test_usdc_deposit_rejects_non_object_json_before_verification(
+    usdc_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        usdc_blueprint,
+        "verify_usdc_transfer_onchain",
+        lambda _tx_hash: pytest.fail("verification should not run"),
+    )
+
+    response = usdc_client.post(
+        "/api/usdc/deposit",
+        json="not-object",
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+    assert _table_count(usdc_client.db_path, "usdc_deposits") == 0
+
+
+def test_usdc_deposit_rejects_non_string_tx_hash_before_verification(
+    usdc_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        usdc_blueprint,
+        "verify_usdc_transfer_onchain",
+        lambda _tx_hash: pytest.fail("verification should not run"),
+    )
+
+    response = usdc_client.post(
+        "/api/usdc/deposit",
+        json={"tx_hash": ["0xabc"]},
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"].startswith("tx_hash required")
+    assert _table_count(usdc_client.db_path, "usdc_deposits") == 0
+
+
+def test_usdc_premium_rejects_non_object_json_without_writes(usdc_client):
+    before_premium = _table_count(usdc_client.db_path, "usdc_premium")
+    before_alice = _balance(usdc_client.db_path, "alice")
+
+    response = usdc_client.post(
+        "/api/usdc/premium",
+        json="not-object",
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+    assert _table_count(usdc_client.db_path, "usdc_premium") == before_premium
+    assert _balance(usdc_client.db_path, "alice") == before_alice
+
+
+def test_usdc_premium_rejects_non_string_tier_without_writes(usdc_client):
+    before_premium = _table_count(usdc_client.db_path, "usdc_premium")
+    before_alice = _balance(usdc_client.db_path, "alice")
+
+    response = usdc_client.post(
+        "/api/usdc/premium",
+        json={"tier": ["basic"]},
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "tier must be a string"
+    assert _table_count(usdc_client.db_path, "usdc_premium") == before_premium
+    assert _balance(usdc_client.db_path, "alice") == before_alice
+
+
+def test_usdc_verify_payment_rejects_non_object_json_before_verification(
+    usdc_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        usdc_blueprint,
+        "verify_usdc_transfer_onchain",
+        lambda _tx_hash: pytest.fail("verification should not run"),
+    )
+
+    response = usdc_client.post("/api/usdc/verify-payment", json=["bad"])
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+
+
+def test_usdc_verify_payment_rejects_non_string_tx_hash_before_verification(
+    usdc_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        usdc_blueprint,
+        "verify_usdc_transfer_onchain",
+        lambda _tx_hash: pytest.fail("verification should not run"),
+    )
+
+    response = usdc_client.post(
+        "/api/usdc/verify-payment",
+        json={"tx_hash": ["0xabc"]},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "tx_hash required"
+
+
 def test_valid_usdc_tip_still_debits_sender_and_credits_creator(usdc_client):
     response = usdc_client.post(
         "/api/usdc/tip",

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -246,8 +246,11 @@ def usdc_deposit():
     if not agent_name:
         return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
 
-    data = request.get_json() or {}
-    tx_hash = data.get("tx_hash", "").strip()
+    data, error = _request_json_object()
+    if error:
+        return error
+    tx_hash_raw = data.get("tx_hash", "")
+    tx_hash = tx_hash_raw.strip() if isinstance(tx_hash_raw, str) else ""
     if not tx_hash or not tx_hash.startswith("0x"):
         return jsonify({"error": "tx_hash required (0x-prefixed Base chain transaction hash)"}), 400
 
@@ -430,8 +433,12 @@ def usdc_premium():
     if not agent_name:
         return jsonify({"error": "Authentication required"}), 401
 
-    data = request.get_json() or {}
+    data, error = _request_json_object()
+    if error:
+        return error
     tier = data.get("tier", "basic")
+    if not isinstance(tier, str):
+        return jsonify({"error": "tier must be a string"}), 400
 
     if tier not in PREMIUM_TIERS:
         return jsonify({
@@ -603,8 +610,11 @@ def usdc_stats():
 @usdc_bp.route('/api/usdc/verify-payment', methods=['POST'])
 def verify_payment():
     """Verify any USDC payment on Base chain. Returns transfer details."""
-    data = request.get_json() or {}
-    tx_hash = data.get("tx_hash", "").strip()
+    data, error = _request_json_object()
+    if error:
+        return error
+    tx_hash_raw = data.get("tx_hash", "")
+    tx_hash = tx_hash_raw.strip() if isinstance(tx_hash_raw, str) else ""
 
     if not tx_hash or not tx_hash.startswith("0x"):
         return jsonify({"error": "tx_hash required"}), 400


### PR DESCRIPTION
Fixes #1232.

Summary:
- routes `/api/usdc/deposit`, `/api/usdc/premium`, and `/api/usdc/verify-payment` through the existing JSON-object helper
- rejects non-object JSON bodies with deterministic `400 {"error": "JSON object required"}` before verification or write paths run
- rejects non-string `tx_hash` values before on-chain verification is attempted
- rejects non-string premium tiers before balance checks or premium writes
- adds regressions proving malformed deposit, premium, and verify-payment requests do not call verification and do not write payment tables

Validation:
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bottube-1232-venv/bin/python -m pytest tests/test_usdc_amount_validation.py -q` -> 17 passed
- `/tmp/bottube-1232-venv/bin/python -m py_compile usdc_blueprint.py tests/test_usdc_amount_validation.py` -> passed
- `git diff --check` -> passed

Note: full-file flake8 is not cited because `usdc_blueprint.py` and this existing test file already contain unrelated pre-existing style violations outside this patch.

No secrets, tokens, hidden prompts, private runtime data, or payout details are included.