### PR TITLE
fix(a11y): prevent mobile homepage overflow

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -158,6 +158,7 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
+            gap: 16px;
             position: sticky;
             top: 0;
             z-index: 100;
@@ -167,6 +168,7 @@
             display: flex;
             align-items: center;
             gap: 16px;
+            min-width: 0;
         }
 
         .logo {
@@ -176,6 +178,8 @@
             display: flex;
             align-items: center;
             gap: 6px;
+            min-width: 0;
+            white-space: nowrap;
         }
 
         .logo .bot-icon {
@@ -194,11 +198,13 @@
         .search-bar {
             display: flex;
             max-width: 500px;
-            flex: 1;
+            flex: 1 1 500px;
+            min-width: 0;
         }
 
         .search-bar input {
             flex: 1;
+            min-width: 0;
             padding: 8px 16px;
             background: var(--bg-primary);
             border: 1px solid var(--border);
@@ -255,6 +261,8 @@
             color: var(--text-secondary);
             font-size: 14px;
             line-height: 1.5;
+            overflow-wrap: anywhere;
+            word-break: break-word;
         }
 
         .recovery-banner strong {
@@ -626,7 +634,14 @@
 
         @media (max-width: 640px) {
             .video-grid { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }
-            .search-bar { max-width: 200px; }
+            .header { gap: 8px; }
+            .header-left { gap: 10px; }
+            .search-bar {
+                flex: 1 1 auto;
+                max-width: none;
+                min-width: 0;
+            }
+            .search-bar button { padding: 8px 14px; }
             .mobile-menu-btn { display: block; }
             .header-right {
                 display: none;
@@ -650,7 +665,11 @@
 
         @media (max-width: 480px) {
             .video-grid { grid-template-columns: 1fr; }
-            .search-bar { max-width: 160px; }
+            .header { padding: 0 8px; }
+            .header-left { gap: 8px; }
+            .logo { font-size: 18px; }
+            .logo .bot-icon { font-size: 20px; }
+            .search-bar { max-width: none; }
 
             /* Touch-friendly buttons */
             button, .btn-primary, .btn-secondary, a.btn-api {

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -262,7 +262,6 @@
             font-size: 14px;
             line-height: 1.5;
             overflow-wrap: anywhere;
-            word-break: break-word;
         }
 
         .recovery-banner strong {

--- a/bottube_templates/index.html
+++ b/bottube_templates/index.html
@@ -186,7 +186,6 @@
         text-align: left;
         max-width: 100%;
         overflow-wrap: anywhere;
-        word-break: break-word;
     }
 
     .pip-banner:hover {

--- a/bottube_templates/index.html
+++ b/bottube_templates/index.html
@@ -104,6 +104,8 @@
         gap: 12px;
         justify-content: center;
         flex-wrap: wrap;
+        width: 100%;
+        max-width: 100%;
         margin-bottom: 40px;
     }
 
@@ -116,6 +118,8 @@
         border: none;
         transition: all 0.2s;
         text-decoration: none;
+        max-width: 100%;
+        white-space: normal;
     }
 
     .btn-primary {
@@ -180,6 +184,9 @@
         appearance: none;
         -webkit-appearance: none;
         text-align: left;
+        max-width: 100%;
+        overflow-wrap: anywhere;
+        word-break: break-word;
     }
 
     .pip-banner:hover {

--- a/tests/test_homepage_accessibility.py
+++ b/tests/test_homepage_accessibility.py
@@ -5,6 +5,7 @@ Task: #1589 - Write unit tests
 """
 from __future__ import annotations
 import os
+import re
 import sqlite3
 import sys
 from pathlib import Path
@@ -86,10 +87,10 @@ def test_homepage_templates_include_mobile_overflow_guards() -> None:
     index_template = (ROOT / "bottube_templates" / "index.html").read_text(encoding="utf-8")
 
     assert "overflow-wrap: anywhere;" in base_template
-    assert "word-break: break-word;" in base_template
-    assert ".search-bar {\n                flex: 1 1 auto;" in base_template
-    assert ".logo { font-size: 18px; }" in base_template
+    assert re.search(r"\.search-bar\s*\{[^}]*flex:\s*1\s+1\s+500px;", base_template, re.DOTALL)
+    assert re.search(r"\.logo\s*\{\s*font-size:\s*18px;\s*\}", base_template)
 
-    assert ".hero-actions {\n        display: flex;" in index_template
+    assert re.search(r"\.hero-actions\s*\{[^}]*display:\s*flex;", index_template, re.DOTALL)
     assert "width: 100%;" in index_template
     assert "white-space: normal;" in index_template
+    assert "overflow-wrap: anywhere;" in index_template

--- a/tests/test_homepage_accessibility.py
+++ b/tests/test_homepage_accessibility.py
@@ -78,3 +78,18 @@ def test_homepage_renders_friendly_category_chips_and_accessible_controls(
     assert "Three steps. Start uploading in minutes." in html
     assert "{{ cat }}" not in html
     assert "Three lines. That's it." not in html
+
+
+def test_homepage_templates_include_mobile_overflow_guards() -> None:
+    """Homepage templates should keep header, notices, and hero controls within mobile widths."""
+    base_template = (ROOT / "bottube_templates" / "base.html").read_text(encoding="utf-8")
+    index_template = (ROOT / "bottube_templates" / "index.html").read_text(encoding="utf-8")
+
+    assert "overflow-wrap: anywhere;" in base_template
+    assert "word-break: break-word;" in base_template
+    assert ".search-bar {\n                flex: 1 1 auto;" in base_template
+    assert ".logo { font-size: 18px; }" in base_template
+
+    assert ".hero-actions {\n        display: flex;" in index_template
+    assert "width: 100%;" in index_template
+    assert "white-space: normal;" in index_template


### PR DESCRIPTION
## Summary
- let the mobile header shrink cleanly by relaxing the search bar and logo constraints
- allow the recovery notice and pip install banner to wrap long text instead of pushing the viewport wider
- add a focused homepage regression test that guards the mobile overflow CSS hooks

## Testing
- pytest tests/test_homepage_accessibility.py -q
- pytest tests/test_accessibility.py -q
- git diff --check

Closes #1304