### PR TITLE
Preserve search query in language switch links

### DIFF
--- a/base.html
+++ b/base.html
@@ -670,7 +670,7 @@
 
         <div class="footer-lang" style="margin:8px 0;">
             {% for lc in SUPPORTED_LOCALES %}
-            <a href="?lang={{ lc }}" style="padding:2px 8px;font-size:12px;border-radius:4px;{% if locale == lc %}background:var(--accent);color:#000;font-weight:600;{% else %}color:var(--text-muted);{% endif %}">{{ lc|upper }}</a>
+            <a href="{{ language_switch_href(lc) }}" style="padding:2px 8px;font-size:12px;border-radius:4px;{% if locale == lc %}background:var(--accent);color:#000;font-weight:600;{% else %}color:var(--text-muted);{% endif %}">{{ lc|upper }}</a>
             {% endfor %}
         </div>
         <div class="footer-copy">{{ _('footer.copyright') }}</div>

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -1341,6 +1341,13 @@ def _translate(key, **kwargs):
     return text
 
 
+def _language_switch_href(locale_code: str) -> str:
+    """Return a query-only language link while preserving current filters."""
+    args = request.args.to_dict(flat=True)
+    args["lang"] = locale_code
+    return "?" + urllib.parse.urlencode(args)
+
+
 _load_translations()
 
 # ---------------------------------------------------------------------------
@@ -1386,6 +1393,7 @@ app.jinja_env.globals["P"] = IP_PREFIX  # default fallback
 app.jinja_env.globals["MAX_DURATION"] = MAX_VIDEO_DURATION
 app.jinja_env.globals["_"] = _translate
 app.jinja_env.globals["SUPPORTED_LOCALES"] = SUPPORTED_LOCALES
+app.jinja_env.globals["language_switch_href"] = _language_switch_href
 
 
 def _build_recovery_notice(db=None):
@@ -1505,7 +1513,7 @@ def set_security_headers(response):
             "img-src 'self' data: https:; "
             "media-src 'self'; "
             "font-src 'self'; "
-            "connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://www.googletagmanager.com; "
+            "connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://www.googletagmanager.com https://www.google.com; "
             "object-src 'none'; "
             "base-uri 'self'; "
             "form-action 'self'; "

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -28,7 +28,7 @@
     <meta name="google-site-verification" content="bkfaNyLjJZI8b35iZYe3I5dqr2ymoreq__ZfU3UgaYM" />
 
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pagead2.googlesyndication.com https://www.googletagmanager.com https://www.google-analytics.com https://stats.g.doubleclick.net https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com https://imasdk.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.bottube.ai https://bottube.ai https://www.google-analytics.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://www.googletagmanager.com; frame-src 'self' https://www.youtube.com https://player.vimeo.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pagead2.googlesyndication.com https://www.googletagmanager.com https://www.google-analytics.com https://stats.g.doubleclick.net https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com https://imasdk.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.bottube.ai https://bottube.ai https://www.google-analytics.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://www.googletagmanager.com https://www.google.com; frame-src 'self' https://www.youtube.com https://player.vimeo.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';">
 
     <!-- DNS Prefetch / Preconnect Hints -->
     <link rel="preconnect" href="https://dofollow.tools" crossorigin>
@@ -925,7 +925,7 @@
 
         <div class="footer-lang" style="margin:8px 0;">
             {% for lc in SUPPORTED_LOCALES %}
-            <a href="?lang={{ lc }}" style="padding:2px 8px;font-size:12px;border-radius:4px;{% if locale == lc %}background:var(--accent);color:#000;font-weight:600;{% else %}color:var(--text-muted);{% endif %}">{{ lc|upper }}</a>
+            <a href="{{ language_switch_href(lc) }}" style="padding:2px 8px;font-size:12px;border-radius:4px;{% if locale == lc %}background:var(--accent);color:#000;font-weight:600;{% else %}color:var(--text-muted);{% endif %}">{{ lc|upper }}</a>
             {% endfor %}
         </div>
         <div class="footer-copy">{{ _('footer.copyright') }}</div>

--- a/tests/test_language_switch_and_csp.py
+++ b/tests/test_language_switch_and_csp.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from flask import Response
+
+from bottube_server import _language_switch_href, app, set_security_headers
+
+
+def test_language_switch_href_preserves_search_query():
+    with app.test_request_context("/search?q=rustchain&page=2"):
+        assert _language_switch_href("es") == "?q=rustchain&page=2&lang=es"
+
+
+def test_language_switch_href_adds_lang_when_no_existing_query():
+    with app.test_request_context("/"):
+        assert _language_switch_href("fr") == "?lang=fr"
+
+
+def test_security_header_allows_google_collect_endpoint():
+    with app.test_request_context("/", base_url="https://bottube.ai/"):
+        response = set_security_headers(Response(""))
+
+    csp = response.headers["Content-Security-Policy"]
+    assert "connect-src" in csp
+    assert "https://www.google.com" in csp
+
+
+def test_template_meta_csp_allows_google_collect_endpoint():
+    template = Path("bottube_templates/base.html").read_text(encoding="utf-8")
+
+    assert "https://www.google.com" in template
+    assert "https://www.google-analytics.com" in template


### PR DESCRIPTION
## Summary
- preserve existing query parameters when rendering footer language-switch links
- keep search context such as `/search?q=rustchain` when changing `lang`
- allow `https://www.google.com` in CSP `connect-src` for GA collect requests, including the template meta CSP
- add regression tests for language-link query preservation and the GA connect-src allowance

Fixes #1289.
Fixes #1290.

## Verification
- `python3 -m compileall bottube_server.py`
- `git diff --check`
- `uv run --no-project --with flask --with pytest --with markupsafe --with requests python -m pytest tests/test_watch_tracking_and_csp.py tests/test_language_switch_and_csp.py`

RTC wallet for any merged-PR reward: `RTC1410e82d545ce0b3ffd21ca83e2465a8f2c3a64e`
