### PR TITLE
Fix header search input accessible name

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -832,7 +832,7 @@
         </div>
 
         <form class="search-bar" action="{{ P }}/search" method="get" role="search" aria-label="{{ _('nav.search') }}">
-            <input type="text" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}">
+            <input type="text" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}" aria-label="{{ _('nav.search_placeholder') }}">
             <button type="submit" aria-label="{{ _('nav.search') }}">{{ _('nav.search') }}</button>
         </form>
 

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -137,6 +137,11 @@ class TestAccessibilityAttributes(unittest.TestCase):
         self.assertIn('aria-label', match.group(0),
                       "Search form missing aria-label")
 
+        input_match = re.search(r'<input[^>]*name="q"[^>]*>', content)
+        self.assertIsNotNone(input_match, "Header search input not found")
+        self.assertIn('aria-label', input_match.group(0),
+                      "Header search input missing accessible name")
+
     def test_agents_page_search_input_has_accessible_name(self):
         """Test that the agents page filter input has a programmatic label."""
         content = self.read_file(self.TEMPLATE_DIR / 'agents.html')


### PR DESCRIPTION
## Summary
- add an accessible name to the shared header search input
- extend the existing accessibility regression test so the input itself is covered, not only the surrounding search landmark and submit button

## Why
The header search form and submit button are named, but the query input only exposed placeholder text. Screen reader users should get a stable accessible name for the field itself.

## Verification
Red test before fix:

```text
python3 -m pytest tests/test_accessibility.py::TestAccessibilityAttributes::test_search_form_has_aria_label -q
FAILED: Header search input missing accessible name
```

After fix:

```text
python3 -m pytest tests/test_accessibility.py::TestAccessibilityAttributes::test_search_form_has_aria_label -q
1 passed

python3 -m pytest tests/test_accessibility.py tests/test_aria_labels.py -q
30 passed, 10 subtests passed

python3 -m pytest tests/test_homepage_accessibility.py::test_homepage_templates_include_mobile_overflow_guards -q
1 passed

python3 -m pytest tests/test_upload_template.py -q
1 passed

git diff --check
pass
```

Note: the full `tests/test_homepage_accessibility.py` run has an unrelated local test-client setup error in this environment before it reaches the page: `AttributeError: module werkzeug has no attribute __version__`.

Wallet: AIjackgo
