### PR TITLE
fix(a11y): announce bridge result updates to screen readers

### DIFF
--- a/bottube_templates/bridge_base.html
+++ b/bottube_templates/bridge_base.html
@@ -170,7 +170,7 @@
       <h2>Public Info</h2>
       <p>Live limits, fees, and aggregate bridge stats on Base.</p>
       <button class="btn btn-dark" id="loadInfoBtn" type="button" aria-label="Refresh public bridge info">Refresh Info</button>
-      <div id="infoPanel" class="panel" style="margin-top:10px;">Loading...</div>
+      <div id="infoPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Loading...</div>
     </div>
 
     <div class="card">
@@ -181,7 +181,7 @@
       <label for="txHashInput">Transaction Hash (Base)</label>
       <input id="txHashInput" type="text" placeholder="0x... (66 character tx hash)">
       <button class="btn btn-primary" id="depositBtn" type="button" aria-label="Verify Base transaction and credit account">Verify Transaction</button>
-      <div id="depositPanel" class="panel" style="margin-top:10px;">Awaiting transaction hash...</div>
+      <div id="depositPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Awaiting transaction hash...</div>
       <div class="warn">Ensure your bound ETH wallet (in profile settings) matches the sender address.</div>
     </div>
 
@@ -193,7 +193,7 @@
       <label for="withdrawAmountInput">Amount to Withdraw (wRTC)</label>
       <input id="withdrawAmountInput" type="number" min="10" step="0.000001" placeholder="Minimum: 10 wRTC">
       <button class="btn btn-primary" id="withdrawBtn" type="button" aria-label="Queue withdrawal to Base">Queue Withdrawal</button>
-      <div id="withdrawPanel" class="panel" style="margin-top:10px;">Queue is currently active.</div>
+      <div id="withdrawPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Queue is currently active.</div>
       {% if swap_url %}
       <a class="link-btn" href="{{ swap_url }}" target="_blank" rel="noopener">Swap wRTC on Uniswap</a>
       {% endif %}
@@ -206,7 +206,7 @@
         <button class="btn btn-dark" id="historyBtn" type="button" aria-label="Load transaction history">Load History</button>
         <input id="historyLimitInput" type="number" min="1" max="200" value="50" style="max-width:100px;">
       </div>
-      <div id="historyPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
+      <div id="historyPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">No requests yet.</div>
     </div>
   </div>
 </section>

--- a/bottube_templates/bridge_wrtc.html
+++ b/bottube_templates/bridge_wrtc.html
@@ -139,7 +139,7 @@
       <h2>Public Info</h2>
       <p>Live limits, fees, and aggregate bridge stats.</p>
       <button class="btn btn-dark" id="loadInfoBtn" type="button" aria-label="Refresh public bridge info">Refresh Info</button>
-      <div id="infoPanel" class="panel" style="margin-top:10px;">Loading...</div>
+      <div id="infoPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Loading...</div>
     </div>
 
     <div class="card">
@@ -150,7 +150,7 @@
       <label for="txSigInput">Transaction Signature (Solana)</label>
       <input id="txSigInput" type="text" placeholder="5X... (Base58 signature)">
       <button class="btn btn-primary" id="depositBtn" type="button" aria-label="Verify Solana transaction and credit account">Verify Transaction</button>
-      <div id="depositPanel" class="panel" style="margin-top:10px;">Awaiting signature...</div>
+      <div id="depositPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Awaiting signature...</div>
       <div class="warn">🔒 Verification is secure. Ensure your bound Solana wallet matches the sender address.</div>
     </div>
 
@@ -162,7 +162,7 @@
       <label for="withdrawAmountInput">Amount to Withdraw (wRTC)</label>
       <input id="withdrawAmountInput" type="number" min="0" step="0.000001" placeholder="Minimum: 1 wRTC">
       <button class="btn btn-primary" id="withdrawBtn" type="button" aria-label="Queue vault withdrawal to Solana">Queue Vault Withdrawal</button>
-      <div id="withdrawPanel" class="panel" style="margin-top:10px;">Queue is currently active.</div>
+      <div id="withdrawPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">Queue is currently active.</div>
       <a class="link-btn" href="{{ wrtc_buy_url }}" target="_blank" rel="noopener">Get wRTC on Raydium ↗</a>
     </div>
 
@@ -173,7 +173,7 @@
         <button class="btn btn-dark" id="historyBtn" type="button" aria-label="Load transaction history">Load History</button>
         <input id="historyLimitInput" type="number" min="1" max="200" value="50" style="max-width:100px;">
       </div>
-      <div id="historyPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
+      <div id="historyPanel" class="panel" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;">No requests yet.</div>
     </div>
   </div>
 </section>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -99,6 +99,24 @@ class TestAccessibilityAttributes(unittest.TestCase):
         self.assertIn('aria-label', match.group(0),
                       "Hero actions container missing aria-label")
 
+    def test_bridge_result_panels_are_live_regions(self):
+        """Bridge status panels should announce updates without stealing focus."""
+        expected_ids = ("infoPanel", "depositPanel", "withdrawPanel", "historyPanel")
+
+        for template_name in ("bridge_wrtc.html", "bridge_base.html"):
+            with self.subTest(template=template_name):
+                content = self.read_file(self.TEMPLATE_DIR / template_name)
+                for panel_id in expected_ids:
+                    match = re.search(rf'<div[^>]*id="{panel_id}"[^>]*>', content)
+                    self.assertIsNotNone(match, f"{template_name} missing {panel_id}")
+                    markup = match.group(0)
+                    self.assertIn('role="status"', markup,
+                                  f"{template_name} {panel_id} missing role='status'")
+                    self.assertIn('aria-live="polite"', markup,
+                                  f"{template_name} {panel_id} missing aria-live")
+                    self.assertIn('aria-atomic="true"', markup,
+                                  f"{template_name} {panel_id} missing aria-atomic")
+
     def test_video_cards_do_not_nest_links(self):
         """Video cards must not put channel or category links inside watch links."""
         for template_name in ('index.html', 'category.html', 'search.html'):


### PR DESCRIPTION
## Summary
- mark the public info, deposit, withdrawal, and history bridge panels as polite live regions on both bridge pages
- keep updates in place so screen readers hear status changes without moving focus
- add an accessibility regression test that locks the live-region attributes in both bridge templates

## Testing
- pytest tests/test_accessibility.py -q
- pytest tests/test_base_wrtc_bridge_validation.py tests/test_wrtc_bridge_validation.py -q
- git diff --check

Closes #1317