### PR TITLE
fix(#1359): pass missing template context to /bridge landing

### DIFF
--- a/tests/test_wrtc_bridge_validation.py
+++ b/tests/test_wrtc_bridge_validation.py
@@ -267,5 +267,8 @@ def test_bridge_landing_handles_user_with_null_sol_address(monkeypatch):
     client = flask_app.test_client()
     resp = client.get("/bridge")
     assert resp.status_code == 200
-    assert captured["kwargs"]["user_sol_address"] == ""
-    assert captured["kwargs"]["user_b(fix(#1359): pass missing template context to /bridge landing)
+    kw = captured["kwargs"]
+    assert kw["user_sol_address"] == ""
+    assert kw["user_balance"] == 0.0
+    assert kw["swap_url"] == bridge_mod.WRTC_BUY_URL
+    assert kw["reserve_wallet"] == bridge_mod.WRTC_RESERVE_WALLET

--- a/tests/test_wrtc_bridge_validation.py
+++ b/tests/test_wrtc_bridge_validation.py
@@ -2,6 +2,7 @@
 """Validation tests for Solana wRTC bridge request parsing."""
 
 import sqlite3
+from pathlib import Path
 
 import pytest
 from flask import Flask, g
@@ -168,3 +169,103 @@ def test_wrtc_html_alias_routes_redirect_to_bridge_console(client, path):
 
     assert resp.status_code == 302
     assert resp.headers["Location"].endswith("/bridge/wrtc")
+
+
+# --- /bridge landing template context tests (regression for #1359) ---
+
+import wrtc_bridge_blueprint as bridge_mod  # noqa: E402
+
+
+def test_bridge_landing_passes_template_context_for_anonymous_user(monkeypatch):
+    """Anonymous user: g.user absent -> all 4 template kwargs set to safe defaults."""
+    from flask import Flask, g
+
+    captured = {}
+
+    def _fake_render(template_name, **kwargs):
+        captured["template_name"] = template_name
+        captured["kwargs"] = kwargs
+        return "<html>fake</html>"
+
+    monkeypatch.setattr(bridge_mod, "render_template", _fake_render)
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.register_blueprint(bridge_mod.wrtc_bp)
+
+    client = flask_app.test_client()
+    resp = client.get("/bridge")
+    assert resp.status_code == 200
+    assert resp.data == b"<html>fake</html>"
+    assert captured["template_name"] == "bridge.html"
+    kw = captured["kwargs"]
+    # 4 missing vars get safe defaults
+    assert kw["user_balance"] == 0
+    assert kw["user_sol_address"] == ""
+    # swap_url and reserve_wallet reuse the existing module constants
+    assert kw["swap_url"] == bridge_mod.WRTC_BUY_URL
+    assert kw["reserve_wallet"] == bridge_mod.WRTC_RESERVE_WALLET
+    # 3 existing vars still present (no regression)
+    assert kw["wrtc_mint"] == bridge_mod.WRTC_MINT
+    assert kw["wrtc_reserve_wallet"] == bridge_mod.WRTC_RESERVE_WALLET
+    assert kw["wrtc_buy_url"] == bridge_mod.WRTC_BUY_URL
+
+
+def test_bridge_landing_uses_authenticated_user_balance_and_sol_address(monkeypatch):
+    """Authenticated user: g.user is set -> user_balance and user_sol_address flow through."""
+    from flask import Flask, g
+
+    captured = {}
+
+    def _fake_render(template_name, **kwargs):
+        captured["kwargs"] = kwargs
+        return "<html>fake</html>"
+
+    monkeypatch.setattr(bridge_mod, "render_template", _fake_render)
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.register_blueprint(bridge_mod.wrtc_bp)
+
+    @flask_app.before_request
+    def _seed_user():
+        g.user = {
+            "id": 42,
+            "agent_name": "alice",
+            "sol_address": "SoLaNaAdDrEsS1111111111111111111111",
+            "rtc_balance": 12.5,
+        }
+
+    client = flask_app.test_client()
+    resp = client.get("/bridge")
+    assert resp.status_code == 200
+    kw = captured["kwargs"]
+    assert kw["user_balance"] == 12.5
+    assert kw["user_sol_address"] == "SoLaNaAdDrEsS1111111111111111111111"
+
+
+def test_bridge_landing_handles_user_with_null_sol_address(monkeypatch):
+    """Auth user with NULL sol_address -> empty string fallback (no 500)."""
+    from flask import Flask, g
+
+    captured = {}
+
+    def _fake_render(template_name, **kwargs):
+        captured["kwargs"] = kwargs
+        return "<html>fake</html>"
+
+    monkeypatch.setattr(bridge_mod, "render_template", _fake_render)
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.register_blueprint(bridge_mod.wrtc_bp)
+
+    @flask_app.before_request
+    def _seed_user():
+        g.user = {"id": 7, "agent_name": "bob", "sol_address": None, "rtc_balance": 0.0}
+
+    client = flask_app.test_client()
+    resp = client.get("/bridge")
+    assert resp.status_code == 200
+    assert captured["kwargs"]["user_sol_address"] == ""
+    assert captured["kwargs"]["user_b(fix(#1359): pass missing template context to /bridge landing)

--- a/wrtc_bridge_blueprint.py
+++ b/wrtc_bridge_blueprint.py
@@ -521,11 +521,18 @@ def wrtc_bridge_history():
 
 @wrtc_bp.route("/bridge")
 def wrtc_bridge_landing():
+    _user = getattr(g, "user", None)
+    user_balance = _user["rtc_balance"] if _user else 0
+    user_sol_address = (_user["sol_address"] or "") if _user else ""
     return render_template(
         "bridge.html",
         wrtc_mint=WRTC_MINT,
         wrtc_reserve_wallet=WRTC_RESERVE_WALLET,
         wrtc_buy_url=WRTC_BUY_URL,
+        user_balance=user_balance,
+        swap_url=WRTC_BUY_URL,
+        reserve_wallet=WRTC_RESERVE_WALLET,
+        user_sol_address=user_sol_address,
     )
 
 


### PR DESCRIPTION
## What this fixes

`https://bottube.ai/bridge` returns **HTTP 500** because `bridge.html` references 4 template variables that `wrtc_bridge_landing()` does not pass: `user_balance`, `swap_url`, `reserve_wallet`, `user_sol_address`.

Repro (re-verified 2026-06-09T21:07:26Z):
```bash
$ for i in 1 2 3; do curl -sk -o /dev/null -w "req %{http_code}\n" https://bottube.ai/bridge; done
500
500
500
```

Sibling pages work fine:
```bash
$ curl -sk -o /dev/null -w "%{http_code}\n" https://bottube.ai/bridge/wrtc
200
$ curl -sk -o /dev/null -w "%{http_code}\n" https://bottube.ai/bridge/base
200
```

## Why this PR (vs. #1360)

PR #1360 (also for #1359) replaces the **entire 542-line** `wrtc_bridge_blueprint.py` with a 15-line stub. The diff is `+9/-533` and **removes 5 production handlers** that the live app and `tests/test_base_wrtc_bridge_validation.py` import:

- `GET /api/wrtc-bridge/info`
- `POST /api/wrtc-bridge/deposit` (Solana deposit verification)
- `POST /api/wrtc-bridge/withdraw` (withdrawal queue)
- `GET /api/wrtc-bridge/history` (deposit/withdraw history)
- `GET /bridge/wrtc` (the sibling wRTC page)

`git show origin/main:wrtc_bridge_blueprint.py | grep "@wrtc_bp.route"` returns 5 distinct routes; #1360 keeps only 1. I posted a CHANGES_REQUESTED review on #1360 explaining this.

This PR is the **right shape of the fix**: 6 additive lines on top of the existing function, no deletions, no behavior change for any of the other 4 endpoints.

## Diff

```diff
 @wrtc_bp.route("/bridge")
 def wrtc_bridge_landing():
+    _user = getattr(g, "user", None)
+    user_balance = _user["rtc_balance"] if _user else 0
+    user_sol_address = (_user["sol_address"] or "") if _user else ""
     return render_template(
         "bridge.html",
         wrtc_mint=WRTC_MINT,
         wrtc_reserve_wallet=WRTC_RESERVE_WALLET,
         wrtc_buy_url=WRTC_BUY_URL,
+        user_balance=user_balance,
+        swap_url=WRTC_BUY_URL,
+        reserve_wallet=WRTC_RESERVE_WALLET,
+        user_sol_address=user_sol_address,
     )
```

## Source-tree context

`bottube_server.py:1462` already populates `g.user` from the session in a `before_request` hook, and `:12152`/`:12524` use the same `g.user["rtc_balance"] if g.user else 0` pattern. The fix matches the existing app convention.

For `user_sol_address` we read from `g.user["sol_address"]` (the live schema column at `bottube_server.py:1792`). For anonymous users (no `g.user`) we return `""` so the template's `{{ user_sol_address or '' }}` renders an empty input as before.

`swap_url` and `reserve_wallet` reuse the existing module constants `WRTC_BUY_URL` (Raydium link with the canonical mint) and `WRTC_RESERVE_WALLET` so the template shows the same canonical values the rest of the bridge uses.

## Tests

3 new tests in `tests/test_wrtc_bridge_validation.py` cover:
- anonymous user (no `g.user`) -> 200, all 4 kwargs safe
- authenticated user with row in `agents` -> 200, `user_balance` and `user_sol_address` flow through
- authenticated user with `sol_address IS NULL` -> 200, empty-string fallback (no AttributeError on `None or ""`)

```bash
$ pytest tests/test_wrtc_bridge_validation.py tests/test_base_wrtc_bridge_validation.py -q
21 passed in 0.49s
```

## Wallet

This is bug-report-fix work, not a code bounty. Bounty #1102 claim lives in `https://github.com/Scottcjn/rustchain-bounties/issues/13575`. Wallet declaration: `jdjioe5-cpu` (handle-fallback per merged PR #13394).

## Bot-fix alternative

Closing this PR in favor of #1360 will re-merge 533 lines of deleted code with a 9-line additive fix on top. If the maintainer prefers the bot-fix, the 4 endpoints above will all 404 / 500. Recommend closing #1360 in favor of this PR.