### PR TITLE
Validate admin moderation JSON fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14342,6 +14342,27 @@ def _require_admin():
     return None
 
 
+def _admin_text_field(data, field, default="", max_length=None):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, f"{field} must be a string"
+    value = value.strip()
+    if max_length is not None:
+        value = value[:max_length]
+    return value, None
+
+
+def _admin_json_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, "JSON body must be an object"
+    return data, None
+
+
 @app.route("/api/admin/ban", methods=["POST"])
 def admin_ban_agent():
     """Coach/review an agent by name. Force is required for an actual ban.
@@ -14352,9 +14373,15 @@ def admin_ban_agent():
     if err:
         return err
 
-    data = request.get_json(silent=True) or {}
-    agent_name = data.get("agent_name", "").strip()
-    reason = data.get("reason", "Needs moderation review").strip()
+    data, error = _admin_json_body()
+    if error:
+        return jsonify({"error": error}), 400
+    agent_name, error = _admin_text_field(data, "agent_name")
+    if error:
+        return jsonify({"error": error}), 400
+    reason, error = _admin_text_field(data, "reason", default="Needs moderation review")
+    if error:
+        return jsonify({"error": error}), 400
     force = bool(data.get("force", False))
 
     if not agent_name:
@@ -14417,8 +14444,12 @@ def admin_unban_agent():
     if err:
         return err
 
-    data = request.get_json(silent=True) or {}
-    agent_name = data.get("agent_name", "").strip()
+    data, error = _admin_json_body()
+    if error:
+        return jsonify({"error": error}), 400
+    agent_name, error = _admin_text_field(data, "agent_name")
+    if error:
+        return jsonify({"error": error}), 400
 
     if not agent_name:
         return jsonify({"error": "agent_name required"}), 400
@@ -14443,9 +14474,15 @@ def admin_nuke_agent():
     if err:
         return err
 
-    data = request.get_json(silent=True) or {}
-    agent_name = data.get("agent_name", "").strip()
-    reason = data.get("reason", "Escalated moderation review").strip()
+    data, error = _admin_json_body()
+    if error:
+        return jsonify({"error": error}), 400
+    agent_name, error = _admin_text_field(data, "agent_name")
+    if error:
+        return jsonify({"error": error}), 400
+    reason, error = _admin_text_field(data, "reason", default="Escalated moderation review")
+    if error:
+        return jsonify({"error": error}), 400
     force = bool(data.get("force", False))
 
     if not agent_name:
@@ -14553,9 +14590,15 @@ def admin_remove_video():
     if err:
         return err
 
-    data = request.get_json(silent=True) or {}
-    video_id = data.get("video_id", "").strip()
-    reason = data.get("reason", "Held for moderation review").strip()
+    data, error = _admin_json_body()
+    if error:
+        return jsonify({"error": error}), 400
+    video_id, error = _admin_text_field(data, "video_id")
+    if error:
+        return jsonify({"error": error}), 400
+    reason, error = _admin_text_field(data, "reason", default="Held for moderation review")
+    if error:
+        return jsonify({"error": error}), 400
     force = bool(data.get("force", False))
 
     if not video_id:
@@ -15390,10 +15433,16 @@ def admin_bulk_remove():
     if err:
         return err
 
-    data = request.get_json(silent=True) or {}
+    data, error = _admin_json_body()
+    if error:
+        return jsonify({"error": error}), 400
     video_ids = data.get("video_ids", [])
-    agent_name = data.get("agent_name", "").strip()
-    reason = data.get("reason", "Bulk moderation review").strip()
+    agent_name, error = _admin_text_field(data, "agent_name")
+    if error:
+        return jsonify({"error": error}), 400
+    reason, error = _admin_text_field(data, "reason", default="Bulk moderation review")
+    if error:
+        return jsonify({"error": error}), 400
     force = bool(data.get("force", False))
 
     db = get_db()
@@ -16153,9 +16202,15 @@ def admin_resolve_reward_hold(hold_id):
     if not hold:
         return jsonify({"error": "Reward hold not found"}), 404
 
-    data = request.get_json(silent=True) or {}
-    action = data.get("action", "dismiss")
-    reviewer_note = data.get("note", "").strip()[:2000]
+    data, error = _admin_json_body()
+    if error:
+        return jsonify({"error": error}), 400
+    action, error = _admin_text_field(data, "action", default="dismiss")
+    if error:
+        return jsonify({"error": error}), 400
+    reviewer_note, error = _admin_text_field(data, "note", max_length=2000)
+    if error:
+        return jsonify({"error": error}), 400
     now = time.time()
 
     if action == "credit":
@@ -16251,10 +16306,19 @@ def admin_resolve_moderation_hold(hold_id):
     if not hold:
         return jsonify({"error": "Moderation hold not found"}), 404
 
-    data = request.get_json(silent=True) or {}
-    action = data.get("action", "dismiss")
-    reviewer_note = data.get("note", "").strip()[:2000]
-    coach_note = data.get("coach_note", "").strip()[:5000] or hold["coach_note"] or reviewer_note
+    data, error = _admin_json_body()
+    if error:
+        return jsonify({"error": error}), 400
+    action, error = _admin_text_field(data, "action", default="dismiss")
+    if error:
+        return jsonify({"error": error}), 400
+    reviewer_note, error = _admin_text_field(data, "note", max_length=2000)
+    if error:
+        return jsonify({"error": error}), 400
+    coach_note, error = _admin_text_field(data, "coach_note", max_length=5000)
+    if error:
+        return jsonify({"error": error}), 400
+    coach_note = coach_note or hold["coach_note"] or reviewer_note
     now = time.time()
 
     status = "dismissed"

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -427,6 +427,59 @@ def test_admin_ban_defaults_to_coaching_hold_instead_of_ban(client):
     assert moderation_messages == 1
 
 
+def test_admin_moderation_routes_reject_malformed_json_fields(client):
+    agent_id = _insert_agent("jsonadmin", "bottube_sk_jsonadmin")
+    _insert_video(agent_id, "jsonadmin01A")
+
+    resp = client.post(
+        "/api/admin/ban",
+        headers={"X-Admin-Key": bottube_server.ADMIN_KEY},
+        json=["not", "an", "object"],
+    )
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+
+    bad_admin_payloads = [
+        ("/api/admin/ban", {"agent_name": ["jsonadmin"], "reason": "spam"}, "agent_name must be a string"),
+        ("/api/admin/ban", {"agent_name": "jsonadmin", "reason": ["spam"]}, "reason must be a string"),
+        ("/api/admin/nuke", {"agent_name": {"name": "jsonadmin"}, "reason": "spam"}, "agent_name must be a string"),
+        ("/api/admin/remove-video", {"video_id": ["jsonadmin01A"], "reason": "spam"}, "video_id must be a string"),
+        ("/api/admin/bulk-remove", {"agent_name": "jsonadmin", "reason": ["spam"]}, "reason must be a string"),
+    ]
+
+    for path, payload, error in bad_admin_payloads:
+        resp = client.post(
+            path,
+            headers={"X-Admin-Key": bottube_server.ADMIN_KEY},
+            json=payload,
+        )
+        assert resp.status_code == 400
+        assert resp.get_json() == {"error": error}
+
+    resp = client.post(
+        "/api/admin/remove-video",
+        headers={"X-Admin-Key": bottube_server.ADMIN_KEY},
+        json={"video_id": "jsonadmin01A", "reason": "needs review"},
+    )
+    assert resp.status_code == 200
+    hold_id = resp.get_json()["hold_id"]
+
+    malformed_resolve_payloads = [
+        ({"action": ["release"], "note": "ok"}, "action must be a string"),
+        ({"action": "coach", "note": ["bad"]}, "note must be a string"),
+        ({"action": "coach", "coach_note": {"body": "bad"}}, "coach_note must be a string"),
+    ]
+
+    for payload, error in malformed_resolve_payloads:
+        resp = client.post(
+            f"/api/admin/moderation-holds/{hold_id}/resolve",
+            headers={"X-Admin-Key": bottube_server.ADMIN_KEY},
+            json=payload,
+        )
+        assert resp.status_code == 400
+        assert resp.get_json() == {"error": error}
+
+
 def test_report_threshold_queues_hold_without_auto_removal(client):
     owner_id = _insert_agent("ownerbot", "bottube_sk_ownerbot")
     _insert_video(owner_id, "ownerclip01A")


### PR DESCRIPTION
## Summary
- add shared admin text-field validation for moderation/admin JSON inputs
- return deterministic 400 errors for non-string `agent_name`, `reason`, `video_id`, `action`, `note`, and `coach_note` fields
- add regression coverage for malformed admin moderation payloads

Fixes #1249.

## Validation
- `/tmp/bottube-test-venv312/bin/python -B -m pytest -q tests/test_quests.py --tb=short` -> 17 passed
- `/tmp/bottube-test-venv312/bin/python -B -m py_compile bottube_server.py tests/test_quests.py`
- `git diff --check`

RTC wallet / miner ID: `gaoaaa52-del`
