### PR TITLE
Validate Gemini JSON request bodies

### DIFF
--- a/gemini_blueprint.py
+++ b/gemini_blueprint.py
@@ -117,6 +117,27 @@ def init_gemini_tables(db=None):
 
 _rate_buckets = {}
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _text_field(data, field, default="", max_length=None):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"{field} must be a string"}), 400)
+    value = value.strip()
+    if max_length is not None:
+        value = value[:max_length]
+    return value, None
+
+
 def _check_rate(agent_id, job_type, max_per_hour):
     """Simple in-memory rate limiter."""
     key = f"{job_type}:{agent_id}"
@@ -320,14 +341,20 @@ def generate_video():
     else:
         agent_id = user_id
 
-    data = request.get_json() or {}
-    prompt = data.get("prompt", "").strip()
+    data, error = _json_object_body()
+    if error:
+        return error
+    prompt, error = _text_field(data, "prompt")
+    if error:
+        return error
     if not prompt:
         return jsonify({"error": "prompt required"}), 400
     if len(prompt) > 2000:
         return jsonify({"error": "prompt too long (max 2000 chars)"}), 400
 
-    negative_prompt = data.get("negative_prompt", "").strip()[:500]
+    negative_prompt, error = _text_field(data, "negative_prompt", max_length=500)
+    if error:
+        return error
     aspect_ratio = data.get("aspect_ratio", "16:9")
     if aspect_ratio not in ("16:9", "9:16", "1:1"):
         aspect_ratio = "16:9"
@@ -401,8 +428,12 @@ def generate_image():
     else:
         agent_id = user_id
 
-    data = request.get_json() or {}
-    prompt = data.get("prompt", "").strip()
+    data, error = _json_object_body()
+    if error:
+        return error
+    prompt, error = _text_field(data, "prompt")
+    if error:
+        return error
     if not prompt:
         return jsonify({"error": "prompt required"}), 400
 
@@ -694,27 +725,33 @@ def free_generate_video():
     if not _HAS_GENAI or not GEMINI_API_KEY:
         return jsonify({"error": "Gemini API not configured"}), 503
 
-    client_ip = _get_client_ip()
-    if not _check_ip_rate(client_ip, "video", FREE_VIDEO_PER_DAY):
-        return jsonify({
-            "error": f"Free tier limit: {FREE_VIDEO_PER_DAY} videos per day. "
-                     "Create a BoTTube account for higher limits."
-        }), 429
-
-    data = request.get_json() or {}
-    prompt = data.get("prompt", "").strip()
+    data, error = _json_object_body()
+    if error:
+        return error
+    prompt, error = _text_field(data, "prompt")
+    if error:
+        return error
     if not prompt:
         return jsonify({"error": "prompt required"}), 400
     if len(prompt) > 2000:
         return jsonify({"error": "prompt too long (max 2000 chars)"}), 400
 
-    negative_prompt = data.get("negative_prompt", "").strip()[:500]
+    negative_prompt, error = _text_field(data, "negative_prompt", max_length=500)
+    if error:
+        return error
     aspect_ratio = data.get("aspect_ratio", "16:9")
     if aspect_ratio not in ("16:9", "9:16", "1:1"):
         aspect_ratio = "16:9"
     resolution = data.get("resolution", "720p")
     if resolution not in ("720p", "1080p"):
         resolution = "720p"
+
+    client_ip = _get_client_ip()
+    if not _check_ip_rate(client_ip, "video", FREE_VIDEO_PER_DAY):
+        return jsonify({
+            "error": f"Free tier limit: {FREE_VIDEO_PER_DAY} videos per day. "
+                     "Create a BoTTube account for higher limits."
+        }), 429
 
     # Use session user if logged in, otherwise guest
     agent_id = session.get("user_id", GUEST_AGENT_ID)
@@ -763,19 +800,23 @@ def free_generate_image():
     if not _HAS_GENAI or not GEMINI_API_KEY:
         return jsonify({"error": "Gemini API not configured"}), 503
 
+    data, error = _json_object_body()
+    if error:
+        return error
+    prompt, error = _text_field(data, "prompt")
+    if error:
+        return error
+    if not prompt:
+        return jsonify({"error": "prompt required"}), 400
+    if len(prompt) > 2000:
+        return jsonify({"error": "prompt too long (max 2000 chars)"}), 400
+
     client_ip = _get_client_ip()
     if not _check_ip_rate(client_ip, "image", FREE_IMAGE_PER_DAY):
         return jsonify({
             "error": f"Free tier limit: {FREE_IMAGE_PER_DAY} images per day. "
                      "Create a BoTTube account for higher limits."
         }), 429
-
-    data = request.get_json() or {}
-    prompt = data.get("prompt", "").strip()
-    if not prompt:
-        return jsonify({"error": "prompt required"}), 400
-    if len(prompt) > 2000:
-        return jsonify({"error": "prompt too long (max 2000 chars)"}), 400
 
     agent_id = session.get("user_id", GUEST_AGENT_ID)
 

--- a/tests/test_gemini_request_validation.py
+++ b/tests/test_gemini_request_validation.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: MIT
+"""Validation tests for Gemini JSON request parsing."""
+
+import sqlite3
+
+import pytest
+from flask import Flask, g
+
+import gemini_blueprint
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "gemini.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            api_key TEXT NOT NULL
+        );
+        INSERT INTO agents (agent_name, api_key)
+        VALUES ('gemini_agent', 'bottube_sk_gemini_agent');
+        """
+    )
+    gemini_blueprint.init_gemini_tables(conn)
+    conn.commit()
+    conn.close()
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+    app.register_blueprint(gemini_blueprint.gemini_bp)
+
+    def _test_get_db():
+        if "test_db" in g:
+            return g.test_db
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        g.test_db = db
+        return db
+
+    @app.teardown_appcontext
+    def _close_db(_exc):
+        db = g.pop("test_db", None)
+        if db is not None:
+            db.close()
+
+    monkeypatch.setattr(gemini_blueprint, "get_db", _test_get_db)
+    monkeypatch.setattr(gemini_blueprint, "_HAS_GENAI", True)
+    monkeypatch.setattr(gemini_blueprint, "GEMINI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        gemini_blueprint,
+        "_generate_image_sync",
+        lambda _prompt: pytest.fail("image generation should not run"),
+    )
+    monkeypatch.setattr(
+        gemini_blueprint.threading,
+        "Thread",
+        lambda *args, **kwargs: pytest.fail("video generation should not start"),
+    )
+    gemini_blueprint._rate_buckets.clear()
+    gemini_blueprint._ip_rate_buckets.clear()
+
+    test_client = app.test_client()
+    test_client.db_path = db_path
+    return test_client
+
+
+def _auth_headers():
+    return {"X-API-Key": "bottube_sk_gemini_agent"}
+
+
+def _job_count(db_path):
+    with sqlite3.connect(str(db_path)) as db:
+        return db.execute("SELECT COUNT(*) FROM gemini_jobs").fetchone()[0]
+
+
+def test_authenticated_video_rejects_non_object_json_without_job(client):
+    resp = client.post(
+        "/api/gemini/generate-video",
+        json=["not", "an", "object"],
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+    assert _job_count(client.db_path) == 0
+
+
+def test_authenticated_video_rejects_non_string_prompt_without_job(client):
+    resp = client.post(
+        "/api/gemini/generate-video",
+        json={"prompt": ["draw this"]},
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "prompt must be a string"
+    assert _job_count(client.db_path) == 0
+
+
+def test_authenticated_video_rejects_non_string_negative_prompt_without_job(client):
+    resp = client.post(
+        "/api/gemini/generate-video",
+        json={"prompt": "draw this", "negative_prompt": ["bad"]},
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "negative_prompt must be a string"
+    assert _job_count(client.db_path) == 0
+
+
+def test_authenticated_image_rejects_non_string_prompt_before_generation(client):
+    resp = client.post(
+        "/api/gemini/generate-image",
+        json={"prompt": {"text": "draw this"}},
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "prompt must be a string"
+    assert _job_count(client.db_path) == 0
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "expected_error"),
+    [
+        ("/api/gemini/free/generate-video", ["bad"], "JSON object required"),
+        ("/api/gemini/free/generate-video", {"prompt": ["bad"]}, "prompt must be a string"),
+        (
+            "/api/gemini/free/generate-video",
+            {"prompt": "draw this", "negative_prompt": ["bad"]},
+            "negative_prompt must be a string",
+        ),
+        ("/api/gemini/free/generate-image", ["bad"], "JSON object required"),
+        ("/api/gemini/free/generate-image", {"prompt": ["bad"]}, "prompt must be a string"),
+    ],
+)
+def test_free_gemini_routes_reject_malformed_json_without_quota_or_job(
+    client, path, payload, expected_error
+):
+    resp = client.post(path, json=payload)
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == expected_error
+    assert _job_count(client.db_path) == 0
+    assert gemini_blueprint._ip_rate_buckets == {}


### PR DESCRIPTION
## Summary
- add shared JSON-object and text-field validation for Gemini generation routes
- reject malformed prompt / negative_prompt fields with deterministic 400 responses before jobs or generation side effects
- move free-tier quota accounting after request validation so malformed requests do not consume IP quota

Fixes #1265.

## Validation
- `/tmp/bottube-test-venv312/bin/python -B -m pytest -q tests/test_gemini_request_validation.py --tb=short` -> 9 passed
- `/tmp/bottube-test-venv312/bin/python -B -m py_compile gemini_blueprint.py tests/test_gemini_request_validation.py` -> passed
- `git diff --check` -> passed

RTC wallet / miner ID: `gaoaaa52-del`
