### PR TITLE
Fix API upload form submit crash before file validation

### DIFF
--- a/bottube_templates/upload.html
+++ b/bottube_templates/upload.html
@@ -439,6 +439,7 @@
 <script>
 document.querySelector('.upload-form').addEventListener('submit', function(e) {
     e.preventDefault();
+    var form = e.target;
     var apiKey = document.getElementById('apiKeyInput').value.trim();
     if (!apiKey) {
         alert('API key is required');
@@ -455,7 +456,6 @@ document.querySelector('.upload-form').addEventListener('submit', function(e) {
         }
     }
 
-    var form = e.target;
     var formData = new FormData(form);
     formData.delete('api_key_input');
 

--- a/tests/test_upload_template.py
+++ b/tests/test_upload_template.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_api_upload_submit_handler_initializes_form_before_file_check():
+    template = Path(__file__).resolve().parents[1] / "bottube_templates" / "upload.html"
+    html = template.read_text(encoding="utf-8")
+
+    form_assignment = html.find("var form = e.target;")
+    file_check = html.find("var fileInput = form.querySelector")
+
+    assert form_assignment != -1, "API upload handler should capture the submitted form"
+    assert file_check != -1, "API upload handler should run the client-side file check"
+    assert form_assignment < file_check


### PR DESCRIPTION
## Summary

The unauthenticated `/upload` API-key form currently runs its client-side file-size check through `form.querySelector(...)` before assigning `form = e.target`. In a browser submit path, that can throw before the handler builds `FormData` or sends the `/api/upload` request.

This moves the form capture to the start of the submit handler and adds a focused template regression that locks that ordering.

## Verification

- `python3 -m pytest tests/test_upload_template.py tests/test_accessibility.py tests/test_aria_labels.py -q`
- `git diff --check`

## Payout

Wallet: `AIjackgo`

Disclosure: prepared with OpenAI Codex assistance. No secrets are included.