### PR TITLE
Fix Discover tag clicks for quoted names

### DIFF
--- a/bottube_templates/discover.html
+++ b/bottube_templates/discover.html
@@ -331,6 +331,12 @@
     // Load trending videos on page load
     document.addEventListener('DOMContentLoaded', () => {
         loadTrending();
+
+        document.getElementById('tagsCloud').addEventListener('click', function(e) {
+            const target = e.target.closest('.tag-item');
+            if (!target) return;
+            searchByTag(target.dataset.tag);
+        });
     });
 
     // Search on Enter key
@@ -447,7 +453,7 @@
                 const data = await response.json();
                 
                 tagsCloud.innerHTML = data.tags.map(tag => `
-                    <span class="tag-item" onclick="searchByTag('${escapeHtml(tag.name)}')">
+                    <span class="tag-item" data-tag="${escapeAttribute(tag.name)}">
                         ${escapeHtml(tag.name)}<span class="tag-count">${tag.count}</span>
                     </span>
                 `).join('');

--- a/tests/test_discover_agent_card_escaping.py
+++ b/tests/test_discover_agent_card_escaping.py
@@ -22,3 +22,12 @@ def test_agent_card_has_attribute_and_url_helpers():
     assert "function safeImageUrl(url)" in html
     assert "parsed.protocol === 'http:' || parsed.protocol === 'https:'" in html
     assert "value.startsWith('/') && !value.startsWith('//')" in html
+
+
+def test_tag_chips_do_not_embed_names_in_inline_javascript():
+    html = DISCOVER_TEMPLATE.read_text(encoding="utf-8")
+
+    assert 'data-tag="${escapeAttribute(tag.name)}"' in html
+    assert "onclick=\"searchByTag('${escapeHtml(tag.name)}')\"" not in html
+    assert "document.getElementById('tagsCloud').addEventListener('click'" in html
+    assert "target.dataset.tag" in html


### PR DESCRIPTION
## Summary
- stop embedding API-backed tag names inside inline JavaScript string literals
- render tag names into data-tag with attribute escaping
- use one delegated click handler to call searchByTag(target.dataset.tag)

## Why
escapeHtml() is safe for visible text, but it is not a JavaScript string-literal encoder. A tag name containing an apostrophe or quote can break the inline onclick handler, making Discover tag chips unclickable.

## Verification
Red before fix:

```text
python3 -m pytest tests/test_discover_agent_card_escaping.py::test_tag_chips_do_not_embed_names_in_inline_javascript -q
FAILED: expected the tag chip to render a data-tag attribute using escapeAttribute(tag.name)
```

After fix:

```text
python3 -m pytest tests/test_discover_agent_card_escaping.py -q
3 passed

python3 -m py_compile tests/test_discover_agent_card_escaping.py
pass

git diff --check
pass
```

Wallet: AIjackgo