### PR TITLE
security(bridges): remove hardcoded admin key, fail-closed hmac auth

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -12,6 +12,7 @@ from flask import Blueprint, request, jsonify, g, session
 import json
 import logging
 import math
+import hmac
 import os
 import sqlite3
 import time
@@ -42,7 +43,14 @@ REWARDS = {
 }
 
 # Admin key for management endpoints
-ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "bottube_admin_key_2026")
+ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "")
+
+def _admin_ok(provided):
+    """Constant-time admin check; fails closed when BOTTUBE_ADMIN_KEY is unset."""
+    if not ADMIN_KEY:
+        return False
+    return hmac.compare_digest(provided or "", ADMIN_KEY)
+
 
 # bananopie availability flag
 _HAS_BANANOPIE = False
@@ -589,7 +597,7 @@ def ban_reward_video_gen():
     # Auth: either session or admin key
     user_id = session.get("user_id")
     admin_key = request.headers.get("X-Admin-Key", "")
-    is_admin = admin_key == ADMIN_KEY
+    is_admin = _admin_ok(admin_key)
 
     if not user_id and not is_admin:
         return jsonify({"error": "Authentication required"}), 401
@@ -664,7 +672,7 @@ def ban_reward_video_gen():
 def ban_platform_status():
     """Check platform hot wallet on-chain balance and system stats."""
     admin_key = request.headers.get("X-Admin-Key", "")
-    if admin_key != ADMIN_KEY:
+    if not _admin_ok(admin_key):
         return jsonify({"error": "Admin key required"}), 401
 
     db = get_db()
@@ -708,7 +716,7 @@ def ban_receive_pending():
     Admin-only.
     """
     admin_key = request.headers.get("X-Admin-Key", "")
-    if admin_key != ADMIN_KEY:
+    if not _admin_ok(admin_key):
         return jsonify({"error": "Admin key required"}), 401
 
     if not _HAS_BANANOPIE or not BANANO_SEED:

--- a/base_wrtc_bridge_blueprint.py
+++ b/base_wrtc_bridge_blueprint.py
@@ -13,6 +13,7 @@ Withdrawal processing uses web3.py for signing and sending.
 """
 
 import json
+import hmac
 import os
 import re
 import secrets
@@ -44,7 +45,14 @@ BASE_WITHDRAW_FEE = float(os.environ.get("BASE_WRTC_WITHDRAW_FEE", "0.5"))
 BASE_WITHDRAW_COOLDOWN = int(os.environ.get("BASE_WRTC_WITHDRAW_COOLDOWN", "3600"))
 
 # Admin key (reuse main BoTTube admin key)
-ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "bottube_admin_key_2026")
+ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "")
+
+def _admin_ok(provided):
+    """Constant-time admin check; fails closed when BOTTUBE_ADMIN_KEY is unset."""
+    if not ADMIN_KEY:
+        return False
+    return hmac.compare_digest(provided or "", ADMIN_KEY)
+
 
 _ETH_ADDR_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 _ETH_TX_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
@@ -560,7 +568,7 @@ def base_bridge_process_withdrawals():
     Requires BOTTUBE_ADMIN_KEY header and BASE_RESERVE_PRIVATE_KEY env.
     """
     admin_key = (request.headers.get("X-Admin-Key") or "").strip()
-    if admin_key != ADMIN_KEY:
+    if not _admin_ok(admin_key):
         return jsonify({"error": "Admin authentication required"}), 401
 
     if not BASE_RESERVE_PRIVATE_KEY:

--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -14,6 +14,7 @@ Exchange rate: market-based or fixed by admin.
 
 from flask import Blueprint, request, jsonify, g, session
 import hashlib
+import hmac
 import math
 import json
 import logging
@@ -45,7 +46,14 @@ MIN_WITHDRAW_RTC = 5.0       # Minimum 5 RTC to withdraw as ERG
 EXPLORER_API = "https://api.ergoplatform.com/api/v1"
 
 # Admin key for management endpoints
-ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "bottube_admin_key_2026")
+ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "")
+
+
+def _admin_ok(provided):
+    """Constant-time admin check; fails closed when BOTTUBE_ADMIN_KEY is unset."""
+    if not ADMIN_KEY:
+        return False
+    return hmac.compare_digest(provided or "", ADMIN_KEY)
 
 # Confirmation threshold (blocks)
 REQUIRED_CONFIRMATIONS = 3
@@ -522,7 +530,7 @@ def process_withdrawals():
       }
     """
     admin_key = request.headers.get("X-Admin-Key", "")
-    if admin_key != ADMIN_KEY:
+    if not _admin_ok(admin_key):
         return jsonify({"error": "Admin key required"}), 401
 
     data = request.get_json() or {}
@@ -547,7 +555,7 @@ def process_withdrawals():
 def pending_withdrawals():
     """Admin endpoint: list pending withdrawals."""
     admin_key = request.headers.get("X-Admin-Key", "")
-    if admin_key != ADMIN_KEY:
+    if not _admin_ok(admin_key):
         return jsonify({"error": "Admin key required"}), 401
 
     db = get_db()

--- a/test_bridge_admin_auth.py
+++ b/test_bridge_admin_auth.py
@@ -1,0 +1,61 @@
+"""Security regression tests for bridge admin-key auth (fail-closed).
+
+Covers the fix that removed the committed default key 'bottube_admin_key_2026'
+and routed all admin checks through a constant-time, fail-closed helper.
+"""
+import importlib.util
+import pathlib
+
+import pytest
+
+HERE = pathlib.Path(__file__).parent
+MODULES = ["banano_blueprint", "ergo_bridge_blueprint", "base_wrtc_bridge_blueprint"]
+OLD_LITERAL = "bottube_admin_key_2026"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, HERE / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:  # pragma: no cover - env-dependent optional deps
+        pytest.skip(f"{name} not importable in this env: {exc}")
+    return mod
+
+
+@pytest.mark.parametrize("name", MODULES)
+def test_unset_key_fails_closed(name):
+    mod = _load(name)
+    mod.ADMIN_KEY = ""  # simulate BOTTUBE_ADMIN_KEY unset
+    # Nothing authenticates when the key is unset — including the old literal.
+    assert mod._admin_ok("") is False
+    assert mod._admin_ok(None) is False
+    assert mod._admin_ok(OLD_LITERAL) is False
+    assert mod._admin_ok("anything") is False
+
+
+@pytest.mark.parametrize("name", MODULES)
+def test_set_key_only_exact_match(name):
+    mod = _load(name)
+    mod.ADMIN_KEY = "real-secret-key-value"
+    assert mod._admin_ok("real-secret-key-value") is True
+    assert mod._admin_ok("") is False
+    assert mod._admin_ok(None) is False
+    assert mod._admin_ok("wrong") is False
+    assert mod._admin_ok(OLD_LITERAL) is False
+
+
+@pytest.mark.parametrize("name", MODULES)
+def test_old_literal_not_present_in_source(name):
+    src = (HERE / f"{name}.py").read_text(newline="")
+    assert OLD_LITERAL not in src
+
+
+def test_usdc_literal_removed():
+    src = (HERE / "usdc_blueprint.py").read_text(newline="")
+    assert OLD_LITERAL not in src
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -24,7 +24,7 @@ USDC_DECIMALS = 6
 TREASURY_ADDRESS = os.environ.get("BOTTUBE_USDC_TREASURY", "0xd10A6AbFED84dDD28F89bB3d836BD20D5da8fEBf")
 
 # Admin key for management endpoints
-ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "bottube_admin_key_2026")
+ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "")
 
 # ERC-20 Transfer event signature
 TRANSFER_EVENT_SIG = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"


### PR DESCRIPTION
## Summary
Four bridge modules defaulted `ADMIN_KEY` to the **committed literal** `bottube_admin_key_2026` when `BOTTUBE_ADMIN_KEY` was unset — a guessable key sitting in public source that guarded withdrawal / refund / mint / platform-admin routes. `base_wrtc_bridge_blueprint` actually **mints wRTC on-chain** to arbitrary addresses behind that gate. (Critical, red-team confirmed.)

## Fix
- `ADMIN_KEY` default → `""` in `banano` / `ergo` / `base_wrtc` / `usdc` blueprints.
- New `_admin_ok()` in the three files with admin checks: **fails closed** when the env key is unset and uses **`hmac.compare_digest`** (constant-time).
- All 6 admin comparison sites routed through the helper.

## Tests
- `test_bridge_admin_auth.py` (10 tests, all green): unset key → denies everything *incl. the old literal*; set key → exact match only; literal absent from source.

## Tri-brain review (Codex 5.5 + Grok; GPT-OSS offline)
- Codex caught a **missing `hmac` import in `ergo`** (mixed CRLF/LF defeated the first insertion) → **fixed**; Codex re-review now clean.
- Grok blast-radius items addressed as rollout/follow-up, not scope creep.

## ⚠️ ROLLOUT (important)
This is fail-closed: **`BOTTUBE_ADMIN_KEY` must be exported in the bottube prod env before deploy**, or bridge admin routes will return 401 (intended). **Rotate** the old literal. Couldn't verify the prod env (NAS unreachable at audit time) — please confirm before deploying.

## Follow-ups (not in this PR — kept reviewable)
- `usdc` `ADMIN_KEY` is currently unused (literal removed for hygiene).
- Unify remaining direct `==` admin checks (`wrtc_bridge`, `paypal_packages`, `scraper_detective`, `bottube_server`) onto one shared fail-closed helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
