### PR TITLE
fix: announce bridge operation results to screen readers

### DIFF
--- a/bottube_templates/bridge_base.html
+++ b/bottube_templates/bridge_base.html
@@ -170,7 +170,7 @@
       <h2>Public Info</h2>
       <p>Live limits, fees, and aggregate bridge stats on Base.</p>
       <button class="btn btn-dark" id="loadInfoBtn" type="button" aria-label="Refresh public bridge info">Refresh Info</button>
-      <div id="infoPanel" class="panel" style="margin-top:10px;">Loading...</div>
+      <div id="infoPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Loading...</div>
     </div>
 
     <div class="card">
@@ -181,7 +181,7 @@
       <label for="txHashInput">Transaction Hash (Base)</label>
       <input id="txHashInput" type="text" placeholder="0x... (66 character tx hash)">
       <button class="btn btn-primary" id="depositBtn" type="button" aria-label="Verify Base transaction and credit account">Verify Transaction</button>
-      <div id="depositPanel" class="panel" style="margin-top:10px;">Awaiting transaction hash...</div>
+      <div id="depositPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Awaiting transaction hash...</div>
       <div class="warn">Ensure your bound ETH wallet (in profile settings) matches the sender address.</div>
     </div>
 
@@ -193,7 +193,7 @@
       <label for="withdrawAmountInput">Amount to Withdraw (wRTC)</label>
       <input id="withdrawAmountInput" type="number" min="10" step="0.000001" placeholder="Minimum: 10 wRTC">
       <button class="btn btn-primary" id="withdrawBtn" type="button" aria-label="Queue withdrawal to Base">Queue Withdrawal</button>
-      <div id="withdrawPanel" class="panel" style="margin-top:10px;">Queue is currently active.</div>
+      <div id="withdrawPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Queue is currently active.</div>
       {% if swap_url %}
       <a class="link-btn" href="{{ swap_url }}" target="_blank" rel="noopener">Swap wRTC on Uniswap</a>
       {% endif %}
@@ -206,7 +206,7 @@
         <button class="btn btn-dark" id="historyBtn" type="button" aria-label="Load transaction history">Load History</button>
         <input id="historyLimitInput" type="number" min="1" max="200" value="50" style="max-width:100px;">
       </div>
-      <div id="historyPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
+      <div id="historyPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">No requests yet.</div>
     </div>
   </div>
 </section>

--- a/bottube_templates/bridge_wrtc.html
+++ b/bottube_templates/bridge_wrtc.html
@@ -139,7 +139,7 @@
       <h2>Public Info</h2>
       <p>Live limits, fees, and aggregate bridge stats.</p>
       <button class="btn btn-dark" id="loadInfoBtn" type="button" aria-label="Refresh public bridge info">Refresh Info</button>
-      <div id="infoPanel" class="panel" style="margin-top:10px;">Loading...</div>
+      <div id="infoPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Loading...</div>
     </div>
 
     <div class="card">
@@ -150,7 +150,7 @@
       <label for="txSigInput">Transaction Signature (Solana)</label>
       <input id="txSigInput" type="text" placeholder="5X... (Base58 signature)">
       <button class="btn btn-primary" id="depositBtn" type="button" aria-label="Verify Solana transaction and credit account">Verify Transaction</button>
-      <div id="depositPanel" class="panel" style="margin-top:10px;">Awaiting signature...</div>
+      <div id="depositPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Awaiting signature...</div>
       <div class="warn">🔒 Verification is secure. Ensure your bound Solana wallet matches the sender address.</div>
     </div>
 
@@ -162,7 +162,7 @@
       <label for="withdrawAmountInput">Amount to Withdraw (wRTC)</label>
       <input id="withdrawAmountInput" type="number" min="0" step="0.000001" placeholder="Minimum: 1 wRTC">
       <button class="btn btn-primary" id="withdrawBtn" type="button" aria-label="Queue vault withdrawal to Solana">Queue Vault Withdrawal</button>
-      <div id="withdrawPanel" class="panel" style="margin-top:10px;">Queue is currently active.</div>
+      <div id="withdrawPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Queue is currently active.</div>
       <a class="link-btn" href="{{ wrtc_buy_url }}" target="_blank" rel="noopener">Get wRTC on Raydium ↗</a>
     </div>
 
@@ -173,7 +173,7 @@
         <button class="btn btn-dark" id="historyBtn" type="button" aria-label="Load transaction history">Load History</button>
         <input id="historyLimitInput" type="number" min="1" max="200" value="50" style="max-width:100px;">
       </div>
-      <div id="historyPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
+      <div id="historyPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">No requests yet.</div>
     </div>
   </div>
 </section>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -200,6 +200,26 @@ class TestARIAPatterns(unittest.TestCase):
         self.assertIn('role="contentinfo"', content,
                       "Footer contentinfo landmark not found")
 
+    def test_bridge_result_panels_are_live_regions(self):
+        """Bridge operation results should be announced by screen readers."""
+        panel_ids = ("infoPanel", "depositPanel", "withdrawPanel", "historyPanel")
+
+        for template_name in ("bridge_wrtc.html", "bridge_base.html"):
+            content = self.read_file(self.TEMPLATE_DIR / template_name)
+            for panel_id in panel_ids:
+                match = re.search(
+                    rf'<div[^>]*id="{panel_id}"[^>]*>',
+                    content,
+                )
+                self.assertIsNotNone(
+                    match,
+                    f"{template_name} is missing #{panel_id}",
+                )
+                panel = match.group(0)
+                self.assertIn('role="status"', panel)
+                self.assertIn('aria-live="polite"', panel)
+                self.assertIn('aria-atomic="true"', panel)
+
 
 class TestAccessibilityDocumentation(unittest.TestCase):
     """Test that accessibility documentation exists."""


### PR DESCRIPTION
## Description

Adds polite, atomic status live regions to the public-info, deposit,
withdrawal, and history result panels on both the Solana and Base bridge
pages.

These panels are updated asynchronously with loading, validation, success, and
error messages. Exposing them as status regions lets screen readers announce
the results without moving keyboard focus.

Fixes #1317

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

- `python -m unittest tests.test_accessibility -v`
- Result: 19 tests passed
- `git diff --check`
- Result: passed

## Checklist

- [x] My code follows the style of this project
- [x] I have performed a self-review of my changes
- [x] I have added tests that prove my fix is effective
- [x] New and existing targeted tests pass

RTC wallet name: `2003elizhang`
