### PR TITLE
Fix SEO audit asset hygiene

### DIFF
--- a/base.html
+++ b/base.html
@@ -652,17 +652,17 @@
             <a href="{{ P }}/blog">{{ _('footer.blog') }}</a>
             <a href="{{ P }}/rss">{{ _('footer.rss') }}</a>
             <a href="{{ P }}/blog/rss">{{ _('footer.blog_rss') }}</a>
-            <a href="https://www.moltbook.com" target="_blank">Moltbook</a>
+            <a href="https://www.moltbook.com" target="_blank" rel="noopener">Moltbook</a>
             <a href="https://discord.gg/VqVVS2CW9Q" target="_blank" rel="noopener">Discord</a>
-            <a href="https://github.com/Scottcjn/bottube" target="_blank">GitHub</a>
+            <a href="https://github.com/Scottcjn/bottube" target="_blank" rel="noopener">GitHub</a>
             <a href="https://grokipedia.com/page/BoTTubeai" target="_blank" rel="noopener">Grokipedia</a>
         </div>
 
         <div class="footer-featured">
             <div class="footer-featured-label">{{ _('footer.featured_on') }}</div>
             <div class="footer-badges">
-                <a href="https://dofollow.tools/product/bottube" target="_blank" rel="noopener"><img src="https://dofollow.tools/badge/badge_dark.svg" alt="Dofollow.Tools"></a>
-                <a href="https://startupfa.me/s/bottube?utm_source=bottube.ai" target="_blank" rel="noopener"><img src="https://startupfa.me/badges/featured-badge-small.webp" alt="Startup Fame"></a>
+                <a href="https://dofollow.tools/product/bottube" target="_blank" rel="noopener"><img src="https://dofollow.tools/badge/badge_dark.svg" alt="BoTTube featured on Dofollow.Tools" loading="lazy" decoding="async" width="120" height="24"></a>
+                <a href="https://startupfa.me/s/bottube?utm_source=bottube.ai" target="_blank" rel="noopener"><img src="https://startupfa.me/badges/featured-badge-small.webp" alt="BoTTube featured on Startup Fame" loading="lazy" decoding="async" width="120" height="24"></a>
                 <a href="https://bowora.com/bottube.ai" target="_blank" rel="noopener">Bowora</a>
                 <a href="https://grokipedia.com/page/BoTTubeai" target="_blank" rel="noopener">Grokipedia</a>
             </div>
@@ -718,8 +718,7 @@
                     if(w && d.stats.views!==undefined) w.textContent=fmt(d.stats.views);
                 }
             }).catch(function(err){
-                // Fallback: fetch from /health endpoint
-                console.log("Footer counters failed, trying /health fallback:", err);
+                // Fallback: fetch from /health endpoint without exposing production console noise.
                 fetch(P+"/health").then(function(r){return r.json()}).then(function(d){
                     var v=document.getElementById("stat-videos");
                     var a=document.getElementById("stat-agents");
@@ -729,7 +728,7 @@
                     if(a && d.agents!==undefined) a.textContent=fmt(d.agents);
                     if(h && d.humans!==undefined) h.textContent=fmt(d.humans);
                     // /health doesn't have views, skip
-                }).catch(function(e){console.error("Health fallback also failed:", e);});
+                }).catch(function(){});
             });
         })();
         </script>

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1500,7 +1500,7 @@ def set_security_headers(response):
         # mitigated by safe_jsonld() / jsonld_safe which escape </ sequences.
         csp = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://stats.g.doubleclick.net https://cdn.jsdelivr.net https://unpkg.com https://www.gstatic.com; "
+            "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://stats.g.doubleclick.net https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com https://www.gstatic.com https://imasdk.googleapis.com; "
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self' data: https:; "
             "media-src 'self'; "

--- a/bottube_templates/agents.html
+++ b/bottube_templates/agents.html
@@ -141,7 +141,7 @@
     {% for agent in agents %}
     <a href="{{ P }}/agent/{{ agent.agent_name }}" class="agent-card" style="color: inherit;">
         <div class="agent-card-header">
-            <img src="{{ agent.avatar_url or (P ~ '/avatar/' ~ agent.agent_name ~ '.svg') }}" class="agent-card-avatar" alt="{{ agent.agent_name }}">
+            <img src="{{ agent.avatar_url or (P ~ '/avatar/' ~ agent.agent_name ~ '.svg') }}" class="agent-card-avatar" alt="{{ agent.agent_name }}" loading="lazy" decoding="async" width="56" height="56">
             <div>
                 <div class="agent-card-name">{{ agent.display_name or agent.agent_name }}</div>
                 <div class="agent-card-handle">@{{ agent.agent_name }}</div>

--- a/bottube_templates/analytics.html
+++ b/bottube_templates/analytics.html
@@ -350,7 +350,10 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script
+    src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+    integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
+    crossorigin="anonymous"></script>
 <script>
     // Fetch summary stats
     async function loadSummary() {

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -28,7 +28,7 @@
     <meta name="google-site-verification" content="bkfaNyLjJZI8b35iZYe3I5dqr2ymoreq__ZfU3UgaYM" />
 
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pagead2.googlesyndication.com https://www.googletagmanager.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.bottube.ai https://bottube.ai; frame-src 'self' https://www.youtube.com https://player.vimeo.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pagead2.googlesyndication.com https://www.googletagmanager.com https://www.google-analytics.com https://stats.g.doubleclick.net https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com https://imasdk.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.bottube.ai https://bottube.ai https://www.google-analytics.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://www.googletagmanager.com; frame-src 'self' https://www.youtube.com https://player.vimeo.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';">
 
     <!-- DNS Prefetch / Preconnect Hints -->
     <link rel="preconnect" href="https://dofollow.tools" crossorigin>

--- a/bottube_templates/beacon_atlas.html
+++ b/bottube_templates/beacon_atlas.html
@@ -8,7 +8,10 @@
 <meta property="og:title" content="Beacon Reputation Atlas">
 <meta property="og:description" content="Explore the trust network of 200+ AI agents and humans on BoTTube.">
 <meta property="og:image" content="https://bottube.ai/static/og-banner.png">
-<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+<script
+  src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"
+  integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+  crossorigin="anonymous"></script>
 <style>
   *{margin:0;padding:0;box-sizing:border-box}
   @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Share+Tech+Mono&display=swap');

--- a/bottube_templates/news_hub.html
+++ b/bottube_templates/news_hub.html
@@ -290,9 +290,9 @@
                     <div class="news-card-thumb">
                         <a href="{{ P }}/watch/{{ item.video_id }}">
                             {% if item.thumbnail %}
-                            <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy">
+                            <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy" decoding="async" width="720" height="720">
                             {% else %}
-                            <img src="{{ P }}/static/og-banner.png" alt="Video thumbnail: {{ item.title }}" loading="lazy">
+                            <img src="{{ P }}/static/og-banner.png" alt="Video thumbnail: {{ item.title }}" loading="lazy" decoding="async" width="1200" height="630">
                             {% endif %}
                         </a>
                     </div>
@@ -321,9 +321,9 @@
                     <div class="weather-card-thumb">
                         <a href="{{ P }}/watch/{{ item.video_id }}">
                             {% if item.thumbnail %}
-                            <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy">
+                            <img src="{{ P }}/thumbnails/{{ item.thumbnail }}" alt="Video thumbnail: {{ item.title }}" loading="lazy" decoding="async" width="720" height="720">
                             {% else %}
-                            <img src="{{ P }}/static/og-banner.png" alt="Video thumbnail: {{ item.title }}" loading="lazy">
+                            <img src="{{ P }}/static/og-banner.png" alt="Video thumbnail: {{ item.title }}" loading="lazy" decoding="async" width="1200" height="630">
                             {% endif %}
                         </a>
                     </div>

--- a/bottube_templates/search.html
+++ b/bottube_templates/search.html
@@ -264,7 +264,7 @@
                 <a href="{{ P }}/watch/{{ video.video_id }}" aria-label="Watch {{ video.title }}">
                     <div class="thumb-wrap">
                         {% if video.thumbnail %}
-                        <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy">
+                        <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy" decoding="async" width="720" height="720">
                         {% else %}
                         <div class="thumb-placeholder">&#9654;</div>
                         {% endif %}
@@ -273,7 +273,7 @@
                         {% endif %}
                     </div>
                     <div class="video-info">
-                        <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}">
+                        <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
                         <div class="video-meta">
                             <div class="video-title">{{ video.title }}</div>
                             <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>

--- a/bottube_templates/trending.html
+++ b/bottube_templates/trending.html
@@ -358,7 +358,7 @@
             <div class="thumb-wrap">
                 <span class="velocity-badge">🔥 Rising</span>
                 {% if v.thumbnail %}
-                <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="{{ v.title }}" loading="lazy">
+                <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy" decoding="async" width="720" height="720">
                 {% else %}
                 <div class="thumb-placeholder">&#9654;</div>
                 {% endif %}
@@ -385,7 +385,7 @@
             <div class="thumb-wrap">
                 <span class="trend-rank">#{{ loop.index }}</span>
                 {% if v.thumbnail %}
-                <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy">
+                <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy" decoding="async" width="720" height="720">
                 {% else %}
                 <div class="thumb-placeholder">&#9654;</div>
                 {% endif %}
@@ -394,7 +394,7 @@
                 {% endif %}
             </div>
             <div class="video-info">
-                <img class="channel-avatar" src="{{ v.avatar_url or (P ~ "/avatar/" ~ v.agent_name ~ ".svg") }}" alt="{{ v.agent_name }}">
+                <img class="channel-avatar" src="{{ v.avatar_url or (P ~ "/avatar/" ~ v.agent_name ~ ".svg") }}" alt="{{ v.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
                 <div class="video-meta">
                     <div class="video-title">{{ v.title }}</div>
                     <div class="video-channel">{{ v.display_name or v.agent_name }}{% if v.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</div>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Live Chat - {{ video_id }}</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.4/socket.io.min.js"></script>
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.4/socket.io.min.js"
+        integrity="sha384-Gr6Lu2Ajx28mzwyVR8CFkULdCU7kMlZ9UthllibdOSo6qAiN+yXNHqtgdTvFXMT4"
+        crossorigin="anonymous"></script>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f0f0f; color: #fff; }

--- a/tests/test_seo_audit_fix_pack.py
+++ b/tests/test_seo_audit_fix_pack.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+def test_static_cdn_scripts_are_version_pinned_with_sri():
+    analytics = read("bottube_templates/analytics.html")
+    atlas = read("bottube_templates/beacon_atlas.html")
+    chat = read("templates/chat.html")
+
+    assert "https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js" in analytics
+    assert "integrity=\"sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ\"" in analytics
+    assert "crossorigin=\"anonymous\"" in analytics
+
+    assert "https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js" in atlas
+    assert "integrity=\"sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i\"" in atlas
+    assert "crossorigin=\"anonymous\"" in atlas
+
+    assert "https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.4/socket.io.min.js" in chat
+    assert "integrity=\"sha384-Gr6Lu2Ajx28mzwyVR8CFkULdCU7kMlZ9UthllibdOSo6qAiN+yXNHqtgdTvFXMT4\"" in chat
+    assert "crossorigin=\"anonymous\"" in chat
+
+
+def test_csp_allows_scripts_used_by_templates():
+    base_template = read("bottube_templates/base.html")
+    server_source = read("bottube_server.py")
+
+    for source in [
+        "https://cdn.jsdelivr.net",
+        "https://cdnjs.cloudflare.com",
+        "https://imasdk.googleapis.com",
+    ]:
+        assert source in base_template
+        assert source in server_source
+
+
+def test_listing_images_have_lazy_decode_and_dimensions():
+    search = read("bottube_templates/search.html")
+    trending = read("bottube_templates/trending.html")
+    agents = read("bottube_templates/agents.html")
+    news_hub = read("bottube_templates/news_hub.html")
+
+    assert 'loading="lazy" decoding="async" width="720" height="720"' in search
+    assert 'loading="lazy" decoding="async" width="40" height="40"' in search
+    assert trending.count('loading="lazy" decoding="async" width="720" height="720"') >= 2
+    assert 'loading="lazy" decoding="async" width="40" height="40"' in trending
+    assert 'loading="lazy" decoding="async" width="56" height="56"' in agents
+    assert news_hub.count('loading="lazy" decoding="async" width="720" height="720"') >= 2
+    assert news_hub.count('loading="lazy" decoding="async" width="1200" height="630"') >= 2
+
+
+def test_legacy_base_footer_badges_do_not_shift_layout_or_log_fallbacks():
+    legacy_base = read("base.html")
+
+    assert "console.log(" not in legacy_base
+    assert "console.error(" not in legacy_base
+    assert 'alt="BoTTube featured on Dofollow.Tools" loading="lazy" decoding="async" width="120" height="24"' in legacy_base
+    assert 'alt="BoTTube featured on Startup Fame" loading="lazy" decoding="async" width="120" height="24"' in legacy_base
+    assert 'href="https://www.moltbook.com" target="_blank" rel="noopener"' in legacy_base
+    assert 'href="https://github.com/Scottcjn/bottube" target="_blank" rel="noopener"' in legacy_base


### PR DESCRIPTION
## Summary

Small SEO/performance fix pack for the rustchain-bounties #121 checklist.

- pins static CDN scripts and adds SRI/crossorigin for Chart.js, D3, and Socket.IO
- aligns template and response CSP source lists so those static CDN scripts and the optional IMA SDK are not blocked
- adds `loading="lazy"`, `decoding="async"`, and stable width/height attributes to search, trending, agents, and news listing images
- hardens the legacy base footer badge markup with contextual alt text, dimensions, lazy/decode hints, `rel="noopener"`, and removes footer fallback console logging
- adds a focused regression test for the SEO audit checks

## Before/After Static Audit

Local static audit over the changed files:

- before: static CDN scripts=3, missing SRI=3; target listing images=10, missing lazy/decode/size=10; legacy footer console logs=2; missing CSP sources=[cdn.jsdelivr, cdnjs.cloudflare, imasdk]
- after: static CDN scripts=3, missing SRI=0; target listing images=10, missing lazy/decode/size=0; legacy footer console logs=0; missing CSP sources=[]

## Validation

- `uv run --no-project --with pytest python -B -m pytest -q tests/test_seo_audit_fix_pack.py tests/test_watch_tracking_and_csp.py` -> 6 passed
- `python3 -B -m py_compile bottube_server.py tests/test_seo_audit_fix_pack.py tests/test_watch_tracking_and_csp.py` -> passed
- `git diff --check` -> passed

## Bounty Scope

This targets the BoTTube SEO Audit Fix Pack checklist items for image attributes/layout stability, static CDN SRI, CSP/source verification, and production debug-log cleanup.
