### PR TITLE
Return JSON errors for malformed x402 video pagination

### DIFF
--- a/tests/test_payment_hardening.py
+++ b/tests/test_payment_hardening.py
@@ -2,9 +2,15 @@ import json
 import os
 import sqlite3
 import sys
+from importlib import metadata
 from pathlib import Path
 
 import pytest
+import werkzeug
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -124,6 +130,49 @@ def test_x402_requires_structured_receipt_and_blocks_cross_endpoint_replay(clien
     replay = client.get("/x402/api/videos", headers={"X-PAYMENT": receipt})
     assert replay.status_code == 402
     assert replay.get_json()["reason"] == "payment_already_consumed"
+
+
+@pytest.mark.parametrize(
+    ("query", "error"),
+    [
+        ("page=not-a-number", "page must be a positive integer"),
+        ("page=0", "page must be a positive integer"),
+        ("page=1.5", "page must be a positive integer"),
+        ("per_page=not-a-number", "per_page must be a positive integer"),
+        ("per_page=0", "per_page must be a positive integer"),
+        ("per_page=true", "per_page must be a positive integer"),
+    ],
+)
+def test_x402_video_list_rejects_invalid_pagination(client, monkeypatch, query, error):
+    tx_hash = "0x" + ("cd" * 32)
+
+    def _fake_verify(tx_hash_arg, network, recipient):
+        return (
+            {
+                "tx_hash": tx_hash_arg,
+                "network": network,
+                "recipient": recipient,
+                "amount_raw": 100,
+                "amount_usdc": 0.0001,
+                "block_number": 123,
+            },
+            None,
+        )
+
+    monkeypatch.setattr(x402_payment, "_verify_evm_usdc_transfer", _fake_verify)
+    receipt = json.dumps(
+        {
+            "tx_hash": tx_hash,
+            "network": "base",
+            "recipient": x402_payment.USDC_RECEIVING_ADDRESS,
+            "amount": "0.000100",
+        }
+    )
+
+    resp = client.get(f"/x402/api/videos?{query}", headers={"X-PAYMENT": receipt})
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": error}
 
 
 def test_store_capture_credits_agent_balance_and_earnings(client, monkeypatch):

--- a/x402_payment.py
+++ b/x402_payment.py
@@ -93,6 +93,21 @@ def _cleanup_payment_cache(now=None):
         _payment_cache.pop(tx_hash, None)
 
 
+def _parse_positive_int_query(name, default, max_value=None):
+    raw_value = request.args.get(name)
+    if raw_value is None or raw_value == "":
+        return default, None
+    try:
+        value = int(raw_value, 10)
+    except ValueError:
+        return None, f"{name} must be a positive integer"
+    if value < 1:
+        return None, f"{name} must be a positive integer"
+    if max_value is not None:
+        value = min(value, max_value)
+    return value, None
+
+
 def _amount_to_raw(amount) -> int:
     value = Decimal(str(amount))
     raw = (value * (Decimal(10) ** USDC_DECIMALS)).quantize(
@@ -434,8 +449,12 @@ def x402_list_videos():
     """Premium video listing with full metadata."""
     from bottube_server import get_db, video_to_dict
 
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(100, max(1, request.args.get("per_page", 50, type=int)))
+    page, error = _parse_positive_int_query("page", 1)
+    if error:
+        return jsonify({"error": error}), 400
+    per_page, error = _parse_positive_int_query("per_page", 50, max_value=100)
+    if error:
+        return jsonify({"error": error}), 400
     sort = request.args.get("sort", "newest")
     agent_name = request.args.get("agent", "")
     offset = (page - 1) * per_page


### PR DESCRIPTION
## Summary
- validate paid x402 video-list `page` and `per_page` params explicitly
- reject malformed, zero, float, and boolean-like pagination values with JSON 400
- preserve default, valid, and capped paid video-list requests

## Tests
- `pytest tests/test_payment_hardening.py tests/test_x402_payment_helpers.py -q`
- `python3 -m py_compile x402_payment.py tests/test_payment_hardening.py tests/test_x402_payment_helpers.py`
- `flake8 x402_payment.py tests/test_payment_hardening.py tests/test_x402_payment_helpers.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`