### PR TITLE
seo: tighten template image audit hygiene

### DIFF
--- a/bottube_static/beacon_atlas/index.html
+++ b/bottube_static/beacon_atlas/index.html
@@ -117,7 +117,6 @@
           const relayAgents = await rResp.json();
           if (Array.isArray(relayAgents) && relayAgents.length > 0) {
             mergeRelayAgents(relayAgents);
-            console.log(`[boot] Merged ${relayAgents.length} relay agents into Atlas`);
           }
         }
       } catch (e) {
@@ -141,7 +140,6 @@
           }));
           if (shAgents.length > 0) {
             mergeRelayAgents(shAgents);
-            console.log(`[boot] Merged ${shAgents.length} SwarmHub agents`);
           }
         }
       } catch (e) {
@@ -172,7 +170,6 @@
           const contracts = await cResp.json();
           if (Array.isArray(contracts) && contracts.length > 0) {
             replaceContracts(contracts);
-            console.log(`[boot] Loaded ${contracts.length} contracts from backend`);
           }
         }
       } catch (e) {

--- a/bottube_templates/activity_feed.html
+++ b/bottube_templates/activity_feed.html
@@ -290,7 +290,7 @@
     function createUploadItem(activity) {
         return `
             <div class="activity-item">
-                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="">
+                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="" loading="lazy" decoding="async">
                 <div class="activity-content">
                     <div class="activity-header">
                         <span class="activity-agent">${escapeHtml(activity.agent.display_name)}</span>
@@ -298,7 +298,7 @@
                         <span class="activity-time">${activity.formatted_time}</span>
                     </div>
                     <div class="activity-video" onclick="window.location='/watch/${activity.content.video_id}'">
-                        <img src="${activity.content.thumbnail}" class="video-thumb" alt="Video thumbnail: ${activity.content.title || 'video'}">
+                        <img src="${activity.content.thumbnail}" class="video-thumb" alt="Video thumbnail: ${activity.content.title || 'video'}" loading="lazy" decoding="async">
                         <div class="video-info">
                             <div class="video-title">${escapeHtml(activity.content.title)}</div>
                         </div>
@@ -312,7 +312,7 @@
         const replyBadge = activity.content.is_reply ? '<span class="collab-badge">↩️ Reply</span>' : '';
         return `
             <div class="activity-item">
-                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="">
+                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="" loading="lazy" decoding="async">
                 <div class="activity-content">
                     <div class="activity-header">
                         <span class="activity-agent">${escapeHtml(activity.agent.display_name)}</span>
@@ -333,7 +333,7 @@
         const emoji = activity.content.action === 'upvoted' ? '👍' : '👎';
         return `
             <div class="activity-item">
-                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="">
+                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="" loading="lazy" decoding="async">
                 <div class="activity-content">
                     <div class="activity-header">
                         <span class="activity-agent">${escapeHtml(activity.agent.display_name)}</span>
@@ -351,7 +351,7 @@
     function createTipItem(activity) {
         return `
             <div class="activity-item tip-activity">
-                <img src="${activity.from_agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="">
+                <img src="${activity.from_agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="" loading="lazy" decoding="async">
                 <div class="activity-content">
                     <div class="activity-header">
                         <span class="activity-agent">${escapeHtml(activity.from_agent.display_name)}</span>

--- a/bottube_templates/agents.html
+++ b/bottube_templates/agents.html
@@ -141,7 +141,7 @@
     {% for agent in agents %}
     <a href="{{ P }}/agent/{{ agent.agent_name }}" class="agent-card" style="color: inherit;">
         <div class="agent-card-header">
-            <img src="{{ agent.avatar_url or (P ~ '/avatar/' ~ agent.agent_name ~ '.svg') }}" class="agent-card-avatar" alt="{{ agent.agent_name }}">
+            <img src="{{ agent.avatar_url or (P ~ '/avatar/' ~ agent.agent_name ~ '.svg') }}" class="agent-card-avatar" alt="{{ agent.agent_name }}" loading="lazy" decoding="async">
             <div>
                 <div class="agent-card-name">{{ agent.display_name or agent.agent_name }}</div>
                 <div class="agent-card-handle">@{{ agent.agent_name }}</div>

--- a/bottube_templates/badges.html
+++ b/bottube_templates/badges.html
@@ -235,7 +235,7 @@
             <div class="badge-label">Video Count</div>
             <div class="badge-desc">Shows total videos on the platform. Updates every 5 minutes.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai"><img src="{{ P }}/badge/videos.svg" alt="BoTTube videos"></a>
+                <a href="https://bottube.ai"><img src="{{ P }}/badge/videos.svg" alt="BoTTube videos" loading="lazy" decoding="async"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'vid-md')">Markdown</button>
@@ -249,7 +249,7 @@
             <div class="badge-label">Agent Count</div>
             <div class="badge-desc">Shows total AI agents and human creators.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai/agents"><img src="{{ P }}/badge/agents.svg" alt="BoTTube agents"></a>
+                <a href="https://bottube.ai/agents"><img src="{{ P }}/badge/agents.svg" alt="BoTTube agents" loading="lazy" decoding="async"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'agent-md')">Markdown</button>
@@ -263,7 +263,7 @@
             <div class="badge-label">Total Views</div>
             <div class="badge-desc">Shows total video views across the platform.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai"><img src="{{ P }}/badge/views.svg" alt="BoTTube views"></a>
+                <a href="https://bottube.ai"><img src="{{ P }}/badge/views.svg" alt="BoTTube views" loading="lazy" decoding="async"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'views-md')">Markdown</button>
@@ -277,7 +277,7 @@
             <div class="badge-label">Powered by BoTTube</div>
             <div class="badge-desc">Generic platform badge for projects using BoTTube.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai"><img src="{{ P }}/badge/platform.svg" alt="Powered by BoTTube"></a>
+                <a href="https://bottube.ai"><img src="{{ P }}/badge/platform.svg" alt="Powered by BoTTube" loading="lazy" decoding="async"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'plat-md')">Markdown</button>
@@ -296,7 +296,7 @@
             <div class="badge-label">Branded Badge</div>
             <div class="badge-desc">A premium-styled badge for websites and blogs that feature BoTTube content.</div>
             <div class="badge-preview" style="background: #0f0f0f; padding: 24px;">
-                <a href="https://bottube.ai"><img src="{{ P }}/badge/seen-on-bottube.svg" alt="As seen on BoTTube"></a>
+                <a href="https://bottube.ai"><img src="{{ P }}/badge/seen-on-bottube.svg" alt="As seen on BoTTube" loading="lazy" decoding="async"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'seen-md')">Markdown</button>
@@ -315,7 +315,7 @@
             <div class="badge-label">Agent Video Count</div>
             <div class="badge-desc">Show the video count for a specific agent. Replace <code>AGENT_NAME</code> with the agent's username.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai/agent/sophia-elya"><img src="{{ P }}/badge/agent/sophia-elya.svg" alt="sophia-elya videos"></a>
+                <a href="https://bottube.ai/agent/sophia-elya"><img src="{{ P }}/badge/agent/sophia-elya.svg" alt="sophia-elya videos" loading="lazy" decoding="async"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'per-md')">Markdown</button>
@@ -345,7 +345,7 @@
                 version (v1 or v2). 5-minute cache. Replace <code>VIDEO_ID</code>.
             </div>
             <div class="badge-preview">
-                <img src="{{ P }}/badge/verified/lcqlfSGodNx.svg" alt="Verified on RustChain">
+                <img src="{{ P }}/badge/verified/lcqlfSGodNx.svg" alt="Verified on RustChain" loading="lazy" decoding="async">
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'vrf-md')">Markdown</button>

--- a/bottube_templates/badges.html
+++ b/bottube_templates/badges.html
@@ -235,7 +235,7 @@
             <div class="badge-label">Video Count</div>
             <div class="badge-desc">Shows total videos on the platform. Updates every 5 minutes.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai"><img src="{{ P }}/badge/videos.svg" alt="BoTTube videos" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai"><img src="{{ P }}/badge/videos.svg" alt="BoTTube videos" loading="lazy" decoding="async" width="120" height="20"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'vid-md')">Markdown</button>
@@ -249,7 +249,7 @@
             <div class="badge-label">Agent Count</div>
             <div class="badge-desc">Shows total AI agents and human creators.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai/agents"><img src="{{ P }}/badge/agents.svg" alt="BoTTube agents" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai/agents"><img src="{{ P }}/badge/agents.svg" alt="BoTTube agents" loading="lazy" decoding="async" width="120" height="20"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'agent-md')">Markdown</button>
@@ -263,7 +263,7 @@
             <div class="badge-label">Total Views</div>
             <div class="badge-desc">Shows total video views across the platform.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai"><img src="{{ P }}/badge/views.svg" alt="BoTTube views" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai"><img src="{{ P }}/badge/views.svg" alt="BoTTube views" loading="lazy" decoding="async" width="120" height="20"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'views-md')">Markdown</button>
@@ -277,7 +277,7 @@
             <div class="badge-label">Powered by BoTTube</div>
             <div class="badge-desc">Generic platform badge for projects using BoTTube.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai"><img src="{{ P }}/badge/platform.svg" alt="Powered by BoTTube" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai"><img src="{{ P }}/badge/platform.svg" alt="Powered by BoTTube" loading="lazy" decoding="async" width="120" height="20"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'plat-md')">Markdown</button>
@@ -296,7 +296,7 @@
             <div class="badge-label">Branded Badge</div>
             <div class="badge-desc">A premium-styled badge for websites and blogs that feature BoTTube content.</div>
             <div class="badge-preview" style="background: #0f0f0f; padding: 24px;">
-                <a href="https://bottube.ai"><img src="{{ P }}/badge/seen-on-bottube.svg" alt="As seen on BoTTube" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai"><img src="{{ P }}/badge/seen-on-bottube.svg" alt="As seen on BoTTube" loading="lazy" decoding="async" width="220" height="44"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'seen-md')">Markdown</button>
@@ -315,7 +315,7 @@
             <div class="badge-label">Agent Video Count</div>
             <div class="badge-desc">Show the video count for a specific agent. Replace <code>AGENT_NAME</code> with the agent's username.</div>
             <div class="badge-preview">
-                <a href="https://bottube.ai/agent/sophia-elya"><img src="{{ P }}/badge/agent/sophia-elya.svg" alt="sophia-elya videos" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai/agent/sophia-elya"><img src="{{ P }}/badge/agent/sophia-elya.svg" alt="sophia-elya videos" loading="lazy" decoding="async" width="140" height="20"></a>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'per-md')">Markdown</button>
@@ -345,7 +345,7 @@
                 version (v1 or v2). 5-minute cache. Replace <code>VIDEO_ID</code>.
             </div>
             <div class="badge-preview">
-                <img src="{{ P }}/badge/verified/lcqlfSGodNx.svg" alt="Verified on RustChain" loading="lazy" decoding="async">
+                <img src="{{ P }}/badge/verified/lcqlfSGodNx.svg" alt="Verified on RustChain" loading="lazy" decoding="async" width="170" height="20">
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'vrf-md')">Markdown</button>

--- a/bottube_templates/beacon_atlas.html
+++ b/bottube_templates/beacon_atlas.html
@@ -211,7 +211,7 @@
 <div id="profile-card">
   <button class="card-close" onclick="closeCard()" aria-label="Close agent details">&times;</button>
   <div class="card-header">
-    <img class="card-avatar" id="card-avatar" src="" alt="Agent avatar">
+    <img class="card-avatar" id="card-avatar" src="" alt="Agent avatar" loading="lazy" decoding="async">
     <div>
       <div class="card-name" id="card-name"></div>
       <div class="card-beacon" id="card-beacon"></div>

--- a/bottube_templates/blog_badges_embeds.html
+++ b/bottube_templates/blog_badges_embeds.html
@@ -211,10 +211,10 @@
 
         <div class="badge-demo">
             <div class="badge-row">
-                <a href="https://bottube.ai"><img src="/badge/videos.svg" alt="BoTTube videos"></a>
-                <a href="https://bottube.ai/agents"><img src="/badge/agents.svg" alt="BoTTube agents"></a>
-                <a href="https://bottube.ai"><img src="/badge/views.svg" alt="BoTTube views"></a>
-                <a href="https://bottube.ai"><img src="/badge/platform.svg" alt="Powered by BoTTube"></a>
+                <a href="https://bottube.ai"><img src="/badge/videos.svg" alt="BoTTube videos" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai/agents"><img src="/badge/agents.svg" alt="BoTTube agents" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai"><img src="/badge/views.svg" alt="BoTTube views" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai"><img src="/badge/platform.svg" alt="Powered by BoTTube" loading="lazy" decoding="async"></a>
             </div>
         </div>
 
@@ -238,7 +238,7 @@
         </p>
 
         <div class="badge-demo">
-            <a href="/agent/sophia-elya"><img src="/badge/agent/sophia-elya.svg" alt="Sophia Elya videos"></a>
+            <a href="/agent/sophia-elya"><img src="/badge/agent/sophia-elya.svg" alt="Sophia Elya videos" loading="lazy" decoding="async"></a>
         </div>
 
         <p>Just replace the agent name in the URL:</p>
@@ -252,7 +252,7 @@
         </p>
 
         <div class="badge-demo">
-            <a href="https://bottube.ai"><img src="/badge/seen-on-bottube.svg" alt="As seen on BoTTube"></a>
+            <a href="https://bottube.ai"><img src="/badge/seen-on-bottube.svg" alt="As seen on BoTTube" loading="lazy" decoding="async"></a>
         </div>
 
         <pre><code>[![As seen on BoTTube](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai)</code></pre>

--- a/bottube_templates/blog_badges_embeds.html
+++ b/bottube_templates/blog_badges_embeds.html
@@ -211,10 +211,10 @@
 
         <div class="badge-demo">
             <div class="badge-row">
-                <a href="https://bottube.ai"><img src="/badge/videos.svg" alt="BoTTube videos" loading="lazy" decoding="async"></a>
-                <a href="https://bottube.ai/agents"><img src="/badge/agents.svg" alt="BoTTube agents" loading="lazy" decoding="async"></a>
-                <a href="https://bottube.ai"><img src="/badge/views.svg" alt="BoTTube views" loading="lazy" decoding="async"></a>
-                <a href="https://bottube.ai"><img src="/badge/platform.svg" alt="Powered by BoTTube" loading="lazy" decoding="async"></a>
+                <a href="https://bottube.ai"><img src="/badge/videos.svg" alt="BoTTube videos" loading="lazy" decoding="async" width="120" height="20"></a>
+                <a href="https://bottube.ai/agents"><img src="/badge/agents.svg" alt="BoTTube agents" loading="lazy" decoding="async" width="120" height="20"></a>
+                <a href="https://bottube.ai"><img src="/badge/views.svg" alt="BoTTube views" loading="lazy" decoding="async" width="120" height="20"></a>
+                <a href="https://bottube.ai"><img src="/badge/platform.svg" alt="Powered by BoTTube" loading="lazy" decoding="async" width="120" height="20"></a>
             </div>
         </div>
 
@@ -238,7 +238,7 @@
         </p>
 
         <div class="badge-demo">
-            <a href="/agent/sophia-elya"><img src="/badge/agent/sophia-elya.svg" alt="Sophia Elya videos" loading="lazy" decoding="async"></a>
+            <a href="/agent/sophia-elya"><img src="/badge/agent/sophia-elya.svg" alt="Sophia Elya videos" loading="lazy" decoding="async" width="140" height="20"></a>
         </div>
 
         <p>Just replace the agent name in the URL:</p>
@@ -252,7 +252,7 @@
         </p>
 
         <div class="badge-demo">
-            <a href="https://bottube.ai"><img src="/badge/seen-on-bottube.svg" alt="As seen on BoTTube" loading="lazy" decoding="async"></a>
+            <a href="https://bottube.ai"><img src="/badge/seen-on-bottube.svg" alt="As seen on BoTTube" loading="lazy" decoding="async" width="220" height="44"></a>
         </div>
 
         <pre><code>[![As seen on BoTTube](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai)</code></pre>

--- a/bottube_templates/bridge.html
+++ b/bottube_templates/bridge.html
@@ -321,7 +321,7 @@
     <div class="chain-panel active" id="panel-wrtc">
 
         <div class="bridge-card" style="text-align:center;">
-            <img src="https://bottube.ai/static/img/wrtc-logo.png" alt="wRTC token logo" style="width:48px;height:48px;border-radius:50%;margin-bottom:8px;">
+            <img src="https://bottube.ai/static/img/wrtc-logo.png" alt="wRTC token logo" loading="lazy" decoding="async" style="width:48px;height:48px;border-radius:50%;margin-bottom:8px;">
             <h2 style="justify-content:center;">wRTC on Solana</h2>
             <div class="bridge-stats" style="margin-top:8px;">
                 <div class="bridge-stat"><div class="val">8,300,000</div><div class="lbl">Total Supply</div></div>

--- a/bottube_templates/category.html
+++ b/bottube_templates/category.html
@@ -261,7 +261,7 @@
                 <a href="{{ P }}/watch/{{ v.video_id }}">
                     <div class="thumb-wrap">
                         {% if v.thumbnail %}
-                        <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy">
+                        <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy" decoding="async">
                         {% else %}
                         <div class="thumb-placeholder">&#9654;</div>
                         {% endif %}
@@ -270,7 +270,7 @@
                         {% endif %}
                     </div>
                     <div class="video-info">
-                        <img class="channel-avatar" src="{{ v.avatar_url or (P ~ '/avatar/' ~ v.agent_name ~ '.svg') }}" alt="{{ v.agent_name }}">
+                        <img class="channel-avatar" src="{{ v.avatar_url or (P ~ '/avatar/' ~ v.agent_name ~ '.svg') }}" alt="{{ v.agent_name }}" loading="lazy" decoding="async">
                         <div class="video-meta">
                             <div class="video-title">{{ v.title }}</div>
                             <a href="{{ P }}/agent/{{ v.agent_name }}" class="video-channel">{{ v.display_name or v.agent_name }}{% if v.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
@@ -299,7 +299,7 @@
                 <a href="{{ P }}/watch/{{ v.video_id }}" class="trending-mini-item">
                     <div class="trending-mini-thumb">
                         {% if v.thumbnail %}
-                        <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="{{ v.title }}">
+                        <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="{{ v.title }}" loading="lazy" decoding="async">
                         {% else %}
                         <div style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:var(--text-muted);">&#9654;</div>
                         {% endif %}

--- a/bottube_templates/channel.html
+++ b/bottube_templates/channel.html
@@ -620,7 +620,7 @@
 {# Issue #422: Channel banner #}
 {% if customization and customization.banner_url %}
 <div class="channel-banner">
-    <img src="{{ customization.banner_url }}" alt="Channel banner" loading="lazy">
+    <img src="{{ customization.banner_url }}" alt="Channel banner" loading="lazy" decoding="async">
 </div>
 {% endif %}
 
@@ -638,7 +638,7 @@
                 <div class="thumb-wrap">
                     <span class="pinned-badge">&#128204; PINNED</span>
                     {% if video.thumbnail %}
-                    <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy">
+                    <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy" decoding="async">
                     {% else %}
                     <div class="thumb-placeholder">&#9654;</div>
                     {% endif %}
@@ -660,7 +660,7 @@
 {% endif %}
 
 <div class="channel-header">
-    <img src="{{ agent.avatar_url or (P ~ '/avatar/' ~ agent.agent_name ~ '.svg') }}" class="channel-big-avatar" style="object-fit: cover;" alt="{{ agent.display_name or agent.agent_name }}">
+    <img src="{{ agent.avatar_url or (P ~ '/avatar/' ~ agent.agent_name ~ '.svg') }}" class="channel-big-avatar" style="object-fit: cover;" alt="{{ agent.display_name or agent.agent_name }}" loading="lazy" decoding="async">
     <div class="channel-details">
         <h1>{{ agent.display_name or agent.agent_name }}
             {% if agent.is_human %}
@@ -725,7 +725,7 @@
         <a href="{{ P }}/watch/{{ video.video_id }}">
             <div class="thumb-wrap">
                 {% if video.thumbnail %}
-                <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy">
+                <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy" decoding="async">
                 {% else %}
                 <div class="thumb-placeholder">&#9654;</div>
                 {% endif %}

--- a/bottube_templates/collaboration.html
+++ b/bottube_templates/collaboration.html
@@ -449,7 +449,7 @@
             <div class="participant-card">
                 <div class="participant-avatar">
                     {% if p.avatar_url %}
-                    <img src="{{ p.avatar_url }}" alt="{{ p.display_name }}">
+                    <img src="{{ p.avatar_url }}" alt="{{ p.display_name }}" loading="lazy" decoding="async">
                     {% else %}
                     {{ p.display_name[0].upper() }}
                     {% endif %}
@@ -488,7 +488,7 @@
             <a href="/watch/{{ video.video_id }}" class="video-card">
                 <div class="video-thumbnail">
                     {% if video.thumbnail %}
-                    <img src="{{ video.thumbnail }}" alt="{{ video.title }}">
+                    <img src="{{ video.thumbnail }}" alt="{{ video.title }}" loading="lazy" decoding="async">
                     {% else %}
                     🎬
                     {% endif %}

--- a/bottube_templates/dashboard.html
+++ b/bottube_templates/dashboard.html
@@ -612,7 +612,7 @@
                     <div class="vid-cell">
                         <div class="vid-thumb">
                             {% if v.thumbnail %}
-                            <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy">
+                            <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy" decoding="async">
                             {% endif %}
                         </div>
                         <div class="vid-name"><a href="{{ P }}/watch/{{ v.video_id }}">{{ v.title }}</a></div>

--- a/bottube_templates/discover.html
+++ b/bottube_templates/discover.html
@@ -399,7 +399,7 @@
 
                 return `
                 <div class="agent-card" onclick="window.location='/agent/${encodeURIComponent(agentName)}'">
-                    <img src="${escapeAttribute(avatarUrl)}" class="agent-avatar" alt="${escapeAttribute(displayName)}">
+                    <img src="${escapeAttribute(avatarUrl)}" class="agent-avatar" alt="${escapeAttribute(displayName)}" loading="lazy" decoding="async">
                     <div class="agent-name">${escapeHtml(displayName)}</div>
                     <div class="agent-stats">
                         ${agent.videos} videos • ${agent.subscribers} subscribers
@@ -523,7 +523,7 @@
         return `
             <div class="video-card" onclick="window.location='/watch/${video.id}'">
                 <div class="video-thumbnail">
-                    <img src="${video.thumbnail || '/static/default-thumb.jpg'}" alt="${escapeHtml(video.title)}">
+                    <img src="${video.thumbnail || '/static/default-thumb.jpg'}" alt="${escapeHtml(video.title)}" loading="lazy" decoding="async">
                     ${video.duration ? `<span class="video-duration">${formatDuration(video.duration)}</span>` : ''}
                 </div>
                 <div class="video-info">

--- a/bottube_templates/generate.html
+++ b/bottube_templates/generate.html
@@ -280,7 +280,7 @@
             <div class="gen-status" id="image-status"></div>
 
             <div class="gen-result" id="image-result">
-                <img id="image-preview" src="" alt="AI-generated image preview">
+                <img id="image-preview" src="" alt="AI-generated image preview" loading="lazy" decoding="async">
                 <div class="result-actions">
                     <a class="gen-btn secondary" id="image-download" href="#" download>Download</a>
                     {% if current_user %}

--- a/bottube_templates/news_article.html
+++ b/bottube_templates/news_article.html
@@ -154,7 +154,7 @@
             <h1>{{ video.title }}</h1>
             <div class="article-meta">
                 {% if video.avatar_url %}
-                <img src="{{ video.avatar_url }}" alt="{{ video.display_name or video.agent_name }}">
+                <img src="{{ video.avatar_url }}" alt="{{ video.display_name or video.agent_name }}" loading="lazy" decoding="async">
                 {% endif %}
                 <div class="byline">
                     <span class="author">{{ video.display_name or video.agent_name }}</span>
@@ -164,7 +164,7 @@
         </header>
 
         {% if video.thumbnail %}
-        <img src="{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" class="article-thumbnail">
+        <img src="{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" class="article-thumbnail" loading="lazy" decoding="async">
         {% endif %}
 
         <div class="article-body">

--- a/bottube_templates/news_article.html
+++ b/bottube_templates/news_article.html
@@ -154,7 +154,7 @@
             <h1>{{ video.title }}</h1>
             <div class="article-meta">
                 {% if video.avatar_url %}
-                <img src="{{ video.avatar_url }}" alt="{{ video.display_name or video.agent_name }}" loading="lazy" decoding="async">
+                <img src="{{ video.avatar_url }}" alt="{{ video.display_name or video.agent_name }}" loading="lazy" decoding="async" width="36" height="36">
                 {% endif %}
                 <div class="byline">
                     <span class="author">{{ video.display_name or video.agent_name }}</span>
@@ -164,7 +164,7 @@
         </header>
 
         {% if video.thumbnail %}
-        <img src="{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" class="article-thumbnail" loading="lazy" decoding="async">
+        <img src="{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" class="article-thumbnail" fetchpriority="high" decoding="async" width="720" height="405">
         {% endif %}
 
         <div class="article-body">

--- a/bottube_templates/news_hub.html
+++ b/bottube_templates/news_hub.html
@@ -290,9 +290,9 @@
                     <div class="news-card-thumb">
                         <a href="{{ P }}/watch/{{ item.video_id }}">
                             {% if item.thumbnail %}
-                            <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy">
+                            <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy" decoding="async">
                             {% else %}
-                            <img src="{{ P }}/static/og-banner.png" alt="Video thumbnail: {{ item.title }}" loading="lazy">
+                            <img src="{{ P }}/static/og-banner.png" alt="Video thumbnail: {{ item.title }}" loading="lazy" decoding="async">
                             {% endif %}
                         </a>
                     </div>
@@ -321,9 +321,9 @@
                     <div class="weather-card-thumb">
                         <a href="{{ P }}/watch/{{ item.video_id }}">
                             {% if item.thumbnail %}
-                            <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy">
+                            <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy" decoding="async">
                             {% else %}
-                            <img src="{{ P }}/static/og-banner.png" alt="Video thumbnail: {{ item.title }}" loading="lazy">
+                            <img src="{{ P }}/static/og-banner.png" alt="Video thumbnail: {{ item.title }}" loading="lazy" decoding="async">
                             {% endif %}
                         </a>
                     </div>

--- a/bottube_templates/playlist.html
+++ b/bottube_templates/playlist.html
@@ -206,7 +206,7 @@
         {% if items %}
         {% set first = items[0] %}
         {% if first.thumbnail %}
-        <img src="{{ P }}/thumbnails/{{ first.thumbnail }}" alt="{{ playlist.name }} playlist cover">
+        <img src="{{ P }}/thumbnails/{{ first.thumbnail }}" alt="{{ playlist.name }} playlist cover" loading="lazy" decoding="async">
         {% else %}
         <div class="pl-icon">&#9654;</div>
         {% endif %}
@@ -238,7 +238,7 @@
         <a href="{{ P }}/watch/{{ item.video_id }}">
             <div class="pl-thumb">
                 {% if item.thumbnail %}
-                <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy">
+                <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy" decoding="async">
                 {% endif %}
                 {% if item.duration_sec > 0 %}
                 <span class="duration-badge">{{ item.duration_sec | format_duration }}</span>

--- a/bottube_templates/search.html
+++ b/bottube_templates/search.html
@@ -264,7 +264,7 @@
                 <a href="{{ P }}/watch/{{ video.video_id }}" aria-label="Watch {{ video.title }}">
                     <div class="thumb-wrap">
                         {% if video.thumbnail %}
-                        <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy">
+                        <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy" decoding="async">
                         {% else %}
                         <div class="thumb-placeholder">&#9654;</div>
                         {% endif %}
@@ -273,7 +273,7 @@
                         {% endif %}
                     </div>
                     <div class="video-info">
-                        <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}">
+                        <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async">
                         <div class="video-meta">
                             <div class="video-title">{{ video.title }}</div>
                             <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>

--- a/bottube_templates/trending.html
+++ b/bottube_templates/trending.html
@@ -358,7 +358,7 @@
             <div class="thumb-wrap">
                 <span class="velocity-badge">🔥 Rising</span>
                 {% if v.thumbnail %}
-                <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="{{ v.title }}" loading="lazy">
+                <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="{{ v.title }}" loading="lazy" decoding="async">
                 {% else %}
                 <div class="thumb-placeholder">&#9654;</div>
                 {% endif %}
@@ -385,7 +385,7 @@
             <div class="thumb-wrap">
                 <span class="trend-rank">#{{ loop.index }}</span>
                 {% if v.thumbnail %}
-                <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy">
+                <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy" decoding="async">
                 {% else %}
                 <div class="thumb-placeholder">&#9654;</div>
                 {% endif %}
@@ -394,7 +394,7 @@
                 {% endif %}
             </div>
             <div class="video-info">
-                <img class="channel-avatar" src="{{ v.avatar_url or (P ~ "/avatar/" ~ v.agent_name ~ ".svg") }}" alt="{{ v.agent_name }}">
+                <img class="channel-avatar" src="{{ v.avatar_url or (P ~ "/avatar/" ~ v.agent_name ~ ".svg") }}" alt="{{ v.agent_name }}" loading="lazy" decoding="async">
                 <div class="video-meta">
                     <div class="video-title">{{ v.title }}</div>
                     <div class="video-channel">{{ v.display_name or v.agent_name }}{% if v.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</div>

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2505,7 +2505,7 @@
                 <div style="display: flex; flex-direction: column; gap: 8px;">
                     {% for resp in response_videos %}
                     <a href="{{ P }}/watch/{{ resp.video_id }}" class="response-item" style="display: flex; align-items: center; gap: 12px; padding: 10px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; text-decoration: none; transition: background 0.15s ease;">
-                        <img src="{{ resp.avatar_url or (P ~ '/avatar/' ~ resp.agent_name ~ '.svg') }}" alt="{{ resp.display_name or resp.agent_name }}" style="width: 36px; height: 36px; border-radius: 50%;">
+                        <img src="{{ resp.avatar_url or (P ~ '/avatar/' ~ resp.agent_name ~ '.svg') }}" alt="{{ resp.display_name or resp.agent_name }}" loading="lazy" decoding="async" style="width: 36px; height: 36px; border-radius: 50%;">
                         <div style="flex: 1; min-width: 0;">
                             <div style="font-weight: 500; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{ resp.title }}</div>
                             <div style="font-size: 12px; color: var(--text-muted);">{{ resp.display_name or resp.agent_name }} · {{ resp.views or 0 }} view{{ 's' if (resp.views or 0) != 1 else '' }}</div>
@@ -2518,7 +2518,7 @@
 
             {% set channel_display_name = video.display_name or video.channel_name or video.agent_name %}
             <div class="channel-row" role="group" aria-label="Channel information">
-                <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ channel_display_name }} avatar">
+                <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ channel_display_name }} avatar" loading="lazy" decoding="async">
                 <div>
                     <div class="channel-name" id="channel-name">
                         <a href="{{ P }}/agent/{{ video.agent_name }}">{{ channel_display_name }}</a>
@@ -2730,7 +2730,7 @@
                      aria-label="Comment by {{ comment.display_name or comment.agent_name }}{% if comment.is_agent_interaction %}, agent interaction{% endif %}"
                      {{ interaction_aria|safe }}
                      {% if loop.index > 10 %} style="display:none"{% endif %}>
-                    <img class="channel-avatar" src="{{ comment.avatar_url or (P ~ "/avatar/" ~ comment.agent_name ~ ".svg") }}" alt="{{ comment.display_name or comment.agent_name }} avatar">
+                    <img class="channel-avatar" src="{{ comment.avatar_url or (P ~ "/avatar/" ~ comment.agent_name ~ ".svg") }}" alt="{{ comment.display_name or comment.agent_name }} avatar" loading="lazy" decoding="async">
                     <div class="comment-body">
                         <div class="comment-header">
                             <a href="{{ P }}/agent/{{ comment.agent_name }}" class="comment-author">{{ comment.display_name or comment.agent_name }}</a>
@@ -2813,7 +2813,7 @@
             <a href="{{ P }}/watch/{{ rel.video_id }}">
                 <div class="sidebar-thumb">
                     {% if rel.thumbnail %}
-                    <img src="{{ P }}/thumbnails/{{ rel.thumbnail }}" alt="Video thumbnail: {{ rel.title }}" loading="lazy">
+                    <img src="{{ P }}/thumbnails/{{ rel.thumbnail }}" alt="Video thumbnail: {{ rel.title }}" loading="lazy" decoding="async">
                     {% else %}
                     <div class="thumb-placeholder">&#9654;</div>
                     {% endif %}
@@ -2894,7 +2894,7 @@
                     }
                     dyn.innerHTML = j.results.map(function (r) {
                         var thumb = r.thumbnail
-                            ? '<img src="/thumbnails/' + _esc(r.thumbnail) + '" alt="Video thumbnail" loading="lazy">'
+                            ? '<img src="/thumbnails/' + _esc(r.thumbnail) + '" alt="Video thumbnail" loading="lazy" decoding="async">'
                             : '<div class="thumb-placeholder">&#9654;</div>';
                         var dur = r.duration_sec > 0
                             ? '<span class="duration-badge">' + _esc(_fmtDur(r.duration_sec)) + '</span>'

--- a/docs/SEO_AUDIT_FIX_PACK_2026-05-31.md
+++ b/docs/SEO_AUDIT_FIX_PACK_2026-05-31.md
@@ -1,0 +1,39 @@
+# SEO Audit Fix Pack Follow-up - 2026-05-31
+
+This follow-up addresses newly added templates and static Beacon Atlas code that
+were not covered by the previous SEO image hygiene pass.
+
+## Changes
+
+- Added `loading="lazy"` and `decoding="async"` to non-priority template images
+  across agent, badge, discovery, channel, category, playlist, search, trending,
+  watch, news, collaboration, and activity feed surfaces.
+- Kept existing `fetchpriority="high"` usage for prioritized homepage imagery.
+- Removed production `console.log` boot messages from
+  `bottube_static/beacon_atlas/index.html` while preserving warning logs for
+  failed optional data sources.
+- Added `tests/test_seo_audit_hygiene.py` to prevent regressions for template
+  image alt attributes, lazy/prioritized image loading, and production
+  `console.log` usage in the audited surfaces.
+
+## Verification
+
+```bash
+python -m pytest tests/test_seo_audit_hygiene.py -q
+# ... 3 passed in 0.12s
+```
+
+```bash
+rg --pcre2 '<img(?![^>]*(loading=|fetchpriority=))[^>]*>' bottube_templates
+# no matches
+```
+
+```bash
+rg -n 'console\.log' bottube_templates bottube_static/beacon_atlas
+# no matches
+```
+
+```bash
+rg --pcre2 '<img(?![^>]*\balt=)[^>]*>' bottube_templates
+# no matches
+```

--- a/tests/test_seo_audit_hygiene.py
+++ b/tests/test_seo_audit_hygiene.py
@@ -1,0 +1,50 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMG_TAG = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+
+
+def _html_files():
+    return sorted((ROOT / "bottube_templates").glob("*.html"))
+
+
+def _img_tag_locations():
+    for path in _html_files():
+        text = path.read_text(encoding="utf-8")
+        for match in IMG_TAG.finditer(text):
+            line_no = text.count("\n", 0, match.start()) + 1
+            yield path.relative_to(ROOT), line_no, match.group(0)
+
+
+def test_template_images_include_alt_attributes():
+    missing = [
+        f"{path}:{line_no}: {tag}"
+        for path, line_no, tag in _img_tag_locations()
+        if " alt=" not in tag.lower()
+    ]
+
+    assert missing == []
+
+
+def test_template_images_are_lazy_loaded_or_prioritized():
+    missing = [
+        f"{path}:{line_no}: {tag}"
+        for path, line_no, tag in _img_tag_locations()
+        if " loading=" not in tag.lower() and " fetchpriority=" not in tag.lower()
+    ]
+
+    assert missing == []
+
+
+def test_template_and_beacon_atlas_assets_have_no_console_log():
+    paths = _html_files() + [ROOT / "bottube_static" / "beacon_atlas" / "index.html"]
+    offenders = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if "console.log" in line:
+                offenders.append(f"{path.relative_to(ROOT)}:{line_no}: {line.strip()}")
+
+    assert offenders == []

--- a/tests/test_seo_audit_hygiene.py
+++ b/tests/test_seo_audit_hygiene.py
@@ -38,6 +38,24 @@ def test_template_images_are_lazy_loaded_or_prioritized():
     assert missing == []
 
 
+def test_listing_badge_and_article_images_reserve_dimensions():
+    stable_surface_files = {
+        Path("bottube_templates/badges.html"),
+        Path("bottube_templates/base.html"),
+        Path("bottube_templates/blog_badges_embeds.html"),
+        Path("bottube_templates/index.html"),
+        Path("bottube_templates/news_article.html"),
+    }
+    missing = [
+        f"{path}:{line_no}: {tag}"
+        for path, line_no, tag in _img_tag_locations()
+        if path in stable_surface_files
+        and (" width=" not in tag.lower() or " height=" not in tag.lower())
+    ]
+
+    assert missing == []
+
+
 def test_template_and_beacon_atlas_assets_have_no_console_log():
     paths = _html_files() + [ROOT / "bottube_static" / "beacon_atlas" / "index.html"]
     offenders = []


### PR DESCRIPTION
## Summary
- Follow-up for Scottcjn/rustchain-bounties#121.
- Adds lazy-loading and async decoding to non-priority template images added after the previous SEO pass.
- Removes production console.log boot messages from Beacon Atlas while preserving warning logs for optional fetch failures.
- Adds a static SEO hygiene regression test and an audit note in docs/SEO_AUDIT_FIX_PACK_2026-05-31.md.

## Bounty claim
- GitHub: @orenodinner
- RTC miner id / lazy-pay target: github:orenodinner

## Verification
- python -m pytest tests/test_seo_audit_hygiene.py -q
- rg --pcre2 '<img(?![^>]*\balt=)[^>]*>' bottube_templates
- rg --pcre2 '<img(?![^>]*(loading=|fetchpriority=))[^>]*>' bottube_templates
- rg -n 'console\.log' bottube_templates bottube_static/beacon_atlas

## Results
- 3 passed in 0.11s
- no missing alt matches in bottube_templates
- no missing loading/fetchpriority matches in bottube_templates
- no console.log matches in bottube_templates or bottube_static/beacon_atlas