### PR TITLE
Validate USDC tip recipient fields

### DIFF
--- a/tests/test_usdc_amount_validation.py
+++ b/tests/test_usdc_amount_validation.py
@@ -114,6 +114,33 @@ def test_usdc_tip_rejects_non_object_json_body(usdc_client):
     assert _table_count(usdc_client.db_path, "usdc_tips") == before_tips
 
 
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        ({"to_agent": ["bob"], "amount_usdc": "1.00"}, "to_agent must be a string"),
+        ({"video_id": ["video-1"], "amount_usdc": "1.00"}, "video_id must be a string"),
+    ],
+)
+def test_usdc_tip_rejects_malformed_recipient_fields_without_writes(
+    usdc_client,
+    payload,
+    error,
+):
+    before_tips = _table_count(usdc_client.db_path, "usdc_tips")
+    before_alice = _balance(usdc_client.db_path, "alice")
+
+    response = usdc_client.post(
+        "/api/usdc/tip",
+        json=payload,
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == error
+    assert _table_count(usdc_client.db_path, "usdc_tips") == before_tips
+    assert _balance(usdc_client.db_path, "alice") == before_alice
+
+
 def test_usdc_deposit_rejects_non_object_json_before_verification(
     usdc_client,
     monkeypatch,

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -72,6 +72,15 @@ def _parse_finite_usdc_amount(data):
     return amount, None
 
 
+def _optional_string_field(data, field_name):
+    value = data.get(field_name)
+    if value is None:
+        return "", None
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"{field_name} must be a string"}), 400)
+    return value.strip(), None
+
+
 def init_usdc_tables(db):
     """Create USDC-related tables if they don't exist."""
     db.executescript("""
@@ -345,8 +354,12 @@ def usdc_tip():
     data, error = _request_json_object()
     if error:
         return error
-    video_id = data.get("video_id")
-    to_agent = data.get("to_agent")
+    video_id, error = _optional_string_field(data, "video_id")
+    if error:
+        return error
+    to_agent, error = _optional_string_field(data, "to_agent")
+    if error:
+        return error
 
     if not video_id and not to_agent:
         return jsonify({"error": "video_id or to_agent required"}), 400


### PR DESCRIPTION
## Summary
- validate optional `video_id` and `to_agent` fields as strings before USDC tip DB/balance logic
- trim valid recipient fields while preserving existing missing-recipient behavior
- add regressions proving malformed recipient fields do not create tips or debit the sender

Fixes #1260.

## Validation
- `/tmp/bottube-gen-venv/bin/python -B -m pytest -q tests/test_usdc_amount_validation.py --tb=short` -> 19 passed
- `/tmp/bottube-gen-venv/bin/python -B -m py_compile usdc_blueprint.py tests/test_usdc_amount_validation.py`
- `git diff --check -- usdc_blueprint.py tests/test_usdc_amount_validation.py`

No production endpoints were probed; this was validated with a local Flask test client.

/claim

RTC wallet / miner ID: `gaoaaa52-del`
