### PR TITLE
fix: validate feed impression event input

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9266,14 +9266,35 @@ def _feed_imp_record(visitor_id, surface, bucket, videos):
     return ids
 
 
+def _feed_event_json_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"ok": False, "error": "JSON body must be an object"}), 400)
+    return data, None
+
+
+def _feed_event_impression_id(data):
+    raw_value = data.get("imp") or data.get("impression_id") or ""
+    if not isinstance(raw_value, str):
+        return None, (jsonify({"ok": False, "error": "invalid impression_id"}), 400)
+    imp_id = raw_value.strip()
+    if not re.fullmatch(r"imp_[a-f0-9]{8,32}", imp_id):
+        return None, (jsonify({"ok": False, "error": "invalid impression_id"}), 400)
+    return imp_id, None
+
+
 @app.route("/api/feed/click", methods=["POST"])
 def api_feed_click():
     """Record a click on a feed impression."""
     _feed_imp_ensure_schema()
-    data = request.get_json(silent=True) or {}
-    imp_id = (data.get("imp") or data.get("impression_id") or "").strip()
-    if not re.fullmatch(r"imp_[a-f0-9]{8,32}", imp_id):
-        return jsonify({"ok": False, "error": "invalid impression_id"}), 400
+    data, error = _feed_event_json_body()
+    if error:
+        return error
+    imp_id, error = _feed_event_impression_id(data)
+    if error:
+        return error
     try:
         conn = sqlite3.connect(str(DB_PATH))
         conn.execute(
@@ -9297,14 +9318,16 @@ def api_feed_click():
 def api_feed_watch():
     """Record a watch-seconds ping for a feed impression. Idempotent in MAX-direction."""
     _feed_imp_ensure_schema()
-    data = request.get_json(silent=True) or {}
-    imp_id = (data.get("imp") or data.get("impression_id") or "").strip()
+    data, error = _feed_event_json_body()
+    if error:
+        return error
+    imp_id, error = _feed_event_impression_id(data)
+    if error:
+        return error
     try:
         seconds = max(0.0, min(86400.0, float(data.get("seconds", 0))))
     except Exception:
         return jsonify({"ok": False, "error": "seconds must be a number"}), 400
-    if not re.fullmatch(r"imp_[a-f0-9]{8,32}", imp_id):
-        return jsonify({"ok": False, "error": "invalid impression_id"}), 400
     try:
         conn = sqlite3.connect(str(DB_PATH))
         conn.execute(

--- a/tests/test_feed_impression_event_validation.py
+++ b/tests/test_feed_impression_event_validation.py
@@ -1,0 +1,78 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_feed_impression_validation_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_feed_impression_validation_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    bottube_server.app.config["TESTING"] = True
+    monkeypatch.setattr(bottube_server, "_feed_imp_ensure_schema", lambda: None)
+    yield bottube_server.app.test_client()
+
+
+@pytest.mark.parametrize("path", ["/api/feed/click", "/api/feed/watch"])
+def test_feed_impression_events_reject_non_object_json(client, path):
+    resp = client.post(path, json=["bad"])
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "JSON body must be an object",
+    }
+
+
+@pytest.mark.parametrize("path", ["/api/feed/click", "/api/feed/watch"])
+def test_feed_impression_events_reject_non_string_impression_id(client, path):
+    resp = client.post(path, json={"imp": ["imp_bad"], "seconds": 1})
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "invalid impression_id",
+    }


### PR DESCRIPTION
## Summary

- validate feed impression event JSON bodies before field access
- reject non-string `imp` / `impression_id` values before `.strip()`
- add focused tests for `/api/feed/click` and `/api/feed/watch`

Fixes #1275.

## Live bug evidence

Verified on `https://bottube.ai` on 2026-05-31:

- `POST /api/feed/click` with `{"imp":["imp_bad"]}` returned HTTP 500 HTML
- `POST /api/feed/watch` with `{"imp":["imp_bad"],"seconds":1}` returned HTTP 500 HTML

## Tests

- `uv run --no-project --with flask --with pytest --with requests python -B -m pytest -q tests/test_feed_impression_event_validation.py --tb=short`
- `python3 -B -m py_compile bottube_server.py tests/test_feed_impression_event_validation.py`
- `git diff --check -- bottube_server.py tests/test_feed_impression_event_validation.py`
- `uv run --no-project --with flake8 python -m flake8 bottube_server.py tests/test_feed_impression_event_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics`

Note: the broader non-blocking flake8 mode still reports existing style warnings in `bottube_server.py`, but the CI-failing E9/F gate is clean for these files.
