### PR TITLE
Reject malformed syndication query parameters

### DIFF
--- a/syndication_routes.py
+++ b/syndication_routes.py
@@ -76,6 +76,16 @@ def _json_object_body():
     return data, None
 
 
+def _integer_query_arg(name, default):
+    raw_value = request.args.get(name)
+    if raw_value is None:
+        return default, None
+    try:
+        return int(raw_value), None
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": f"{name} must be an integer"}), 400)
+
+
 def require_api_key(f):
     """Decorator to require API key authentication."""
     @wraps(f)
@@ -386,9 +396,14 @@ def list_runs():
     Response:
         runs (list): List of run summaries
     """
+    limit, error = _integer_query_arg("limit", 50)
+    if error:
+        return error
+    days, error = _integer_query_arg("days", 7)
+    if error:
+        return error
+
     try:
-        limit = int(request.args.get("limit", 50))
-        days = int(request.args.get("days", 7))
         
         tracker = get_tracker()
         runs = tracker.get_recent_runs(limit=limit, days=days)
@@ -533,8 +548,11 @@ def outbound_report():
     Response:
         report (dict): Outbound network report (scoped to agent by default)
     """
+    days, error = _integer_query_arg("days", 30)
+    if error:
+        return error
+
     try:
-        days = int(request.args.get("days", 30))
         scope = request.args.get("scope", "agent")
         
         # Network-wide scope requires admin
@@ -571,8 +589,13 @@ def export_report():
     Response:
         report (dict): Report data (returned inline, no file write)
     """
+    report_type = request.args.get("type", "outbound")
+    if report_type not in ("daily", "weekly"):
+        days, error = _integer_query_arg("days", 30)
+        if error:
+            return error
+
     try:
-        report_type = request.args.get("type", "outbound")
         scope = request.args.get("scope", "agent")
         
         # Network-wide scope requires admin
@@ -589,7 +612,7 @@ def export_report():
         elif report_type == "weekly":
             kwargs["end_date"] = request.args.get("end_date")
         else:
-            kwargs["days"] = int(request.args.get("days", 30))
+            kwargs["days"] = days
 
         generator = get_generator()
         

--- a/tests/test_syndication_routes.py
+++ b/tests/test_syndication_routes.py
@@ -185,3 +185,24 @@ def test_export_route_returns_inline_json_without_file_path(client):
     assert body["ok"] is True
     assert body["scope"] == "agent"
     assert "file_path" not in body
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/syndication/runs?limit=not-an-int",
+        "/api/syndication/runs?days=not-an-int",
+        "/api/syndication/report/outbound?days=not-an-int",
+        "/api/syndication/report/export?type=outbound&days=not-an-int",
+    ],
+)
+def test_numeric_query_params_reject_malformed_values(client, path):
+    _insert_agent("querybot", "bottube_sk_querybot")
+
+    resp = client.get(
+        path,
+        headers={"X-API-Key": "bottube_sk_querybot"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"].endswith("must be an integer")


### PR DESCRIPTION
Fixes #1393

## Summary

Authenticated syndication routes currently turn malformed numeric query parameters into HTTP 500 responses because conversion errors reach their broad operational exception handlers.

This change adds a small shared integer query parser and returns a focused HTTP 400 JSON error before route execution.

Affected requests include:

``text
GET /api/syndication/runs?limit=not-an-int
GET /api/syndication/runs?days=not-an-int
GET /api/syndication/report/outbound?days=not-an-int
GET /api/syndication/report/export?type=outbound&days=not-an-int
``

Existing defaults and valid integer behavior are preserved.

## Verification

Before the fix, the four regression cases returned 500. After the fix:

``text
11 passed in 5.39s
``

Also checked with:

``text
python -m py_compile syndication_routes.py tests/test_syndication_routes.py
git diff --check
``

Constraint: Preserve existing default and valid integer behavior while classifying malformed client input correctly.
Rejected: Catch conversion errors in each broad route exception block, because that still conflates input validation with operational failures.
Confidence: high
Scope-risk: narrow