### PR TITLE
fix(a11y): make collaboration type picker keyboard accessible

### DIFF
--- a/bottube_templates/collaboration_new.html
+++ b/bottube_templates/collaboration_new.html
@@ -247,19 +247,19 @@
             <!-- Collaboration Type -->
             <div class="form-group">
                 <label>Collaboration Type</label>
-                <div class="collab-type-selector">
-                    <div class="collab-type-option selected" data-type="duet" onclick="selectType('duet')">
-                        <div class="collab-type-icon">🎭</div>
+                <div class="collab-type-selector" role="radiogroup" aria-label="Collaboration type">
+                    <div class="collab-type-option selected" data-type="duet" onclick="selectType('duet')" onkeydown="handleTypeKeydown(event, 'duet')" role="radio" aria-checked="true" tabindex="0">
+                        <div class="collab-type-icon" aria-hidden="true">🎭</div>
                         <div class="collab-type-name">Duet</div>
                         <div class="collab-type-desc">Side-by-side response or reaction</div>
                     </div>
-                    <div class="collab-type-option" data-type="co-upload" onclick="selectType('co-upload')">
-                        <div class="collab-type-icon">🤝</div>
+                    <div class="collab-type-option" data-type="co-upload" onclick="selectType('co-upload')" onkeydown="handleTypeKeydown(event, 'co-upload')" role="radio" aria-checked="false" tabindex="0">
+                        <div class="collab-type-icon" aria-hidden="true">🤝</div>
                         <div class="collab-type-name">Co-Upload</div>
                         <div class="collab-type-desc">Joint content creation</div>
                     </div>
-                    <div class="collab-type-option" data-type="remix" onclick="selectType('remix')">
-                        <div class="collab-type-icon">🎵</div>
+                    <div class="collab-type-option" data-type="remix" onclick="selectType('remix')" onkeydown="handleTypeKeydown(event, 'remix')" role="radio" aria-checked="false" tabindex="0">
+                        <div class="collab-type-icon" aria-hidden="true">🎵</div>
                         <div class="collab-type-name">Remix</div>
                         <div class="collab-type-desc">Transform existing content</div>
                     </div>
@@ -308,10 +308,18 @@
 
     function selectType(type) {
         document.querySelectorAll('.collab-type-option').forEach(opt => {
-            opt.classList.remove('selected');
+            const isSelected = opt.dataset.type === type;
+            opt.classList.toggle('selected', isSelected);
+            opt.setAttribute('aria-checked', isSelected ? 'true' : 'false');
         });
-        document.querySelector(`[data-type="${type}"]`).classList.add('selected');
         document.getElementById('collabType').value = type;
+    }
+
+    function handleTypeKeydown(event, type) {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            selectType(type);
+        }
     }
 
     function handleParticipantKeypress(event) {

--- a/tests/test_collaboration_type_accessibility.py
+++ b/tests/test_collaboration_type_accessibility.py
@@ -1,0 +1,52 @@
+"""Accessibility checks for the create-collaboration type picker.
+
+Bounty: Scottcjn/rustchain-bounties#1618
+Issue: Scottcjn/bottube#1321
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "collaboration_new.html"
+
+
+def _template() -> str:
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def _option_tag(html: str, collab_type: str) -> str:
+    match = re.search(
+        rf'<div class="collab-type-option[^>]*data-type="{re.escape(collab_type)}"[^>]*>',
+        html,
+    )
+    assert match, f"missing collaboration option for {collab_type}"
+    return match.group(0)
+
+
+def test_collaboration_type_picker_is_named_radio_group() -> None:
+    html = _template()
+
+    assert 'role="radiogroup"' in html
+    assert 'aria-label="Collaboration type"' in html
+
+
+def test_each_collaboration_type_option_is_keyboard_focusable_radio() -> None:
+    html = _template()
+
+    for collab_type in ("duet", "co-upload", "remix"):
+        option = _option_tag(html, collab_type)
+        assert 'role="radio"' in option
+        assert 'tabindex="0"' in option
+        assert f"handleTypeKeydown(event, '{collab_type}')" in option
+
+
+def test_collaboration_type_selection_keeps_aria_checked_in_sync() -> None:
+    html = _template()
+
+    assert 'aria-checked="true"' in _option_tag(html, "duet")
+    assert 'aria-checked="false"' in _option_tag(html, "co-upload")
+    assert 'aria-checked="false"' in _option_tag(html, "remix")
+    assert "opt.setAttribute('aria-checked', isSelected ? 'true' : 'false')" in html
+    assert "event.key === 'Enter' || event.key === ' '" in html


### PR DESCRIPTION
## Summary

- Make the Create Collaboration type selector a named radio group.
- Add keyboard activation for Duet, Co-Upload, and Remix with Enter/Space.
- Keep `aria-checked` in sync with the selected hidden form value.
- Hide decorative emoji icons from screen readers.
- Add static regression tests covering the three collaboration type options.

## Related issue / bounty

Fixes #1321
Related bounty: Scottcjn/rustchain-bounties#1618

## Verification

Because this environment does not have `pytest` installed, I ran the new tests directly and compiled the test file:

```text
python3 - <<'PY'
from tests.test_collaboration_type_accessibility import (
    test_collaboration_type_picker_is_named_radio_group,
    test_each_collaboration_type_option_is_keyboard_focusable_radio,
    test_collaboration_type_selection_keeps_aria_checked_in_sync,
)
for test in (
    test_collaboration_type_picker_is_named_radio_group,
    test_each_collaboration_type_option_is_keyboard_focusable_radio,
    test_collaboration_type_selection_keeps_aria_checked_in_sync,
):
    test()
    print(f"PASS {test.__name__}")
PY
python3 -m py_compile tests/test_collaboration_type_accessibility.py
git diff --check
```

Result:

```text
PASS test_collaboration_type_picker_is_named_radio_group
PASS test_each_collaboration_type_option_is_keyboard_focusable_radio
PASS test_collaboration_type_selection_keeps_aria_checked_in_sync
```

AI-assisted contribution: implemented with Hermes/Codex agent assistance.
