### PR TITLE
Add cache validators to video list API

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -26,6 +26,7 @@ import urllib.parse
 import urllib.request
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.utils import formatdate, parsedate_to_datetime
 from functools import wraps
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -37,6 +38,7 @@ from flask import (
     flash,
     g,
     jsonify,
+    make_response,
     redirect,
     render_template,
     request,
@@ -6653,6 +6655,60 @@ def update_video(video_id):
 # Video listing / detail
 # ---------------------------------------------------------------------------
 
+def _video_list_etag(
+    *,
+    page: int,
+    per_page: int,
+    sort: str,
+    agent_name: str,
+    total: int,
+    latest_ts: float,
+    engagement_revision: int,
+) -> str:
+    cache_key = json.dumps(
+        {
+            "agent": agent_name,
+            "latest_ts": latest_ts,
+            "page": page,
+            "per_page": per_page,
+            "engagement_revision": engagement_revision,
+            "sort": sort,
+            "total": total,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(cache_key.encode("utf-8")).hexdigest()[:24]
+    return f'W/"videos-{digest}"'
+
+
+def _client_has_video_list_etag(etag: str) -> bool:
+    raw_header = request.headers.get("If-None-Match", "")
+    if not raw_header:
+        return False
+    candidates = {part.strip() for part in raw_header.split(",")}
+    return "*" in candidates or etag in candidates
+
+
+def _client_has_fresh_video_list_date(latest_ts: float) -> bool:
+    raw_header = request.headers.get("If-Modified-Since", "")
+    if not raw_header:
+        return False
+    try:
+        modified_since = parsedate_to_datetime(raw_header)
+    except (TypeError, ValueError):
+        return False
+    if modified_since is None:
+        return False
+    return int(latest_ts or 0) <= int(modified_since.timestamp())
+
+
+def _add_video_list_cache_headers(response: Response, *, etag: str, latest_ts: float) -> Response:
+    response.headers["ETag"] = etag
+    response.headers["Last-Modified"] = formatdate(int(latest_ts or 0), usegmt=True)
+    response.headers["Cache-Control"] = "public, max-age=30"
+    return response
+
 @app.route("/api/videos")
 def list_videos():
     """List videos with pagination and sorting."""
@@ -6678,16 +6734,45 @@ def list_videos():
         params.append(agent_name)
     where = "WHERE " + " AND ".join(where_clauses)
 
-    total = db.execute(
-        f"SELECT COUNT(*) FROM videos v JOIN agents a ON v.agent_id = a.id {where}",
+    stats = db.execute(
+        f"""SELECT
+                COUNT(*) AS total,
+                COALESCE(MAX(v.created_at), 0) AS latest_ts,
+                COALESCE(MAX(
+                    MAX(
+                        COALESCE((SELECT MAX(vw.created_at) FROM views vw WHERE vw.video_id = v.video_id), 0),
+                        COALESCE((SELECT MAX(vt.created_at) FROM votes vt WHERE vt.video_id = v.video_id), 0)
+                    )
+                ), 0) AS latest_engagement_ts,
+                COALESCE(SUM(v.views + v.likes + v.dislikes), 0) AS engagement_revision
+            FROM videos v JOIN agents a ON v.agent_id = a.id {where}""",
         params,
-    ).fetchone()[0]
+    ).fetchone()
+    total = int(stats["total"] or 0)
+    latest_ts = max(float(stats["latest_ts"] or 0), float(stats["latest_engagement_ts"] or 0))
+    engagement_revision = int(stats["engagement_revision"] or 0)
     pages = math.ceil(total / per_page) if total else 0
     if pages:
         page = min(page, pages)
     else:
         page = 1
     offset = (page - 1) * per_page
+    etag = _video_list_etag(
+        page=page,
+        per_page=per_page,
+        sort=sort,
+        agent_name=agent_name,
+        total=total,
+        latest_ts=latest_ts,
+        engagement_revision=engagement_revision,
+    )
+
+    if request.headers.get("If-None-Match"):
+        is_fresh = _client_has_video_list_etag(etag)
+    else:
+        is_fresh = _client_has_fresh_video_list_date(latest_ts)
+    if is_fresh:
+        return _add_video_list_cache_headers(make_response("", 304), etag=etag, latest_ts=latest_ts)
 
     rows = db.execute(
         f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url
@@ -6704,13 +6789,14 @@ def list_videos():
         d["avatar_url"] = row["avatar_url"]
         videos.append(d)
 
-    return jsonify({
+    response = jsonify({
         "videos": videos,
         "page": page,
         "per_page": per_page,
         "total": total,
         "pages": pages,
     })
+    return _add_video_list_cache_headers(response, etag=etag, latest_ts=latest_ts)
 
 
 @app.route("/api/videos/<video_id>")

--- a/tests/test_video_list_cache_headers.py
+++ b/tests/test_video_list_cache_headers.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: MIT
+import time
+
+
+def _insert_agent(db, name="cache_owner"):
+    cur = db.execute(
+        """
+        INSERT INTO agents (agent_name, display_name, api_key, created_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        (name, name.replace("_", " ").title(), f"{name}_key", time.time()),
+    )
+    return int(cur.lastrowid)
+
+
+def _insert_video(db, agent_id, video_id, created_at):
+    db.execute(
+        """
+        INSERT INTO videos (video_id, agent_id, title, filename, created_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (video_id, agent_id, f"Video {video_id}", f"{video_id}.mp4", created_at),
+    )
+
+
+def test_video_list_returns_cache_validators(app, client):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        agent_id = _insert_agent(db)
+        _insert_video(db, agent_id, "cache_video_1", 1_800_000_000)
+        db.commit()
+
+    response = client.get("/api/videos")
+
+    assert response.status_code == 200
+    assert response.headers["ETag"].startswith('W/"videos-')
+    assert response.headers["Last-Modified"] == "Fri, 15 Jan 2027 08:00:00 GMT"
+    assert response.headers["Cache-Control"] == "public, max-age=30"
+
+
+def test_video_list_if_none_match_returns_304(app, client):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        agent_id = _insert_agent(db)
+        _insert_video(db, agent_id, "cache_video_2", 1_800_000_000)
+        db.commit()
+
+    first = client.get("/api/videos")
+    response = client.get("/api/videos", headers={"If-None-Match": first.headers["ETag"]})
+
+    assert response.status_code == 304
+    assert response.data == b""
+    assert response.headers["ETag"] == first.headers["ETag"]
+    assert response.headers["Cache-Control"] == "public, max-age=30"
+
+
+def test_video_list_if_modified_since_returns_304(app, client):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        agent_id = _insert_agent(db)
+        _insert_video(db, agent_id, "cache_video_3", 1_800_000_000)
+        db.commit()
+
+    first = client.get("/api/videos")
+    response = client.get(
+        "/api/videos",
+        headers={"If-Modified-Since": first.headers["Last-Modified"]},
+    )
+
+    assert response.status_code == 304
+    assert response.headers["ETag"] == first.headers["ETag"]
+
+
+def test_video_list_etag_changes_after_newer_video(app, client):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        agent_id = _insert_agent(db)
+        _insert_video(db, agent_id, "cache_video_4", 1_800_000_000)
+        db.commit()
+
+    first = client.get("/api/videos")
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        _insert_video(db, agent_id, "cache_video_5", 1_800_000_060)
+        db.commit()
+
+    second = client.get("/api/videos")
+
+    assert second.status_code == 200
+    assert second.headers["ETag"] != first.headers["ETag"]
+    assert second.headers["Last-Modified"] == "Fri, 15 Jan 2027 08:01:00 GMT"
+
+
+def test_video_list_etag_changes_after_visible_engagement(app, client):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        agent_id = _insert_agent(db)
+        _insert_video(db, agent_id, "cache_video_6", 1_800_000_000)
+        db.commit()
+
+    first = client.get("/api/videos")
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        db.execute("UPDATE videos SET views = views + 1 WHERE video_id = ?", ("cache_video_6",))
+        db.execute(
+            "INSERT INTO views (video_id, ip_address, created_at) VALUES (?, ?, ?)",
+            ("cache_video_6", "203.0.113.6", 1_800_000_060),
+        )
+        db.commit()
+
+    second = client.get("/api/videos")
+
+    assert second.status_code == 200
+    assert second.headers["ETag"] != first.headers["ETag"]
+    assert second.headers["Last-Modified"] == "Fri, 15 Jan 2027 08:01:00 GMT"
+
+
+def test_video_list_if_modified_since_sees_engagement_on_older_video(app, client):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        agent_id = _insert_agent(db)
+        _insert_video(db, agent_id, "cache_newer_video", 1_800_000_200)
+        _insert_video(db, agent_id, "cache_older_video", 1_800_000_000)
+        db.commit()
+
+    first = client.get("/api/videos")
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        db.execute("UPDATE videos SET likes = likes + 1 WHERE video_id = ?", ("cache_older_video",))
+        db.execute(
+            "INSERT INTO votes (agent_id, video_id, vote, created_at) VALUES (?, ?, ?, ?)",
+            (agent_id, "cache_older_video", 1, 1_800_000_260),
+        )
+        db.commit()
+
+    second = client.get(
+        "/api/videos",
+        headers={"If-Modified-Since": first.headers["Last-Modified"]},
+    )
+
+    assert second.status_code == 200
+    assert second.headers["ETag"] != first.headers["ETag"]
+    assert second.headers["Last-Modified"] == "Fri, 15 Jan 2027 08:04:20 GMT"


### PR DESCRIPTION
## Summary
- add weak ETag, Last-Modified, and Cache-Control headers to `GET /api/videos`
- return `304 Not Modified` for matching `If-None-Match` or fresh `If-Modified-Since` requests
- include visible video count/page/sort plus upload and engagement revisions in the cache validator so clients do not reuse stale list data after new uploads, views, or votes

Fixes #1259

## Validation
- `/tmp/bottube-test-venv312/bin/python -B -m pytest -q tests/test_video_list_cache_headers.py tests/test_upload_api.py::TestVideoListEndpoint --tb=short` -> 8 passed
- `/tmp/bottube-test-venv312/bin/python -B -m py_compile bottube_server.py tests/test_video_list_cache_headers.py` -> passed
- `git diff --check` -> passed

## Safety
No credentials, payments, uploads, external services, or live account actions were used. This is a read-only API response/header change with local Flask client tests.

RTC wallet / miner ID: `gaoaaa52-del`
