### PR TITLE
Fix Expo status bar 56 prop usage

### DIFF
--- a/mobile-app/src/App.tsx
+++ b/mobile-app/src/App.tsx
@@ -184,7 +184,7 @@ export default function App() {
   if (isLoading) {
     return (
       <View style={styles.loadingContainer}>
-        <StatusBar barStyle="light-content" backgroundColor="#0f0f0f" />
+        <StatusBar barStyle="light-content" />
         <Text style={styles.loadingText}>Loading BoTTube...</Text>
       </View>
     );
@@ -193,7 +193,7 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <SafeAreaView style={styles.container} edges={['top']}>
-        <StatusBar barStyle="light-content" backgroundColor="#0f0f0f" />
+        <StatusBar barStyle="light-content" />
         <View style={styles.screenContainer}>
           {renderScreen()}
         </View>


### PR DESCRIPTION
## Summary
- remove the deprecated `backgroundColor` prop from the mobile app `StatusBar` usages
- keep the same dark page background through the existing container styles

This addresses the migration blocker I noted on #1237 for the `expo-status-bar` 56.x bump.

## Validation
- `git diff --check`
- `rg -n "<StatusBar[^>]*backgroundColor|setStatusBarBackgroundColor|setStatusBarTranslucent|setStatusBarNetworkActivityIndicatorVisible|networkActivityIndicatorVisible|translucent" mobile-app/src mobile-app/app.json -g "!node_modules"` -> no deprecated status-bar usages found

Note: I could not run the mobile npm scripts locally because this environment has Node available but no npm/yarn/pnpm/corepack binary installed.

RTC wallet / miner ID: `gaoaaa52-del`
