### PR TITLE
Validate agent directory query params

### DIFF
--- a/agent_discovery.py
+++ b/agent_discovery.py
@@ -22,6 +22,22 @@ from flask import Blueprint, Response, current_app, jsonify, request
 discovery_bp = Blueprint("agent_discovery", __name__)
 
 
+def _parse_agent_directory_int(name: str, default: int, min_value: int, max_value: int | None = None) -> int:
+    raw_value = request.args.get(name)
+    if raw_value is None or raw_value == "":
+        value = default
+    else:
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be an integer") from exc
+
+    value = max(min_value, value)
+    if max_value is not None:
+        value = min(max_value, value)
+    return value
+
+
 # ═══════════════════════════════════════════════════════════════
 # GOOGLE A2A — Agent Card
 # Spec: https://google.github.io/A2A
@@ -546,8 +562,11 @@ def api_agents_directory():
 
     db = get_db()
     q = request.args.get("q", "").strip()
-    page = max(1, int(request.args.get("page", 1)))
-    limit = min(100, max(1, int(request.args.get("limit", 20))))
+    try:
+        page = _parse_agent_directory_int("page", 1, min_value=1)
+        limit = _parse_agent_directory_int("limit", 20, min_value=1, max_value=100)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     sort = request.args.get("sort", "popular")
     agent_type = request.args.get("type", "all")
     offset = (page - 1) * limit

--- a/tests/test_agent_directory_query_validation.py
+++ b/tests/test_agent_directory_query_validation.py
@@ -1,0 +1,78 @@
+import sys
+import types
+
+import pytest
+from flask import Flask
+
+
+class FakeResult:
+    def __init__(self, one=None, rows=None):
+        self.one = one
+        self.rows = rows or []
+
+    def fetchone(self):
+        return self.one
+
+    def fetchall(self):
+        return self.rows
+
+
+class FakeDB:
+    def __init__(self):
+        self.calls = []
+
+    def execute(self, sql, params=()):
+        self.calls.append((sql, params))
+        if "COUNT(*)" in sql:
+            return FakeResult(one=(0,))
+        return FakeResult(rows=[])
+
+
+@pytest.fixture
+def agent_directory_client(monkeypatch):
+    fake_db = FakeDB()
+    monkeypatch.setitem(
+        sys.modules,
+        "bottube_server",
+        types.SimpleNamespace(get_db=lambda: fake_db),
+    )
+
+    from agent_discovery import discovery_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(discovery_bp)
+    return app.test_client(), fake_db
+
+
+def test_agent_directory_rejects_malformed_limit(agent_directory_client):
+    client, fake_db = agent_directory_client
+
+    resp = client.get("/api/agents?limit=abc")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "limit must be an integer"}
+    assert fake_db.calls == []
+
+
+def test_agent_directory_rejects_malformed_page(agent_directory_client):
+    client, fake_db = agent_directory_client
+
+    resp = client.get("/api/agents?page=abc")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "page must be an integer"}
+    assert fake_db.calls == []
+
+
+def test_agent_directory_clamps_valid_numeric_bounds(agent_directory_client):
+    client, fake_db = agent_directory_client
+
+    resp = client.get("/api/agents?page=0&limit=250")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["page"] == 1
+    assert body["limit"] == 100
+    assert body["total"] == 0
+    assert len(fake_db.calls) == 2


### PR DESCRIPTION
## Summary

- validate `/api/agents` `page` and `limit` query params before SQL pagination
- return deterministic 400 JSON errors for malformed integer values
- preserve existing numeric clamping behavior for valid values
- add regression coverage for malformed `limit`, malformed `page`, and valid bound clamping

Closes #1271.

## Validation

- `uv run --no-project --with flask --with pytest python -B -m pytest -q tests/test_agent_directory_query_validation.py --tb=short`
- `python3 -B -m py_compile agent_discovery.py tests/test_agent_directory_query_validation.py`
- `git diff --check -- agent_discovery.py tests/test_agent_directory_query_validation.py`

## Live reproduction before fix

- `GET https://bottube.ai/api/agents?limit=abc` returned HTTP 500 HTML.
- `GET https://bottube.ai/api/agents?page=abc` returned HTTP 500 HTML.

## Duplicate boundary

Closed issue #1007 and closed, unmerged PR #1008 covered this route earlier, but they were closed without merge. Live production still returns 500 for the same requests as of 2026-05-31, so this PR re-submits the still-needed fix with current regression tests.
