### PR TITLE
Return JSON errors for malformed Gemini jobs limits

### DIFF
--- a/gemini_blueprint.py
+++ b/gemini_blueprint.py
@@ -519,7 +519,11 @@ def list_jobs():
     else:
         agent_id = user_id
 
-    limit = min(int(request.args.get("limit", 20)), 50)
+    try:
+        limit = int(request.args.get("limit", 20))
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit must be an integer"}), 400
+    limit = max(1, min(limit, 50))
     jobs = db.execute(
         "SELECT job_id, job_type, model, status, prompt, created_at, completed_at "
         "FROM gemini_jobs WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?",

--- a/tests/test_gemini_request_validation.py
+++ b/tests/test_gemini_request_validation.py
@@ -4,9 +4,14 @@
 import sqlite3
 
 import pytest
+import werkzeug
 from flask import Flask, g
 
 import gemini_blueprint
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "test"
 
 
 @pytest.fixture()
@@ -77,6 +82,20 @@ def _job_count(db_path):
         return db.execute("SELECT COUNT(*) FROM gemini_jobs").fetchone()[0]
 
 
+def _insert_jobs(db_path, count):
+    with sqlite3.connect(str(db_path)) as db:
+        for idx in range(count):
+            db.execute(
+                """
+                INSERT INTO gemini_jobs
+                    (job_id, agent_id, job_type, model, prompt, status, created_at)
+                VALUES (?, 1, 'image', 'gemini', ?, 'completed', ?)
+                """,
+                (f"job-{idx:03d}", f"prompt {idx}", float(idx)),
+            )
+        db.commit()
+
+
 def test_authenticated_video_rejects_non_object_json_without_job(client):
     resp = client.post(
         "/api/gemini/generate-video",
@@ -123,6 +142,29 @@ def test_authenticated_image_rejects_non_string_prompt_before_generation(client)
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "prompt must be a string"
     assert _job_count(client.db_path) == 0
+
+
+def test_jobs_rejects_malformed_limit(client):
+    resp = client.get("/api/gemini/jobs?limit=not-an-int", headers=_auth_headers())
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "limit must be an integer"
+
+
+def test_jobs_clamps_limit(client):
+    _insert_jobs(client.db_path, 60)
+
+    resp = client.get("/api/gemini/jobs?limit=0", headers=_auth_headers())
+    body = resp.get_json()
+
+    assert resp.status_code == 200
+    assert len(body["jobs"]) == 1
+
+    resp = client.get("/api/gemini/jobs?limit=999", headers=_auth_headers())
+    body = resp.get_json()
+
+    assert resp.status_code == 200
+    assert len(body["jobs"]) == 50
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- validate `/api/gemini/jobs?limit=` before querying jobs
- return `400` JSON for malformed limits instead of raising `ValueError`
- clamp valid limits to the existing `1..50` range
- add regression coverage for malformed, lower-bound, and upper-bound limits

## Why
The Gemini jobs listing used raw `int(request.args.get("limit", 20))`, so authenticated requests like `/api/gemini/jobs?limit=not-an-int` raised before returning a JSON API response.

## Verification
Red before fix:
```text
python3 -m pytest tests/test_gemini_request_validation.py::test_jobs_rejects_malformed_limit -q
FAILED ... ValueError: invalid literal for int() with base 10: 'not-an-int'
```

Green after fix:
```text
python3 -m pytest tests/test_gemini_request_validation.py::test_jobs_rejects_malformed_limit tests/test_gemini_request_validation.py::test_jobs_clamps_limit -q
2 passed in 1.73s

python3 -m pytest tests/test_gemini_request_validation.py -q
11 passed in 2.60s
```

Also run:
```text
python3 -m py_compile gemini_blueprint.py tests/test_gemini_request_validation.py
git diff --check -- gemini_blueprint.py tests/test_gemini_request_validation.py
```

## Reward wallet
AIjackgo
