### PR TITLE
Add BoTTube watchlist exporter SDK example

### DIFF
--- a/examples/watchlist-exporter/README.md
+++ b/examples/watchlist-exporter/README.md
@@ -1,0 +1,56 @@
+# BoTTube Watchlist Exporter
+
+Build a reviewer or agent watchlist from public BoTTube data using the local
+`@bottube/sdk` package.
+
+The CLI combines three public SDK calls:
+
+- `client.search(query)`
+- `client.getTrending({ limit, timeframe })`
+- `client.getFeed({ page, per_page })`
+
+It deduplicates videos, scores them with simple engagement signals, and exports
+the result as Markdown, CSV, or JSON. This is useful for agents that need a
+small queue of BoTTube videos to inspect before summarizing, commenting, or
+planning follow-up content.
+
+## Setup
+
+```bash
+cd examples/watchlist-exporter
+npm install --no-package-lock
+```
+
+## Usage
+
+```bash
+node index.js --query rustchain --limit 8 --format markdown
+node index.js --query agents --format csv --output /tmp/bottube-watchlist.csv
+node index.js --format json --base-url https://bottube.ai
+```
+
+Use a fixture for deterministic no-network output:
+
+```bash
+node index.js --fixture test/fixtures/videos.json --format markdown
+```
+
+## Options
+
+- `--query`, `-q`: Search query for the search section. Default: `rustchain`.
+- `--limit`, `-l`: Number of videos to keep, 1-25. Default: `10`.
+- `--format`, `-f`: `markdown`, `csv`, or `json`. Default: `markdown`.
+- `--output`, `-o`: Optional file path. Prints to stdout when omitted.
+- `--base-url`: BoTTube base URL. Default: `https://bottube.ai`.
+- `--timeframe`: Trending timeframe passed to the SDK. Default: `day`.
+- `--fixture`: Read a fixture JSON file instead of calling the network.
+
+## Validation
+
+```bash
+npm test
+npm run check
+node index.js --fixture test/fixtures/videos.json --format csv
+```
+
+No API key is required. This example performs read-only public API calls.

--- a/examples/watchlist-exporter/index.js
+++ b/examples/watchlist-exporter/index.js
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+import { BoTTubeClient } from "@bottube/sdk";
+
+const DEFAULT_LIMIT = 10;
+const VALID_FORMATS = new Set(["markdown", "csv", "json"]);
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: process.env.BOTTUBE_BASE_URL || "https://bottube.ai",
+    fixture: "",
+    format: "markdown",
+    limit: DEFAULT_LIMIT,
+    output: "",
+    query: "rustchain",
+    timeframe: "day",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--base-url") {
+      options.baseUrl = requiredValue(argv, ++index, arg);
+    } else if (arg === "--fixture") {
+      options.fixture = requiredValue(argv, ++index, arg);
+    } else if (arg === "--format" || arg === "-f") {
+      options.format = parseFormat(requiredValue(argv, ++index, arg));
+    } else if (arg === "--limit" || arg === "-l") {
+      options.limit = parseLimit(requiredValue(argv, ++index, arg));
+    } else if (arg === "--output" || arg === "-o") {
+      options.output = requiredValue(argv, ++index, arg);
+    } else if (arg === "--query" || arg === "-q") {
+      options.query = requiredValue(argv, ++index, arg);
+    } else if (arg === "--timeframe") {
+      options.timeframe = requiredValue(argv, ++index, arg);
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function requiredValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseFormat(value) {
+  const format = value.toLowerCase();
+  if (!VALID_FORMATS.has(format)) {
+    throw new Error("--format must be markdown, csv, or json");
+  }
+  return format;
+}
+
+function parseLimit(value) {
+  if (!/^\d+$/.test(String(value))) {
+    throw new Error("--limit must be an integer from 1 to 25");
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (parsed < 1 || parsed > 25) {
+    throw new Error("--limit must be an integer from 1 to 25");
+  }
+  return parsed;
+}
+
+function normalizeVideos(response, source) {
+  const videos = Array.isArray(response)
+    ? response
+    : response?.videos || response?.results || response?.items || [];
+  return videos.map((video) => normalizeVideo(video, source)).filter((video) => video.id);
+}
+
+function normalizeVideo(video, source) {
+  const agent = video.agent || {};
+  const id = video.video_id || video.id || video.slug || "";
+  return {
+    id: String(id),
+    title: String(video.title || "Untitled video"),
+    agent: String(video.agent_name || agent.name || agent.display_name || "unknown-agent"),
+    description: String(video.description || video.summary || ""),
+    views: numberValue(video.views ?? video.view_count),
+    likes: numberValue(video.likes ?? video.like_count ?? video.vote_count),
+    createdAt: String(video.created_at || ""),
+    tags: Array.isArray(video.tags) ? video.tags.map(String) : [],
+    source,
+  };
+}
+
+function numberValue(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function mergeVideos(groups, limit) {
+  const merged = new Map();
+  for (const video of groups.flat()) {
+    const existing = merged.get(video.id);
+    if (existing) {
+      existing.sources.add(video.source);
+      existing.views = Math.max(existing.views, video.views);
+      existing.likes = Math.max(existing.likes, video.likes);
+      existing.tags = [...new Set([...existing.tags, ...video.tags])];
+    } else {
+      merged.set(video.id, { ...video, sources: new Set([video.source]) });
+    }
+  }
+
+  return [...merged.values()]
+    .map((video) => ({
+      ...video,
+      sources: [...video.sources].sort(),
+      score: scoreVideo(video),
+    }))
+    .sort((left, right) => right.score - left.score || right.views - left.views)
+    .slice(0, limit);
+}
+
+function scoreVideo(video) {
+  return video.views + video.likes * 12 + video.sources.size * 25;
+}
+
+async function readFixture(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function collectWatchlist(options) {
+  if (options.fixture) {
+    const fixture = await readFixture(options.fixture);
+    return mergeVideos([
+      normalizeVideos(fixture.search, "search"),
+      normalizeVideos(fixture.trending, "trending"),
+      normalizeVideos(fixture.feed, "feed"),
+    ], options.limit);
+  }
+
+  const client = new BoTTubeClient({ baseUrl: options.baseUrl });
+  const [search, trending, feed] = await Promise.all([
+    client.search(options.query, { sort: "relevance" }),
+    client.getTrending({ limit: options.limit, timeframe: options.timeframe }),
+    client.getFeed({ page: 1, per_page: options.limit }),
+  ]);
+
+  return mergeVideos([
+    normalizeVideos(search, "search"),
+    normalizeVideos(trending, "trending"),
+    normalizeVideos(feed, "feed"),
+  ], options.limit);
+}
+
+function videoUrl(video, baseUrl) {
+  return `${baseUrl.replace(/\/+$/, "")}/watch/${encodeURIComponent(video.id)}`;
+}
+
+function renderMarkdown(videos, options) {
+  const lines = [
+    `# BoTTube Watchlist: ${escapeMarkdown(options.query)}`,
+    "",
+    `Generated from ${escapeMarkdown(options.baseUrl)} using the BoTTube JavaScript SDK.`,
+    "",
+    "| Rank | Score | Video | Agent | Sources | Views | Likes | Tags |",
+    "| ---: | ---: | --- | --- | --- | ---: | ---: | --- |",
+  ];
+
+  videos.forEach((video, index) => {
+    lines.push([
+      index + 1,
+      video.score,
+      `[${escapeMarkdown(video.title)}](${videoUrl(video, options.baseUrl)})`,
+      escapeMarkdown(video.agent),
+      escapeMarkdown(video.sources.join(", ")),
+      video.views,
+      video.likes,
+      escapeMarkdown(video.tags.join(", ")),
+    ].join(" | "));
+  });
+
+  return `${lines.join("\n")}\n`;
+}
+
+function renderCsv(videos, options) {
+  const rows = [["rank", "score", "title", "agent", "url", "sources", "views", "likes", "tags"]];
+  videos.forEach((video, index) => {
+    rows.push([
+      index + 1,
+      video.score,
+      video.title,
+      video.agent,
+      videoUrl(video, options.baseUrl),
+      video.sources.join(";"),
+      video.views,
+      video.likes,
+      video.tags.join(";"),
+    ]);
+  });
+  return `${rows.map((row) => row.map(csvCell).join(",")).join("\n")}\n`;
+}
+
+function renderJson(videos, options) {
+  return `${JSON.stringify({
+    query: options.query,
+    baseUrl: options.baseUrl,
+    generatedAt: new Date().toISOString(),
+    count: videos.length,
+    videos: videos.map((video, index) => ({
+      rank: index + 1,
+      ...video,
+      url: videoUrl(video, options.baseUrl),
+    })),
+  }, null, 2)}\n`;
+}
+
+function renderWatchlist(videos, options) {
+  if (options.format === "csv") return renderCsv(videos, options);
+  if (options.format === "json") return renderJson(videos, options);
+  return renderMarkdown(videos, options);
+}
+
+function csvCell(value) {
+  const text = String(value ?? "");
+  if (!/[",\n\r]/.test(text)) return text;
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+function escapeMarkdown(value) {
+  return String(value ?? "").replace(/[\\`*_{}\[\]()#+\-.!|<>]/g, "\\$&");
+}
+
+function printHelp() {
+  console.log(`BoTTube Watchlist Exporter
+
+Usage:
+  node index.js [options]
+
+Options:
+  -q, --query <text>    Search query (default: rustchain)
+  -l, --limit <n>       Number of videos, 1-25 (default: 10)
+  -f, --format <type>   markdown, csv, or json (default: markdown)
+  -o, --output <path>   Write output to a file instead of stdout
+      --base-url <url>  BoTTube base URL (default: https://bottube.ai)
+      --timeframe <t>   Trending timeframe (default: day)
+      --fixture <path>  Read fixture JSON instead of calling the network
+  -h, --help            Show this help
+`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const videos = await collectWatchlist(options);
+  const output = renderWatchlist(videos, options);
+
+  if (options.output) {
+    await writeFile(options.output, output);
+    console.error(`Wrote ${videos.length} videos to ${options.output}`);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+export {
+  collectWatchlist,
+  csvCell,
+  escapeMarkdown,
+  mergeVideos,
+  normalizeVideo,
+  normalizeVideos,
+  parseArgs,
+  parseLimit,
+  renderCsv,
+  renderJson,
+  renderMarkdown,
+  renderWatchlist,
+  scoreVideo,
+  videoUrl,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`bottube-watchlist: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/examples/watchlist-exporter/index.test.js
+++ b/examples/watchlist-exporter/index.test.js
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  csvCell,
+  mergeVideos,
+  normalizeVideos,
+  parseArgs,
+  parseLimit,
+  renderCsv,
+  renderMarkdown,
+  videoUrl,
+} from "./index.js";
+
+test("parseLimit rejects malformed values instead of truncating", () => {
+  assert.equal(parseLimit("3"), 3);
+  assert.throws(() => parseLimit("3abc"), /integer/);
+  assert.throws(() => parseLimit("0"), /integer/);
+  assert.throws(() => parseLimit("26"), /integer/);
+});
+
+test("parseArgs handles format, output, and fixture options", () => {
+  assert.deepEqual(parseArgs([
+    "--query", "agents",
+    "--limit", "7",
+    "--format", "csv",
+    "--output", "/tmp/watchlist.csv",
+    "--fixture", "fixture.json",
+  ]), {
+    baseUrl: "https://bottube.ai",
+    fixture: "fixture.json",
+    format: "csv",
+    limit: 7,
+    output: "/tmp/watchlist.csv",
+    query: "agents",
+    timeframe: "day",
+  });
+});
+
+test("normalizeVideos accepts SDK response variants", () => {
+  const normalized = normalizeVideos({
+    videos: [
+      {
+        id: "abc",
+        title: "Demo",
+        agent: { display_name: "Agent Display" },
+        views: "12",
+        likes: "2",
+        tags: ["sdk"],
+      },
+    ],
+  }, "search");
+
+  assert.deepEqual(normalized[0], {
+    id: "abc",
+    title: "Demo",
+    agent: "Agent Display",
+    description: "",
+    views: 12,
+    likes: 2,
+    createdAt: "",
+    tags: ["sdk"],
+    source: "search",
+  });
+});
+
+test("mergeVideos deduplicates videos and accumulates sources", () => {
+  const videos = mergeVideos([
+    normalizeVideos({ videos: [{ video_id: "a", title: "A", views: 10, likes: 1 }] }, "search"),
+    normalizeVideos({ videos: [{ id: "a", title: "A", views: 15, likes: 2 }] }, "trending"),
+    normalizeVideos({ videos: [{ id: "b", title: "B", views: 100, likes: 0 }] }, "feed"),
+  ], 10);
+
+  const mergedA = videos.find((video) => video.id === "a");
+  assert.deepEqual(mergedA.sources, ["search", "trending"]);
+  assert.equal(mergedA.views, 15);
+  assert.equal(mergedA.likes, 2);
+});
+
+test("renderers produce markdown links and escaped CSV cells", () => {
+  const options = { baseUrl: "https://bottube.ai", query: "rustchain" };
+  const videos = [{
+    id: "abc 123",
+    title: "Demo, with comma",
+    agent: "reviewer",
+    views: 20,
+    likes: 3,
+    score: 56,
+    tags: ["a", "b"],
+    sources: ["search"],
+  }];
+
+  assert.equal(videoUrl(videos[0], options.baseUrl), "https://bottube.ai/watch/abc%20123");
+  assert.match(renderMarkdown(videos, options), /Demo, with comma/);
+  assert.match(renderCsv(videos, options), /"Demo, with comma"/);
+  assert.equal(csvCell('a "quoted" value'), '"a ""quoted"" value"');
+});

--- a/examples/watchlist-exporter/package.json
+++ b/examples/watchlist-exporter/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "bottube-watchlist-exporter",
+  "version": "1.0.0",
+  "description": "Export a review watchlist from BoTTube search, trending, and feed data using the JavaScript SDK.",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-watchlist": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "check": "node --check index.js && node --check index.test.js",
+    "test": "node --test index.test.js"
+  },
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "keywords": [
+    "bottube",
+    "sdk",
+    "watchlist",
+    "export",
+    "csv",
+    "markdown"
+  ],
+  "author": "keon0711",
+  "license": "MIT"
+}

--- a/examples/watchlist-exporter/test/fixtures/videos.json
+++ b/examples/watchlist-exporter/test/fixtures/videos.json
@@ -1,0 +1,64 @@
+{
+  "search": {
+    "videos": [
+      {
+        "video_id": "alpha",
+        "title": "RustChain Agent Demo",
+        "agent_name": "atlas-agent",
+        "description": "A short RustChain walkthrough for agents.",
+        "views": 120,
+        "likes": 8,
+        "created_at": "2026-05-01T00:00:00Z",
+        "tags": ["rustchain", "agents"]
+      },
+      {
+        "video_id": "beta",
+        "title": "BoTTube Search Notes",
+        "agent_name": "review-bot",
+        "description": "Search tips for BoTTube reviewers.",
+        "views": 40,
+        "likes": 3,
+        "created_at": "2026-05-02T00:00:00Z",
+        "tags": ["bottube"]
+      }
+    ]
+  },
+  "trending": {
+    "videos": [
+      {
+        "id": "alpha",
+        "title": "RustChain Agent Demo",
+        "agent": { "name": "atlas-agent" },
+        "description": "A short RustChain walkthrough for agents.",
+        "views": 120,
+        "likes": 8,
+        "created_at": "2026-05-01T00:00:00Z",
+        "tags": ["rustchain", "agents"]
+      },
+      {
+        "id": "gamma",
+        "title": "Daily Agent Brief",
+        "agent": { "display_name": "Briefing Bot" },
+        "description": "A daily briefing workflow.",
+        "views": 75,
+        "likes": 5,
+        "created_at": "2026-05-03T00:00:00Z",
+        "tags": ["briefing"]
+      }
+    ]
+  },
+  "feed": {
+    "videos": [
+      {
+        "video_id": "delta",
+        "title": "Fresh Upload Queue",
+        "agent_name": "feed-agent",
+        "description": "How to triage fresh uploads.",
+        "views": 10,
+        "likes": 1,
+        "created_at": "2026-05-04T00:00:00Z",
+        "tags": ["workflow"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- add `examples/watchlist-exporter`, a Node.js CLI that uses the local `@bottube/sdk`
- combine SDK search, trending, and feed responses into a deduplicated ranked watchlist
- export Markdown, CSV, or JSON for reviewer/agent triage workflows
- include fixture mode plus node:test coverage for parsing, normalization, dedupe, URLs, and CSV escaping

## Validation

- `npm install --no-package-lock`
- `npm test`
- `npm run check`
- `node index.js --fixture test/fixtures/videos.json --format csv`
- `node index.js --fixture test/fixtures/videos.json --format markdown --limit 3`
- `node index.js --query rustchain --limit 2 --format json --output /tmp/bottube-watchlist-live.json`
- parsed `/tmp/bottube-watchlist-live.json` and confirmed `count: 2`, first result `nZeg8k3pJlY`, sources `search,trending`

## Safety

This example uses public read-only SDK calls only. It does not require an API key and does not upload, comment, vote, transfer funds, or mutate production state.
