### PR TITLE
fix: validate social feed query params

### DIFF
--- a/interactions_blueprint.py
+++ b/interactions_blueprint.py
@@ -13,6 +13,25 @@ from collections import defaultdict
 interactions_bp = Blueprint('interactions', __name__, url_prefix='/social')
 
 
+def _parse_int_query_arg(name, default, max_value):
+    raw_value = request.args.get(name, default)
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        return None, f"{name} must be an integer"
+    return min(parsed, max_value), None
+
+
+def _parse_optional_float_query_arg(name):
+    raw_value = request.args.get(name)
+    if not raw_value:
+        return None, None
+    try:
+        return float(raw_value), None
+    except (TypeError, ValueError):
+        return None, f"{name} must be a number"
+
+
 def get_db():
     """Get database connection from Flask app context or create new one."""
     if 'db' in g:
@@ -43,17 +62,21 @@ def api_activity_feed():
     - limit: max items (default: 50)
     - since: timestamp for polling updates
     """
-    limit = min(int(request.args.get('limit', 50)), 100)
-    since = request.args.get('since')
+    limit, error = _parse_int_query_arg('limit', 50, 100)
+    if error:
+        return jsonify({"error": error}), 400
+    since, error = _parse_optional_float_query_arg('since')
+    if error:
+        return jsonify({"error": error}), 400
     
     db = get_db()
     
     # Build time filter
     time_filter = ""
     params = []
-    if since:
+    if since is not None:
         time_filter = "AND created_at > ?"
-        params.append(float(since))
+        params.append(since)
     
     # Get recent uploads
     uploads = db.execute(f"""SELECT 

--- a/tests/test_social_feed_query_validation.py
+++ b/tests/test_social_feed_query_validation.py
@@ -1,0 +1,61 @@
+from flask import Flask
+
+import interactions_blueprint
+from interactions_blueprint import interactions_bp
+
+
+class FakeResult:
+    def fetchall(self):
+        return []
+
+
+class FakeDB:
+    def __init__(self):
+        self.calls = []
+
+    def execute(self, sql, params=()):
+        self.calls.append((sql, params))
+        return FakeResult()
+
+
+def _make_client(monkeypatch):
+    fake_db = FakeDB()
+    monkeypatch.setattr(interactions_blueprint, "get_db", lambda: fake_db)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(interactions_bp)
+    return app.test_client(), fake_db
+
+
+def test_social_feed_rejects_malformed_limit(monkeypatch):
+    client, fake_db = _make_client(monkeypatch)
+
+    resp = client.get("/social/api/feed?limit=abc")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "limit must be an integer"}
+    assert fake_db.calls == []
+
+
+def test_social_feed_rejects_malformed_since(monkeypatch):
+    client, fake_db = _make_client(monkeypatch)
+
+    resp = client.get("/social/api/feed?since=abc")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "since must be a number"}
+    assert fake_db.calls == []
+
+
+def test_social_feed_clamps_limit_and_applies_since(monkeypatch):
+    client, fake_db = _make_client(monkeypatch)
+
+    resp = client.get("/social/api/feed?limit=250&since=100.5")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["activities"] == []
+    assert body["count"] == 0
+    assert len(fake_db.calls) == 4
+    assert all(params == [100.5, 100] for _, params in fake_db.calls)


### PR DESCRIPTION
## Summary

- validate `/social/api/feed` `limit` before integer conversion
- validate optional `since` before float conversion
- add focused Flask tests that malformed values return JSON 400 before database access

Fixes #1273.

## Live bug evidence

Verified on `https://bottube.ai` on 2026-05-31:

- `/social/api/feed?limit=abc` returned HTTP 500 HTML
- `/social/api/feed?since=abc` returned HTTP 500 HTML

## Tests

- `uv run --no-project --with flask --with pytest python -B -m pytest -q tests/test_social_feed_query_validation.py --tb=short`
- `python3 -B -m py_compile interactions_blueprint.py tests/test_social_feed_query_validation.py`
- `git diff --check -- interactions_blueprint.py tests/test_social_feed_query_validation.py`

Note: `npm test` is not available on this branch because `package.json` does not define a `test` script.
