### PR TITLE
Reject malformed Ergo history limits

### DIFF
--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -488,7 +488,13 @@ def ergo_history():
     else:
         agent_id = user_id
 
-    limit = min(int(request.args.get("limit", 20)), 50)
+    try:
+        limit = int(request.args.get("limit", 20))
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit must be a positive integer"}), 400
+    if limit < 1:
+        return jsonify({"error": "limit must be a positive integer"}), 400
+    limit = min(limit, 50)
 
     deposits = db.execute(
         "SELECT tx_id, amount_erg, fee_erg, rtc_credited, status, created_at "

--- a/tests/test_ergo_bridge_validation.py
+++ b/tests/test_ergo_bridge_validation.py
@@ -149,3 +149,30 @@ def test_ergo_withdraw_rejects_invalid_amount_without_queue_or_debit(client, amo
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "amount_rtc must be a finite positive number"
     assert _counts_and_balance(client.db_path) == before
+
+
+@pytest.mark.parametrize("limit", ["abc", "-5", "0"])
+def test_ergo_history_rejects_invalid_limit(client, limit):
+    app = client.application
+
+    with app.test_request_context(
+        f"/api/ergo/history?limit={limit}",
+        headers=_auth_headers(),
+    ):
+        resp, status = ergo_bridge_blueprint.ergo_history()
+
+    assert status == 400
+    assert resp.get_json()["error"] == "limit must be a positive integer"
+
+
+def test_ergo_history_clamps_large_limit(client):
+    app = client.application
+
+    with app.test_request_context(
+        "/api/ergo/history?limit=500",
+        headers=_auth_headers(),
+    ):
+        resp = ergo_bridge_blueprint.ergo_history()
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"deposits": [], "withdrawals": []}


### PR DESCRIPTION
## Summary
- reject malformed `limit` query values on `/api/ergo/history` with JSON 400
- reject zero and negative limits instead of passing them into SQL
- keep the existing clamp to 50 for large valid limits

## Tests
- red before fix: `PYTHONPATH=/tmp/bottube_pytest_compat:. python3 -m pytest tests/test_ergo_bridge_validation.py::test_ergo_history_rejects_invalid_limit -q` raised `ValueError: invalid literal for int()` for `limit=abc`
- `PYTHONPATH=/tmp/bottube_pytest_compat:. python3 -m pytest tests/test_ergo_bridge_validation.py -q` (14 passed)
- `python3 -m py_compile ergo_bridge_blueprint.py tests/test_ergo_bridge_validation.py`
- `flake8 ergo_bridge_blueprint.py tests/test_ergo_bridge_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics` (0)
- `git diff --check`

Note: this local machine has Flask 2.3.2 with Werkzeug 3.1.6, so direct Flask test-client runs need a temporary `sitecustomize` shim for `werkzeug.__version__`; the shim is not part of this PR.
