### PR TITLE
Fix GPU marketplace API auth crashes

### DIFF
--- a/gpu_marketplace.py
+++ b/gpu_marketplace.py
@@ -192,11 +192,46 @@ def transfer_rtc(from_id: int, to_id: int, amount: float, memo: str = "") -> boo
     except Exception:
         return False
 
+
+def require_gpu_api_key(f):
+    """Require an agent API key and expose the agent on flask.g."""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        api_key = request.headers.get("X-API-Key", "")
+        if not api_key:
+            return jsonify({"error": "Missing X-API-Key header"}), 401
+
+        db = get_db()
+        agent = db.execute(
+            "SELECT * FROM agents WHERE api_key = ?", (api_key,)
+        ).fetchone()
+        if not agent:
+            return jsonify({"error": "Invalid API key"}), 401
+
+        try:
+            if agent["is_banned"]:
+                return jsonify({
+                    "error": "Account banned",
+                    "reason": agent["ban_reason"] or "",
+                }), 403
+        except (IndexError, KeyError):
+            pass
+
+        db.execute(
+            "UPDATE agents SET last_active = ? WHERE id = ?",
+            (time.time(), agent["id"]),
+        )
+        db.commit()
+        g.agent = agent
+        return f(*args, **kwargs)
+    return decorated
+
 # ---------------------------------------------------------------------------
 # PROVIDER ENDPOINTS
 # ---------------------------------------------------------------------------
 
 @gpu_bp.route('/providers/register', methods=['POST'])
+@require_gpu_api_key
 def register_provider():
     """Register as a GPU provider.
 
@@ -240,6 +275,7 @@ def register_provider():
 
 
 @gpu_bp.route('/providers/heartbeat', methods=['POST'])
+@require_gpu_api_key
 def provider_heartbeat():
     """Send heartbeat to stay online and receive jobs.
 
@@ -329,6 +365,7 @@ def list_providers():
 
 
 @gpu_bp.route('/providers/stats', methods=['GET'])
+@require_gpu_api_key
 def provider_stats():
     """Get stats for the authenticated provider."""
     agent = g.agent
@@ -358,6 +395,7 @@ def provider_stats():
 # ---------------------------------------------------------------------------
 
 @gpu_bp.route('/jobs/submit', methods=['POST'])
+@require_gpu_api_key
 def submit_job():
     """Submit a GPU rendering job.
 
@@ -409,6 +447,7 @@ def submit_job():
 
 
 @gpu_bp.route('/jobs/claim', methods=['POST'])
+@require_gpu_api_key
 def claim_job():
     """Claim a pending job as a GPU provider.
 
@@ -467,6 +506,7 @@ def claim_job():
 
 
 @gpu_bp.route('/jobs/start', methods=['POST'])
+@require_gpu_api_key
 def start_job():
     """Mark a claimed job as started (running).
 
@@ -506,6 +546,7 @@ def start_job():
 
 
 @gpu_bp.route('/jobs/complete', methods=['POST'])
+@require_gpu_api_key
 def complete_job():
     """Mark a job as completed and receive payment.
 
@@ -581,6 +622,7 @@ def complete_job():
 
 
 @gpu_bp.route('/jobs/fail', methods=['POST'])
+@require_gpu_api_key
 def fail_job():
     """Mark a job as failed.
 
@@ -658,6 +700,7 @@ def get_job_status(job_id):
 
 
 @gpu_bp.route('/jobs/list', methods=['GET'])
+@require_gpu_api_key
 def list_jobs():
     """List jobs (filtered by status or requester)."""
     agent = g.agent

--- a/tests/test_gpu_marketplace_auth.py
+++ b/tests/test_gpu_marketplace_auth.py
@@ -1,0 +1,80 @@
+import sqlite3
+
+import pytest
+import werkzeug
+from flask import Flask
+
+from gpu_marketplace import gpu_bp, init_gpu_tables
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    if not hasattr(werkzeug, "__version__"):
+        monkeypatch.setattr(werkzeug, "__version__", "test", raising=False)
+
+    db_path = tmp_path / "bottube_gpu.db"
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(db_path))
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            display_name TEXT,
+            api_key TEXT UNIQUE NOT NULL,
+            is_banned INTEGER DEFAULT 0,
+            ban_reason TEXT,
+            last_active REAL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE balances (
+            miner_id TEXT PRIMARY KEY,
+            amount_i64 INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO agents (agent_name, display_name, api_key, last_active)
+        VALUES ('gpu_agent', 'GPU Agent', 'bottube_sk_gpu_agent', 0)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO balances (miner_id, amount_i64)
+        VALUES ('gpu_agent', 1000000)
+        """
+    )
+    conn.commit()
+    conn.close()
+    init_gpu_tables(str(db_path))
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(gpu_bp)
+
+    yield app.test_client()
+
+
+def test_provider_registration_requires_api_key(client):
+    resp = client.post("/api/gpu/providers/register", json={"gpu_model": "RTX 3080"})
+
+    assert resp.status_code == 401
+    assert resp.get_json() == {"error": "Missing X-API-Key header"}
+
+
+def test_provider_registration_sets_authenticated_agent(client):
+    resp = client.post(
+        "/api/gpu/providers/register",
+        headers={"X-API-Key": "bottube_sk_gpu_agent"},
+        json={"gpu_model": "RTX 3080", "gpu_vram_gb": 10},
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["provider_id"].startswith("gpu_")
+    assert data["gpu_model"] == "RTX 3080"


### PR DESCRIPTION
## Summary
- add a GPU-marketplace API-key guard that loads `g.agent` before mutating routes run
- keep public GPU marketplace reads public (`providers/list`, job status, marketplace stats)
- add focused regression tests for missing-key rejection and valid-key provider registration

## Why
The GPU marketplace blueprint is registered directly, but several routes dereference `g.agent` without an auth decorator. That makes unauthenticated calls crash and prevents valid API-key calls from loading an agent identity before provider/job actions run.

## Verification
Red before fix:

```text
python3 -m pytest tests/test_gpu_marketplace_auth.py -q
FAILED tests/test_gpu_marketplace_auth.py::test_provider_registration_requires_api_key
FAILED tests/test_gpu_marketplace_auth.py::test_provider_registration_sets_authenticated_agent
AttributeError: agent
```

After fix:

```text
python3 -m pytest tests/test_gpu_marketplace_auth.py -q
2 passed

python3 -m py_compile gpu_marketplace.py tests/test_gpu_marketplace_auth.py
pass

git diff --check
pass
```

Note: I also tried nearby full-app auth tests, but this local environment fails before route execution because Flask 2.3.2 expects `werkzeug.__version__` and the installed Werkzeug no longer exposes it. The focused GPU blueprint test patches that test-client compatibility issue locally and exercises the route behavior directly.

Wallet: AIjackgo
