### PR TITLE
Return JSON errors for malformed bridge history limits

### DIFF
--- a/base_wrtc_bridge_blueprint.py
+++ b/base_wrtc_bridge_blueprint.py
@@ -164,6 +164,19 @@ def _finite_amount(value):
     return amount
 
 
+def _parse_history_limit(default: int = 50, max_value: int = 200):
+    raw_value = request.args.get("limit")
+    if raw_value is None or raw_value == "":
+        return default, None
+    try:
+        limit = int(raw_value, 10)
+    except ValueError:
+        return None, (jsonify({"error": "limit must be a positive integer"}), 400)
+    if limit < 1:
+        return None, (jsonify({"error": "limit must be a positive integer"}), 400)
+    return min(limit, max_value), None
+
+
 # ─── On-Chain Verification ────────────────────────────────────
 
 def verify_base_wrtc_transfer(tx_hash):
@@ -529,7 +542,9 @@ def base_bridge_history():
     if not agent:
         return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
 
-    limit = min(200, max(1, request.args.get("limit", 50, type=int)))
+    limit, error = _parse_history_limit()
+    if error:
+        return error
     db = get_db()
     init_base_wrtc_tables(db)
 

--- a/tests/test_base_wrtc_bridge_validation.py
+++ b/tests/test_base_wrtc_bridge_validation.py
@@ -2,9 +2,15 @@
 """Validation tests for Base wRTC bridge request parsing."""
 
 import sqlite3
+from importlib import metadata
 
 import pytest
+import werkzeug
 from flask import Flask, g
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
 
 
 @pytest.fixture()
@@ -121,6 +127,17 @@ def test_base_bridge_withdraw_rejects_non_finite_amounts(client, amount):
 
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "amount must be a finite number"
+
+
+@pytest.mark.parametrize("limit", ["not-a-number", "0", "-5", "1.5", "true"])
+def test_base_bridge_history_rejects_invalid_limit(client, limit):
+    resp = client.get(
+        f"/api/base-bridge/history?limit={limit}",
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "limit must be a positive integer"
 
 
 def test_rejected_base_bridge_withdrawal_does_not_queue_or_debit(client):

--- a/tests/test_wrtc_bridge_validation.py
+++ b/tests/test_wrtc_bridge_validation.py
@@ -2,9 +2,15 @@
 """Validation tests for Solana wRTC bridge request parsing."""
 
 import sqlite3
+from importlib import metadata
 
 import pytest
+import werkzeug
 from flask import Flask, g
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
 
 
 @pytest.fixture()
@@ -130,6 +136,17 @@ def test_wrtc_withdraw_rejects_non_finite_amounts(client, amount):
 
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "amount must be a finite number"
+
+
+@pytest.mark.parametrize("limit", ["not-a-number", "0", "-5", "1.5", "true"])
+def test_wrtc_history_rejects_invalid_limit(client, limit):
+    resp = client.get(
+        f"/api/wrtc-bridge/history?limit={limit}",
+        headers=_auth_headers(),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "limit must be a positive integer"
 
 
 def test_rejected_wrtc_withdrawal_does_not_queue_or_debit(client):

--- a/wrtc_bridge_blueprint.py
+++ b/wrtc_bridge_blueprint.py
@@ -67,6 +67,19 @@ def _finite_amount(data: dict, field_name: str = "amount"):
     return amount, None
 
 
+def _parse_history_limit(default: int = 50, max_value: int = 200):
+    raw_value = request.args.get("limit")
+    if raw_value is None or raw_value == "":
+        return default, None
+    try:
+        limit = int(raw_value, 10)
+    except ValueError:
+        return None, (jsonify({"error": "limit must be a positive integer"}), 400)
+    if limit < 1:
+        return None, (jsonify({"error": "limit must be a positive integer"}), 400)
+    return min(limit, max_value), None
+
+
 def get_db():
     """Get database connection from Flask g."""
     if "db" in g:
@@ -467,7 +480,9 @@ def wrtc_bridge_history():
     if not agent:
         return jsonify({"error": "Authentication required. Provide X-API-Key header."}), 401
 
-    limit = min(200, max(1, request.args.get("limit", 50, type=int)))
+    limit, error = _parse_history_limit()
+    if error:
+        return error
     db = get_db()
     init_wrtc_tables(db)
 


### PR DESCRIPTION
## Summary
- validate Solana and Base bridge history `limit` query params explicitly
- reject malformed, non-positive, float, and boolean-like values with JSON 400
- preserve default, valid, and capped history requests

## Tests
- `pytest tests/test_wrtc_bridge_validation.py tests/test_base_wrtc_bridge_validation.py -q`
- `python3 -m py_compile wrtc_bridge_blueprint.py base_wrtc_bridge_blueprint.py tests/test_wrtc_bridge_validation.py tests/test_base_wrtc_bridge_validation.py`
- `flake8 wrtc_bridge_blueprint.py base_wrtc_bridge_blueprint.py tests/test_wrtc_bridge_validation.py tests/test_base_wrtc_bridge_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`