### PR TITLE
Validate BAN video reward JSON fields

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -92,6 +92,15 @@ def _parse_positive_ban_amount(data):
     return amount, None
 
 
+def _json_text_field(data, name, default=""):
+    value = data.get(name, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"{name} must be a string"}), 400)
+    return value.strip(), None
+
+
 def init_ban_tables(db=None):
     """Create Banano-related tables if they don't exist."""
     if db is None:
@@ -585,10 +594,19 @@ def ban_reward_video_gen():
     if not user_id and not is_admin:
         return jsonify({"error": "Authentication required"}), 401
 
-    data = request.get_json() or {}
-    agent_name = data.get("agent_name", "").strip()
-    video_id = data.get("video_id", "").strip()
-    gen_method = data.get("gen_method", "text").strip().lower()
+    data, error = _request_json_object()
+    if error:
+        return error
+    agent_name, error = _json_text_field(data, "agent_name")
+    if error:
+        return error
+    video_id, error = _json_text_field(data, "video_id")
+    if error:
+        return error
+    gen_method, error = _json_text_field(data, "gen_method", "text")
+    if error:
+        return error
+    gen_method = gen_method.lower()
 
     if not video_id:
         return jsonify({"error": "video_id required"}), 400

--- a/tests/test_banano_amount_validation.py
+++ b/tests/test_banano_amount_validation.py
@@ -31,11 +31,18 @@ def ban_client(tmp_path):
         db.execute(
             "CREATE TABLE agents (id INTEGER PRIMARY KEY, agent_name TEXT UNIQUE NOT NULL)"
         )
+        db.execute(
+            "CREATE TABLE videos (video_id TEXT PRIMARY KEY, agent_id INTEGER NOT NULL)"
+        )
         banano_blueprint.init_ban_tables(db)
         now = time.time()
         db.executemany(
             "INSERT INTO agents (id, agent_name) VALUES (?, ?)",
             [(1, "alice"), (2, "bob")],
+        )
+        db.execute(
+            "INSERT INTO videos (video_id, agent_id) VALUES (?, ?)",
+            ("video-1", 1),
         )
         db.execute(
             """
@@ -113,4 +120,61 @@ def test_valid_ban_tip_still_records_sender_and_recipient_rows(ban_client):
         (1, "reward", 10.0, "credited"),
         (1, "tip_sent", 1.25, "credited"),
         (2, "tip_received", 1.25, "credited"),
+    ]
+
+
+def test_ban_video_generation_reward_rejects_non_object_json(ban_client):
+    before = _ban_transaction_count(ban_client.db_path)
+
+    response = ban_client.post("/ban/reward-video-gen", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+    assert _ban_transaction_count(ban_client.db_path) == before
+
+
+@pytest.mark.parametrize("field", ["agent_name", "video_id", "gen_method"])
+def test_ban_video_generation_reward_rejects_non_string_fields(ban_client, field):
+    before = _ban_transaction_count(ban_client.db_path)
+    payload = {
+        "agent_name": "alice",
+        "video_id": "video-1",
+        "gen_method": "text",
+    }
+    payload[field] = ["not", "a", "string"]
+
+    response = ban_client.post("/ban/reward-video-gen", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == f"{field} must be a string"
+    assert _ban_transaction_count(ban_client.db_path) == before
+
+
+def test_valid_ban_video_generation_reward_still_records_reward(ban_client):
+    response = ban_client.post(
+        "/ban/reward-video-gen",
+        json={"agent_name": "alice", "video_id": "video-1", "gen_method": "text"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "ok": True,
+        "amount_ban": 2.0,
+        "gen_method": "text",
+        "reason": "AI video generation (text)",
+        "video_id": "video-1",
+    }
+
+    with sqlite3.connect(ban_client.db_path) as db:
+        rows = db.execute(
+            """
+            SELECT agent_id, tx_type, amount_ban, reason, video_id, status
+            FROM ban_transactions
+            ORDER BY id
+            """
+        ).fetchall()
+
+    assert rows == [
+        (1, "reward", 10.0, "seed_balance", "", "credited"),
+        (1, "reward", 2.0, "video_gen_text", "video-1", "credited"),
     ]


### PR DESCRIPTION
## Summary
- validate `/ban/reward-video-gen` JSON bodies before reading reward fields
- reject non-object JSON and non-string `agent_name`, `video_id`, and `gen_method` values with JSON 400 responses
- add regression coverage for malformed reward payloads plus the valid reward path

Fixes #1251.

## Tests
- `/tmp/bottube-test-venv312/bin/python -B -m pytest -q tests/test_banano_amount_validation.py --tb=short`
- `/tmp/bottube-test-venv312/bin/python -B -m py_compile banano_blueprint.py tests/test_banano_amount_validation.py`
- `git diff --check`

RTC wallet / miner ID: `gaoaaa52-del`
