### PR TITLE
fix(a11y): avoid nested video-card links

### DIFF
--- a/bottube_templates/category.html
+++ b/bottube_templates/category.html
@@ -258,7 +258,7 @@
         <div class="video-grid">
             {% for v in videos %}
             <div class="video-card">
-                <a href="{{ P }}/watch/{{ v.video_id }}">
+                <a class="video-thumbnail-link" href="{{ P }}/watch/{{ v.video_id }}" aria-label="Watch {{ v.title }}">
                     <div class="thumb-wrap">
                         {% if v.thumbnail %}
                         <img src="{{ P }}/thumbnails/{{ v.thumbnail }}" alt="Video thumbnail: {{ v.title }}" loading="lazy">
@@ -269,15 +269,17 @@
                         <span class="duration-badge">{{ v.duration_sec | format_duration }}</span>
                         {% endif %}
                     </div>
-                    <div class="video-info">
-                        <img class="channel-avatar" src="{{ v.avatar_url or (P ~ '/avatar/' ~ v.agent_name ~ '.svg') }}" alt="{{ v.agent_name }}">
-                        <div class="video-meta">
-                            <div class="video-title">{{ v.title }}</div>
-                            <a href="{{ P }}/agent/{{ v.agent_name }}" class="video-channel">{{ v.display_name or v.agent_name }}{% if v.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
-                            <div class="video-stats">{{ v.views | format_views }} views &middot; {{ v.created_at | time_ago }}</div>
-                        </div>
-                    </div>
                 </a>
+                <div class="video-info">
+                    <img class="channel-avatar" src="{{ v.avatar_url or (P ~ '/avatar/' ~ v.agent_name ~ '.svg') }}" alt="{{ v.agent_name }}">
+                    <div class="video-meta">
+                        <a class="video-title-link" href="{{ P }}/watch/{{ v.video_id }}">
+                            <div class="video-title">{{ v.title }}</div>
+                        </a>
+                        <a href="{{ P }}/agent/{{ v.agent_name }}" class="video-channel">{{ v.display_name or v.agent_name }}{% if v.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
+                        <div class="video-stats">{{ v.views | format_views }} views &middot; {{ v.created_at | time_ago }}</div>
+                    </div>
+                </div>
             </div>
             {% endfor %}
         </div>

--- a/bottube_templates/index.html
+++ b/bottube_templates/index.html
@@ -940,7 +940,7 @@
     <div class="video-grid">
         {% for video in trending[2:] %}
         <div class="video-card">
-            <a href="{{ P }}/watch/{{ video.video_id }}" aria-label="Watch {{ video.title }}">
+            <a class="video-thumbnail-link" href="{{ P }}/watch/{{ video.video_id }}" aria-label="Watch {{ video.title }}">
                 <div class="thumb-wrap">
                     {% if video.thumbnail %}
                     <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy" decoding="async" width="720" height="720">
@@ -951,15 +951,17 @@
                     <span class="duration-badge">{{ video.duration_sec | format_duration }}</span>
                     {% endif %}
                 </div>
-                <div class="video-info">
-                    <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
-                    <div class="video-meta">
-                        <div class="video-title">{{ video.title }}</div>
-                        <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
-                        <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
-                    </div>
-                </div>
             </a>
+            <div class="video-info">
+                <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
+                <div class="video-meta">
+                    <a class="video-title-link" href="{{ P }}/watch/{{ video.video_id }}">
+                        <div class="video-title">{{ video.title }}</div>
+                    </a>
+                    <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
+                    <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
+                </div>
+            </div>
         </div>
         {% endfor %}
     </div>
@@ -1097,18 +1099,20 @@
                 var watchUrl = '/watch/' + _esc(v.video_id) + (v._imp ? '?imp=' + _esc(v._imp) : '');
                 return ''
                     + '<div class="video-card">'
-                    +   '<a href="' + watchUrl + '" aria-label="Watch ' + _esc(v.title) + '">'
+                    +   '<a class="video-thumbnail-link" href="' + watchUrl + '" aria-label="Watch ' + _esc(v.title) + '">'
                     +     '<div class="thumb-wrap">' + thumb + dur + '</div>'
-                    +     '<div class="video-info">'
-                    +       '<img class="channel-avatar" src="' + _esc(avatar) + '" alt="Channel avatar" loading="lazy" decoding="async" width="40" height="40">'
-                    +       '<div class="video-meta">'
-                    +         '<div class="video-title">' + _esc(v.title) + '</div>'
-                    +         '<a href="/agent/' + _esc(v.agent_name) + '" class="video-channel">' + _esc(v.display_name || v.agent_name) + ' ' + human + '</a>'
-                    +         '<div class="video-stats">' + _fmtViews(v.views) + ' &middot; ' + _ago(v.created_at) + '</div>'
-                    +         why
-                    +       '</div>'
-                    +     '</div>'
                     +   '</a>'
+                    +   '<div class="video-info">'
+                    +     '<img class="channel-avatar" src="' + _esc(avatar) + '" alt="Channel avatar" loading="lazy" decoding="async" width="40" height="40">'
+                    +     '<div class="video-meta">'
+                    +       '<a class="video-title-link" href="' + watchUrl + '">'
+                    +         '<div class="video-title">' + _esc(v.title) + '</div>'
+                    +       '</a>'
+                    +       '<a href="/agent/' + _esc(v.agent_name) + '" class="video-channel">' + _esc(v.display_name || v.agent_name) + ' ' + human + '</a>'
+                    +       '<div class="video-stats">' + _fmtViews(v.views) + ' &middot; ' + _ago(v.created_at) + '</div>'
+                    +       why
+                    +     '</div>'
+                    +   '</div>'
                     + '</div>';
             }).join('');
         })
@@ -1126,7 +1130,7 @@
     <div class="video-grid">
         {% for video in recent %}
         <div class="video-card">
-            <a href="{{ P }}/watch/{{ video.video_id }}" aria-label="Watch {{ video.title }}">
+            <a class="video-thumbnail-link" href="{{ P }}/watch/{{ video.video_id }}" aria-label="Watch {{ video.title }}">
                 <div class="thumb-wrap">
                     {% if video.thumbnail %}
                     <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy" decoding="async" width="720" height="720">
@@ -1137,15 +1141,17 @@
                     <span class="duration-badge">{{ video.duration_sec | format_duration }}</span>
                     {% endif %}
                 </div>
-                <div class="video-info">
-                    <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
-                    <div class="video-meta">
-                        <div class="video-title">{{ video.title }}</div>
-                        <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
-                        <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
-                    </div>
-                </div>
             </a>
+            <div class="video-info">
+                <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
+                <div class="video-meta">
+                    <a class="video-title-link" href="{{ P }}/watch/{{ video.video_id }}">
+                        <div class="video-title">{{ video.title }}</div>
+                    </a>
+                    <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
+                    <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
+                </div>
+            </div>
         </div>
         {% endfor %}
     </div>

--- a/bottube_templates/search.html
+++ b/bottube_templates/search.html
@@ -261,7 +261,7 @@
         <div class="video-grid" role="list" aria-label="Search results">
             {% for video in videos %}
             <div class="video-card" role="listitem">
-                <a href="{{ P }}/watch/{{ video.video_id }}" aria-label="Watch {{ video.title }}">
+                <a class="video-thumbnail-link" href="{{ P }}/watch/{{ video.video_id }}" aria-label="Watch {{ video.title }}">
                     <div class="thumb-wrap">
                         {% if video.thumbnail %}
                         <img src="{{ P }}/thumbnails/{{ video.thumbnail }}" alt="Video thumbnail: {{ video.title }}" loading="lazy" decoding="async" width="720" height="720">
@@ -272,18 +272,20 @@
                         <span class="duration-badge">{{ video.duration_sec | format_duration }}</span>
                         {% endif %}
                     </div>
-                    <div class="video-info">
-                        <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
-                        <div class="video-meta">
-                            <div class="video-title">{{ video.title }}</div>
-                            <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
-                            <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
-                            {% if video.category %}
-                            <a href="{{ P }}/category/{{ video.category }}" class="category-tag" style="font-size:11px;color:var(--text-muted);text-decoration:none;">{{ categories_map.get(video.category, {}).get('icon', '') }} {{ categories_map.get(video.category, {}).get('name', video.category) }}</a>
-                            {% endif %}
-                        </div>
-                    </div>
                 </a>
+                <div class="video-info">
+                    <img class="channel-avatar" src="{{ video.avatar_url or (P ~ "/avatar/" ~ video.agent_name ~ ".svg") }}" alt="{{ video.agent_name }}" loading="lazy" decoding="async" width="40" height="40">
+                    <div class="video-meta">
+                        <a class="video-title-link" href="{{ P }}/watch/{{ video.video_id }}">
+                            <div class="video-title">{{ video.title }}</div>
+                        </a>
+                        <a href="{{ P }}/agent/{{ video.agent_name }}" class="video-channel">{{ video.display_name or video.agent_name }}{% if video.is_human %} <span class="badge-human-sm">Human</span>{% else %} <span class="badge-ai-sm">AI</span>{% endif %}</a>
+                        <div class="video-stats">{{ video.views | format_views }} views &middot; {{ video.created_at | time_ago }}</div>
+                        {% if video.category %}
+                        <a href="{{ P }}/category/{{ video.category }}" class="category-tag" style="font-size:11px;color:var(--text-muted);text-decoration:none;">{{ categories_map.get(video.category, {}).get('icon', '') }} {{ categories_map.get(video.category, {}).get('name', video.category) }}</a>
+                        {% endif %}
+                    </div>
+                </div>
             </div>
             {% endfor %}
         </div>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -99,17 +99,20 @@ class TestAccessibilityAttributes(unittest.TestCase):
         self.assertIn('aria-label', match.group(0),
                       "Hero actions container missing aria-label")
 
-    def test_homepage_video_cards_do_not_nest_links(self):
-        """Video cards must not put channel links inside watch links."""
-        content = self.read_file(self.TEMPLATE_DIR / 'index.html')
-        parser = _NestedAnchorParser()
-        parser.feed(content)
-        self.assertEqual(
-            parser.nested_anchors,
-            0,
-            "Homepage template contains invalid nested anchor elements",
-        )
+    def test_video_cards_do_not_nest_links(self):
+        """Video cards must not put channel or category links inside watch links."""
+        for template_name in ('index.html', 'category.html', 'search.html'):
+            with self.subTest(template=template_name):
+                content = self.read_file(self.TEMPLATE_DIR / template_name)
+                parser = _NestedAnchorParser()
+                parser.feed(content)
+                self.assertEqual(
+                    parser.nested_anchors,
+                    0,
+                    f"{template_name} contains invalid nested anchor elements",
+                )
 
+        content = self.read_file(self.TEMPLATE_DIR / 'index.html')
         hybrid_card = re.search(
             r"return ''(?P<markup>.*?)\+ '</div>';",
             content,

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -9,7 +9,27 @@ and keyboard navigation support as required by WCAG 2.1 Level AA.
 import os
 import re
 import unittest
+from html.parser import HTMLParser
 from pathlib import Path
+
+
+class _NestedAnchorParser(HTMLParser):
+    """Count nested anchors in server-rendered template markup."""
+
+    def __init__(self):
+        super().__init__()
+        self.anchor_depth = 0
+        self.nested_anchors = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            if self.anchor_depth:
+                self.nested_anchors += 1
+            self.anchor_depth += 1
+
+    def handle_endtag(self, tag):
+        if tag == "a" and self.anchor_depth:
+            self.anchor_depth -= 1
 
 
 class TestAccessibilityAttributes(unittest.TestCase):
@@ -78,6 +98,31 @@ class TestAccessibilityAttributes(unittest.TestCase):
                       "Hero actions should have role='group'")
         self.assertIn('aria-label', match.group(0),
                       "Hero actions container missing aria-label")
+
+    def test_homepage_video_cards_do_not_nest_links(self):
+        """Video cards must not put channel links inside watch links."""
+        content = self.read_file(self.TEMPLATE_DIR / 'index.html')
+        parser = _NestedAnchorParser()
+        parser.feed(content)
+        self.assertEqual(
+            parser.nested_anchors,
+            0,
+            "Homepage template contains invalid nested anchor elements",
+        )
+
+        hybrid_card = re.search(
+            r"return ''(?P<markup>.*?)\+ '</div>';",
+            content,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(hybrid_card, "Hybrid recommendation card renderer not found")
+        markup = hybrid_card.group("markup")
+        thumbnail_close = markup.find("+   '</a>'")
+        video_info = markup.find("'<div class=\"video-info\">'")
+        channel_link = markup.find("'<a href=\"/agent/")
+        self.assertGreaterEqual(thumbnail_close, 0)
+        self.assertGreater(video_info, thumbnail_close)
+        self.assertGreater(channel_link, video_info)
     
     def test_search_form_has_aria_label(self):
         """Test that search form has proper accessibility attributes."""


### PR DESCRIPTION
Fixes #1311

## Summary

- close homepage thumbnail links before the card metadata block
- keep video-title and channel links as valid siblings instead of nesting anchors
- apply the same markup structure to server-rendered Trending/Recent cards and JavaScript-rendered hybrid recommendations
- add regression coverage for nested anchors in the homepage template and the hybrid card renderer

## Why

The live homepage source nests the channel link inside a watch link. Chromium repairs that invalid markup into three equivalent watch links per card, including an avatar-only focus target, followed by the channel link. The repaired DOM creates redundant keyboard navigation and obscures link purpose.

## Validation

- `python -m pytest -q tests/test_accessibility.py --tb=short` -> 19 passed
- `python -m py_compile tests/test_accessibility.py`
- `git diff --check`
- live Chromium DOM inspection on June 6, 2026 reproduced the duplicate focus targets before this fix

## Bounty

Submitted for maintainer assessment under:

- Scottcjn/rustchain-bounties#1618 (accessibility report, 1 RTC)
- Scottcjn/rustchain-bounties#1102 (UI bug, 3 RTC)

Please apply whichever single bounty category best fits; this is not a request for duplicate payment.

RTC wallet: `RTCf69dd944558d4e843a4a676495a97638055caea2`