### PR TITLE
Reject invalid Banano transaction pagination

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -439,6 +439,8 @@ def ban_transactions(agent_name):
         offset = int(request.args.get("offset", 0))
     except (ValueError, TypeError):
         return jsonify({"error": "Invalid pagination parameters"}), 400
+    if limit < 1 or offset < 0:
+        return jsonify({"error": "Invalid pagination parameters"}), 400
 
     txs = db.execute(
         "SELECT * FROM ban_transactions WHERE agent_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?",

--- a/tests/test_banano_amount_validation.py
+++ b/tests/test_banano_amount_validation.py
@@ -1,11 +1,17 @@
 # SPDX-License-Identifier: MIT
 import sqlite3
 import time
+from importlib import metadata
 
 import pytest
+import werkzeug
 from flask import Flask, g
 
 import banano_blueprint
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
 
 
 @pytest.fixture
@@ -148,6 +154,14 @@ def test_ban_video_generation_reward_rejects_non_string_fields(ban_client, field
     assert response.status_code == 400
     assert response.get_json()["error"] == f"{field} must be a string"
     assert _ban_transaction_count(ban_client.db_path) == before
+
+
+@pytest.mark.parametrize("query", ["limit=0", "limit=-1", "offset=-1"])
+def test_ban_transactions_rejects_non_positive_pagination(ban_client, query):
+    response = ban_client.get(f"/ban/transactions/alice?{query}")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Invalid pagination parameters"
 
 
 def test_valid_ban_video_generation_reward_still_records_reward(ban_client):


### PR DESCRIPTION
## Summary
- reject zero/negative Banano transaction history pagination
- keep malformed pagination returning the existing JSON 400
- preserve valid requests and the existing 100-row limit cap

## Tests
- `pytest tests/test_banano_amount_validation.py -q`
- `python3 -m py_compile banano_blueprint.py tests/test_banano_amount_validation.py`
- `flake8 banano_blueprint.py tests/test_banano_amount_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`