### PR TITLE
Fix watch subscribe aria-label channel name

### DIFF
--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2516,11 +2516,12 @@
             </div>
             {% endif %}
 
+            {% set channel_display_name = video.display_name or video.channel_name or video.agent_name %}
             <div class="channel-row" role="group" aria-label="Channel information">
-                <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.display_name or video.agent_name }} avatar">
+                <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ channel_display_name }} avatar">
                 <div>
                     <div class="channel-name" id="channel-name">
-                        <a href="{{ P }}/agent/{{ video.agent_name }}">{{ video.display_name or video.agent_name }}</a>
+                        <a href="{{ P }}/agent/{{ video.agent_name }}">{{ channel_display_name }}</a>
                         {% if video.is_human %}
                         <span class="badge-human">Human</span>
                         {% else %}
@@ -2534,12 +2535,12 @@
                 </div>
                 <div class="channel-row-right">
                     {% if current_user and current_user.agent_name != video.agent_name %}
-                    <button id="watch-sub-btn" aria-label="Subscribe to {{ video.channel_name }}" class="watch-sub-btn {{ 'following' if is_following else 'not-following' }}"
+                    <button id="watch-sub-btn" aria-label="Subscribe to {{ channel_display_name }}" class="watch-sub-btn {{ 'following' if is_following else 'not-following' }}"
                             onclick="toggleWatchSubscribe()">
                         {{ 'Following' if is_following else 'Subscribe' }}
                     </button>
                     {% elif not current_user %}
-                    <a href="{{ P }}/login" aria-label="Subscribe to {{ video.channel_name }}" class="watch-sub-btn not-following">Subscribe</a>
+                    <a href="{{ P }}/login" aria-label="Subscribe to {{ channel_display_name }}" class="watch-sub-btn not-following">Subscribe</a>
                     {% endif %}
                 </div>
             </div>

--- a/tests/test_watch_page_accessibility.py
+++ b/tests/test_watch_page_accessibility.py
@@ -251,3 +251,17 @@ def test_watch_page_has_persistent_theme_toggle(client):
     assert "function toggleWatchTheme()" in html
     assert "function setWatchTheme(theme, persist)" in html
     assert "watch-theme-light" in html
+
+
+def test_logged_out_watch_subscribe_link_names_channel(client):
+    """Issue #1245: logged-out subscribe links need a non-empty channel name."""
+    agent_id = _insert_agent("labelbot", "bottube_sk_labelbot")
+    _insert_video(agent_id, "watchsuba11y01")
+
+    resp = client.get("/watch/watchsuba11y01")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert 'class="watch-sub-btn not-following"' in html
+    assert 'aria-label="Subscribe to Labelbot"' in html
+    assert 'aria-label="Subscribe to "' not in html


### PR DESCRIPTION
## Summary
- derive one watch-page channel display name from `display_name`, `channel_name`, or `agent_name`
- use that value for the channel avatar, visible channel link, and Subscribe aria-labels
- add regression coverage for the logged-out Subscribe link so it cannot render `Subscribe to ` with an empty target

Fixes #1245.

## Validation
- `/tmp/bottube-test-venv312/bin/python -B -m pytest -q tests/test_watch_page_accessibility.py --tb=short`

RTC wallet / miner ID: `gaoaaa52-del`
