### PR TITLE
fix(a11y): promote /search results heading to <h1> (Refs #1387)

### DIFF
--- a/bottube_templates/search.html
+++ b/bottube_templates/search.html
@@ -242,9 +242,9 @@
     <!-- Results Area -->
     <main>
         <div class="search-results-header">
-            <h2 class="section-title" id="search-results-heading" style="margin:0;">
+            <h1 class="section-title" id="search-results-heading" style="margin:0;">
                 Results for "{{ query }}"
-            </h2>
+            </h1>
             <span class="results-count">{{ total }} videos</span>
         </div>
 

--- a/tests/test_search_results_h1_heading.py
+++ b/tests/test_search_results_h1_heading.py
@@ -1,0 +1,105 @@
+"""Regression tests for Bottube search results h1 heading (Bottube #1387).
+
+The /search?q=... results page must expose a page-level <h1> inside
+<main> so that screen-reader and keyboard users navigating by headings
+can identify the page purpose (WCAG 1.3.1 / 2.4.6 / 4.1.2).
+
+Before this fix, the results heading was <h2 class="section-title">
+and the page had no <h1>, creating a heading-hierarchy gap and
+making the search page inconsistent with every other top-level
+Bottube template (index.html, channel.html, activity_feed.html,
+etc., all of which start with <h1>).
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+TEMPLATE_DIR = Path(__file__).parent.parent / "bottube_templates"
+
+
+class TestSearchResultsH1Heading(unittest.TestCase):
+    TEMPLATE = TEMPLATE_DIR / "search.html"
+
+    def _read(self):
+        with open(self.TEMPLATE, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_page_uses_h1_for_results_heading(self):
+        """The search results heading must be an <h1>, not <h2>."""
+        content = self._read()
+        match = re.search(
+            r'<(h1|h2)\b[^>]*id="search-results-heading"[^>]*>',
+            content,
+        )
+        self.assertIsNotNone(
+            match,
+            "Expected an <h1>/<h2> with id='search-results-heading' in search.html",
+        )
+        self.assertEqual(
+            match.group(1),
+            "h1",
+            (
+                "search-results-heading must be an <h1> (not <h2>) so the "
+                "search results page exposes a page-level heading for "
+                "WCAG 1.3.1 / 2.4.6 compliance. Found: <%s>" % match.group(1)
+            ),
+        )
+
+    def test_h1_carries_section_title_class(self):
+        """The h1 must keep the .section-title class so the visual style is unchanged."""
+        content = self._read()
+        match = re.search(
+            r'<h1\b[^>]*id="search-results-heading"[^>]*>',
+            content,
+        )
+        self.assertIsNotNone(match, "search-results-heading h1 not found")
+        tag = match.group(0)
+        self.assertIn(
+            "section-title",
+            tag,
+            "search-results-heading <h1> must keep the .section-title class "
+            "to preserve the existing visual style (only the tag changed).",
+        )
+
+    def test_no_lingering_h2_for_results(self):
+        """There must be no <h2 id='search-results-heading'> left over."""
+        content = self._read()
+        self.assertNotIn(
+            '<h2 class="section-title" id="search-results-heading"',
+            content,
+            "Lingering <h2 id='search-results-heading'> still present; the fix "
+            "must replace the h2 tag with h1, not duplicate it.",
+        )
+
+    def test_query_text_preserved(self):
+        """The query placeholder must still render in the heading text."""
+        content = self._read()
+        match = re.search(
+            r'<h1\b[^>]*id="search-results-heading"[^>]*>(.*?)</h1>',
+            content,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match, "search-results-heading <h1> not found")
+        inner = match.group(1)
+        self.assertIn(
+            "{{ query }}",
+            inner,
+            "Heading text must still render the search query; do not remove "
+            "the {{ query }} placeholder.",
+        )
+
+    def test_results_count_preserved(self):
+        """The {{ total }} videos count must remain next to the heading."""
+        content = self._read()
+        self.assertIn(
+            '{{ total }} videos',
+            content,
+            "Results count 'total videos' span was removed; the fix should "
+            "only change the heading tag, not remove the count.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Promotes the `/search?q=...` results page heading from `<h2 class="section-title">` to `<h1 class="section-title">` so the page exposes a page-level heading. Fixes the heading-hierarchy gap and brings `/search` in line with every other top-level BoTTube template (index.html, channel.html, activity_feed.html, analytics.html, etc.), all of which start with `<h1>`.

Refs #1387

## Why (WCAG)

- **WCAG 1.3.1 (Info and Relationships):** Document structure must be conveyed programmatically; the page's primary purpose was hidden from the heading axis.
- **WCAG 2.4.6 (Headings and Labels):** Headings describe the topic/purpose; the search results page had no top-level heading.
- **WCAG 4.1.2 (Name, Role, Value):** Screen-reader heading navigation jumped from the site nav to nested content with no page-level entry point.

The current `<h2 id="search-results-heading">` is the only heading on the page; promoting it to `<h1>` is the minimal correct fix.

## Diff

```diff
--- a/bottube_templates/search.html
+++ b/bottube_templates/search.html
@@ -242,9 +242,9 @@
     <!-- Results Area -->
     <main>
         <div class="search-results-header">
-            <h2 class="section-title" id="search-results-heading" style="margin:0;">
+            <h1 class="section-title" id="search-results-heading" style="margin:0;">
                 Results for "{{ query }}"
-            </h2>
+            </h1>
             <span class="results-count">{{ total }} videos</span>
         </div>
```

The `.section-title` class and the inline `style="margin:0;"` are preserved, so the visual style is unchanged. Only the tag changed.

## Tests

New file `tests/test_search_results_h1_heading.py` (5 assertions) locks the fix:

- The heading must be `<h1>` (not `<h2>`).
- The `<h1>` must keep `.section-title` (visual style preserved).
- No `<h2 id="search-results-heading">` left over.
- The `{{ query }}` placeholder is preserved.
- The `{{ total }} videos` count is preserved.

```
$ python3 -m pytest tests/test_search_results_h1_heading.py -v
============================= test session starts ==============================
collected 5 items

tests/test_search_results_h1_heading.py::TestSearchResultsH1Heading::test_h1_carries_section_title_class PASSED
tests/test_search_results_h1_heading.py::TestSearchResultsH1Heading::test_no_lingering_h2_for_results PASSED
tests/test_search_results_h1_heading.py::TestSearchResultsH1Heading::test_page_uses_h1_for_results_heading PASSED
tests/test_search_results_h1_heading.py::TestSearchResultsH1Heading::test_query_text_preserved PASSED
tests/test_search_results_h1_heading.py::TestSearchResultsH1Heading::test_results_count_preserved PASSED

============================== 5 passed in 0.06s ==============================
```

## Live verification

```
$ curl -sL 'https://bottube.ai/search?q=rustchain' | grep -i 'h1\|h2\|search results for'
"id": "SearchResultsPage", "name": "Search results for: rustchain", ...
<h2 class="section-title" id="search-results-heading">Search results for "rustchain"</h2>
```

After this PR merges and a Flask reload, the same fetch will return `<h1 class="section-title" id="search-results-heading">` (deployment drift is the same as #1375 / #1378 / #1379 / #1361; the source fix is what is reviewable here).

## What this PR does NOT change

- No routes added or removed.
- No CSS touched.
- No public API changed.
- No other template touched.
- No destructive patterns; diff is +2/-2 in a single template + 105 lines of new test code.

Refs #1387