### PR TITLE
Fix report form retry after error

### DIFF
--- a/bottube_templates/report.html
+++ b/bottube_templates/report.html
@@ -90,7 +90,7 @@
 
     <div class="form-row">By submitting you confirm the report is made in good faith. Knowingly false reports may result in account suspension.</div>
 
-    <div id="r-toast" class="toast">Report received. Thank you. Reference: <code id="r-ref"></code></div>
+    <div id="r-toast" class="toast"><span id="r-toast-message">Report received. Thank you. Reference:</span> <code id="r-ref"></code></div>
 
     <div class="submit-row">
       <a href="{{ P }}/aup" style="color:var(--text-secondary);font-size:13px;">Read the AUP →</a>
@@ -104,8 +104,11 @@ function submitReport(ev) {
   ev.preventDefault();
   var btn = document.getElementById('r-submit');
   var toast = document.getElementById('r-toast');
+  var message = document.getElementById('r-toast-message');
   var ref = document.getElementById('r-ref');
   toast.classList.remove('show', 'error');
+  message.textContent = 'Report received. Thank you. Reference:';
+  ref.textContent = '';
   btn.disabled = true;
   btn.textContent = 'Submitting…';
 
@@ -128,11 +131,11 @@ function submitReport(ev) {
         document.getElementById('report-form').reset();
       } else {
         toast.classList.add('show', 'error');
-        toast.textContent = (resp.body && resp.body.error) ? resp.body.error : 'Submission failed. Please email abuse@elyanlabs.ai if urgent.';
+        message.textContent = (resp.body && resp.body.error) ? resp.body.error : 'Submission failed. Please email abuse@elyanlabs.ai if urgent.';
       }
     }).catch(function () {
       toast.classList.add('show', 'error');
-      toast.textContent = 'Network error. Please try again or email abuse@elyanlabs.ai.';
+      message.textContent = 'Network error. Please try again or email abuse@elyanlabs.ai.';
     }).finally(function () {
       btn.disabled = false;
       btn.textContent = 'Submit report';

--- a/tests/test_report_template.py
+++ b/tests/test_report_template.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPORT_TEMPLATE = ROOT / "bottube_templates" / "report.html"
+
+
+def test_report_errors_do_not_remove_success_reference_node():
+    html = REPORT_TEMPLATE.read_text(encoding="utf-8")
+
+    assert 'id="r-toast-message"' in html
+    assert "document.getElementById('r-toast-message')" in html
+    assert "toast.textContent =" not in html
+    assert "ref.textContent = resp.body.report_id" in html


### PR DESCRIPTION
## Summary
- keep the public report toast message and reference id in separate stable nodes
- avoid replacing the whole toast with `textContent` on error states
- add a template regression so future error paths cannot remove the success reference node

## Why
The report page starts with `Report received... <code id="r-ref"></code>`, but error paths assigned `toast.textContent`. That removes the `r-ref` node. If the user corrects the report and the next submit succeeds, the success path can throw while writing the report id, producing misleading feedback in the abuse reporting flow.

## Verification
Red before fix:

```text
python3 -m pytest tests/test_report_template.py -q
FAILED: assert id=r-toast-message in html
```

After fix:

```text
python3 -m pytest tests/test_report_template.py -q
1 passed

python3 -m py_compile tests/test_report_template.py
pass

git diff --check
pass
```

Note: I also tried `tests/test_public_report_input_validation.py`, but this local environment fails before route execution because Flask 2.3.2 expects `werkzeug.__version__` and the installed Werkzeug no longer exposes it.

Wallet: AIjackgo
