### PR TITLE
fix(api): validate non-string JSON fields in comment routes (#1196)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7143,8 +7143,16 @@ def add_comment(video_id):
         return jsonify({"error": "Video not found"}), 404
 
     data = request.get_json(silent=True) or {}
-    content = data.get("content", "").strip()
-    comment_type = (data.get("comment_type") or "comment").strip().lower()
+    if not isinstance(data, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+    raw_content = data.get("content")
+    if raw_content is None or not isinstance(raw_content, str):
+        return jsonify({"error": "content is required and must be a string"}), 400
+    content = raw_content.strip()
+    raw_comment_type = data.get("comment_type")
+    if raw_comment_type is not None and not isinstance(raw_comment_type, str):
+        return jsonify({"error": "comment_type must be a string"}), 400
+    comment_type = (raw_comment_type or "comment").strip().lower()
     if not content:
         return jsonify({"error": "content is required"}), 400
     if comment_type not in COMMENT_TYPES:
@@ -7233,8 +7241,16 @@ def web_add_comment(video_id):
         return jsonify({"error": "Video not found"}), 404
 
     data = request.get_json(silent=True) or {}
-    content = data.get("content", "").strip()
-    comment_type = (data.get("comment_type") or "comment").strip().lower()
+    if not isinstance(data, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+    raw_content = data.get("content")
+    if raw_content is None or not isinstance(raw_content, str):
+        return jsonify({"error": "content is required and must be a string"}), 400
+    content = raw_content.strip()
+    raw_comment_type = data.get("comment_type")
+    if raw_comment_type is not None and not isinstance(raw_comment_type, str):
+        return jsonify({"error": "comment_type must be a string"}), 400
+    comment_type = (raw_comment_type or "comment").strip().lower()
     if not content:
         return jsonify({"error": "content is required"}), 400
     if comment_type not in COMMENT_TYPES:


### PR DESCRIPTION
## Summary

Fixes #1196 — Comment routes crash on non-string JSON fields before validation.

## Problem

Both `POST /api/videos/<video_id>/comment` and `POST /api/videos/<video_id>/web-comment` call `.strip()` directly on JSON field values. Valid JSON with `null`, arrays, objects, or numbers raises `AttributeError` instead of returning a deterministic 400.

Examples that crash:
```json
{"content": null}
{"content": "good video", "comment_type": ["review"]}
```

## Fix

- Validate `content` is a string before calling `.strip()`
- Validate `comment_type` is a string (if provided) before calling `.strip().lower()`
- Reject non-object JSON payloads in web-comment route with 400
- Return deterministic 400 validation errors instead of 500 server errors

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `{"content": null}` | 500 AttributeError | 400 "content is required and must be a string" |
| `{"content": 123}` | 500 AttributeError | 400 "content is required and must be a string" |
| `{"comment_type": ["x"]}` | 500 AttributeError | 400 "comment_type must be a string" |
| `"hello"` (non-object body) | 500 AttributeError | 400 "Request body must be a JSON object" |

## Test plan

```bash
curl -X POST http://localhost:5000/api/videos/test/comment \
  -H 'X-API-Key: test' -H 'Content-Type: application/json' \
  -d '{"content": null}'
# Expected: 400, not 500

curl -X POST http://localhost:5000/api/videos/test/comment \
  -H 'X-API-Key: test' -H 'Content-Type: application/json' \
  -d '{"content": "hello", "comment_type": ["review"]}'
# Expected: 400, not 500
```