### PR TITLE
fix: Discover endpoints return 400 on malformed numeric query params

### DIFF
--- a/search_blueprint.py
+++ b/search_blueprint.py
@@ -202,7 +202,10 @@ def api_tags():
     Query params:
     - limit: max tags to return (default: 50)
     """
-    limit = min(int(request.args.get('limit', 50)), 100)
+    try:
+        limit = _parse_int_query('limit', 50, min_val=1, max_val=100)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     
     db = get_db()
     
@@ -231,8 +234,11 @@ def api_tags():
 @search_bp.route('/api/tag/<tag_name>')
 def api_videos_by_tag(tag_name):
     """Get videos by specific tag."""
-    limit = min(int(request.args.get('limit', 20)), 50)
-    offset = int(request.args.get('offset', 0))
+    try:
+        limit = _parse_int_query('limit', 20, min_val=1, max_val=50)
+        offset = _parse_int_query('offset', 0, min_val=0)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     
     db = get_db()
     
@@ -304,7 +310,10 @@ def api_trending():
     Get trending videos based on recent views + engagement velocity.
     Uses formula: (views_24h * 2 + comments_24h * 5) for recency weighting.
     """
-    limit = min(int(request.args.get('limit', 20)), 50)
+    try:
+        limit = _parse_int_query('limit', 20, min_val=1, max_val=50)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     
     db = get_db()
     
@@ -371,7 +380,10 @@ def api_for_you():
     Authenticate via X-API-Key header to get personalized results.
     Falls back to trending if no key provided.
     """
-    limit = min(int(request.args.get('limit', 20)), 50)
+    try:
+        limit = _parse_int_query('limit', 20, min_val=1, max_val=50)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
 
     # Authenticate agent via API key header (not raw agent_id param)
     api_key = request.headers.get('X-API-Key', '').strip()


### PR DESCRIPTION
## Summary

Fixes #1242

The remaining Discover endpoints still use direct `int(...)` conversion on numeric query parameters, causing 500 HTML responses on malformed input instead of deterministic JSON 400 responses.

## Changes

Replaces unsafe `int(request.args.get(...))` calls with the existing `_parse_int_query` helper in four endpoints:

| Endpoint | Before | After |
|---|---|---|
| `/api/tags` | `min(int(request.args.get('limit', 50)), 100)` | `_parse_int_query('limit', 50, min_val=1, max_val=100)` |
| `/api/tag/<tag_name>` | `int(request.args.get('limit', 20))` + `int(request.args.get('offset', 0))` | `_parse_int_query` for both |
| `/api/trending` | `min(int(request.args.get('limit', 20)), 50)` | `_parse_int_query('limit', 20, min_val=1, max_val=50)` |
| `/api/for-you` | `min(int(request.args.get('limit', 20)), 50)` | `_parse_int_query('limit', 20, min_val=1, max_val=50)` |

## Before

```bash
curl -i 'https://bottube.ai/discover/api/tags?limit=abc'
# HTTP/2 500  (HTML error page)
```

## After

```json
{"error": "Invalid 'limit' parameter: expected an integer."}
# HTTP 400
```

Consistent with the pattern already established in `/api/search` and `/api/agents` (from #1144).

/attempt #1242