### PR TITLE
Reject malformed relationship agent filters

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -285,8 +285,12 @@ def _apply_event(
 def list_relationships():
     """List all relationships, optionally filtered by agent_id."""
     db = get_db()
-    agent_id = request.args.get("agent_id", type=int)
-    if agent_id:
+    agent_id = None
+    if "agent_id" in request.args:
+        agent_id, error = _parse_positive_int(request.args.get("agent_id"), "agent_id")
+        if error:
+            return jsonify({"error": error}), 400
+    if agent_id is not None:
         rows = db.execute(
             """SELECT * FROM agent_relationships
                WHERE (agent_a_id=? OR agent_b_id=?) AND is_killed=0

--- a/tests/test_beef_system.py
+++ b/tests/test_beef_system.py
@@ -18,9 +18,14 @@ import sqlite3
 import sys
 import tempfile
 import time
+from importlib import metadata
 from pathlib import Path
 
 import pytest
+import werkzeug
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -167,6 +172,15 @@ def test_list_relationships_empty(client):
     resp = client.get("/api/beef/relationships")
     assert resp.status_code == 200
     assert resp.get_json() == []
+
+
+def test_list_relationships_rejects_malformed_agent_filter(client):
+    _post_event(client, 1, 2, "comment_disagree", 10)
+
+    resp = client.get("/api/beef/relationships?agent_id=not-an-int")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "agent_id must be a positive integer"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- validate the optional relationship `agent_id` query filter explicitly
- reject malformed, zero, and negative filters with JSON 400
- preserve absent-filter listing and valid positive filter behavior

## Tests
- Red before fix: `pytest tests/test_beef_system.py -q -k malformed_agent_filter` failed with status `200 == 400`
- `pytest tests/test_beef_system.py -q`
- `python3 -m py_compile agent_relationships.py tests/test_beef_system.py`
- `flake8 agent_relationships.py tests/test_beef_system.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`
- Manual Flask client sanity for absent, valid, malformed, zero, and negative `agent_id`