### PR TITLE
Reject malformed recent comments query params

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7672,11 +7672,40 @@ def get_comments(video_id):
     return jsonify({"comments": comments, "count": len(comments)})
 
 
+def _parse_recent_comments_limit():
+    raw_value = request.args.get("limit")
+    if raw_value in (None, ""):
+        return 50, None
+    try:
+        limit = int(raw_value)
+    except (TypeError, ValueError):
+        return None, "limit must be an integer"
+    return min(100, max(1, limit)), None
+
+
+def _parse_recent_comments_since():
+    raw_value = request.args.get("since")
+    if raw_value in (None, ""):
+        return 0, None
+    try:
+        since = float(raw_value)
+    except (TypeError, ValueError):
+        return None, "since must be a number"
+    if not math.isfinite(since):
+        return None, "since must be a finite number"
+    return since, None
+
+
 @app.route("/api/comments/recent")
 def recent_comments():
     """Get recent comments across all videos since a timestamp."""
-    since = request.args.get("since", 0, type=float)
-    limit = min(100, max(1, request.args.get("limit", 50, type=int)))
+    since, error = _parse_recent_comments_since()
+    if error:
+        return jsonify({"error": error}), 400
+    limit, error = _parse_recent_comments_limit()
+    if error:
+        return jsonify({"error": error}), 400
+
     db = get_db()
     rows = db.execute(
         """SELECT c.*, a.agent_name, a.display_name, a.avatar_url

--- a/tests/test_recent_comments_query_validation.py
+++ b/tests/test_recent_comments_query_validation.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+import pytest
+
+
+def test_recent_comments_rejects_malformed_limit(client):
+    response = client.get("/api/comments/recent?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit must be an integer"}
+
+
+def test_recent_comments_rejects_malformed_since(client):
+    response = client.get("/api/comments/recent?since=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "since must be a number"}
+
+
+@pytest.mark.parametrize("value", ["NaN", "Infinity", "-Infinity"])
+def test_recent_comments_rejects_non_finite_since(client, value):
+    response = client.get(f"/api/comments/recent?since={value}")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "since must be a finite number"}
+


### PR DESCRIPTION
## Summary

- validate `/api/comments/recent` `since` and `limit` query params before querying comments
- return JSON 400 errors for malformed `limit`, malformed `since`, and non-finite `since`
- add focused regression coverage for the malformed query cases

Closes #1389.

## Validation

- `uv run --no-project --with flask --with pytest --with requests python -B -m pytest -q tests/test_recent_comments_query_validation.py --tb=short` -> 5 passed
- `uv run --no-project --with flask --with pytest --with requests python -B -m pytest -q tests/test_recent_comments_query_validation.py tests/test_agent_interaction_visibility.py::TestGetCommentsAPI --tb=short` -> 8 passed
- `uv run --no-project --with flask --with pytest --with requests python -B -m py_compile bottube_server.py tests/test_recent_comments_query_validation.py` -> passed
- `git diff --check -- bottube_server.py tests/test_recent_comments_query_validation.py` -> passed
