### PR TITLE
Validate Beacon verify JSON bodies

### DIFF
--- a/agent_discovery.py
+++ b/agent_discovery.py
@@ -822,9 +822,21 @@ def beacon_verify():
     POST {"agent_name": "...", "beacon_id": "bcn_..."}
     Returns whether the claimed beacon matches.
     """
-    data = request.get_json(silent=True) or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
+
     agent_name = data.get("agent_name", "")
     claimed_id = data.get("beacon_id", "")
+    if not isinstance(agent_name, str):
+        return jsonify({"error": "agent_name must be a string"}), 400
+    if not isinstance(claimed_id, str):
+        return jsonify({"error": "beacon_id must be a string"}), 400
+
+    agent_name = agent_name.strip()
+    claimed_id = claimed_id.strip()
 
     if not agent_name or not claimed_id:
         return jsonify({"error": "agent_name and beacon_id required"}), 400

--- a/tests/test_beacon_verify_json_validation.py
+++ b/tests/test_beacon_verify_json_validation.py
@@ -1,0 +1,76 @@
+import sys
+import types
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def beacon_client(monkeypatch):
+    class FakeBeacon:
+        beacon_id = "bcn_expected"
+
+        def verify_identity(self, claimed_id):
+            return claimed_id == self.beacon_id
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sophia_beacon",
+        types.SimpleNamespace(get_beacon=lambda _agent_name: FakeBeacon()),
+    )
+
+    from agent_discovery import discovery_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(discovery_bp)
+    return app.test_client()
+
+
+def test_beacon_verify_rejects_non_object_json(beacon_client):
+    resp = beacon_client.post("/api/beacon/verify", json="not-object")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON object required"}
+
+
+def test_beacon_verify_rejects_non_string_agent_name(beacon_client):
+    resp = beacon_client.post(
+        "/api/beacon/verify",
+        json={"agent_name": ["alice"], "beacon_id": "bcn_expected"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "agent_name must be a string"}
+
+
+def test_beacon_verify_rejects_non_string_beacon_id(beacon_client):
+    resp = beacon_client.post(
+        "/api/beacon/verify",
+        json={"agent_name": "alice", "beacon_id": ["bcn_expected"]},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "beacon_id must be a string"}
+
+
+def test_beacon_verify_preserves_missing_field_error(beacon_client):
+    resp = beacon_client.post("/api/beacon/verify", json={})
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "agent_name and beacon_id required"}
+
+
+def test_beacon_verify_validates_trimmed_strings(beacon_client):
+    resp = beacon_client.post(
+        "/api/beacon/verify",
+        json={"agent_name": " alice ", "beacon_id": " bcn_expected "},
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {
+        "agent_name": "alice",
+        "claimed_beacon": "bcn_expected",
+        "verified": True,
+        "expected_beacon": "bcn_expected",
+    }


### PR DESCRIPTION
## Summary

- validate `POST /api/beacon/verify` JSON body shape before field access
- reject non-string `agent_name` and `beacon_id` values with deterministic 400 JSON responses
- trim accepted string values before Beacon verification
- add focused regression coverage for malformed Beacon verify payloads

Closes #1269.

## Validation

- `uv run --no-project --with flask --with pytest python -B -m pytest -q tests/test_beacon_verify_json_validation.py --tb=short`
- `python3 -B -m py_compile agent_discovery.py tests/test_beacon_verify_json_validation.py`
- `git diff --check -- agent_discovery.py tests/test_beacon_verify_json_validation.py`

## Live reproduction before fix

- `POST https://bottube.ai/api/beacon/verify` with JSON string body returned HTTP 500 HTML.
- `POST https://bottube.ai/api/beacon/verify` with `agent_name` as an array returned HTTP 500 HTML.

## Duplicate boundary

Closed issue #1230 and closed, unmerged PR #1231 covered a related Beacon/x402 validation path, but they were closed without merge. Live production still returns 500 for this Beacon verify path as of 2026-05-31, so this PR re-submits the still-needed Beacon verify fix with current regression tests.
