### PR TITLE
fix: validate public utility JSON input

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1539,6 +1539,27 @@ def _verify_csrf():
         abort(403)
 
 
+def _public_json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"ok": False, "error": "JSON body must be an object"}), 400)
+    return data, None
+
+
+def _public_string_field(data, field, default="", max_length=None):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, f"{field} must be a string"
+    value = value.strip()
+    if max_length is not None:
+        value = value[:max_length]
+    return value, None
+
+
 # ---------------------------------------------------------------------------
 # Scrape / Visitor Monitoring
 # ---------------------------------------------------------------------------
@@ -13503,9 +13524,15 @@ def notification_settings_save():
 @app.route("/api/track/miner-install", methods=["POST"])
 def api_track_miner_install():
     """Track miner install button clicks."""
-    data = request.get_json(silent=True) or {}
-    source = data.get("source", "unknown")  # pip or npm
-    page = data.get("page", "unknown")
+    data, error = _public_json_object_body()
+    if error:
+        return error
+    source, field_error = _public_string_field(data, "source", "unknown", 64)
+    if field_error:
+        return jsonify({"ok": False, "error": field_error}), 400
+    page, field_error = _public_string_field(data, "page", "unknown", 128)
+    if field_error:
+        return jsonify({"ok": False, "error": field_error}), 400
     ip = request.headers.get("X-Forwarded-For", request.remote_addr)
     app.logger.info(f"[MINER-TRACK] source={source} page={page} ip={ip}")
 
@@ -14415,8 +14442,12 @@ def push_subscribe():
 @app.route("/api/push/unsubscribe", methods=["POST"])
 def push_unsubscribe():
     """Remove a push notification subscription."""
-    data = request.get_json(silent=True) or {}
-    endpoint = data.get("endpoint", "")
+    data, error = _public_json_object_body()
+    if error:
+        return error
+    endpoint, field_error = _public_string_field(data, "endpoint", "", 2048)
+    if field_error:
+        return jsonify({"ok": False, "error": field_error}), 400
     if endpoint:
         db = get_db()
         db.execute("DELETE FROM push_subscriptions WHERE endpoint = ?", (endpoint,))

--- a/tests/test_public_utility_json_validation.py
+++ b/tests/test_public_utility_json_validation.py
@@ -1,0 +1,96 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_public_utility_json_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_public_utility_json_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    def fail_get_db():
+        raise AssertionError("invalid public utility input must not touch the DB")
+
+    monkeypatch.setattr(bottube_server, "get_db", fail_get_db)
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/api/push/unsubscribe", "/api/track/miner-install"],
+)
+def test_public_utility_endpoints_reject_non_object_json(client, path):
+    resp = client.post(path, json=["bad"])
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "JSON body must be an object",
+    }
+
+
+def test_push_unsubscribe_rejects_non_string_endpoint(client):
+    resp = client.post("/api/push/unsubscribe", json={"endpoint": ["bad"]})
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "endpoint must be a string",
+    }
+
+
+def test_miner_install_tracking_rejects_non_string_fields(client):
+    resp = client.post(
+        "/api/track/miner-install",
+        json={"source": ["pip"], "page": {"path": "/miner"}},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "source must be a string",
+    }


### PR DESCRIPTION
## Summary

- validate public utility JSON bodies before field access
- reject non-string utility fields before database/logging paths
- add regression tests for `/api/push/unsubscribe` and `/api/track/miner-install`

Fixes #1277.

## Live bug evidence

Verified on `https://bottube.ai` on 2026-05-31:

- `POST /api/push/unsubscribe` with JSON body `["bad"]` returned HTTP 500 HTML
- `POST /api/track/miner-install` with JSON body `["bad"]` returned HTTP 500 HTML

## Tests

- `uv run --no-project --with flask --with pytest --with requests python -B -m pytest -q tests/test_public_utility_json_validation.py --tb=short`
- `python3 -B -m py_compile bottube_server.py tests/test_public_utility_json_validation.py`
- `git diff --check -- bottube_server.py tests/test_public_utility_json_validation.py`
- `uv run --no-project --with flake8 python -m flake8 bottube_server.py tests/test_public_utility_json_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics`
