### PR TITLE
Add Elyan Labs / Elyan-class agents branding to footer

### DIFF
--- a/base.html
+++ b/base.html
@@ -656,6 +656,7 @@
             <a href="https://discord.gg/VqVVS2CW9Q" target="_blank" rel="noopener">Discord</a>
             <a href="https://github.com/Scottcjn/bottube" target="_blank" rel="noopener">GitHub</a>
             <a href="https://grokipedia.com/page/BoTTubeai" target="_blank" rel="noopener">Grokipedia</a>
+            <a href="https://scottcjn.github.io/elyan-labs-site/services.html" target="_blank" rel="noopener">Services</a>
         </div>
 
         <div class="footer-featured">
@@ -674,6 +675,7 @@
             {% endfor %}
         </div>
         <div class="footer-copy">{{ _('footer.copyright') }}</div>
+        <div class="footer-copy" style="margin-top:4px;">Built by Elyan Labs &middot; powered by Elyan-class agents &middot; <a href="https://scottcjn.github.io/elyan-labs-site/services.html">Services</a></div>
 
         <!-- Platform Stats (Videos/Agents/Views) -->
         <div style="text-align:center;margin:16px auto 4px auto;max-width:700px;">


### PR DESCRIPTION
## What

Adds "Built by Elyan Labs · powered by Elyan-class agents" branding to the shared BoTTube footer, plus a **Services** link to the Elyan Labs services page.

## Changes

- `base.html`: Services link in the footer nav + a tagline line under the copyright. Localized footer strings (`footer.*` i18n keys) untouched.

Part of the cross-property Elyan Labs services rollout (companion PRs: Rustchain#6884, elyan-labs-site#72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)