### PR TITLE
Reject malformed USDC payout addresses

### DIFF
--- a/tests/test_usdc_amount_validation.py
+++ b/tests/test_usdc_amount_validation.py
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: MIT
 import sqlite3
 import time
+from importlib import metadata
 
 import pytest
+import werkzeug
 from flask import Flask, g
 
 import usdc_blueprint
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
 
 
 @pytest.fixture
@@ -96,6 +101,22 @@ def test_usdc_payout_rejects_malformed_amounts_without_writes(usdc_client, amoun
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "amount_usdc must be a finite number"
+    assert _table_count(usdc_client.db_path, "usdc_payouts") == before_payouts
+    assert _balance(usdc_client.db_path, "alice") == before_alice
+
+
+def test_usdc_payout_rejects_non_string_address_without_writes(usdc_client):
+    before_payouts = _table_count(usdc_client.db_path, "usdc_payouts")
+    before_alice = _balance(usdc_client.db_path, "alice")
+
+    response = usdc_client.post(
+        "/api/usdc/payout",
+        json={"to_address": ["0x" + "a" * 40], "amount_usdc": "1.25"},
+        headers=usdc_client.auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "to_address must be a string"
     assert _table_count(usdc_client.db_path, "usdc_payouts") == before_payouts
     assert _balance(usdc_client.db_path, "alice") == before_alice
 

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -519,7 +519,9 @@ def usdc_payout():
     if error:
         return error
     to_address_raw = data.get("to_address", "")
-    to_address = to_address_raw.strip() if isinstance(to_address_raw, str) else ""
+    if not isinstance(to_address_raw, str):
+        return jsonify({"error": "to_address must be a string"}), 400
+    to_address = to_address_raw.strip()
 
     if amount < 1.0:
         return jsonify({"error": "Minimum payout is 1.00 USDC"}), 400


### PR DESCRIPTION
## Summary
- reject non-string USDC payout `to_address` values before address format validation
- preserve the existing malformed string address response
- preserve valid payout creation

## Tests
- Red before fix: `pytest tests/test_usdc_amount_validation.py -q -k non_string_address` returned the generic Base-address error instead of `to_address must be a string`
- `pytest tests/test_usdc_amount_validation.py -q`
- `python3 -m py_compile usdc_blueprint.py tests/test_usdc_amount_validation.py`
- `flake8 usdc_blueprint.py tests/test_usdc_amount_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`
- Manual Flask client sanity for non-string address, malformed string address, and valid payout