### PR TITLE
Reject malformed leaderboard limit params

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9780,10 +9780,24 @@ def my_quests():
     })
 
 
+def _parse_leaderboard_limit(default=25, max_value=100):
+    raw_value = request.args.get("limit")
+    if raw_value in (None, ""):
+        return default, None
+    try:
+        limit = int(raw_value)
+    except (TypeError, ValueError):
+        return None, "limit must be an integer"
+    return min(max_value, max(1, limit)), None
+
+
 @app.route("/api/quests/leaderboard")
 def quest_leaderboard():
     """Public leaderboard for completed quests and earned quest RTC."""
-    limit = min(100, max(1, request.args.get("limit", 25, type=int)))
+    limit, error = _parse_leaderboard_limit()
+    if error:
+        return jsonify({"error": error}), 400
+
     db = get_db()
     rows = db.execute(
         """
@@ -9868,7 +9882,10 @@ def agent_streak():
 @app.route("/api/gamification/leaderboard")
 def gamification_leaderboard():
     """Combined leaderboard showing levels, XP, quest completion, and streaks."""
-    limit = min(100, max(1, request.args.get("limit", 25, type=int)))
+    limit, error = _parse_leaderboard_limit()
+    if error:
+        return jsonify({"error": error}), 400
+
     db = get_db()
     
     rows = db.execute(

--- a/tests/test_leaderboard_query_validation.py
+++ b/tests/test_leaderboard_query_validation.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+
+
+def test_quests_leaderboard_rejects_malformed_limit(client):
+    response = client.get("/api/quests/leaderboard?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit must be an integer"}
+
+
+def test_gamification_leaderboard_rejects_malformed_limit(client):
+    response = client.get("/api/gamification/leaderboard?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit must be an integer"}
+


### PR DESCRIPTION
## Summary

- validate `limit` before running public quest/gamification leaderboard queries
- return JSON 400 for malformed `limit` values
- preserve existing 1..100 clamp behavior for valid integer values
- add focused regression tests for both public leaderboard endpoints

Closes #1391.

## Validation

- `uv run --no-project --with flask --with pytest --with requests python -B -m pytest -q tests/test_leaderboard_query_validation.py --tb=short` -> 2 passed
- `uv run --no-project --with flask --with pytest --with requests python -B -m pytest -q tests/test_leaderboard_query_validation.py tests/test_quests.py --tb=short` -> 19 passed, 17 warnings
- `uv run --no-project --with flask --with pytest --with requests python -B -m py_compile bottube_server.py tests/test_leaderboard_query_validation.py` -> passed
- `git diff --check -- bottube_server.py tests/test_leaderboard_query_validation.py` -> passed
