### PR TITLE
Keep RSS and Atom feeds well-formed for unsafe media fields

### DIFF
--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -30,6 +30,17 @@ def escape_xml(text):
     )
 
 
+def _cdata_safe(text):
+    """Escape a string for safe inclusion inside a CDATA section."""
+    return str(text or "").replace("]]>", "]]]]><![CDATA[>")
+
+
+def _video_description_html(fields):
+    thumb = escape_xml(fields["thumb"])
+    desc = _cdata_safe(escape_xml(fields["desc"]))
+    return f'<img src="{thumb}" /><p>{desc}</p>'
+
+
 def _to_rfc2822(value):
     """Convert various timestamp formats to RFC 2822 for RSS pubDate."""
     if value is None or value == "":
@@ -169,14 +180,14 @@ def rss_feed():
         lines += [
             "  <item>",
             f"    <title>{escape_xml(f['title'])}</title>",
-            f"    <link>{f['watch']}</link>",
+            f"    <link>{escape_xml(f['watch'])}</link>",
             f'    <guid isPermaLink="false">{escape_xml(f["id"])}</guid>',
-            f'    <description><![CDATA[<img src="{f["thumb"]}" /><p>{escape_xml(f["desc"])}</p>]]></description>',
+            f"    <description><![CDATA[{_video_description_html(f)}]]></description>",
             f"    <pubDate>{_to_rfc2822(f['created_at'])}</pubDate>",
             f"    <dc:creator>{escape_xml(f['author'])}</dc:creator>",
             f"    <category>{escape_xml(f['category'])}</category>",
-            f'    <media:content url="{f["stream"]}" type="video/mp4" medium="video" />',
-            f'    <media:thumbnail url="{f["thumb"]}" />',
+            f'    <media:content url="{escape_xml(f["stream"])}" type="video/mp4" medium="video" />',
+            f'    <media:thumbnail url="{escape_xml(f["thumb"])}" />',
             "  </item>",
         ]
 
@@ -222,16 +233,16 @@ def atom_feed():
         lines += [
             "  <entry>",
             f"    <title>{escape_xml(f['title'])}</title>",
-            f'    <link href="{f["watch"]}" rel="alternate" />',
+            f'    <link href="{escape_xml(f["watch"])}" rel="alternate" />',
             f"    <id>urn:bottube:video:{escape_xml(f['id'])}</id>",
             f"    <updated>{updated}</updated>",
             f"    <published>{updated}</published>",
             f"    <author><name>{escape_xml(f['author'])}</name></author>",
             f"    <category term=\"{escape_xml(f['category'])}\" />",
             f"    <summary>{escape_xml(f['desc'])}</summary>",
-            f'    <content type="html"><![CDATA[<img src="{f["thumb"]}" /><p>{escape_xml(f["desc"])}</p>]]></content>',
-            f'    <media:content url="{f["stream"]}" type="video/mp4" medium="video" />',
-            f'    <media:thumbnail url="{f["thumb"]}" />',
+            f'    <content type="html"><![CDATA[{_video_description_html(f)}]]></content>',
+            f'    <media:content url="{escape_xml(f["stream"])}" type="video/mp4" medium="video" />',
+            f'    <media:thumbnail url="{escape_xml(f["thumb"])}" />',
             "  </entry>",
         ]
 
@@ -262,14 +273,14 @@ def rss_feed_agent(agent_name):
         lines += [
             "  <item>",
             f"    <title>{escape_xml(f['title'])}</title>",
-            f"    <link>{f['watch']}</link>",
+            f"    <link>{escape_xml(f['watch'])}</link>",
             f'    <guid isPermaLink="false">{escape_xml(f["id"])}</guid>',
-            f'    <description><![CDATA[<img src="{f["thumb"]}" /><p>{escape_xml(f["desc"])}</p>]]></description>',
+            f"    <description><![CDATA[{_video_description_html(f)}]]></description>",
             f"    <pubDate>{_to_rfc2822(f['created_at'])}</pubDate>",
             f"    <dc:creator>{escape_xml(f['author'])}</dc:creator>",
             f"    <category>{escape_xml(f['category'])}</category>",
-            f'    <media:content url="{f["stream"]}" type="video/mp4" medium="video" />',
-            f'    <media:thumbnail url="{f["thumb"]}" />',
+            f'    <media:content url="{escape_xml(f["stream"])}" type="video/mp4" medium="video" />',
+            f'    <media:thumbnail url="{escape_xml(f["thumb"])}" />',
             "  </item>",
         ]
     
@@ -303,16 +314,16 @@ def atom_feed_agent(agent_name):
         lines += [
             "  <entry>",
             f"    <title>{escape_xml(f['title'])}</title>",
-            f'    <link href="{f["watch"]}" rel="alternate" />',
+            f'    <link href="{escape_xml(f["watch"])}" rel="alternate" />',
             f"    <id>urn:bottube:video:{escape_xml(f['id'])}</id>",
             f"    <updated>{updated}</updated>",
             f"    <published>{updated}</published>",
             f"    <author><name>{escape_xml(f['author'])}</name></author>",
             f"    <category term=\"{escape_xml(f['category'])}\" />",
             f"    <summary>{escape_xml(f['desc'])}</summary>",
-            f'    <content type="html"><![CDATA[<img src="{f["thumb"]}" /><p>{escape_xml(f["desc"])}</p>]]></content>',
-            f'    <media:content url="{f["stream"]}" type="video/mp4" medium="video" />',
-            f'    <media:thumbnail url="{f["thumb"]}" />',
+            f'    <content type="html"><![CDATA[{_video_description_html(f)}]]></content>',
+            f'    <media:content url="{escape_xml(f["stream"])}" type="video/mp4" medium="video" />',
+            f'    <media:thumbnail url="{escape_xml(f["thumb"])}" />',
             "  </entry>",
         ]
     

--- a/tests/test_feed_blueprint.py
+++ b/tests/test_feed_blueprint.py
@@ -1,15 +1,20 @@
 import datetime as dt
 import sys
+import xml.etree.ElementTree as ET
 from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 import pytest
+import werkzeug
 from flask import Flask
 
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "test"
 
 import feed_blueprint
 
@@ -126,3 +131,29 @@ def test_fetch_videos_returns_empty_list_when_request_fails(monkeypatch):
     monkeypatch.setattr(feed_blueprint.requests, "get", fake_get)
 
     assert feed_blueprint._fetch_videos() == []
+
+
+def test_feed_routes_escape_url_attributes_and_cdata(monkeypatch):
+    app = Flask(__name__)
+    app.register_blueprint(feed_blueprint.feed_bp)
+
+    def fake_fetch_videos(agent=None, category=None, limit=20):
+        return [
+            {
+                "video_id": "feedxml01",
+                "title": "Feed XML",
+                "description": "before ]]> after",
+                "agent_name": "creator",
+                "category": "music",
+                "thumbnail_url": "https://cdn.example.test/thumb.jpg?x=1&y=<bad>",
+                "created_at": 0,
+            }
+        ]
+
+    monkeypatch.setattr(feed_blueprint, "_fetch_videos", fake_fetch_videos)
+
+    client = app.test_client()
+    for path in ("/feed/rss", "/feed/atom"):
+        response = client.get(path)
+        assert response.status_code == 200
+        ET.fromstring(response.get_data(as_text=True))


### PR DESCRIPTION
## Summary
- escape watch/stream/thumbnail URL fields before writing them into RSS/Atom XML elements and attributes
- split `]]>` inside feed description HTML snippets so CDATA cannot be prematurely closed
- cover global RSS and Atom generation with an XML parser regression for unsafe API-provided media fields

## Why
The feed blueprint assembles XML strings from API video payloads. A thumbnail URL such as `...?x=1&y=<bad>` or a description containing `]]>` can make `/feed/rss` or `/feed/atom` return malformed XML.

The same escaping helpers are applied to the global and agent-specific RSS/Atom item builders.

## Verification
Red before fix:
```text
python3 -m pytest tests/test_feed_blueprint.py::test_feed_routes_escape_url_attributes_and_cdata -q
FAILED ... xml.etree.ElementTree.ParseError: not well-formed (invalid token)
```

Green after fix:
```text
python3 -m pytest tests/test_feed_blueprint.py::test_feed_routes_escape_url_attributes_and_cdata -q
1 passed in 0.11s

python3 -m pytest tests/test_feed_blueprint.py -q
13 passed in 0.13s
```

Also run:
```text
python3 -m py_compile feed_blueprint.py tests/test_feed_blueprint.py
git diff --check
```

## Reward wallet
AIjackgo
