### PR TITLE
fix: validate MCP bridge JSON input

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -18475,9 +18475,20 @@ def mcp_bridge():
     if request.method == "GET":
         return jsonify(_mcp_descriptor())
 
-    data = request.get_json(silent=True) or {}
-    tool_name = (data.get("tool") or data.get("method") or "").strip()
-    args = data.get("args") or data.get("params") or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
+        return jsonify({"ok": False, "error": "JSON body must be an object"}), 400
+
+    raw_tool_name = data.get("tool") or data.get("method") or ""
+    if not isinstance(raw_tool_name, str):
+        return jsonify({"ok": False, "error": "tool must be a string"}), 400
+    tool_name = raw_tool_name.strip()
+
+    args = data["args"] if "args" in data else data.get("params", {})
+    if args is None:
+        args = {}
     if not isinstance(args, dict):
         return jsonify({"ok": False, "error": "args must be an object"}), 400
 

--- a/tests/test_mcp_bridge_validation.py
+++ b/tests/test_mcp_bridge_validation.py
@@ -1,0 +1,85 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_mcp_bridge_validation_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_mcp_bridge_validation_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client():
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def test_mcp_rejects_non_object_json(client):
+    resp = client.post("/mcp", json=["bad"])
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "JSON body must be an object",
+    }
+
+
+def test_mcp_rejects_non_string_tool_name(client):
+    resp = client.post("/mcp", json={"tool": ["feed.get"]})
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "tool must be a string",
+    }
+
+
+def test_mcp_rejects_non_object_args(client):
+    resp = client.post("/mcp", json={"tool": "feed.get", "args": ["bad"]})
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "args must be an object",
+    }


### PR DESCRIPTION
## Summary

- validate `/mcp` JSON body shape before field access
- reject non-string `tool` / `method` values before `.strip()`
- preserve object validation for `args` / `params`
- add focused MCP bridge input validation tests

Fixes #1279.

## Live bug evidence

Verified on `https://bottube.ai` on 2026-05-31:

- `POST /mcp` with JSON body `["bad"]` returned HTTP 500 HTML
- `POST /mcp` with JSON body `{"tool":["feed.get"]}` returned HTTP 500 HTML

## Tests

- `uv run --no-project --with flask --with pytest --with requests python -B -m pytest -q tests/test_mcp_bridge_validation.py --tb=short`
- `python3 -B -m py_compile bottube_server.py tests/test_mcp_bridge_validation.py`
- `git diff --check -- bottube_server.py tests/test_mcp_bridge_validation.py`
- `uv run --no-project --with flake8 python -m flake8 bottube_server.py tests/test_mcp_bridge_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics`
