### PR TITLE
Reject non-finite social feed timestamps

### DIFF
--- a/interactions_blueprint.py
+++ b/interactions_blueprint.py
@@ -6,6 +6,7 @@ Features: Activity feed, reply threading, collab badges, conversations view, rel
 
 import sqlite3
 import json
+import math
 from datetime import datetime, timedelta
 from flask import Blueprint, render_template, jsonify, request, g
 from collections import defaultdict
@@ -27,9 +28,12 @@ def _parse_optional_float_query_arg(name):
     if not raw_value:
         return None, None
     try:
-        return float(raw_value), None
+        parsed = float(raw_value)
     except (TypeError, ValueError):
         return None, f"{name} must be a number"
+    if not math.isfinite(parsed):
+        return None, f"{name} must be a finite number"
+    return parsed, None
 
 
 def get_db():

--- a/tests/test_social_feed_query_validation.py
+++ b/tests/test_social_feed_query_validation.py
@@ -48,6 +48,17 @@ def test_social_feed_rejects_malformed_since(monkeypatch):
     assert fake_db.calls == []
 
 
+def test_social_feed_rejects_non_finite_since(monkeypatch):
+    client, fake_db = _make_client(monkeypatch)
+
+    for value in ("NaN", "Infinity", "-Infinity"):
+        resp = client.get(f"/social/api/feed?since={value}")
+
+        assert resp.status_code == 400
+        assert resp.get_json() == {"error": "since must be a finite number"}
+    assert fake_db.calls == []
+
+
 def test_social_feed_clamps_limit_and_applies_since(monkeypatch):
     client, fake_db = _make_client(monkeypatch)
 


### PR DESCRIPTION
## Summary
- reject non-finite `since` query values on `/social/api/feed`
- keep the existing malformed-string error for non-numeric input
- preserve finite timestamp filtering and limit clamping behavior

## Tests
- red before fix: `PYTHONPATH=/tmp/bottube_pytest_compat:. python3 -m pytest tests/test_social_feed_query_validation.py::test_social_feed_rejects_non_finite_since -q` returned 200 for `since=NaN`
- `PYTHONPATH=/tmp/bottube_pytest_compat:. python3 -m pytest tests/test_social_feed_query_validation.py -q` (4 passed)
- `python3 -m py_compile interactions_blueprint.py tests/test_social_feed_query_validation.py`
- `flake8 interactions_blueprint.py tests/test_social_feed_query_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics` (0)
- `git diff --check`

Note: this local machine has Flask 2.3.2 with Werkzeug 3.1.6, so Flask test-client runs need a temporary external `sitecustomize` shim for `werkzeug.__version__`; the shim is not part of this PR.
