### PR TITLE
Reject invalid checkout agent ids

### DIFF
--- a/paypal_packages.py
+++ b/paypal_packages.py
@@ -303,6 +303,8 @@ def _optional_int_field(data: dict, field_name: str):
         return None, None
     if isinstance(value, bool) or not isinstance(value, int):
         return None, (jsonify({"error": f"{field_name} must be an integer"}), 400)
+    if value <= 0:
+        return None, (jsonify({"error": f"{field_name} must be a positive integer"}), 400)
     return value, None
 
 

--- a/tests/test_paypal_store_validation.py
+++ b/tests/test_paypal_store_validation.py
@@ -2,11 +2,16 @@
 """Validation tests for PayPal store request parsing."""
 
 import sqlite3
+from importlib import metadata
 
 import pytest
+import werkzeug
 from flask import Flask, g
 
 import paypal_packages
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
 
 
 @pytest.fixture()
@@ -59,6 +64,8 @@ def test_store_checkout_rejects_non_object_json_before_paypal_call(client, monke
         ({"package_id": ["creator"], "email": "buyer@example.com"}, "package_id must be a string"),
         ({"package_id": "creator", "agent_id": ["123"]}, "agent_id must be an integer"),
         ({"package_id": "creator", "agent_id": True}, "agent_id must be an integer"),
+        ({"package_id": "creator", "agent_id": 0}, "agent_id must be a positive integer"),
+        ({"package_id": "creator", "agent_id": -1}, "agent_id must be a positive integer"),
         ({"package_id": "creator", "email": ["buyer@example.com"]}, "email must be a string"),
     ],
 )


### PR DESCRIPTION
## Summary
- reject present non-positive checkout `agent_id` values before PayPal order creation
- preserve guest email checkout and valid positive agent checkout
- keep omitted `agent_id` optional

## Tests
- Red before fix: `pytest tests/test_paypal_store_validation.py -q -k malformed_fields` showed `agent_id=0` misclassified as missing identity and `agent_id=-1` reached the patched PayPal call
- `pytest tests/test_paypal_store_validation.py tests/test_payment_hardening.py -q`
- `python3 -m py_compile paypal_packages.py tests/test_paypal_store_validation.py tests/test_payment_hardening.py`
- `flake8 paypal_packages.py tests/test_paypal_store_validation.py tests/test_payment_hardening.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`
- Manual Flask client sanity for `agent_id` 0, -1, valid agent checkout, and guest email checkout