### PR TITLE
Return JSON errors for malformed Whisper backfills

### DIFF
--- a/tests/test_whisper_transcription.py
+++ b/tests/test_whisper_transcription.py
@@ -14,6 +14,7 @@ Covers:
 """
 from __future__ import annotations
 
+import importlib.metadata
 import os
 import sqlite3
 import sys
@@ -24,6 +25,10 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import werkzeug
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = importlib.metadata.version("werkzeug")
 
 # ---------------------------------------------------------------------------
 # Path setup
@@ -482,6 +487,39 @@ def test_search_endpoint(tmp_db, flask_client, monkeypatch):
 def test_search_endpoint_no_query(flask_client):
     resp = flask_client.get("/api/transcript/search")
     assert resp.status_code == 400
+
+
+def test_backfill_rejects_non_object_json(flask_client):
+    resp = flask_client.post("/api/transcript/backfill", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_backfill_rejects_invalid_batch_size(flask_client):
+    resp = flask_client.post("/api/transcript/backfill", json={"batch_size": "not-an-int"})
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "batch_size must be a positive integer"
+
+
+@pytest.mark.parametrize("batch_size", [0, -1, True, 1.5, float("inf")])
+def test_backfill_rejects_non_positive_or_non_integer_batch_size(
+    flask_client,
+    monkeypatch,
+    batch_size,
+):
+    import whisper_transcription_blueprint as wtb
+
+    def fail_backfill(**_kwargs):
+        raise AssertionError("invalid batch_size should not enqueue backfill work")
+
+    monkeypatch.setattr(wtb.wt, "backfill_existing_videos", fail_backfill)
+
+    resp = flask_client.post("/api/transcript/backfill", json={"batch_size": batch_size})
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "batch_size must be a positive integer"
 
 
 def test_trigger_transcription_video_not_found(flask_client):

--- a/whisper_transcription_blueprint.py
+++ b/whisper_transcription_blueprint.py
@@ -25,6 +25,51 @@ log = logging.getLogger("bottube.whisper_transcription_blueprint")
 whisper_bp = Blueprint("whisper_transcription", __name__)
 
 
+def _request_json_object():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _parse_positive_int(data, field_name: str, default: int):
+    value = data.get(field_name, default)
+    if isinstance(value, bool):
+        return None, (
+            jsonify({"error": f"{field_name} must be a positive integer"}),
+            400,
+        )
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None, (
+                jsonify({"error": f"{field_name} must be a positive integer"}),
+                400,
+            )
+        try:
+            parsed = int(stripped, 10)
+        except ValueError:
+            return None, (
+                jsonify({"error": f"{field_name} must be a positive integer"}),
+                400,
+            )
+    else:
+        return None, (
+            jsonify({"error": f"{field_name} must be a positive integer"}),
+            400,
+        )
+    if parsed < 1:
+        return None, (
+            jsonify({"error": f"{field_name} must be a positive integer"}),
+            400,
+        )
+    return parsed, None
+
+
 def _video_dir() -> str:
     return os.environ.get(
         "BOTTUBE_VIDEO_DIR",
@@ -170,9 +215,15 @@ def trigger_backfill():
     Body (JSON, optional):
         { "force": false, "batch_size": 50 }
     """
-    body = request.get_json(silent=True) or {}
+    body, error = _request_json_object()
+    if error:
+        return error
+
     force = bool(body.get("force", False))
-    batch_size = int(body.get("batch_size", 50))
+    batch_size, error = _parse_positive_int(body, "batch_size", 50)
+    if error:
+        return error
+
     enqueued = wt.backfill_existing_videos(
         video_dir=_video_dir(),
         force=force,


### PR DESCRIPTION
## Summary
- validate `/api/transcript/backfill` JSON bodies before reading fields
- reject malformed, non-positive, boolean, float, and non-finite `batch_size` values with 400 JSON
- keep invalid requests from reaching `backfill_existing_videos`

## Tests
- `pytest tests/test_whisper_transcription.py -q -k \"backfill_rejects\"`
- `pytest tests/test_whisper_transcription.py -q`
- `python3 -m py_compile whisper_transcription_blueprint.py tests/test_whisper_transcription.py`
- `flake8 whisper_transcription_blueprint.py tests/test_whisper_transcription.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`