### PR TITLE
fix: tolerate malformed bt-proof JSON

### DIFF
--- a/scraper_detective.py
+++ b/scraper_detective.py
@@ -615,7 +615,11 @@ def _get_client_ip() -> str:
 def bt_proof():
     """Receive JS challenge proof. Proves that JavaScript executed in browser."""
     ip = _get_client_ip()
-    data = request.get_json(silent=True) or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
+        data = {}
 
     detective.record_js_proof(ip)
 

--- a/tests/test_scraper_detective_bt_proof.py
+++ b/tests/test_scraper_detective_bt_proof.py
@@ -1,0 +1,57 @@
+from flask import Flask
+
+import scraper_detective
+from scraper_detective import scraper_bp
+
+
+class FakeDetective:
+    def __init__(self):
+        self.proofs = []
+        self._js_proof = {}
+
+    def record_js_proof(self, ip):
+        self.proofs.append(ip)
+        self._js_proof[ip] = {
+            "proved": True,
+            "proved_at": 1.0,
+            "page_views": 0,
+        }
+
+
+def _client(monkeypatch):
+    fake = FakeDetective()
+    monkeypatch.setattr(scraper_detective, "detective", fake)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(scraper_bp)
+    return app.test_client(), fake
+
+
+def test_bt_proof_accepts_non_object_json_without_crashing(monkeypatch):
+    client, fake = _client(monkeypatch)
+
+    resp = client.post("/api/bt-proof", json=["bad"])
+
+    assert resp.status_code == 204
+    assert fake.proofs == ["127.0.0.1"]
+
+
+def test_bt_proof_accepts_falsy_non_object_json_without_crashing(monkeypatch):
+    client, fake = _client(monkeypatch)
+
+    resp = client.post("/api/bt-proof", json=[])
+
+    assert resp.status_code == 204
+    assert fake.proofs == ["127.0.0.1"]
+
+
+def test_bt_proof_preserves_browser_flags(monkeypatch):
+    client, fake = _client(monkeypatch)
+
+    resp = client.post("/api/bt-proof", json={"wd": True, "pl": 0})
+
+    assert resp.status_code == 204
+    entry = fake._js_proof["127.0.0.1"]
+    assert entry["webdriver_detected"] is True
+    assert entry["no_plugins"] is True


### PR DESCRIPTION
## Summary

- make scraper-detective `/api/bt-proof` tolerate non-object JSON telemetry
- preserve existing 204 proof behavior and optional `wd` / `pl` flag handling
- add focused regression tests

Fixes #1284.

## Live bug evidence

Verified on `https://bottube.ai` on 2026-05-31:

- `POST /api/bt-proof` with JSON body `["bad"]` returned HTTP 500 HTML

## Tests

- `uv run --no-project --with flask --with pytest python -B -m pytest -q tests/test_scraper_detective_bt_proof.py --tb=short`
- `python3 -B -m py_compile scraper_detective.py tests/test_scraper_detective_bt_proof.py`
- `git diff --check -- scraper_detective.py tests/test_scraper_detective_bt_proof.py`
- `uv run --no-project --with flake8 python -m flake8 scraper_detective.py tests/test_scraper_detective_bt_proof.py --count --select=E9,F63,F7,F82 --show-source --statistics`
