### PR TITLE
Keep news RSS categories XML-safe

### DIFF
--- a/news_routes.py
+++ b/news_routes.py
@@ -1,6 +1,7 @@
 """News section -- aggregates the_daily_byte + skywatch_ai into a news portal."""
 import sqlite3
 import time
+from html import escape
 from datetime import datetime, timezone
 from flask import Blueprint, render_template, Response
 
@@ -72,7 +73,7 @@ def news_rss():
             f"      <guid isPermaLink=\"true\">{link}</guid>\n"
             f"      <pubDate>{pub_date}</pubDate>\n"
             f"      <description><![CDATA[{(item['description'] or '')[:300]}]]></description>\n"
-            f"      <category>{item['category'] or 'news'}</category>\n"
+            f"      <category>{escape(item['category'] or 'news')}</category>\n"
             f"      <dc:creator><![CDATA[{item['display_name'] or item['agent_name']}]]></dc:creator>\n"
             f"    </item>"
         )

--- a/tests/test_news_routes_rss.py
+++ b/tests/test_news_routes_rss.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+"""RSS rendering tests for news routes."""
+
+import time
+import xml.etree.ElementTree as ET
+
+from flask import Flask
+
+import news_routes
+
+
+class Row(dict):
+    def __getitem__(self, key):
+        return self.get(key)
+
+
+def test_news_rss_escapes_category_xml(monkeypatch):
+    row = Row(
+        video_id="news-1",
+        title="Storm update",
+        description="Weather and climate briefing",
+        created_at=time.time(),
+        thumbnail="thumb.jpg",
+        duration_sec=8,
+        views=1,
+        category="weather & climate <alerts>",
+        agent_name="the_daily_byte",
+        display_name="Daily Byte",
+        avatar_url="",
+    )
+    monkeypatch.setattr(news_routes, "_get_news_videos", lambda _limit=30: [row])
+    monkeypatch.setattr(news_routes, "_get_weather_videos", lambda _limit=20: [])
+
+    app = Flask(__name__)
+    app.register_blueprint(news_routes.news_bp)
+
+    response = app.test_client().get("/news/rss")
+
+    assert response.status_code == 200
+    ET.fromstring(response.text)
+    assert "<category>weather &amp; climate &lt;alerts&gt;</category>" in response.text


### PR DESCRIPTION
## Summary
- escape RSS category text in `/news/rss`
- keep the existing RSS item structure and fallback `news` category
- add a regression test that parses the generated RSS as XML

## Tests
- red before fix: `PYTHONPATH=/tmp/bottube_pytest_compat:. python3 -m pytest tests/test_news_routes_rss.py -q` raised `xml.etree.ElementTree.ParseError` for category `weather & climate <alerts>`
- `PYTHONPATH=/tmp/bottube_pytest_compat:. python3 -m pytest tests/test_news_routes_rss.py -q` (1 passed)
- `python3 -m py_compile news_routes.py tests/test_news_routes_rss.py`
- `flake8 news_routes.py tests/test_news_routes_rss.py --count --select=E9,F63,F7,F82 --show-source --statistics` (0)
- `git diff --check`

Note: this local machine has Flask 2.3.2 with Werkzeug 3.1.6, so Flask test-client runs need a temporary external `sitecustomize` shim for `werkzeug.__version__`; the shim is not part of this PR.
