### PR TITLE
Reject boolean video generation durations

### DIFF
--- a/tests/test_generation_routes.py
+++ b/tests/test_generation_routes.py
@@ -2,9 +2,14 @@
 
 import sys
 import types
+from importlib import metadata
 
 import pytest
+import werkzeug
 from flask import Flask
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
 
 
 @pytest.fixture
@@ -123,6 +128,28 @@ def test_legacy_generate_video_rejects_malformed_fields(legacy_generation_client
     )
     assert title_resp.status_code == 400
     assert title_resp.get_json() == {"error": "title must be a string"}
+
+
+def test_legacy_generate_video_rejects_boolean_duration_before_start(
+    legacy_generation_client,
+    monkeypatch,
+):
+    import video_gen_blueprint
+
+    monkeypatch.setattr(
+        video_gen_blueprint.threading,
+        "Thread",
+        lambda *_args, **_kwargs: pytest.fail("generation should not start"),
+    )
+
+    resp = legacy_generation_client.post(
+        "/api/generate-video",
+        json={"prompt": "make a video", "duration": True},
+        headers={"X-API-Key": "test-key"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "duration must be an integer"}
 
 
 def test_legacy_generate_video_rejects_non_string_body_api_key(

--- a/video_gen_blueprint.py
+++ b/video_gen_blueprint.py
@@ -141,6 +141,16 @@ def _string_field(data: dict, field_name: str, default: str = ""):
     return value.strip(), None
 
 
+def _integer_field(data: dict, field_name: str, default: int):
+    value = data.get(field_name, default)
+    if isinstance(value, bool):
+        return None, (jsonify({"error": f"{field_name} must be an integer"}), 400)
+    try:
+        return int(value), None
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": f"{field_name} must be an integer"}), 400)
+
+
 def _require_api_key_or_json(f):
     """Accept X-API-Key header (standard) or agent_api_key in JSON body."""
     @wraps(f)
@@ -931,10 +941,10 @@ def generate_video():
     if len(prompt) > PROMPT_MAX_LEN:
         return jsonify({"error": f"prompt exceeds {PROMPT_MAX_LEN} characters"}), 400
 
-    try:
-        duration = min(MAX_DURATION, max(1, int(data.get("duration", MAX_DURATION))))
-    except (TypeError, ValueError):
-        return jsonify({"error": "duration must be an integer"}), 400
+    duration, error = _integer_field(data, "duration", MAX_DURATION)
+    if error:
+        return error
+    duration = min(MAX_DURATION, max(1, duration))
     category, error = _string_field(data, "category", "other")
     if error:
         return error


### PR DESCRIPTION
## Summary
- reject JSON boolean `duration` values in the legacy video generation endpoint
- preserve numeric string and integer durations
- preserve existing duration clamping before job startup

## Tests
- Red before fix: `pytest tests/test_generation_routes.py -q -k boolean_duration` showed `duration=true` reached generation startup as duration `1`
- `pytest tests/test_generation_routes.py -q`
- `python3 -m py_compile video_gen_blueprint.py tests/test_generation_routes.py`
- `flake8 video_gen_blueprint.py tests/test_generation_routes.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`
- Manual Flask client sanity for boolean, invalid string, numeric string, and clamped duration