### PR TITLE
fix: route wRTC alias pages to bridge console

### DIFF
--- a/tests/test_wrtc_bridge_validation.py
+++ b/tests/test_wrtc_bridge_validation.py
@@ -151,3 +151,20 @@ def test_rejected_wrtc_withdrawal_does_not_queue_or_debit(client):
 
     assert queued == 0
     assert balance == 1000.0
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/wrtc",
+        "/wrtc/deposit",
+        "/wrtc/withdraw",
+        "/wrtc/history",
+        "/premium/wrtc",
+    ],
+)
+def test_wrtc_html_alias_routes_redirect_to_bridge_console(client, path):
+    resp = client.get(path)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/bridge/wrtc")

--- a/wrtc_bridge_blueprint.py
+++ b/wrtc_bridge_blueprint.py
@@ -17,7 +17,7 @@ import time
 import urllib.error
 import urllib.request
 
-from flask import Blueprint, g, jsonify, render_template, request
+from flask import Blueprint, g, jsonify, redirect, render_template, request, url_for
 
 wrtc_bp = Blueprint("wrtc_bridge", __name__)
 
@@ -538,3 +538,12 @@ def wrtc_bridge_page():
         wrtc_buy_url=WRTC_BUY_URL,
         wrtc_decimals=WRTC_DECIMALS,
     )
+
+
+@wrtc_bp.route("/wrtc")
+@wrtc_bp.route("/wrtc/deposit")
+@wrtc_bp.route("/wrtc/withdraw")
+@wrtc_bp.route("/wrtc/history")
+@wrtc_bp.route("/premium/wrtc")
+def wrtc_bridge_alias():
+    return redirect(url_for("wrtc_bridge.wrtc_bridge_page"))


### PR DESCRIPTION
## Summary
Fixes #1369.

Adds compatibility routes for the natural wRTC bridge URLs that were returning the in-app 404 page:

- `/wrtc`
- `/wrtc/deposit`
- `/wrtc/withdraw`
- `/wrtc/history`
- `/premium/wrtc`

Each route now redirects to the existing canonical `/bridge/wrtc` bridge console instead of duplicating bridge page logic.

## Verification
- Added a regression test proving the five affected HTML routes redirect to `/bridge/wrtc`.
- Red check before fix: `5 failed, 9 passed` in `tests/test_wrtc_bridge_validation.py`, with all five aliases returning 404.
- Green check after fix: `.venv/bin/python -m pytest tests/test_wrtc_bridge_validation.py -q` -> `14 passed`.
- Adjacent bridge checks: `.venv/bin/python -m pytest tests/test_wrtc_bridge_validation.py tests/test_base_wrtc_bridge_validation.py -q` -> `23 passed`.