### PR TITLE
Reject malformed modern generation durations

### DIFF
--- a/generation/routes.py
+++ b/generation/routes.py
@@ -61,6 +61,25 @@ def _string_field(data: dict, field_name: str, default: str = ""):
     return value.strip(), None
 
 
+def _integer_field(data: dict, field_names, default: int = 0, error_name: str = "value"):
+    for field_name in field_names:
+        if field_name in data:
+            value = data[field_name]
+            break
+    else:
+        value = default
+    if isinstance(value, bool):
+        return None, (jsonify({"error": f"{error_name} must be an integer"}), 400)
+    if isinstance(value, int):
+        return value, None
+    if isinstance(value, str):
+        try:
+            return int(value), None
+        except ValueError:
+            pass
+    return None, (jsonify({"error": f"{error_name} must be an integer"}), 400)
+
+
 def _require_api_key(f):
     """Accept X-API-Key header or agent_api_key in JSON body."""
     @wraps(f)
@@ -136,6 +155,12 @@ def create_generation_job():
     if len(prompt) > 500:
         return jsonify({"error": "prompt exceeds 500 characters"}), 400
 
+    duration, error = _integer_field(
+        data, ("durationSec", "duration"), default=8, error_name="duration"
+    )
+    if error:
+        return error
+
     # Rate limit
     remaining = _check_rate(g.api_key)
     if remaining is not None:
@@ -148,7 +173,7 @@ def create_generation_job():
     try:
         req = GenerationRequest(
             prompt=prompt,
-            duration=data.get("durationSec", data.get("duration", 8)),
+            duration=duration,
             aspect_ratio=data.get("aspectRatio", data.get("aspect_ratio", "1:1")),
             mode=data.get("mode", "text_to_video"),
             category=data.get("category", "other"),

--- a/tests/test_generation_job_duration_validation.py
+++ b/tests/test_generation_job_duration_validation.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: MIT
+"""Validation tests for modern generation job duration parsing."""
+
+import sys
+import types
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture()
+def generation_routes(monkeypatch):
+    created_requests = []
+
+    class FakeDB:
+        def execute(self, *_args, **_kwargs):
+            return self
+
+        def fetchone(self):
+            return {
+                "id": 1,
+                "agent_name": "generation_bot",
+                "api_key": "test-key",
+                "is_banned": 0,
+            }
+
+    fake_server = types.SimpleNamespace(get_db=lambda: FakeDB())
+    monkeypatch.setitem(sys.modules, "bottube_server", fake_server)
+
+    import generation.routes as routes
+
+    monkeypatch.setattr(routes, "_check_rate", lambda _api_key: None)
+    monkeypatch.setattr(routes, "_record_rate", lambda _api_key: None)
+
+    def _create_job(_owner_id, req):
+        created_requests.append(req)
+        return "job-1"
+
+    monkeypatch.setattr(routes, "create_job", _create_job)
+
+    class DummyThread:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(routes.threading, "Thread", DummyThread)
+    routes.created_requests = created_requests
+    return routes
+
+
+def _post_generation_job(routes, payload):
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/api/generation/jobs",
+        method="POST",
+        json=payload,
+        headers={"X-API-Key": "test-key"},
+    ):
+        return routes.create_generation_job()
+
+
+def test_generation_job_rejects_boolean_duration(generation_routes):
+    resp, status = _post_generation_job(
+        generation_routes,
+        {"prompt": "make a video", "duration": True},
+    )
+
+    assert status == 400
+    assert resp.get_json() == {"error": "duration must be an integer"}
+    assert generation_routes.created_requests == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"prompt": "make a video", "duration": "long"},
+        {"prompt": "make a video", "duration": 1.9},
+        {"prompt": "make a video", "durationSec": True},
+        {"prompt": "make a video", "durationSec": 2.5},
+    ],
+)
+def test_generation_job_rejects_malformed_duration_aliases(
+    generation_routes,
+    payload,
+):
+    resp, status = _post_generation_job(generation_routes, payload)
+
+    assert status == 400
+    assert resp.get_json() == {"error": "duration must be an integer"}
+    assert generation_routes.created_requests == []
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_duration"),
+    [
+        ({"prompt": "make a video"}, 8),
+        ({"prompt": "make a video", "duration": "12"}, 12),
+        ({"prompt": "make a video", "durationSec": "15", "duration": "12"}, 15),
+    ],
+)
+def test_generation_job_preserves_valid_duration_inputs(
+    generation_routes,
+    payload,
+    expected_duration,
+):
+    resp, status = _post_generation_job(generation_routes, payload)
+
+    assert status == 202
+    assert resp.get_json()["ok"] is True
+    assert generation_routes.created_requests[-1].duration == expected_duration


### PR DESCRIPTION
## Summary
- validate modern generation job `duration` and `durationSec` before building `GenerationRequest`
- reject booleans, floats, and non-integer strings with `{"error":"duration must be an integer"}`
- preserve default duration, numeric strings, and `durationSec` precedence

## Tests
- red before fix: `python3 -m pytest tests/test_generation_job_duration_validation.py -q` returned 202 instead of 400 for `duration: true`
- `python3 -m pytest tests/test_generation_job_duration_validation.py -q` (8 passed)
- `PYTHONPATH=/tmp/bottube_pytest_compat:. python3 -m pytest tests/test_generation_routes.py -q` (6 passed)
- `python3 -m py_compile generation/routes.py tests/test_generation_job_duration_validation.py tests/test_generation_routes.py`
- `flake8 generation/routes.py tests/test_generation_job_duration_validation.py tests/test_generation_routes.py --count --select=E9,F63,F7,F82 --show-source --statistics` (0)
- `git diff --check`

Note: this local machine has Flask 2.3.2 with Werkzeug 3.1.6, so the existing Flask test-client route tests need a temporary external `sitecustomize` shim for `werkzeug.__version__`; the shim is not part of this PR. The new direct request-context tests avoid that dependency.
