### PR TITLE
Fix creator analytics public video id metrics

### DIFF
--- a/analytics_blueprint.py
+++ b/analytics_blueprint.py
@@ -20,6 +20,11 @@ def get_db():
     """Get database connection from Flask app context or create new one."""
     if 'db' in g:
         return g.db
+    try:
+        from bottube_server import get_db as app_get_db
+        return app_get_db()
+    except ImportError:
+        pass
     # Fallback: create connection directly
     db = sqlite3.connect(str(Path(__file__).parent / "bottube.db"))
     db.row_factory = sqlite3.Row
@@ -73,7 +78,7 @@ def api_views():
     if video_id:
         # Check if video exists and belongs to the agent
         video_exists = db.execute(
-            """SELECT 1 FROM videos WHERE id = ? AND agent_id = ?""",
+            """SELECT 1 FROM videos WHERE video_id = ? AND agent_id = ?""",
             (video_id, agent_id)
         ).fetchone()
         if not video_exists:
@@ -96,7 +101,7 @@ def api_views():
     else:
         # Get all videos by this agent
         videos = db.execute(
-            "SELECT id FROM videos WHERE agent_id = ?",
+            "SELECT video_id FROM videos WHERE agent_id = ?",
             (agent_id,)
         ).fetchall()
         video_ids = [v[0] for v in videos]
@@ -156,7 +161,7 @@ def api_engagement():
     
     # Get agent's videos
     videos = db.execute(
-        "SELECT id FROM videos WHERE agent_id = ?",
+        "SELECT video_id FROM videos WHERE agent_id = ?",
         (agent_id,)
     ).fetchall()
     video_ids = [v[0] for v in videos]
@@ -189,27 +194,42 @@ def api_engagement():
     # Tips count (from earnings table with 'tip' reason)
     tips_result = db.execute(
         f"""SELECT COALESCE(SUM(amount), 0) FROM earnings 
-            WHERE agent_id = ? AND reason LIKE '%tip%' AND created_at >= ?""",
-        (agent_id, start_timestamp)
+            WHERE agent_id = ? AND video_id IN ({placeholders})
+            AND reason LIKE '%tip%' AND created_at >= ?""",
+        (agent_id, *video_ids, start_timestamp)
     ).fetchone()
     total_tips = tips_result[0] if tips_result else 0
     
-    # Breakdown by video
+    # Breakdown by video. Pre-aggregate each event table so repeated equal
+    # votes/tips are counted instead of collapsed by DISTINCT during joins.
     by_video = db.execute(
         f"""SELECT 
-                v.id,
+                v.video_id,
                 v.title,
-                COUNT(DISTINCT c.id) as comments,
-                COALESCE(SUM(DISTINCT vo.vote), 0) as votes,
-                COALESCE(SUM(DISTINCT e.amount), 0) as tips
+                COALESCE(c.comments, 0) as comments,
+                COALESCE(vo.votes, 0) as votes,
+                COALESCE(e.tips, 0) as tips
             FROM videos v
-            LEFT JOIN comments c ON c.video_id = v.id AND c.created_at >= ?
-            LEFT JOIN votes vo ON vo.video_id = v.id AND vo.created_at >= ?
-            LEFT JOIN earnings e ON e.video_id = v.id AND e.agent_id = v.agent_id 
-                AND e.reason LIKE '%tip%' AND e.created_at >= ?
+            LEFT JOIN (
+                SELECT video_id, COUNT(*) as comments
+                FROM comments
+                WHERE created_at >= ?
+                GROUP BY video_id
+            ) c ON c.video_id = v.video_id
+            LEFT JOIN (
+                SELECT video_id, SUM(vote) as votes
+                FROM votes
+                WHERE created_at >= ?
+                GROUP BY video_id
+            ) vo ON vo.video_id = v.video_id
+            LEFT JOIN (
+                SELECT agent_id, video_id, SUM(amount) as tips
+                FROM earnings
+                WHERE reason LIKE '%tip%' AND created_at >= ?
+                GROUP BY agent_id, video_id
+            ) e ON e.video_id = v.video_id AND e.agent_id = v.agent_id
             WHERE v.agent_id = ?
-            GROUP BY v.id
-            ORDER BY (comments + votes) DESC""",
+            ORDER BY (COALESCE(c.comments, 0) + COALESCE(vo.votes, 0)) DESC""",
         (start_timestamp, start_timestamp, start_timestamp, agent_id)
     ).fetchall()
     
@@ -263,7 +283,7 @@ def api_top_videos():
         order_clause = "ORDER BY view_count DESC"
     
     query = f"""SELECT 
-            v.id,
+            v.video_id,
             v.title,
             v.created_at,
             COALESCE(vc.count, 0) as view_count,
@@ -273,17 +293,17 @@ def api_top_videos():
         FROM videos v
         LEFT JOIN (
             SELECT video_id, COUNT(*) as count FROM views GROUP BY video_id
-        ) vc ON vc.video_id = v.id
+        ) vc ON vc.video_id = v.video_id
         LEFT JOIN (
             SELECT video_id, COUNT(*) as count FROM comments GROUP BY video_id
-        ) cc ON cc.video_id = v.id
+        ) cc ON cc.video_id = v.video_id
         LEFT JOIN (
             SELECT video_id, SUM(vote) as sum_votes FROM votes GROUP BY video_id
-        ) vc2 ON vc2.video_id = v.id
+        ) vc2 ON vc2.video_id = v.video_id
         LEFT JOIN (
-            SELECT video_id, SUM(amount) as total FROM earnings 
-            WHERE reason LIKE '%tip%' GROUP BY video_id
-        ) te ON te.video_id = v.id
+            SELECT agent_id, video_id, SUM(amount) as total FROM earnings
+            WHERE reason LIKE '%tip%' GROUP BY agent_id, video_id
+        ) te ON te.video_id = v.video_id AND te.agent_id = v.agent_id
         WHERE v.agent_id = ?
         {order_clause}
         LIMIT ?"""
@@ -320,7 +340,7 @@ def api_audience():
     
     # Get agent's videos
     videos = db.execute(
-        "SELECT id FROM videos WHERE agent_id = ?",
+        "SELECT video_id FROM videos WHERE agent_id = ?",
         (agent_id,)
     ).fetchall()
     video_ids = [v[0] for v in videos]
@@ -386,7 +406,7 @@ def api_export_csv():
         writer.writerow(['video_id', 'title', 'created_at', 'views', 'comments', 'votes', 'tips_rtc'])
         
         videos = db.execute("""SELECT 
-                v.id,
+                v.video_id,
                 v.title,
                 v.created_at,
                 COALESCE(vc.count, 0) as view_count,
@@ -396,17 +416,17 @@ def api_export_csv():
             FROM videos v
             LEFT JOIN (
                 SELECT video_id, COUNT(*) as count FROM views GROUP BY video_id
-            ) vc ON vc.video_id = v.id
+            ) vc ON vc.video_id = v.video_id
             LEFT JOIN (
                 SELECT video_id, COUNT(*) as count FROM comments GROUP BY video_id
-            ) cc ON cc.video_id = v.id
+            ) cc ON cc.video_id = v.video_id
             LEFT JOIN (
                 SELECT video_id, SUM(vote) as sum_votes FROM votes GROUP BY video_id
-            ) vc2 ON vc2.video_id = v.id
+            ) vc2 ON vc2.video_id = v.video_id
             LEFT JOIN (
-                SELECT video_id, SUM(amount) as total FROM earnings 
-                WHERE reason LIKE '%tip%' GROUP BY video_id
-            ) te ON te.video_id = v.id
+                SELECT agent_id, video_id, SUM(amount) as total FROM earnings
+                WHERE reason LIKE '%tip%' GROUP BY agent_id, video_id
+            ) te ON te.video_id = v.video_id AND te.agent_id = v.agent_id
             WHERE v.agent_id = ?
             ORDER BY v.created_at DESC""", (agent_id,)).fetchall()
         
@@ -428,7 +448,7 @@ def api_export_csv():
         writer.writerow(['date', 'views'])
         
         videos = db.execute(
-            "SELECT id FROM videos WHERE agent_id = ?",
+            "SELECT video_id FROM videos WHERE agent_id = ?",
             (agent_id,)
         ).fetchall()
         video_ids = [v[0] for v in videos]
@@ -481,7 +501,7 @@ def api_summary():
     
     # Total views (all time)
     video_ids = db.execute(
-        "SELECT id FROM videos WHERE agent_id = ?",
+        "SELECT video_id FROM videos WHERE agent_id = ?",
         (agent_id,)
     ).fetchall()
     
@@ -503,7 +523,7 @@ def api_summary():
     # Subscribers
     subscribers = db.execute(
         """SELECT COUNT(*) FROM subscriptions 
-           WHERE channel_id = (SELECT id FROM agents WHERE id = ?)""",
+           WHERE following_id = (SELECT id FROM agents WHERE id = ?)""",
         (agent_id,)
     ).fetchone()[0]
     

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -8,19 +8,27 @@ Tests cover:
 """
 
 import os
+import csv
+import io
 import sqlite3
 import sys
 import time
 from pathlib import Path
 
 import pytest
+import werkzeug
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "test"
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-os.environ.setdefault("BOTTUBE_DB_PATH", "/tmp/bottube_test_analytics.db")
-os.environ.setdefault("BOTTUBE_DB", "/tmp/bottube_test_analytics.db")
+_bootstrap_db_path = f"/tmp/bottube_test_analytics_{os.getpid()}.db"
+os.environ.setdefault("BOTTUBE_DB_PATH", _bootstrap_db_path)
+os.environ.setdefault("BOTTUBE_DB", _bootstrap_db_path)
 
 _orig_sqlite_connect = sqlite3.connect
 
@@ -143,6 +151,57 @@ def _insert_view(video_id, ip="127.0.0.1", created_at=None):
         db.commit()
 
 
+def _insert_comment(video_id, agent_id, created_at=None):
+    """Insert a test comment for a public video id."""
+    if created_at is None:
+        created_at = time.time()
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO comments (video_id, agent_id, content, created_at)
+            VALUES (?, ?, 'analytics comment', ?)
+            """,
+            (video_id, agent_id, created_at),
+        )
+        db.commit()
+
+
+def _insert_vote(video_id, agent_id, vote=1, created_at=None):
+    """Insert a test vote for a public video id."""
+    if created_at is None:
+        created_at = time.time()
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO votes (agent_id, video_id, vote, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (agent_id, video_id, vote, created_at),
+        )
+        db.commit()
+
+
+def _insert_earning(agent_id, amount, reason, video_id, created_at=None):
+    """Insert a test earning for a public video id."""
+    if created_at is None:
+        created_at = time.time()
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            INSERT INTO earnings (agent_id, amount, reason, video_id, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (agent_id, amount, reason, video_id, created_at),
+        )
+        db.commit()
+
+
 # =============================================================================
 # Analytics Page Access Tests
 # =============================================================================
@@ -230,6 +289,71 @@ class TestAnalyticsApiCoreMetrics:
         data = response.get_json()
         
         assert data["totals"]["videos"] == 5
+
+    def test_creator_analytics_blueprint_uses_public_video_ids(self, client):
+        """Blueprint analytics should count events stored by public video_id."""
+        now = time.time()
+        owner_id = _insert_agent("blueprintowner", "test-key-blueprint-owner")
+        commenter_one_id = _insert_agent("blueprintcommenter1", "test-key-blueprint-commenter-1")
+        commenter_two_id = _insert_agent("blueprintcommenter2", "test-key-blueprint-commenter-2")
+        unrelated_id = _insert_agent("blueprintunrelated", "test-key-blueprint-unrelated")
+        video_id = _insert_video(owner_id, "public-analytics-clip", "Public ID Analytics")
+
+        _insert_view(video_id, "10.0.0.1", created_at=now)
+        _insert_view(video_id, "10.0.0.2", created_at=now)
+        _insert_comment(video_id, commenter_one_id, created_at=now)
+        _insert_vote(video_id, commenter_one_id, vote=1, created_at=now)
+        _insert_vote(video_id, commenter_two_id, vote=1, created_at=now)
+        _insert_earning(owner_id, 0.25, "tip_received", video_id, created_at=now)
+        _insert_earning(owner_id, 0.25, "tip_received", video_id, created_at=now)
+        _insert_earning(unrelated_id, 9.0, "tip_received", video_id, created_at=now)
+
+        views = client.get(f"/analytics/api/views?agent_id={owner_id}&period=7d")
+        filtered_views = client.get(
+            f"/analytics/api/views?agent_id={owner_id}&video_id={video_id}&period=7d"
+        )
+        engagement = client.get(f"/analytics/api/engagement?agent_id={owner_id}&period=7d")
+        top = client.get(f"/analytics/api/top-videos?agent_id={owner_id}&metric=engagement")
+        audience = client.get(f"/analytics/api/audience?agent_id={owner_id}")
+        summary = client.get(f"/analytics/api/summary?agent_id={owner_id}")
+        export = client.get(f"/analytics/api/export/csv?agent_id={owner_id}&type=videos")
+
+        assert views.status_code == 200
+        assert views.get_json()["total_views"] == 2
+        assert filtered_views.status_code == 200
+        assert filtered_views.get_json()["total_views"] == 2
+
+        assert engagement.status_code == 200
+        engagement_body = engagement.get_json()
+        assert engagement_body["total_comments"] == 1
+        assert engagement_body["total_votes"] == 2
+        assert engagement_body["total_tips"] == 0.5
+        assert engagement_body["by_video"][0]["video_id"] == video_id
+        assert engagement_body["by_video"][0]["comments"] == 1
+        assert engagement_body["by_video"][0]["votes"] == 2
+        assert engagement_body["by_video"][0]["tips"] == 0.5
+
+        assert top.status_code == 200
+        top_video = top.get_json()["videos"][0]
+        assert top_video["video_id"] == video_id
+        assert top_video["views"] == 2
+        assert top_video["comments"] == 1
+        assert top_video["votes"] == 2
+        assert top_video["tips"] == 0.5
+
+        assert audience.status_code == 200
+        assert audience.get_json()["human_viewers"] == 2
+
+        assert summary.status_code == 200
+        assert summary.get_json()["total_views"] == 2
+
+        assert export.status_code == 200
+        export_rows = list(csv.DictReader(io.StringIO(export.get_data(as_text=True))))
+        assert export_rows[0]["video_id"] == video_id
+        assert export_rows[0]["views"] == "2"
+        assert export_rows[0]["comments"] == "1"
+        assert export_rows[0]["votes"] == "2"
+        assert export_rows[0]["tips_rtc"] == "0.5"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- make the creator analytics blueprint use the app database connection when available instead of falling back to a stale local `bottube.db`
- switch direct `/analytics/api/*` filters/joins from numeric `videos.id` to public `videos.video_id`, matching `views`, `comments`, `votes`, and `earnings`
- pre-aggregate per-video comments/votes/tips so duplicate equal votes/tips are counted, and scope tip aggregates by recipient `agent_id`
- update the subscriber summary query for the current `subscriptions.following_id` schema

## Why
The analytics blueprint endpoints could report zeros or crash for real creator data because related tables store public video ids, while these routes queried numeric `videos.id`. `api_summary` also referenced the stale `subscriptions.channel_id` column.

A focused regression covers:
- all-videos and explicit-video views
- engagement totals and per-video breakdown
- top videos by engagement
- audience summary
- dashboard summary
- CSV export
- duplicate equal votes/tips and unrelated-agent tip leakage

## Verification
Red before fix:
```text
python3 -m pytest tests/test_analytics_dashboard.py::TestAnalyticsApiCoreMetrics::test_creator_analytics_blueprint_uses_public_video_ids -q
FAILED ... sqlite3.OperationalError: no such table: videos
FAILED ... sqlite3.OperationalError: no such column: channel_id
FAILED ... assert 1 == 2  # SUM(DISTINCT vote) undercount
```

Green after fix:
```text
python3 -m pytest tests/test_analytics_dashboard.py::TestAnalyticsApiCoreMetrics::test_creator_analytics_blueprint_uses_public_video_ids -q
1 passed in 2.34s
```

Also run:
```text
python3 -m py_compile analytics_blueprint.py tests/test_analytics_dashboard.py
git diff --check
```

Known unrelated local test gaps:
```text
python3 -m pytest tests/test_analytics_dashboard.py -q
13 failed, 2 passed
```
The remaining failures are on older routes outside this patch: `/analytics` redirects with Flask 308 trailing-slash behavior, and `/api/dashboard/analytics` raises `AttributeError: module 'datetime' has no attribute 'utcfromtimestamp'` in `bottube_server.py`.

## Reward wallet
AIjackgo
