### PR TITLE
Validate wRTC bridge JSON request bodies

### DIFF
--- a/tests/test_wrtc_bridge_validation.py
+++ b/tests/test_wrtc_bridge_validation.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: MIT
+"""Validation tests for Solana wRTC bridge request parsing."""
+
+import sqlite3
+
+import pytest
+from flask import Flask, g
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    import wrtc_bridge_blueprint as bridge
+
+    db_path = tmp_path / "wrtc_bridge.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            api_key TEXT NOT NULL,
+            sol_address TEXT,
+            rtc_balance REAL DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO agents (agent_name, api_key, sol_address, rtc_balance)
+        VALUES (?, ?, ?, ?)
+        """,
+        (
+            "bridgeuser",
+            "bottube_sk_bridgeuser",
+            "11111111111111111111111111111111",
+            1000.0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.config["DATABASE"] = str(db_path)
+    flask_app.register_blueprint(bridge.wrtc_bp)
+
+    def _test_get_db():
+        if "test_db" in g:
+            return g.test_db
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        g.test_db = db
+        return db
+
+    monkeypatch.setattr(bridge, "get_db", _test_get_db)
+
+    yield flask_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _auth_headers():
+    return {"X-API-Key": "bottube_sk_bridgeuser"}
+
+
+def _withdraw(client, payload):
+    return client.post(
+        "/api/wrtc-bridge/withdraw",
+        json=payload,
+        headers=_auth_headers(),
+    )
+
+
+def test_wrtc_deposit_rejects_non_object_json(client):
+    resp = client.post(
+        "/api/wrtc-bridge/deposit",
+        json=["not", "an", "object"],
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_wrtc_deposit_rejects_non_string_tx_signature(client, monkeypatch):
+    import wrtc_bridge_blueprint as bridge
+
+    monkeypatch.setattr(
+        bridge,
+        "verify_wrtc_transfer",
+        lambda _tx_signature: pytest.fail("verification should not run"),
+    )
+
+    resp = client.post(
+        "/api/wrtc-bridge/deposit",
+        json={"tx_signature": ["abc"]},
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "tx_signature must be a string"
+
+
+def test_wrtc_withdraw_rejects_non_object_json(client):
+    resp = _withdraw(client, [{"to_address": "11111111111111111111111111111111"}])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_wrtc_withdraw_rejects_non_string_to_address(client):
+    resp = _withdraw(
+        client,
+        {"to_address": ["11111111111111111111111111111111"], "amount": 10},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "to_address must be a string"
+
+
+@pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True])
+def test_wrtc_withdraw_rejects_non_finite_amounts(client, amount):
+    resp = _withdraw(
+        client,
+        {"to_address": "11111111111111111111111111111111", "amount": amount},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "amount must be a finite number"
+
+
+def test_rejected_wrtc_withdrawal_does_not_queue_or_debit(client):
+    resp = _withdraw(
+        client,
+        {"to_address": "11111111111111111111111111111111", "amount": "NaN"},
+    )
+    assert resp.status_code == 400
+
+    import wrtc_bridge_blueprint as bridge
+
+    with sqlite3.connect(client.application.config["DATABASE"]) as db:
+        bridge.init_wrtc_tables(db)
+        queued = db.execute("SELECT COUNT(*) FROM wrtc_withdrawals").fetchone()[0]
+        balance = db.execute(
+            "SELECT rtc_balance FROM agents WHERE api_key = ?",
+            ("bottube_sk_bridgeuser",),
+        ).fetchone()[0]
+
+    assert queued == 0
+    assert balance == 1000.0

--- a/wrtc_bridge_blueprint.py
+++ b/wrtc_bridge_blueprint.py
@@ -38,6 +38,35 @@ WRTC_MAX_WITHDRAW = float(os.environ.get("BOTTUBE_WRTC_MAX_WITHDRAW", "100000"))
 _SOLANA_ADDR_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
 
 
+def _request_json_object():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _string_field(data: dict, field_name: str):
+    value = data.get(field_name, "")
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"{field_name} must be a string"}), 400)
+    return value.strip(), None
+
+
+def _finite_amount(data: dict, field_name: str = "amount"):
+    value = data.get(field_name, 0)
+    if isinstance(value, bool):
+        return None, (jsonify({"error": f"{field_name} must be a finite number"}), 400)
+    try:
+        amount = float(value)
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": f"{field_name} must be a finite number"}), 400)
+    if amount != amount or amount in (float("inf"), float("-inf")):
+        return None, (jsonify({"error": f"{field_name} must be a finite number"}), 400)
+    return amount, None
+
+
 def get_db():
     """Get database connection from Flask g."""
     if "db" in g:
@@ -264,8 +293,12 @@ def wrtc_bridge_deposit():
     if not agent:
         return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
 
-    data = request.get_json(silent=True) or {}
-    tx_signature = (data.get("tx_signature") or "").strip()
+    data, error = _request_json_object()
+    if error:
+        return error
+    tx_signature, error = _string_field(data, "tx_signature")
+    if error:
+        return error
     if len(tx_signature) < 32:
         return jsonify({"error": "tx_signature is required"}), 400
 
@@ -361,12 +394,15 @@ def wrtc_bridge_withdraw():
     if not agent:
         return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
 
-    data = request.get_json(silent=True) or {}
-    to_address = (data.get("to_address") or "").strip()
-    try:
-        amount = float(data.get("amount", 0))
-    except (TypeError, ValueError):
-        amount = 0.0
+    data, error = _request_json_object()
+    if error:
+        return error
+    to_address, error = _string_field(data, "to_address")
+    if error:
+        return error
+    amount, error = _finite_amount(data)
+    if error:
+        return error
 
     if not _SOLANA_ADDR_RE.match(to_address):
         return jsonify({"error": "Valid Solana destination address is required"}), 400


### PR DESCRIPTION
## Summary
- add JSON-object guards for Solana wRTC bridge deposit and withdrawal bodies
- validate `tx_signature` and `to_address` before calling `.strip()`
- reject non-finite or malformed withdrawal amounts before queue/debit logic
- add focused route tests covering malformed input and no-write/no-debit behavior

Fixes #1255.

## Validation
- `/tmp/bottube-gen-venv/bin/python -B -m pytest -q tests/test_wrtc_bridge_validation.py --tb=short` -> 9 passed
- `/tmp/bottube-gen-venv/bin/python -B -m py_compile wrtc_bridge_blueprint.py tests/test_wrtc_bridge_validation.py`
- `git diff --check -- wrtc_bridge_blueprint.py tests/test_wrtc_bridge_validation.py`

No production endpoints were probed; this was validated with a local Flask test client.

/claim

RTC wallet / miner ID: `gaoaaa52-del`
