### PR TITLE
Fix Ergo admin withdrawal JSON validation

### DIFF
--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -533,9 +533,13 @@ def process_withdrawals():
     if not _admin_ok(admin_key):
         return jsonify({"error": "Admin key required"}), 401
 
-    data = request.get_json() or {}
+    data, error = _request_json_object()
+    if error:
+        return error
     withdrawal_id = data.get("withdrawal_id")
-    tx_id = data.get("tx_id", "").strip()
+    tx_id, error = _string_field(data, "tx_id")
+    if error:
+        return error
 
     if not withdrawal_id or not tx_id:
         return jsonify({"error": "withdrawal_id and tx_id required"}), 400

--- a/tests/test_ergo_bridge_validation.py
+++ b/tests/test_ergo_bridge_validation.py
@@ -4,9 +4,14 @@
 import sqlite3
 
 import pytest
+import werkzeug
 from flask import Flask, g
 
 import ergo_bridge_blueprint
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "test"
 
 
 @pytest.fixture()
@@ -56,6 +61,7 @@ def client(tmp_path, monkeypatch):
             db.close()
 
     monkeypatch.setattr(ergo_bridge_blueprint, "get_db", _test_get_db)
+    monkeypatch.setattr(ergo_bridge_blueprint, "ADMIN_KEY", "test-admin")
 
     test_client = app.test_client()
     test_client.db_path = db_path
@@ -64,6 +70,10 @@ def client(tmp_path, monkeypatch):
 
 def _auth_headers():
     return {"X-API-Key": "bottube_sk_ergo_agent"}
+
+
+def _admin_headers():
+    return {"X-Admin-Key": "test-admin"}
 
 
 def _counts_and_balance(db_path):
@@ -148,4 +158,32 @@ def test_ergo_withdraw_rejects_invalid_amount_without_queue_or_debit(client, amo
 
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "amount_rtc must be a finite positive number"
+    assert _counts_and_balance(client.db_path) == before
+
+
+def test_process_withdrawals_rejects_non_object_json(client):
+    before = _counts_and_balance(client.db_path)
+
+    resp = client.post(
+        "/api/ergo/process-withdrawals",
+        json=["withdrawal_id", "tx_id"],
+        headers=_admin_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+    assert _counts_and_balance(client.db_path) == before
+
+
+def test_process_withdrawals_rejects_non_string_tx_id(client):
+    before = _counts_and_balance(client.db_path)
+
+    resp = client.post(
+        "/api/ergo/process-withdrawals",
+        json={"withdrawal_id": 1, "tx_id": ["ergo_tx"]},
+        headers=_admin_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "tx_id must be a string"
     assert _counts_and_balance(client.db_path) == before


### PR DESCRIPTION
## Summary
- Reuse the Ergo bridge JSON-object parser in `/api/ergo/process-withdrawals`.
- Validate `tx_id` with the existing string-field helper before calling `.strip()`.
- Add regression tests for non-object admin JSON and non-string `tx_id` values.

## Root cause
The public Ergo deposit/withdraw routes already rejected malformed JSON through shared helpers, but the admin withdrawal-completion route still used `request.get_json() or {}` and then called `.get(...)` / `.strip()` directly. JSON arrays or non-string `tx_id` values could raise `AttributeError` before returning a 400 response.

## Verification
- RED before fix: `python3 -m pytest tests/test_ergo_bridge_validation.py::test_process_withdrawals_rejects_non_object_json tests/test_ergo_bridge_validation.py::test_process_withdrawals_rejects_non_string_tx_id -q` failed with `AttributeError` on `.get` and `.strip()` in `process_withdrawals`.
- GREEN after fix: same focused command -> `2 passed`
- `python3 -m pytest tests/test_ergo_bridge_validation.py -q` -> `12 passed`
- `python3 -m py_compile ergo_bridge_blueprint.py tests/test_ergo_bridge_validation.py`
- `git diff --check`

Wallet: AIjackgo
