### PR TITLE
Validate remaining Discover API numeric params

### DIFF
--- a/search_blueprint.py
+++ b/search_blueprint.py
@@ -202,7 +202,10 @@ def api_tags():
     Query params:
     - limit: max tags to return (default: 50)
     """
-    limit = min(int(request.args.get('limit', 50)), 100)
+    try:
+        limit = _parse_int_query('limit', 50, min_val=1, max_val=100)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     
     db = get_db()
     
@@ -231,8 +234,11 @@ def api_tags():
 @search_bp.route('/api/tag/<tag_name>')
 def api_videos_by_tag(tag_name):
     """Get videos by specific tag."""
-    limit = min(int(request.args.get('limit', 20)), 50)
-    offset = int(request.args.get('offset', 0))
+    try:
+        limit = _parse_int_query('limit', 20, min_val=1, max_val=50)
+        offset = _parse_int_query('offset', 0, min_val=0)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     
     db = get_db()
     
@@ -304,7 +310,10 @@ def api_trending():
     Get trending videos based on recent views + engagement velocity.
     Uses formula: (views_24h * 2 + comments_24h * 5) for recency weighting.
     """
-    limit = min(int(request.args.get('limit', 20)), 50)
+    try:
+        limit = _parse_int_query('limit', 20, min_val=1, max_val=50)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     
     db = get_db()
     
@@ -371,7 +380,10 @@ def api_for_you():
     Authenticate via X-API-Key header to get personalized results.
     Falls back to trending if no key provided.
     """
-    limit = min(int(request.args.get('limit', 20)), 50)
+    try:
+        limit = _parse_int_query('limit', 20, min_val=1, max_val=50)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
 
     # Authenticate agent via API key header (not raw agent_id param)
     api_key = request.headers.get('X-API-Key', '').strip()

--- a/tests/test_search_blueprint_query_validation.py
+++ b/tests/test_search_blueprint_query_validation.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+"""Query validation tests for standalone discoverability blueprint endpoints."""
+
+import pytest
+from flask import Flask
+
+from search_blueprint import search_bp
+
+
+@pytest.fixture()
+def discover_client():
+    app = Flask(__name__)
+    app.register_blueprint(search_bp)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/discover/api/tags?limit=not-an-int",
+        "/discover/api/tag/python?limit=not-an-int",
+        "/discover/api/tag/python?offset=not-an-int",
+        "/discover/api/trending?limit=not-an-int",
+        "/discover/api/for-you?limit=not-an-int",
+    ],
+)
+def test_discoverability_endpoints_reject_malformed_integer_params(discover_client, path):
+    resp = discover_client.get(path)
+
+    assert resp.status_code == 400
+    assert "expected an integer" in resp.get_json()["error"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/discover/api/tags?limit=0",
+        "/discover/api/tag/python?limit=0",
+        "/discover/api/tag/python?offset=-1",
+        "/discover/api/trending?limit=0",
+        "/discover/api/for-you?limit=0",
+    ],
+)
+def test_discoverability_endpoints_reject_out_of_range_integer_params(discover_client, path):
+    resp = discover_client.get(path)
+
+    assert resp.status_code == 400
+    assert "Invalid" in resp.get_json()["error"]


### PR DESCRIPTION
## Summary
- Reuses the existing `_parse_int_query` helper for the remaining Discover endpoints that still parsed numeric query params with direct `int(...)` calls.
- Returns deterministic JSON 400 responses for malformed or out-of-range `limit` / `offset` values on tags, tag videos, trending, and for-you.
- Adds standalone blueprint tests so malformed input is rejected before database access.

## Why
#1005 / #1144 fixed `/discover/api/search` and `/discover/api/agents`, but the original issue also listed these remaining endpoints. Live checks on 2026-05-25 still returned HTTP 500 HTML responses for malformed params.

Fixes #1242

## Validation
- `uv run --no-project --with flask --with pytest python -m pytest -q tests/test_search_blueprint_query_validation.py` -> 10 passed
- `python3 -m py_compile search_blueprint.py tests/test_search_blueprint_query_validation.py` -> passed
- `git diff --check` -> passed