### PR TITLE
Reject malformed chat send bodies

### DIFF
--- a/chat_handlers.py
+++ b/chat_handlers.py
@@ -57,6 +57,15 @@ def init_chat_tables(db):
     db.commit()
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
 # ── Routes ──────────────────────────────────────────────────────
 @chat_bp.route("/chat/<video_id>")
 def chat_page(video_id):
@@ -90,7 +99,9 @@ def send_message(video_id):
     """REST fallback for sending a chat message (non-WebSocket clients)."""
     db = get_db()
     init_chat_tables(db)
-    data = request.get_json(force=True)
+    data, error = _json_object_body()
+    if error:
+        return error
     username = session.get("username", data.get("username", "Anonymous"))
     msg_text = (data.get("message") or "").strip()
     if not msg_text or len(msg_text) > 500:

--- a/tests/test_chat_handlers_validation.py
+++ b/tests/test_chat_handlers_validation.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+from importlib import metadata
+
+import pytest
+import werkzeug
+from flask import Flask, g
+
+import chat_handlers
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
+
+
+@pytest.fixture()
+def chat_client(tmp_path):
+    db_path = tmp_path / "chat.db"
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["DATABASE"] = str(db_path)
+    app.config["SECRET_KEY"] = "test-secret"
+    app.register_blueprint(chat_handlers.chat_bp)
+
+    @app.teardown_request
+    def teardown_request(_exc):
+        db = getattr(g, "db", None)
+        if db is not None:
+            db.close()
+            g.db = None
+
+    with app.app_context():
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        g.db = db
+        chat_handlers.init_chat_tables(db)
+
+    client = app.test_client()
+    client.db_path = db_path
+    return client
+
+
+def _chat_message_count(db_path):
+    with sqlite3.connect(db_path) as db:
+        return db.execute("SELECT COUNT(*) FROM chat_messages").fetchone()[0]
+
+
+def test_send_message_rejects_non_object_json_without_insert(chat_client):
+    resp = chat_client.post("/api/chat/video-1/send", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON object required"}
+    assert _chat_message_count(chat_client.db_path) == 0
+
+
+def test_send_message_still_records_valid_json_object(chat_client):
+    resp = chat_client.post(
+        "/api/chat/video-1/send",
+        json={"username": "Ada", "message": "Hello chat"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "sent"
+    assert _chat_message_count(chat_client.db_path) == 1


### PR DESCRIPTION
## Summary
- validate chat send JSON bodies before reading fields
- return JSON 400 for non-object request bodies
- preserve valid chat message insertion

## Tests
- Red before fix: `pytest tests/test_chat_handlers_validation.py -q` crashed with `list` has no `.get` on JSON arrays
- `pytest tests/test_chat_handlers_validation.py -q`
- `python3 -m py_compile chat_handlers.py tests/test_chat_handlers_validation.py`
- `flake8 chat_handlers.py tests/test_chat_handlers_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`