### PR TITLE
Validate Ergo bridge JSON request bodies

### DIFF
--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -14,6 +14,7 @@ Exchange rate: market-based or fixed by admin.
 
 from flask import Blueprint, request, jsonify, g, session
 import hashlib
+import math
 import json
 import logging
 import os
@@ -233,6 +234,34 @@ def _debit_rtc(db, agent_id, amount):
 # API Routes
 # ---------------------------------------------------------------------------
 
+def _request_json_object():
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _string_field(data, field_name):
+    value = data.get(field_name, "")
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"{field_name} must be a string"}), 400)
+    return value.strip(), None
+
+
+def _positive_finite_amount(value):
+    if isinstance(value, bool):
+        return None
+    try:
+        amount = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(amount) or amount <= 0:
+        return None
+    return amount
+
+
 @ergo_bp.route("/api/ergo/info")
 def ergo_info():
     """Public info about the ERG ↔ RTC bridge."""
@@ -286,8 +315,12 @@ def ergo_deposit():
     else:
         agent_id = user_id
 
-    data = request.get_json() or {}
-    tx_id = data.get("tx_id", "").strip()
+    data, error = _request_json_object()
+    if error:
+        return error
+    tx_id, error = _string_field(data, "tx_id")
+    if error:
+        return error
     if not tx_id:
         return jsonify({"error": "tx_id required"}), 400
 
@@ -377,9 +410,15 @@ def ergo_withdraw():
     else:
         agent_id = user_id
 
-    data = request.get_json() or {}
-    amount_rtc = float(data.get("amount_rtc", 0))
-    to_address = data.get("address", "").strip()
+    data, error = _request_json_object()
+    if error:
+        return error
+    amount_rtc = _positive_finite_amount(data.get("amount_rtc", 0))
+    if amount_rtc is None:
+        return jsonify({"error": "amount_rtc must be a finite positive number"}), 400
+    to_address, error = _string_field(data, "address")
+    if error:
+        return error
 
     if amount_rtc < MIN_WITHDRAW_RTC:
         return jsonify({

--- a/tests/test_ergo_bridge_validation.py
+++ b/tests/test_ergo_bridge_validation.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: MIT
+"""Validation tests for Ergo bridge request parsing."""
+
+import sqlite3
+
+import pytest
+from flask import Flask, g
+
+import ergo_bridge_blueprint
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "ergo_bridge.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            api_key TEXT NOT NULL,
+            rtc_balance REAL DEFAULT 0
+        );
+        CREATE TABLE earnings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id INTEGER,
+            amount REAL,
+            source TEXT,
+            created_at REAL
+        );
+        INSERT INTO agents (agent_name, api_key, rtc_balance)
+        VALUES ('ergo_agent', 'bottube_sk_ergo_agent', 100.0);
+        """
+    )
+    ergo_bridge_blueprint.init_ergo_tables(conn)
+    conn.commit()
+    conn.close()
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+    app.register_blueprint(ergo_bridge_blueprint.ergo_bp)
+
+    def _test_get_db():
+        if "test_db" in g:
+            return g.test_db
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        g.test_db = db
+        return db
+
+    @app.teardown_appcontext
+    def _close_db(_exc):
+        db = g.pop("test_db", None)
+        if db is not None:
+            db.close()
+
+    monkeypatch.setattr(ergo_bridge_blueprint, "get_db", _test_get_db)
+
+    test_client = app.test_client()
+    test_client.db_path = db_path
+    return test_client
+
+
+def _auth_headers():
+    return {"X-API-Key": "bottube_sk_ergo_agent"}
+
+
+def _counts_and_balance(db_path):
+    with sqlite3.connect(str(db_path)) as db:
+        return {
+            "deposits": db.execute("SELECT COUNT(*) FROM ergo_deposits").fetchone()[0],
+            "withdrawals": db.execute(
+                "SELECT COUNT(*) FROM ergo_withdrawals"
+            ).fetchone()[0],
+            "balance": db.execute(
+                "SELECT rtc_balance FROM agents WHERE api_key = ?",
+                ("bottube_sk_ergo_agent",),
+            ).fetchone()[0],
+        }
+
+
+def test_ergo_deposit_rejects_non_object_json(client):
+    before = _counts_and_balance(client.db_path)
+
+    resp = client.post(
+        "/api/ergo/deposit",
+        json=["not", "an", "object"],
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+    assert _counts_and_balance(client.db_path) == before
+
+
+def test_ergo_deposit_rejects_non_string_tx_id(client):
+    before = _counts_and_balance(client.db_path)
+
+    resp = client.post(
+        "/api/ergo/deposit",
+        json={"tx_id": ["abc"]},
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "tx_id must be a string"
+    assert _counts_and_balance(client.db_path) == before
+
+
+def test_ergo_withdraw_rejects_non_object_json(client):
+    before = _counts_and_balance(client.db_path)
+
+    resp = client.post(
+        "/api/ergo/withdraw",
+        json=[{"amount_rtc": 10, "address": "9abc"}],
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+    assert _counts_and_balance(client.db_path) == before
+
+
+def test_ergo_withdraw_rejects_non_string_address(client):
+    before = _counts_and_balance(client.db_path)
+
+    resp = client.post(
+        "/api/ergo/withdraw",
+        json={"amount_rtc": 10, "address": ["9abc"]},
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "address must be a string"
+    assert _counts_and_balance(client.db_path) == before
+
+
+@pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True, 0, -1])
+def test_ergo_withdraw_rejects_invalid_amount_without_queue_or_debit(client, amount):
+    before = _counts_and_balance(client.db_path)
+
+    resp = client.post(
+        "/api/ergo/withdraw",
+        json={"amount_rtc": amount, "address": "9abc"},
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "amount_rtc must be a finite positive number"
+    assert _counts_and_balance(client.db_path) == before


### PR DESCRIPTION
## Summary
- add shared JSON object, string field, and finite positive amount validation for Ergo bridge requests
- reject malformed deposit/withdraw fields with deterministic 400 responses before chain verification, withdrawal queueing, or RTC debit logic
- add regression coverage proving rejected requests do not create bridge rows or debit balances

Fixes #1263.

## Validation
- `/tmp/bottube-test-venv312/bin/python -B -m pytest -q tests/test_ergo_bridge_validation.py --tb=short` -> 10 passed
- `/tmp/bottube-test-venv312/bin/python -B -m pytest -q tests/test_ergo_bridge_validation.py tests/test_base_wrtc_bridge_validation.py tests/test_banano_amount_validation.py --tb=short` -> 33 passed
- `/tmp/bottube-test-venv312/bin/python -B -m py_compile ergo_bridge_blueprint.py tests/test_ergo_bridge_validation.py` -> passed
- `git diff --check HEAD~1..HEAD` -> passed

RTC wallet / miner ID: `gaoaaa52-del`
