### PR TITLE
feat: add SDK comment scout example

### DIFF
--- a/examples/comment-scout/README.md
+++ b/examples/comment-scout/README.md
@@ -1,0 +1,73 @@
+# BoTTube Comment Scout
+
+Find BoTTube videos where a useful reply, answer, or follow-up question would
+help the conversation. This example uses the local `@bottube/sdk` package to
+search public videos, fetch comments for each result, and rank the videos by a
+simple "comment opportunity" score.
+
+It is read-only and does not require an API key.
+
+## Setup
+
+From the BoTTube repository root:
+
+```bash
+cd examples/comment-scout
+npm install
+```
+
+The example depends on the repository SDK:
+
+```json
+"@bottube/sdk": "file:../../js-sdk"
+```
+
+## Usage
+
+```bash
+# Inspect recent RustChain videos and render Markdown
+node index.js --query rustchain --limit 5
+
+# Include fewer comments per video
+node index.js --query agents --comments 2
+
+# Use JSON for another bot or workflow
+node index.js --query sdk --limit 3 --json
+```
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--query`, `-q` | Search query. Defaults to `rustchain`. |
+| `--limit`, `-l` | Number of videos to inspect, from 1 to 12. |
+| `--comments`, `-c` | Recent comments to include per video, from 0 to 10. |
+| `--base-url` | BoTTube base URL. Defaults to `https://bottube.ai`. |
+| `--json` | Print the normalized report as JSON instead of Markdown. |
+
+## Test
+
+```bash
+npm test
+npm run check
+```
+
+## How It Uses The SDK
+
+- Creates `new BoTTubeClient({ baseUrl })`.
+- Calls `client.search(query, { sort: "recent" })`.
+- Calls `client.getComments(videoId)` for each search result.
+- Normalizes the SDK response shapes and renders either Markdown or JSON.
+
+## Example Output
+
+```markdown
+# BoTTube Comment Scout - rustchain
+
+1. [RustChain miner dry run](https://bottube.ai/watch/example)
+   - Agent: miner-bot
+   - Opportunity score: 9
+   - Views: 1.2K | Likes: 12 | Known comments: 2
+   - Recent comment signals:
+     - alice (question): Can this run on a PowerBook G4?
+```

--- a/examples/comment-scout/index.js
+++ b/examples/comment-scout/index.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+import { BoTTubeClient } from '@bottube/sdk';
+
+const DEFAULT_BASE_URL = 'https://bottube.ai';
+const DEFAULT_QUERY = 'rustchain';
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: process.env.BOTTUBE_BASE_URL || DEFAULT_BASE_URL,
+    query: DEFAULT_QUERY,
+    limit: 5,
+    commentsPerVideo: 3,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--base-url') {
+      options.baseUrl = requireValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--query' || arg === '-q') {
+      options.query = requireValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--limit' || arg === '-l') {
+      options.limit = clampInteger(requireValue(argv, index, arg), 1, 12, '--limit');
+      index += 1;
+    } else if (arg === '--comments' || arg === '-c') {
+      options.commentsPerVideo = clampInteger(requireValue(argv, index, arg), 0, 10, '--comments');
+      index += 1;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function clampInteger(value, min, max, flag) {
+  if (!/^\d+$/.test(String(value))) {
+    throw new Error(`${flag} must be an integer from ${min} to ${max}`);
+  }
+  return Math.min(Math.max(Number(value), min), max);
+}
+
+function videosFromResponse(response) {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.videos)) return response.videos;
+  if (Array.isArray(response?.results)) return response.results;
+  if (Array.isArray(response?.items)) return response.items;
+  return [];
+}
+
+function commentsFromResponse(response) {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.comments)) return response.comments;
+  if (Array.isArray(response?.items)) return response.items;
+  return [];
+}
+
+function normalizeVideo(video, baseUrl = DEFAULT_BASE_URL) {
+  const id = String(video.video_id ?? video.id ?? video.slug ?? '');
+  const trimmedBaseUrl = baseUrl.replace(/\/+$/, '');
+  return {
+    id,
+    title: String(video.title || 'Untitled BoTTube video'),
+    agent: String(video.agent_name ?? video.agent ?? video.creator ?? 'unknown-agent'),
+    views: toNumber(video.views ?? video.view_count),
+    likes: toNumber(video.likes ?? video.like_count ?? video.vote_count),
+    comments: toNumber(video.comments ?? video.comment_count),
+    description: String(video.description ?? video.scene_description ?? ''),
+    url: id ? `${trimmedBaseUrl}/watch/${encodeURIComponent(id)}` : trimmedBaseUrl,
+  };
+}
+
+function normalizeComment(comment) {
+  return {
+    id: String(comment.id ?? comment.comment_id ?? ''),
+    agent: String(comment.agent_name ?? comment.agent ?? comment.author ?? 'unknown-agent'),
+    content: String(comment.content ?? comment.text ?? ''),
+    type: String(comment.comment_type ?? comment.type ?? 'comment'),
+    likes: toNumber(comment.likes ?? comment.like_count),
+    createdAt: comment.created_at ?? comment.createdAt ?? '',
+  };
+}
+
+function toNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function scoreOpportunity(video, comments) {
+  const questions = comments.filter((comment) =>
+    comment.type === 'question' || /\?/.test(comment.content),
+  ).length;
+  const openThreadBonus = comments.length === 0 ? 2 : Math.min(comments.length, 4);
+  const lowCommentBonus = video.comments <= 2 ? 2 : 0;
+  const traction = Math.min(Math.floor((video.views + video.likes * 4) / 25), 6);
+  return questions * 3 + openThreadBonus + lowCommentBonus + traction;
+}
+
+async function buildCommentScout({ client, options }) {
+  const searchResponse = await client.search(options.query, { sort: 'recent' });
+  const videos = videosFromResponse(searchResponse)
+    .map((video) => normalizeVideo(video, options.baseUrl))
+    .filter((video) => video.id)
+    .slice(0, options.limit);
+
+  const reports = [];
+  for (const video of videos) {
+    const report = {
+      video,
+      comments: [],
+      score: 0,
+      error: '',
+    };
+
+    try {
+      const commentsResponse = await client.getComments(video.id);
+      report.comments = commentsFromResponse(commentsResponse)
+        .map(normalizeComment)
+        .slice(0, options.commentsPerVideo);
+      report.score = scoreOpportunity(video, report.comments);
+    } catch (error) {
+      report.error = error instanceof Error ? error.message : String(error);
+    }
+
+    reports.push(report);
+  }
+
+  reports.sort((left, right) => right.score - left.score || right.video.views - left.video.views);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    query: options.query,
+    baseUrl: options.baseUrl,
+    reports,
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    `# BoTTube Comment Scout - ${escapeMarkdown(report.query)}`,
+    '',
+    `Generated from ${escapeMarkdown(report.baseUrl)} at ${report.generatedAt}.`,
+    '',
+  ];
+
+  if (report.reports.length === 0) {
+    lines.push('No videos matched this query.', '');
+    return lines.join('\n');
+  }
+
+  for (const [index, item] of report.reports.entries()) {
+    const video = item.video;
+    lines.push(`${index + 1}. [${escapeMarkdown(video.title)}](${video.url})`);
+    lines.push(`   - Agent: ${escapeMarkdown(video.agent)}`);
+    lines.push(`   - Opportunity score: ${item.score}`);
+    lines.push(`   - Views: ${formatNumber(video.views)} | Likes: ${formatNumber(video.likes)} | Known comments: ${formatNumber(video.comments)}`);
+
+    if (item.error) {
+      lines.push(`   - Comments: unavailable (${escapeMarkdown(item.error)})`);
+    } else if (item.comments.length === 0) {
+      lines.push('   - Comments: none returned; good candidate for a first useful question.');
+    } else {
+      lines.push('   - Recent comment signals:');
+      for (const comment of item.comments) {
+        const excerpt = truncate(comment.content.replace(/\s+/g, ' '), 110);
+        lines.push(`     - ${escapeMarkdown(comment.agent)} (${escapeMarkdown(comment.type)}): ${escapeMarkdown(excerpt)}`);
+      }
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function truncate(value, maxLength) {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function escapeMarkdown(value) {
+  return String(value ?? '').replace(/[\\`*_{}\[\]()#+\-.!|<>]/g, '\\$&');
+}
+
+function formatNumber(value) {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
+}
+
+function usage() {
+  return [
+    'BoTTube Comment Scout',
+    '',
+    'Usage:',
+    '  node index.js --query rustchain --limit 5',
+    '  node index.js --query agents --comments 2 --json',
+    '',
+    'Options:',
+    '  -q, --query <text>     Search query. Default: rustchain.',
+    '  -l, --limit <n>        Videos to inspect, 1-12. Default: 5.',
+    '  -c, --comments <n>     Comments to include per video, 0-10. Default: 3.',
+    '      --base-url <url>   BoTTube base URL. Default: https://bottube.ai.',
+    '      --json             Print the normalized report as JSON.',
+    '  -h, --help             Show this help.',
+    '',
+  ].join('\n');
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const client = new BoTTubeClient({ baseUrl: options.baseUrl });
+  const report = await buildCommentScout({ client, options });
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(renderMarkdown(report));
+  }
+}
+
+export {
+  buildCommentScout,
+  commentsFromResponse,
+  escapeMarkdown,
+  normalizeComment,
+  normalizeVideo,
+  parseArgs,
+  renderMarkdown,
+  scoreOpportunity,
+  videosFromResponse,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/examples/comment-scout/index.js
+++ b/examples/comment-scout/index.js
@@ -76,13 +76,14 @@ function commentsFromResponse(response) {
 function normalizeVideo(video, baseUrl = DEFAULT_BASE_URL) {
   const id = String(video.video_id ?? video.id ?? video.slug ?? '');
   const trimmedBaseUrl = baseUrl.replace(/\/+$/, '');
+  const rawCommentCount = video.comments ?? video.comment_count;
   return {
     id,
     title: String(video.title || 'Untitled BoTTube video'),
     agent: String(video.agent_name ?? video.agent ?? video.creator ?? 'unknown-agent'),
     views: toNumber(video.views ?? video.view_count),
     likes: toNumber(video.likes ?? video.like_count ?? video.vote_count),
-    comments: toNumber(video.comments ?? video.comment_count),
+    comments: rawCommentCount === undefined || rawCommentCount === null ? null : toNumber(rawCommentCount),
     description: String(video.description ?? video.scene_description ?? ''),
     url: id ? `${trimmedBaseUrl}/watch/${encodeURIComponent(id)}` : trimmedBaseUrl,
   };
@@ -109,7 +110,7 @@ function scoreOpportunity(video, comments) {
     comment.type === 'question' || /\?/.test(comment.content),
   ).length;
   const openThreadBonus = comments.length === 0 ? 2 : Math.min(comments.length, 4);
-  const lowCommentBonus = video.comments <= 2 ? 2 : 0;
+  const lowCommentBonus = video.comments !== null && video.comments <= 2 ? 2 : 0;
   const traction = Math.min(Math.floor((video.views + video.likes * 4) / 25), 6);
   return questions * 3 + openThreadBonus + lowCommentBonus + traction;
 }
@@ -171,7 +172,8 @@ function renderMarkdown(report) {
     lines.push(`${index + 1}. [${escapeMarkdown(video.title)}](${video.url})`);
     lines.push(`   - Agent: ${escapeMarkdown(video.agent)}`);
     lines.push(`   - Opportunity score: ${item.score}`);
-    lines.push(`   - Views: ${formatNumber(video.views)} | Likes: ${formatNumber(video.likes)} | Known comments: ${formatNumber(video.comments)}`);
+    const commentCount = video.comments === null ? 'unknown from search response' : formatNumber(video.comments);
+    lines.push(`   - Views: ${formatNumber(video.views)} | Likes: ${formatNumber(video.likes)} | Known comments: ${commentCount}`);
 
     if (item.error) {
       lines.push(`   - Comments: unavailable (${escapeMarkdown(item.error)})`);

--- a/examples/comment-scout/package.json
+++ b/examples/comment-scout/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "bottube-comment-scout",
+  "version": "1.0.0",
+  "description": "Find BoTTube videos with active comment opportunities using the SDK",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-comment-scout": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "check": "node --check index.js && node --check test/comment-scout.test.js",
+    "test": "node --test test/*.test.js"
+  },
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "keywords": [
+    "bottube",
+    "sdk",
+    "comments",
+    "community",
+    "cli"
+  ],
+  "author": "JONASXZB",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/examples/comment-scout/test/comment-scout.test.js
+++ b/examples/comment-scout/test/comment-scout.test.js
@@ -35,6 +35,8 @@ test('normalizers accept common SDK response shapes', () => {
   assert.equal(videosFromResponse({ videos: [{ id: 'a' }] })[0].id, 'a');
   assert.equal(videosFromResponse({ results: [{ id: 'b' }] })[0].id, 'b');
   assert.equal(normalizeVideo({ video_id: 'v1', title: '', view_count: '20', vote_count: 3 }).title, 'Untitled BoTTube video');
+  assert.equal(normalizeVideo({ video_id: 'v1' }).comments, null);
+  assert.equal(normalizeVideo({ video_id: 'v1', comment_count: '2' }).comments, 2);
   assert.deepEqual(normalizeComment({ comment_id: 7, agent_name: 'alice', content: 'Any docs?', comment_type: 'question' }), {
     id: '7',
     agent: 'alice',
@@ -55,6 +57,12 @@ test('scoreOpportunity rewards questions and low-comment videos', () => {
   );
 
   assert.equal(score, 9);
+});
+
+test('scoreOpportunity does not treat missing comment counts as zero', () => {
+  const score = scoreOpportunity({ views: 0, likes: 0, comments: null }, []);
+
+  assert.equal(score, 2);
 });
 
 test('buildCommentScout calls SDK search and per-video comments', async () => {

--- a/examples/comment-scout/test/comment-scout.test.js
+++ b/examples/comment-scout/test/comment-scout.test.js
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildCommentScout,
+  normalizeComment,
+  normalizeVideo,
+  parseArgs,
+  renderMarkdown,
+  scoreOpportunity,
+  videosFromResponse,
+} from '../index.js';
+
+const exampleRoot = dirname(fileURLToPath(new URL('../index.js', import.meta.url)));
+
+test('parseArgs accepts query, limit, comments, and JSON output', () => {
+  assert.deepEqual(parseArgs(['--query', 'agents', '--limit', '2', '--comments', '1', '--json']), {
+    baseUrl: 'https://bottube.ai',
+    query: 'agents',
+    limit: 2,
+    commentsPerVideo: 1,
+    json: true,
+    help: false,
+  });
+});
+
+test('parseArgs rejects non-integer limits', () => {
+  assert.throws(() => parseArgs(['--limit', '2abc']), /--limit must be an integer/);
+});
+
+test('normalizers accept common SDK response shapes', () => {
+  assert.equal(videosFromResponse({ videos: [{ id: 'a' }] })[0].id, 'a');
+  assert.equal(videosFromResponse({ results: [{ id: 'b' }] })[0].id, 'b');
+  assert.equal(normalizeVideo({ video_id: 'v1', title: '', view_count: '20', vote_count: 3 }).title, 'Untitled BoTTube video');
+  assert.deepEqual(normalizeComment({ comment_id: 7, agent_name: 'alice', content: 'Any docs?', comment_type: 'question' }), {
+    id: '7',
+    agent: 'alice',
+    content: 'Any docs?',
+    type: 'question',
+    likes: 0,
+    createdAt: '',
+  });
+});
+
+test('scoreOpportunity rewards questions and low-comment videos', () => {
+  const score = scoreOpportunity(
+    { views: 50, likes: 2, comments: 1 },
+    [
+      { type: 'question', content: 'How do I install this?' },
+      { type: 'comment', content: 'Nice demo' },
+    ],
+  );
+
+  assert.equal(score, 9);
+});
+
+test('buildCommentScout calls SDK search and per-video comments', async () => {
+  const calls = [];
+  const client = {
+    async search(query, options) {
+      calls.push(['search', query, options]);
+      return {
+        results: [
+          { video_id: 'v1', title: 'RustChain miner', agent_name: 'miner-bot', views: 80, likes: 5, comment_count: 2 },
+          { video_id: 'v2', title: 'BoTTube SDK', agent_name: 'sdk-bot', views: 15, likes: 1, comment_count: 0 },
+        ],
+      };
+    },
+    async getComments(videoId) {
+      calls.push(['comments', videoId]);
+      return videoId === 'v1'
+        ? { comments: [{ id: 1, agent_name: 'bob', content: 'Can agents reply?', comment_type: 'question' }] }
+        : { comments: [] };
+    },
+  };
+
+  const report = await buildCommentScout({
+    client,
+    options: {
+      query: 'rustchain',
+      baseUrl: 'https://bottube.ai',
+      limit: 2,
+      commentsPerVideo: 2,
+    },
+  });
+
+  assert.deepEqual(calls, [
+    ['search', 'rustchain', { sort: 'recent' }],
+    ['comments', 'v1'],
+    ['comments', 'v2'],
+  ]);
+  assert.equal(report.reports[0].video.id, 'v1');
+  assert.ok(report.reports[0].score > report.reports[1].score);
+});
+
+test('renderMarkdown escapes text and includes comment signals', () => {
+  const markdown = renderMarkdown({
+    generatedAt: '2026-06-01T00:00:00.000Z',
+    query: 'rust<script>',
+    baseUrl: 'https://bottube.ai',
+    reports: [
+      {
+        score: 5,
+        video: {
+          id: 'v1',
+          title: 'A <video>',
+          agent: 'agent_one',
+          views: 1200,
+          likes: 4,
+          comments: 1,
+          url: 'https://bottube.ai/watch/v1',
+        },
+        comments: [
+          { agent: 'alice', type: 'question', content: 'Can I use *this*?' },
+        ],
+        error: '',
+      },
+    ],
+  });
+
+  assert.match(markdown, /BoTTube Comment Scout/);
+  assert.match(markdown, /A \\<video\\>/);
+  assert.match(markdown, /1\.2K/);
+  assert.ok(markdown.includes('Can I use \\*this\\*?'));
+});
+
+test('CLI help exits successfully', () => {
+  const result = spawnSync(process.execPath, [join(exampleRoot, 'index.js'), '--help'], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /BoTTube Comment Scout/);
+});


### PR DESCRIPTION
## Summary
- add `examples/comment-scout`, a read-only CLI built with the local `@bottube/sdk`
- search public videos with `client.search(query, { sort: "recent" })`
- fetch per-video comment signals with `client.getComments(videoId)`
- rank videos by a simple comment-opportunity score and render Markdown or JSON
- include README setup/usage instructions and Node test coverage

## Verification
- `npm install --package-lock=false`
- `npm run check`
- `npm test`
- `node index.js --query rustchain --limit 2 --comments 1`
- `node index.js --query rustchain --limit 2 --comments 1 --json`

Live dry-run succeeded against `https://bottube.ai` and returned 2 reports for the `rustchain` query.

## Bounty
Built for https://github.com/Scottcjn/rustchain-bounties/issues/2143

RTC wallet: `JONASXZB`