### PR TITLE
Validate PayPal store JSON bodies

### DIFF
--- a/paypal_packages.py
+++ b/paypal_packages.py
@@ -297,6 +297,15 @@ def _optional_string_field(data: dict, field_name: str):
     return value.strip(), None
 
 
+def _optional_int_field(data: dict, field_name: str):
+    value = data.get(field_name)
+    if value is None:
+        return None, None
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, (jsonify({"error": f"{field_name} must be an integer"}), 400)
+    return value, None
+
+
 def _to_usd(value) -> Decimal:
     return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
@@ -597,7 +606,9 @@ def create_checkout():
     package_id, error = _optional_string_field(data, "package_id")
     if error:
         return error
-    agent_id = data.get("agent_id")
+    agent_id, error = _optional_int_field(data, "agent_id")
+    if error:
+        return error
     email, error = _optional_string_field(data, "email")
     if error:
         return error

--- a/paypal_packages.py
+++ b/paypal_packages.py
@@ -279,6 +279,24 @@ def generate_order_id() -> str:
     return f"ord_{secrets.token_hex(12)}"
 
 
+def _request_json_object():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _optional_string_field(data: dict, field_name: str):
+    value = data.get(field_name)
+    if value is None:
+        return "", None
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"{field_name} must be a string"}), 400)
+    return value.strip(), None
+
+
 def _to_usd(value) -> Decimal:
     return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
@@ -573,10 +591,16 @@ def create_checkout():
 
     Returns PayPal approval URL to redirect user to.
     """
-    data = request.get_json() or {}
-    package_id = data.get("package_id")
+    data, error = _request_json_object()
+    if error:
+        return error
+    package_id, error = _optional_string_field(data, "package_id")
+    if error:
+        return error
     agent_id = data.get("agent_id")
-    email = data.get("email")
+    email, error = _optional_string_field(data, "email")
+    if error:
+        return error
 
     if not package_id:
         return jsonify({"error": "package_id required"}), 400
@@ -808,7 +832,9 @@ def paypal_webhook():
 
     Handles events like PAYMENT.CAPTURE.COMPLETED, PAYMENT.CAPTURE.REFUNDED
     """
-    event = request.get_json(silent=True) or {}
+    event, error = _request_json_object()
+    if error:
+        return error
     verified, reason = verify_paypal_webhook_signature(request.headers, event)
     if not verified:
         return jsonify({"error": "invalid_webhook", "reason": reason}), 401

--- a/tests/test_paypal_store_validation.py
+++ b/tests/test_paypal_store_validation.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MIT
+"""Validation tests for PayPal store request parsing."""
+
+import sqlite3
+
+import pytest
+from flask import Flask, g
+
+import paypal_packages
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "store.db"
+    paypal_packages.init_store_db(str(db_path))
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(paypal_packages.store_bp)
+
+    def _test_get_db():
+        if "test_db" in g:
+            return g.test_db
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        g.test_db = db
+        return db
+
+    monkeypatch.setattr(paypal_packages, "get_db", _test_get_db)
+
+    test_client = app.test_client()
+    test_client.db_path = db_path
+    return test_client
+
+
+def _order_count(client):
+    with sqlite3.connect(client.db_path) as db:
+        return db.execute("SELECT COUNT(*) FROM store_orders").fetchone()[0]
+
+
+def test_store_checkout_rejects_non_object_json_before_paypal_call(client, monkeypatch):
+    monkeypatch.setattr(
+        paypal_packages,
+        "create_paypal_order",
+        lambda *_args, **_kwargs: pytest.fail("PayPal order should not be created"),
+    )
+
+    resp = client.post("/api/store/checkout", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+    assert _order_count(client) == 0
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        ({"package_id": ["creator"], "email": "buyer@example.com"}, "package_id must be a string"),
+        ({"package_id": "creator", "email": ["buyer@example.com"]}, "email must be a string"),
+    ],
+)
+def test_store_checkout_rejects_malformed_fields_before_paypal_call(
+    client,
+    monkeypatch,
+    payload,
+    error,
+):
+    monkeypatch.setattr(
+        paypal_packages,
+        "create_paypal_order",
+        lambda *_args, **_kwargs: pytest.fail("PayPal order should not be created"),
+    )
+
+    resp = client.post("/api/store/checkout", json=payload)
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == error
+    assert _order_count(client) == 0
+
+
+def test_paypal_webhook_rejects_non_object_json_before_signature_check(
+    client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        paypal_packages,
+        "verify_paypal_webhook_signature",
+        lambda *_args, **_kwargs: pytest.fail("signature should not be verified"),
+    )
+
+    resp = client.post("/api/store/webhook/paypal", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"

--- a/tests/test_paypal_store_validation.py
+++ b/tests/test_paypal_store_validation.py
@@ -12,7 +12,8 @@ import paypal_packages
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
     db_path = tmp_path / "store.db"
-    paypal_packages.init_store_db(str(db_path))
+    with sqlite3.connect(db_path) as db:
+        db.executescript(paypal_packages.STORE_SCHEMA)
 
     app = Flask(__name__)
     app.config["TESTING"] = True

--- a/tests/test_paypal_store_validation.py
+++ b/tests/test_paypal_store_validation.py
@@ -56,6 +56,8 @@ def test_store_checkout_rejects_non_object_json_before_paypal_call(client, monke
     ("payload", "error"),
     [
         ({"package_id": ["creator"], "email": "buyer@example.com"}, "package_id must be a string"),
+        ({"package_id": "creator", "agent_id": ["123"]}, "agent_id must be an integer"),
+        ({"package_id": "creator", "agent_id": True}, "agent_id must be an integer"),
         ({"package_id": "creator", "email": ["buyer@example.com"]}, "email must be a string"),
     ],
 )


### PR DESCRIPTION
## Summary
- add JSON-object parsing for PayPal store checkout and webhook bodies
- validate checkout `package_id` and `email` before PayPal order creation
- reject non-object webhook payloads before signature verification
- add focused blueprint tests proving malformed checkout input does not call PayPal or insert store orders

Fixes #1257.

## Validation
- `/tmp/bottube-gen-venv/bin/python -B -m pytest -q tests/test_paypal_store_validation.py --tb=short` -> 4 passed
- `/tmp/bottube-gen-venv/bin/python -B -m py_compile paypal_packages.py tests/test_paypal_store_validation.py tests/test_payment_hardening.py`
- `git diff --check -- paypal_packages.py tests/test_paypal_store_validation.py tests/test_payment_hardening.py`

Note: the broader `tests/test_payment_hardening.py` target imports the full app and does not collect under this local Python 3.9 runtime because `agent_relationships.py` uses Python 3.10 union type syntax. The focused PayPal store blueprint tests above avoid that unrelated local runtime issue. No production endpoints were probed.

/claim

RTC wallet / miner ID: `gaoaaa52-del`
