### PR TITLE
Fix syndication JSON body validation crashes

### DIFF
--- a/syndication_routes.py
+++ b/syndication_routes.py
@@ -66,6 +66,15 @@ def _is_admin_request() -> bool:
     return bool(ADMIN_KEY and admin_key == ADMIN_KEY)
 
 
+def _json_object_body():
+    data = request.get_json()
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON body must be an object"}), 400)
+    return data, None
+
+
 def require_api_key(f):
     """Decorator to require API key authentication."""
     @wraps(f)
@@ -104,7 +113,9 @@ def start_run():
     Response:
         run_id (int): The new run ID
     """
-    data = request.get_json() or {}
+    data, error = _json_object_body()
+    if error:
+        return error
     
     run_type = data.get("run_type")
     if not run_type:
@@ -143,7 +154,9 @@ def end_run(run_id):
     Response:
         ok (bool): Success indicator
     """
-    data = request.get_json() or {}
+    data, error = _json_object_body()
+    if error:
+        return error
     
     status = data.get("status", "completed")
     if status not in ("completed", "failed", "partial", "cancelled"):
@@ -193,7 +206,9 @@ def log_item():
     Response:
         item_id (int): The new item ID
     """
-    data = request.get_json() or {}
+    data, error = _json_object_body()
+    if error:
+        return error
     
     run_id = data.get("run_id")
     content_id = data.get("content_id")
@@ -256,7 +271,9 @@ def update_item(item_id):
     Response:
         ok (bool): Success indicator
     """
-    data = request.get_json() or {}
+    data, error = _json_object_body()
+    if error:
+        return error
 
     status = data.get("status")
     if not status or status not in ("success", "failed", "pending", "skipped"):

--- a/tests/test_syndication_routes.py
+++ b/tests/test_syndication_routes.py
@@ -4,6 +4,11 @@ import sys
 from pathlib import Path
 
 import pytest
+import werkzeug
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "test"
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -99,6 +104,28 @@ def test_update_item_requires_owner_scope(client):
         json={"status": "success", "external_id": "x_123"},
     )
     assert allowed.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        ("post", "/api/syndication/run/start", ["run_type"]),
+        ("post", "/api/syndication/run/1/end", ["status"]),
+        ("post", "/api/syndication/item", ["run_id"]),
+        ("put", "/api/syndication/item/1", ["status"]),
+    ],
+)
+def test_write_routes_reject_non_object_json(client, method, path, payload):
+    _insert_agent("jsonbot", "bottube_sk_jsonbot")
+
+    resp = getattr(client, method)(
+        path,
+        headers={"X-API-Key": "bottube_sk_jsonbot"},
+        json=payload,
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON body must be an object"}
 
 
 def test_report_routes_scope_normal_agents_and_expand_for_admin(client):


### PR DESCRIPTION
## Summary
- Reject non-object JSON bodies before syndication write routes read fields.
- Preserve the existing missing-body behavior as an empty object for route defaults.
- Cover malformed array payloads on run start/end, item create, and item update.

## Root cause
The authenticated syndication write endpoints used `request.get_json() or {}` and immediately called `.get(...)`. A JSON array is truthy and has no `.get`, so malformed client input raised `AttributeError` inside the route instead of returning a 400 response.

## Verification
- RED before fix: `python3 -m pytest tests/test_syndication_routes.py::test_write_routes_reject_non_object_json -q` failed with `AttributeError: list object has no attribute get` in the syndication routes.
- GREEN after fix: `python3 -m pytest tests/test_syndication_routes.py::test_write_routes_reject_non_object_json -q` -> `4 passed`
- `python3 -m pytest tests/test_syndication_routes.py -q` -> `7 passed`
- `python3 -m py_compile syndication_routes.py tests/test_syndication_routes.py`
- `git diff --check`

Wallet: AIjackgo
