### PR TITLE
Keep captions search on the configured database

### DIFF
--- a/captions_blueprint.py
+++ b/captions_blueprint.py
@@ -41,10 +41,14 @@ WHISPER_MODEL = os.environ.get("BOTTUBE_WHISPER_MODEL", "whisper-1")
 
 def _db_path() -> str:
     from pathlib import Path
-    return os.environ.get(
-        "BOTTUBE_DB_PATH",
-        str(Path(__file__).resolve().parent / "bottube.db"),
+    if "DB_PATH" in globals():
+        return str(globals()["DB_PATH"])
+    if os.environ.get("BOTTUBE_DB_PATH"):
+        return os.environ["BOTTUBE_DB_PATH"]
+    base_dir = Path(
+        os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent))
     )
+    return str(base_dir / "bottube.db")
 
 
 def _connect_db() -> sqlite3.Connection:
@@ -499,6 +503,19 @@ def find_caption_video_ids(query: str, limit: int = 200) -> list[str]:
         return []
 
 
+def _parse_caption_limit(default: int = 50, max_value: int = 500) -> int:
+    raw_value = request.args.get("limit")
+    if raw_value is None or raw_value == "":
+        return default
+    try:
+        limit = int(raw_value, 10)
+    except ValueError:
+        raise ValueError("limit must be a positive integer")
+    if limit < 1:
+        raise ValueError("limit must be a positive integer")
+    return min(limit, max_value)
+
+
 @captions_bp.route("/api/videos/<video_id>/captions")
 def get_captions(video_id):
     """Serve VTT or SRT captions for a video."""
@@ -565,5 +582,10 @@ def search_captions():
     if not query:
         return jsonify({"error": "Query parameter 'q' is required"}), 400
 
-    video_ids = find_caption_video_ids(query, limit=request.args.get("limit", 50, type=int))
+    try:
+        limit = _parse_caption_limit()
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    video_ids = find_caption_video_ids(query, limit=limit)
     return jsonify({"query": query, "count": len(video_ids), "video_ids": video_ids})

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -2,9 +2,15 @@ import os
 import sqlite3
 import sys
 import time
+from importlib import metadata
 from pathlib import Path
 
 import pytest
+import werkzeug
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -211,3 +217,13 @@ def test_api_search_matches_caption_text(client):
     caption_resp = client.get("/api/search/captions?q=swamp sermon")
     assert caption_resp.status_code == 200
     assert caption_resp.get_json()["video_ids"] == ["captionvid2"]
+
+
+@pytest.mark.parametrize("limit", ["not-a-number", "0", "-5", "1.5", "true"])
+def test_caption_search_rejects_invalid_limit(client, limit):
+    bottube_server.app.config["PROPAGATE_EXCEPTIONS"] = False
+
+    resp = client.get(f"/api/search/captions?q=swamp sermon&limit={limit}")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "limit must be a positive integer"}


### PR DESCRIPTION
## Summary
- make captions storage honor the configured DB path used by tests and app wiring
- reject malformed, non-positive, float, and boolean-like caption search limits with JSON 400
- keep valid/default/capped caption search limits returning normal results

## Tests
- `pytest tests/test_captions.py -q`
- `python3 -m py_compile captions_blueprint.py tests/test_captions.py`
- `flake8 captions_blueprint.py tests/test_captions.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`