### PR TITLE
fix(a11y): make collaboration type cards keyboard operable

### DIFF
--- a/bottube_templates/collaboration_new.html
+++ b/bottube_templates/collaboration_new.html
@@ -41,6 +41,8 @@
     }
 
     .collab-type-option {
+        display: block;
+        width: 100%;
         background: var(--bg-secondary);
         border: 2px solid var(--border);
         border-radius: var(--radius);
@@ -48,6 +50,7 @@
         text-align: center;
         cursor: pointer;
         transition: all 0.2s;
+        color: var(--text-primary);
     }
 
     .collab-type-option:hover {
@@ -246,23 +249,23 @@
             
             <!-- Collaboration Type -->
             <div class="form-group">
-                <label>Collaboration Type</label>
-                <div class="collab-type-selector">
-                    <div class="collab-type-option selected" data-type="duet" onclick="selectType('duet')">
+                <label id="collab-type-label">Collaboration Type</label>
+                <div class="collab-type-selector" role="radiogroup" aria-labelledby="collab-type-label">
+                    <button type="button" class="collab-type-option selected" data-type="duet" role="radio" aria-checked="true" tabindex="0" onclick="selectType('duet')" onkeydown="handleTypeOptionKeydown(event, 'duet')">
                         <div class="collab-type-icon">🎭</div>
                         <div class="collab-type-name">Duet</div>
                         <div class="collab-type-desc">Side-by-side response or reaction</div>
-                    </div>
-                    <div class="collab-type-option" data-type="co-upload" onclick="selectType('co-upload')">
+                    </button>
+                    <button type="button" class="collab-type-option" data-type="co-upload" role="radio" aria-checked="false" tabindex="-1" onclick="selectType('co-upload')" onkeydown="handleTypeOptionKeydown(event, 'co-upload')">
                         <div class="collab-type-icon">🤝</div>
                         <div class="collab-type-name">Co-Upload</div>
                         <div class="collab-type-desc">Joint content creation</div>
-                    </div>
-                    <div class="collab-type-option" data-type="remix" onclick="selectType('remix')">
+                    </button>
+                    <button type="button" class="collab-type-option" data-type="remix" role="radio" aria-checked="false" tabindex="-1" onclick="selectType('remix')" onkeydown="handleTypeOptionKeydown(event, 'remix')">
                         <div class="collab-type-icon">🎵</div>
                         <div class="collab-type-name">Remix</div>
                         <div class="collab-type-desc">Transform existing content</div>
-                    </div>
+                    </button>
                 </div>
                 <input type="hidden" name="type" id="collabType" value="duet">
             </div>
@@ -309,9 +312,41 @@
     function selectType(type) {
         document.querySelectorAll('.collab-type-option').forEach(opt => {
             opt.classList.remove('selected');
+            opt.setAttribute('aria-checked', 'false');
+            opt.setAttribute('tabindex', '-1');
         });
-        document.querySelector(`[data-type="${type}"]`).classList.add('selected');
+        const selectedOption = document.querySelector(`[data-type="${type}"]`);
+        selectedOption.classList.add('selected');
+        selectedOption.setAttribute('aria-checked', 'true');
+        selectedOption.setAttribute('tabindex', '0');
         document.getElementById('collabType').value = type;
+    }
+
+    function handleTypeOptionKeydown(event, type) {
+        if (event.key === ' ' || event.key === 'Enter') {
+            event.preventDefault();
+            selectType(type);
+            document.querySelector(`[data-type="${type}"]`).focus();
+            return;
+        }
+
+        const types = ['duet', 'co-upload', 'remix'];
+        const currentIndex = types.indexOf(type);
+        if (currentIndex === -1) {
+            return;
+        }
+
+        if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+            event.preventDefault();
+            const nextType = types[(currentIndex + 1) % types.length];
+            selectType(nextType);
+            document.querySelector(`[data-type="${nextType}"]`).focus();
+        } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            const previousType = types[(currentIndex - 1 + types.length) % types.length];
+            selectType(previousType);
+            document.querySelector(`[data-type="${previousType}"]`).focus();
+        }
     }
 
     function handleParticipantKeypress(event) {

--- a/bottube_templates/collaboration_new.html
+++ b/bottube_templates/collaboration_new.html
@@ -308,14 +308,19 @@
 
 <script>
     let selectedParticipants = [];
+    const collabTypeSelector = '.collab-type-selector';
+
+    function getTypeOption(type) {
+        return document.querySelector(`${collabTypeSelector} [data-type="${type}"]`);
+    }
 
     function selectType(type) {
-        document.querySelectorAll('.collab-type-option').forEach(opt => {
+        document.querySelectorAll(`${collabTypeSelector} .collab-type-option`).forEach(opt => {
             opt.classList.remove('selected');
             opt.setAttribute('aria-checked', 'false');
             opt.setAttribute('tabindex', '-1');
         });
-        const selectedOption = document.querySelector(`[data-type="${type}"]`);
+        const selectedOption = getTypeOption(type);
         selectedOption.classList.add('selected');
         selectedOption.setAttribute('aria-checked', 'true');
         selectedOption.setAttribute('tabindex', '0');
@@ -326,7 +331,7 @@
         if (event.key === ' ' || event.key === 'Enter') {
             event.preventDefault();
             selectType(type);
-            document.querySelector(`[data-type="${type}"]`).focus();
+            getTypeOption(type).focus();
             return;
         }
 
@@ -340,12 +345,12 @@
             event.preventDefault();
             const nextType = types[(currentIndex + 1) % types.length];
             selectType(nextType);
-            document.querySelector(`[data-type="${nextType}"]`).focus();
+            getTypeOption(nextType).focus();
         } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
             event.preventDefault();
             const previousType = types[(currentIndex - 1 + types.length) % types.length];
             selectType(previousType);
-            document.querySelector(`[data-type="${previousType}"]`).focus();
+            getTypeOption(previousType).focus();
         }
     }
 

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -181,15 +181,26 @@ class TestAccessibilityAttributes(unittest.TestCase):
         self.assertIn('id="collab-type-label"', content,
                       "Collaboration type selector missing visible label id")
 
-        for collab_type in ("duet", "co-upload", "remix"):
-            self.assertRegex(
-                content,
-                rf'data-type="{re.escape(collab_type)}"[^>]*role="radio"[^>]*aria-checked=',
-                f"{collab_type} option should expose radio semantics",
-            )
+        expected_states = {
+            "duet": ('aria-checked="true"', 'tabindex="0"'),
+            "co-upload": ('aria-checked="false"', 'tabindex="-1"'),
+            "remix": ('aria-checked="false"', 'tabindex="-1"'),
+        }
+        for collab_type, (checked_state, tab_index) in expected_states.items():
+            with self.subTest(option=collab_type):
+                self.assertRegex(
+                    content,
+                    rf'data-type="{re.escape(collab_type)}"[^>]*role="radio"[^>]*{checked_state}[^>]*{tab_index}',
+                    f"{collab_type} option should expose the expected radio state",
+                )
 
-        self.assertIn('handleTypeOptionKeydown', content,
+        self.assertIn('function handleTypeOptionKeydown', content,
                       "Collaboration type cards missing keyboard handler")
+        for key in ('ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'):
+            self.assertIn(f"'{key}'", content,
+                          f"Collaboration type cards should handle {key}")
+        self.assertIn("getTypeOption(type).focus()", content,
+                      "Keyboard activation should keep focus on the selected radio")
     
     def test_skip_link_present(self):
         """Test that skip link for keyboard navigation is present."""

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -168,6 +168,28 @@ class TestAccessibilityAttributes(unittest.TestCase):
                     rf'[^<]*{re.escape(label_text)}',
                     f"{control_id} missing associated label",
                 )
+
+    def test_collaboration_type_cards_expose_keyboard_radio_group(self):
+        """Collaboration type cards should expose radio semantics and keyboard support."""
+        content = self.read_file(self.TEMPLATE_DIR / 'collaboration_new.html')
+
+        self.assertRegex(
+            content,
+            r'<div[^>]*class="collab-type-selector"[^>]*role="radiogroup"[^>]*aria-labelledby="collab-type-label"',
+            "Collaboration type selector should expose a named radio group",
+        )
+        self.assertIn('id="collab-type-label"', content,
+                      "Collaboration type selector missing visible label id")
+
+        for collab_type in ("duet", "co-upload", "remix"):
+            self.assertRegex(
+                content,
+                rf'data-type="{re.escape(collab_type)}"[^>]*role="radio"[^>]*aria-checked=',
+                f"{collab_type} option should expose radio semantics",
+            )
+
+        self.assertIn('handleTypeOptionKeydown', content,
+                      "Collaboration type cards missing keyboard handler")
     
     def test_skip_link_present(self):
         """Test that skip link for keyboard navigation is present."""


### PR DESCRIPTION
## Summary
- convert the collaboration type cards into a named radio group with stable checked state
- support keyboard selection with Enter, Space, and arrow keys while keeping the hidden form value in sync
- add an accessibility regression test for the collaboration type selector semantics

## Testing
- pytest tests/test_accessibility.py -q
- git diff --check

## Notes
- pytest tests/test_collaboration.py -q currently fails in this checkout because the collaboration API routes are returning unrelated 404s before this template change is exercised

Closes #1321