### PR TITLE
fix(a11y): label bridge history limit inputs

### DIFF
--- a/bottube_templates/bridge_base.html
+++ b/bottube_templates/bridge_base.html
@@ -204,6 +204,7 @@
       <p>Latest deposits and withdrawals for your authenticated account on Base.</p>
       <div class="row">
         <button class="btn btn-dark" id="historyBtn" type="button" aria-label="Load transaction history">Load History</button>
+        <label class="sr-only" for="historyLimitInput">History entries to load</label>
         <input id="historyLimitInput" type="number" min="1" max="200" value="50" style="max-width:100px;">
       </div>
       <div id="historyPanel" class="panel" style="margin-top:10px;">No requests yet.</div>

--- a/bottube_templates/bridge_wrtc.html
+++ b/bottube_templates/bridge_wrtc.html
@@ -171,6 +171,7 @@
       <p>Latest verified deposits and queued/sent withdrawals for the authenticated account.</p>
       <div class="row">
         <button class="btn btn-dark" id="historyBtn" type="button" aria-label="Load transaction history">Load History</button>
+        <label class="sr-only" for="historyLimitInput">History entries to load</label>
         <input id="historyLimitInput" type="number" min="1" max="200" value="50" style="max-width:100px;">
       </div>
       <div id="historyPanel" class="panel" style="margin-top:10px;">No requests yet.</div>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -104,6 +104,23 @@ class TestAccessibilityAttributes(unittest.TestCase):
             r'<label[^>]*for="agent-search"[^>]*>Search agents</label>',
             "Agents page search input missing associated label",
         )
+
+    def test_bridge_history_limit_inputs_have_accessible_names(self):
+        """Bridge history limits must identify what their numeric value controls."""
+        for template_name in ('bridge_base.html', 'bridge_wrtc.html'):
+            with self.subTest(template=template_name):
+                content = self.read_file(self.TEMPLATE_DIR / template_name)
+                self.assertRegex(
+                    content,
+                    r'<label[^>]*class="sr-only"[^>]*for="historyLimitInput"[^>]*>'
+                    r'History entries to load</label>',
+                    f"{template_name} history limit is missing its label",
+                )
+                self.assertRegex(
+                    content,
+                    r'<input[^>]*id="historyLimitInput"[^>]*>',
+                    f"{template_name} history limit input not found",
+                )
     
     def test_skip_link_present(self):
         """Test that skip link for keyboard navigation is present."""


### PR DESCRIPTION
Fixes #1313

## Summary

- add a screen-reader-only label for the history result-limit input on the Solana wRTC bridge
- add the same associated label on the Base bridge
- add regression coverage requiring both bridge templates to keep the accessible name

## Why

On both live bridge pages, the compact numeric input beside **Load History** is exposed as an unnamed spinbutton with value `50`. Users navigating form controls cannot determine what the number controls. The associated `sr-only` label names it **History entries to load** without changing the compact visual layout.

## Validation

- `python -m pytest -q tests/test_accessibility.py --tb=short` -> 19 passed, 2 subtests passed
- `python -m py_compile tests/test_accessibility.py`
- `git diff --check`
- live Chromium accessibility/DOM inspection on both bridge pages, June 6, 2026

## Bounty

Submitted for maintainer assessment under Scottcjn/rustchain-bounties#1618 (1 RTC accessibility report).

RTC wallet: `RTCf69dd944558d4e843a4a676495a97638055caea2`