### PR TITLE
fix(a11y): label authenticated form inputs

### DIFF
--- a/bottube_templates/collaboration_new.html
+++ b/bottube_templates/collaboration_new.html
@@ -283,7 +283,7 @@
 
             <!-- Initial Participants -->
             <div class="form-group">
-                <label>Invite Creators (optional)</label>
+                <label for="participantInput">Invite Creators (optional)</label>
                 <div class="participants-input">
                     <input type="text" id="participantInput" placeholder="@username" onkeypress="handleParticipantKeypress(event)">
                     <button type="button" class="btn btn-secondary" onclick="addParticipant()" style="padding: 10px 16px;">Add</button>

--- a/bottube_templates/settings_wallet.html
+++ b/bottube_templates/settings_wallet.html
@@ -13,6 +13,7 @@
   <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:16px;margin-bottom:16px;">
     <h3 style="margin:0 0 10px 0;">Linked Receiving Wallet</h3>
     <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center;">
+      <label class="sr-only" for="linked-rtc-wallet">Linked RTC wallet address</label>
       <input id="linked-rtc-wallet" type="text" value="{{ rtc_wallet }}" placeholder="RTC..." autocomplete="off"
              style="flex:1;min-width:320px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 12px;color:var(--text-primary);">
       <button id="save-linked-btn"

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -104,6 +104,22 @@ class TestAccessibilityAttributes(unittest.TestCase):
             r'<label[^>]*for="agent-search"[^>]*>Search agents</label>',
             "Agents page search input missing associated label",
         )
+
+    def test_authenticated_form_inputs_have_associated_labels(self):
+        """Collaboration and wallet text inputs need programmatic labels."""
+        controls = (
+            ('collaboration_new.html', 'participantInput', 'Invite Creators'),
+            ('settings_wallet.html', 'linked-rtc-wallet', 'Linked RTC wallet address'),
+        )
+        for template_name, control_id, label_text in controls:
+            with self.subTest(template=template_name, control=control_id):
+                content = self.read_file(self.TEMPLATE_DIR / template_name)
+                self.assertRegex(
+                    content,
+                    rf'<label[^>]*for="{re.escape(control_id)}"[^>]*>'
+                    rf'[^<]*{re.escape(label_text)}',
+                    f"{control_id} missing associated label",
+                )
     
     def test_skip_link_present(self):
         """Test that skip link for keyboard navigation is present."""


### PR DESCRIPTION
## Summary

- associate the visible Invite Creators label with the collaboration participant input
- add a screen-reader-only label to the linked RTC wallet input
- add regression coverage for both authenticated form controls

## Accessibility impact

Both controls previously relied on placeholder text or an unassociated heading/label. The explicit `for`/`id` associations give each text input a stable programmatic name for screen-reader form navigation while preserving the existing layout.

WCAG: 1.3.1, 3.3.2, 4.1.2.

## Validation

- `python -m pytest -q tests/test_accessibility.py --tb=short` -> 19 passed, 2 subtests passed
- `python -m py_compile tests/test_accessibility.py`
- `git diff --check`

Fixes #1315

Bounty claim: Scottcjn/rustchain-bounties#1618 (1 RTC, subject to maintainer approval)
RTC wallet: `RTCf69dd944558d4e843a4a676495a97638055caea2`