### PR TITLE
fix: handle non-object JSON in CSRF checks

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1523,7 +1523,8 @@ def _verify_csrf():
     )
     if not token:
         data = request.get_json(silent=True) or {}
-        token = data.get("csrf_token", "")
+        if isinstance(data, dict):
+            token = data.get("csrf_token", "")
     expected = session.get("csrf_token", "")
     if not expected or not token or not secrets.compare_digest(token, expected):
         # Return JSON for AJAX/API requests so JS can handle the error

--- a/tests/test_csrf_json_validation.py
+++ b/tests/test_csrf_json_validation.py
@@ -1,0 +1,75 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault(
+    "BOTTUBE_DB_PATH",
+    "/tmp/bottube_test_csrf_json_validation_bootstrap.db",
+)
+os.environ.setdefault(
+    "BOTTUBE_DB",
+    "/tmp/bottube_test_csrf_json_validation_bootstrap.db",
+)
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import paypal_packages  # noqa: E402
+
+
+_orig_init_store_db = paypal_packages.init_store_db
+
+
+def _test_init_store_db(db_path=None):
+    bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
+    Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
+    return _orig_init_store_db(bootstrap_path)
+
+
+paypal_packages.init_store_db = _test_init_store_db
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client():
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def test_csrf_rejects_non_object_json_without_crashing(client):
+    resp = client.post("/giveaway/enter", json=["bad"])
+
+    assert resp.status_code == 403
+    assert resp.get_json() == {
+        "error": "Session expired. Please refresh the page.",
+        "csrf_error": True,
+    }
+
+
+def test_csrf_rejects_falsy_non_object_json_without_crashing(client):
+    resp = client.post("/giveaway/enter", json=[])
+
+    assert resp.status_code == 403
+    assert resp.get_json() == {
+        "error": "Session expired. Please refresh the page.",
+        "csrf_error": True,
+    }


### PR DESCRIPTION
## Summary

- guard `_verify_csrf()` so it only reads `csrf_token` from object JSON bodies
- preserve the existing JSON 403 CSRF failure response for malformed JSON shapes
- add focused tests using `/giveaway/enter` as a public reproduction route

Fixes #1281.

## Live bug evidence

Verified on `https://bottube.ai` on 2026-05-31:

- `POST /giveaway/enter` with JSON body `["bad"]` returned HTTP 500 HTML

## Tests

- `uv run --no-project --with flask --with pytest --with requests python -B -m pytest -q tests/test_csrf_json_validation.py --tb=short`
- `python3 -B -m py_compile bottube_server.py tests/test_csrf_json_validation.py`
- `git diff --check -- bottube_server.py tests/test_csrf_json_validation.py`
- `uv run --no-project --with flake8 python -m flake8 bottube_server.py tests/test_csrf_json_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics`
