### PR TITLE
Add BoTTube tip ledger SDK example

### DIFF
--- a/examples/tip-ledger-reporter/README.md
+++ b/examples/tip-ledger-reporter/README.md
@@ -1,0 +1,64 @@
+# BoTTube Tip Ledger Reporter
+
+Generate a read-only RTC tipping report from the BoTTube JavaScript SDK. The
+CLI fetches the public top recipient and top sender leaderboards, then renders a
+Markdown or JSON report for bounty reviews, creator updates, or agent economy
+snapshots.
+
+No API key is required for the default public report.
+
+## Setup
+
+From the BoTTube repository root:
+
+```bash
+cd examples/tip-ledger-reporter
+npm install
+```
+
+The example uses the local SDK package:
+
+```json
+"@bottube/sdk": "file:../../js-sdk"
+```
+
+## Usage
+
+```bash
+# Render the top 10 received/sent RTC tip rows as Markdown
+node index.js
+
+# Limit to the top 5 and print JSON
+node index.js --limit 5 --format json
+
+# Use a local fixture for deterministic review or CI
+node index.js --fixture test-fixture.json --format markdown
+
+# Write a report to disk
+node index.js --limit 12 --out /tmp/bottube-tip-ledger.md
+```
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--base-url` | BoTTube base URL. Defaults to `https://bottube.ai`. |
+| `--limit`, `-l` | Number of recipient/sender rows to include, from 1 to 25. |
+| `--format`, `-f` | Output format: `markdown` or `json`. |
+| `--fixture` | Read a saved JSON fixture instead of calling the live API. |
+| `--out`, `-o` | Write output to a file instead of stdout. |
+
+## SDK Methods Used
+
+- `client.getTipsLeaderboard()`
+- `client.getTippers()`
+
+The CLI is intentionally read-only. It does not tip, upload, vote, register an
+agent, edit a wallet, withdraw funds, or require a private token.
+
+## Test
+
+```bash
+npm test
+npm run check
+```

--- a/examples/tip-ledger-reporter/index.js
+++ b/examples/tip-ledger-reporter/index.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+import { BoTTubeClient } from '@bottube/sdk';
+
+const DEFAULT_BASE_URL = 'https://bottube.ai';
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: process.env.BOTTUBE_BASE_URL || DEFAULT_BASE_URL,
+    limit: 10,
+    format: 'markdown',
+    fixture: '',
+    out: '',
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--base-url') {
+      options.baseUrl = requireValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--limit' || arg === '-l') {
+      options.limit = parseBoundedInteger(requireValue(argv, index, arg), 1, 25, '--limit');
+      index += 1;
+    } else if (arg === '--format' || arg === '-f') {
+      options.format = parseFormat(requireValue(argv, index, arg));
+      index += 1;
+    } else if (arg === '--fixture') {
+      options.fixture = requireValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--out' || arg === '-o') {
+      options.out = requireValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseBoundedInteger(value, min, max, flag) {
+  if (!/^\d+$/.test(String(value))) {
+    throw new Error(`${flag} must be an integer from ${min} to ${max}`);
+  }
+  return Math.min(Math.max(Number(value), min), max);
+}
+
+function parseFormat(value) {
+  if (value !== 'markdown' && value !== 'json') {
+    throw new Error('--format must be "markdown" or "json"');
+  }
+  return value;
+}
+
+function rowsFromResponse(response) {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.leaderboard)) return response.leaderboard;
+  if (Array.isArray(response?.items)) return response.items;
+  if (Array.isArray(response?.results)) return response.results;
+  return [];
+}
+
+function normalizeTipRow(row, direction) {
+  const totalField = direction === 'received' ? row.total_received : row.total_sent;
+  const fallbackTotal = row.total ?? row.amount ?? row.rtc ?? 0;
+  return {
+    agent: normalizeText(row.agent_name ?? row.agent ?? row.name ?? 'unknown-agent'),
+    displayName: normalizeText(row.display_name ?? row.displayName ?? row.agent_name ?? row.agent ?? 'Unknown agent'),
+    direction,
+    tipCount: toNumber(row.tip_count ?? row.count ?? row.tips),
+    totalRtc: toNumber(totalField ?? fallbackTotal),
+    isHuman: Boolean(row.is_human),
+  };
+}
+
+function normalizeText(value) {
+  return String(value ?? '').replace(/[\r\n\t]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function toNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function buildTipLedgerReport({ client, options, fixtureData = null }) {
+  const source = fixtureData ?? await fetchLiveTipData(client);
+  const recipients = rowsFromResponse(source.received ?? source.recipients ?? source.leaderboard)
+    .map((row) => normalizeTipRow(row, 'received'))
+    .sort(sortTipRows)
+    .slice(0, options.limit);
+  const senders = rowsFromResponse(source.sent ?? source.senders ?? source.tippers)
+    .map((row) => normalizeTipRow(row, 'sent'))
+    .sort(sortTipRows)
+    .slice(0, options.limit);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    baseUrl: options.baseUrl,
+    limit: options.limit,
+    recipients,
+    senders,
+    totals: {
+      recipientRows: recipients.length,
+      senderRows: senders.length,
+      receivedRtc: sumRtc(recipients),
+      sentRtc: sumRtc(senders),
+    },
+  };
+}
+
+async function fetchLiveTipData(client) {
+  const [received, sent] = await Promise.all([
+    client.getTipsLeaderboard(),
+    client.getTippers(),
+  ]);
+  return { received, sent };
+}
+
+function sortTipRows(left, right) {
+  return right.totalRtc - left.totalRtc || right.tipCount - left.tipCount || left.agent.localeCompare(right.agent);
+}
+
+function sumRtc(rows) {
+  return Number(rows.reduce((total, row) => total + row.totalRtc, 0).toFixed(6));
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    '# BoTTube RTC Tip Ledger Report',
+    '',
+    `Generated from ${escapeMarkdown(report.baseUrl)} at ${report.generatedAt}.`,
+    '',
+    `Included rows per leaderboard: ${report.limit}`,
+    '',
+    '## Top Tip Recipients',
+    '',
+    renderTable(report.recipients, 'received'),
+    '',
+    '## Top Tip Senders',
+    '',
+    renderTable(report.senders, 'sent'),
+    '',
+    '## Totals In This Report',
+    '',
+    `- Recipient rows: ${report.totals.recipientRows}`,
+    `- Sender rows: ${report.totals.senderRows}`,
+    `- RTC received by listed recipients: ${formatRtc(report.totals.receivedRtc)}`,
+    `- RTC sent by listed senders: ${formatRtc(report.totals.sentRtc)}`,
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function renderTable(rows, direction) {
+  if (rows.length === 0) return 'No rows returned.';
+  const totalHeader = direction === 'received' ? 'RTC received' : 'RTC sent';
+  const lines = [
+    `| Rank | Agent | Display name | Tips | ${totalHeader} | Type |`,
+    '| ---: | --- | --- | ---: | ---: | --- |',
+  ];
+  rows.forEach((row, index) => {
+    lines.push(`| ${index + 1} | ${escapeMarkdown(row.agent)} | ${escapeMarkdown(row.displayName)} | ${row.tipCount} | ${formatRtc(row.totalRtc)} | ${row.isHuman ? 'human' : 'agent'} |`);
+  });
+  return lines.join('\n');
+}
+
+function formatRtc(value) {
+  return Number(value).toFixed(6).replace(/\.?0+$/, '');
+}
+
+function escapeMarkdown(value) {
+  return normalizeText(value).replace(/[\\`*_{}\[\]()#+\-.!|<>]/g, '\\$&');
+}
+
+async function loadFixture(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+function usage() {
+  return [
+    'BoTTube Tip Ledger Reporter',
+    '',
+    'Usage:',
+    '  node index.js --limit 10',
+    '  node index.js --limit 5 --format json',
+    '  node index.js --fixture test-fixture.json --out /tmp/tips.md',
+    '',
+    'Options:',
+    '      --base-url <url>     BoTTube base URL. Default: https://bottube.ai.',
+    '  -l, --limit <n>          Rows per leaderboard, 1-25. Default: 10.',
+    '  -f, --format <format>    markdown or json. Default: markdown.',
+    '      --fixture <path>     Read fixture JSON instead of live API.',
+    '  -o, --out <path>         Write output to a file.',
+    '  -h, --help               Show this help.',
+    '',
+  ].join('\n');
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const fixtureData = options.fixture ? await loadFixture(options.fixture) : null;
+  const client = new BoTTubeClient({ baseUrl: options.baseUrl });
+  const report = await buildTipLedgerReport({ client, options, fixtureData });
+  const output = options.format === 'json'
+    ? `${JSON.stringify(report, null, 2)}\n`
+    : renderMarkdown(report);
+
+  if (options.out) {
+    await writeFile(options.out, output);
+  } else {
+    console.log(output);
+  }
+}
+
+export {
+  buildTipLedgerReport,
+  escapeMarkdown,
+  normalizeTipRow,
+  parseArgs,
+  renderMarkdown,
+  rowsFromResponse,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/examples/tip-ledger-reporter/index.test.js
+++ b/examples/tip-ledger-reporter/index.test.js
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildTipLedgerReport,
+  escapeMarkdown,
+  normalizeTipRow,
+  parseArgs,
+  renderMarkdown,
+  rowsFromResponse,
+} from './index.js';
+
+const exampleRoot = dirname(fileURLToPath(new URL('./index.js', import.meta.url)));
+
+test('parseArgs accepts output controls', () => {
+  assert.deepEqual(parseArgs(['--base-url', 'https://example.test/', '--limit', '3', '--format', 'json', '--out', '/tmp/tips.json']), {
+    baseUrl: 'https://example.test/',
+    limit: 3,
+    format: 'json',
+    fixture: '',
+    out: '/tmp/tips.json',
+    help: false,
+  });
+});
+
+test('parseArgs rejects malformed limit and format values', () => {
+  assert.throws(() => parseArgs(['--limit', '2abc']), /--limit must be an integer/);
+  assert.throws(() => parseArgs(['--format', 'csv']), /--format must be/);
+});
+
+test('rowsFromResponse accepts common leaderboard shapes', () => {
+  assert.deepEqual(rowsFromResponse([{ agent_name: 'a' }]), [{ agent_name: 'a' }]);
+  assert.deepEqual(rowsFromResponse({ leaderboard: [{ agent_name: 'b' }] }), [{ agent_name: 'b' }]);
+  assert.deepEqual(rowsFromResponse({ items: [{ agent_name: 'c' }] }), [{ agent_name: 'c' }]);
+});
+
+test('normalizeTipRow keeps received and sent totals separate', () => {
+  assert.deepEqual(
+    normalizeTipRow({ agent_name: 'alice\nagent', display_name: 'Alice\tA', tip_count: '4', total_received: '1.25', is_human: true }, 'received'),
+    {
+      agent: 'alice agent',
+      displayName: 'Alice A',
+      direction: 'received',
+      tipCount: 4,
+      totalRtc: 1.25,
+      isHuman: true,
+    },
+  );
+
+  assert.equal(normalizeTipRow({ agent_name: 'bob', total_sent: '2.5' }, 'sent').totalRtc, 2.5);
+});
+
+test('buildTipLedgerReport uses SDK tip methods and sorts by RTC total', async () => {
+  const calls = [];
+  const client = {
+    async getTipsLeaderboard() {
+      calls.push('received');
+      return {
+        leaderboard: [
+          { agent_name: 'small', total_received: 0.2, tip_count: 4 },
+          { agent_name: 'large', total_received: 1.5, tip_count: 2 },
+        ],
+      };
+    },
+    async getTippers() {
+      calls.push('sent');
+      return {
+        leaderboard: [
+          { agent_name: 'sender', total_sent: 0.8, tip_count: 1 },
+        ],
+      };
+    },
+  };
+
+  const report = await buildTipLedgerReport({
+    client,
+    options: { baseUrl: 'https://bottube.ai', limit: 5 },
+  });
+
+  assert.deepEqual(calls.sort(), ['received', 'sent']);
+  assert.equal(report.recipients[0].agent, 'large');
+  assert.equal(report.totals.receivedRtc, 1.7);
+  assert.equal(report.totals.sentRtc, 0.8);
+});
+
+test('buildTipLedgerReport can use fixture data without calling SDK', async () => {
+  const client = {
+    async getTipsLeaderboard() {
+      throw new Error('should not call live received endpoint');
+    },
+    async getTippers() {
+      throw new Error('should not call live sent endpoint');
+    },
+  };
+
+  const report = await buildTipLedgerReport({
+    client,
+    options: { baseUrl: 'https://fixture.test', limit: 1 },
+    fixtureData: {
+      received: { leaderboard: [{ agent_name: 'fixture-recipient', total_received: 9, tip_count: 3 }] },
+      sent: { leaderboard: [{ agent_name: 'fixture-sender', total_sent: 5, tip_count: 2 }] },
+    },
+  });
+
+  assert.equal(report.recipients.length, 1);
+  assert.equal(report.recipients[0].agent, 'fixture-recipient');
+  assert.equal(report.senders[0].agent, 'fixture-sender');
+});
+
+test('renderMarkdown escapes table-breaking text', () => {
+  const markdown = renderMarkdown({
+    generatedAt: '2026-06-02T00:00:00.000Z',
+    baseUrl: 'https://bottube.ai',
+    limit: 1,
+    recipients: [
+      { agent: 'alice|agent', displayName: 'Alice <A>', tipCount: 2, totalRtc: 1.2, isHuman: false },
+    ],
+    senders: [],
+    totals: { recipientRows: 1, senderRows: 0, receivedRtc: 1.2, sentRtc: 0 },
+  });
+
+  assert.match(markdown, /Tip Ledger/);
+  assert.ok(markdown.includes('alice\\|agent'));
+  assert.ok(markdown.includes('Alice \\<A\\>'));
+});
+
+test('escapeMarkdown normalizes newlines', () => {
+  assert.equal(escapeMarkdown('a\nb|c'), 'a b\\|c');
+});
+
+test('CLI help exits successfully', () => {
+  const result = spawnSync(process.execPath, [join(exampleRoot, 'index.js'), '--help'], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /BoTTube Tip Ledger Reporter/);
+});

--- a/examples/tip-ledger-reporter/package.json
+++ b/examples/tip-ledger-reporter/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "bottube-tip-ledger-reporter",
+  "version": "1.0.0",
+  "description": "Generate BoTTube RTC tip leaderboard reports with the BoTTube JavaScript SDK",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-tip-ledger-reporter": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "check": "node --check index.js && node --check index.test.js",
+    "test": "node --test index.test.js"
+  },
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "keywords": [
+    "bottube",
+    "sdk",
+    "rtc",
+    "tips",
+    "leaderboard"
+  ],
+  "author": "keon0711",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}


### PR DESCRIPTION
## Summary\n- add `examples/tip-ledger-reporter`, a read-only Node CLI built with the local `@bottube/sdk` package\n- fetch public RTC tip recipient and sender leaderboards with `client.getTipsLeaderboard()` and `client.getTippers()`\n- render Markdown or JSON tip ledger reports for creator updates, bounty reviews, or agent economy snapshots\n- include fixture/no-network mode, output-file support, README setup/usage docs, and node:test coverage\n\n## Verification\n- `npm install --package-lock=false` from `examples/tip-ledger-reporter`\n- `npm test` from `examples/tip-ledger-reporter`\n- `npm run check` from `examples/tip-ledger-reporter`\n- `node index.js --limit 5 --format json` from `examples/tip-ledger-reporter`\n- `git diff --check -- examples/tip-ledger-reporter`\n\nThe live public API call reached `https://bottube.ai` through the SDK and returned top tip recipient/sender rows.\n\n## Bounty\nBuilt for https://github.com/Scottcjn/rustchain-bounties/issues/2143\n\nRTC payout wallet: `RTC1410e82d545ce0b3ffd21ca83e2465a8f2c3a64e`