### PR TITLE
Reject malformed syndication report dates

### DIFF
--- a/syndication_routes.py
+++ b/syndication_routes.py
@@ -25,6 +25,7 @@ Issue #360 Changes:
 
 import json
 import time
+from datetime import datetime
 from functools import wraps
 from pathlib import Path
 
@@ -74,6 +75,17 @@ def _json_object_body():
     if not isinstance(data, dict):
         return None, (jsonify({"error": "JSON body must be an object"}), 400)
     return data, None
+
+
+def _date_query_arg(name):
+    value = request.args.get(name)
+    if value is None:
+        return None, None
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": f"{name} must use YYYY-MM-DD"}), 400)
+    return value, None
 
 
 def require_api_key(f):
@@ -461,8 +473,11 @@ def daily_report():
     Response:
         report (dict): Daily report data (scoped to agent by default)
     """
+    date_str, error = _date_query_arg("date")
+    if error:
+        return error
+
     try:
-        date_str = request.args.get("date")
         scope = request.args.get("scope", "agent")
         
         # Network-wide scope requires admin
@@ -494,8 +509,11 @@ def weekly_report():
     Response:
         report (dict): Weekly report data (scoped to agent by default)
     """
+    end_date, error = _date_query_arg("end_date")
+    if error:
+        return error
+
     try:
-        end_date = request.args.get("end_date")
         scope = request.args.get("scope", "agent")
         
         # Network-wide scope requires admin
@@ -571,8 +589,17 @@ def export_report():
     Response:
         report (dict): Report data (returned inline, no file write)
     """
+    report_type = request.args.get("type", "outbound")
+    if report_type == "daily":
+        report_date, error = _date_query_arg("date")
+        if error:
+            return error
+    elif report_type == "weekly":
+        report_end_date, error = _date_query_arg("end_date")
+        if error:
+            return error
+
     try:
-        report_type = request.args.get("type", "outbound")
         scope = request.args.get("scope", "agent")
         
         # Network-wide scope requires admin
@@ -585,9 +612,9 @@ def export_report():
 
         kwargs = {"agent_id": agent_id}
         if report_type == "daily":
-            kwargs["date_str"] = request.args.get("date")
+            kwargs["date_str"] = report_date
         elif report_type == "weekly":
-            kwargs["end_date"] = request.args.get("end_date")
+            kwargs["end_date"] = report_end_date
         else:
             kwargs["days"] = int(request.args.get("days", 30))
 

--- a/tests/test_syndication_routes.py
+++ b/tests/test_syndication_routes.py
@@ -185,3 +185,24 @@ def test_export_route_returns_inline_json_without_file_path(client):
     assert body["ok"] is True
     assert body["scope"] == "agent"
     assert "file_path" not in body
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/syndication/report/daily?date=not-a-date",
+        "/api/syndication/report/weekly?end_date=not-a-date",
+        "/api/syndication/report/export?type=daily&date=not-a-date",
+        "/api/syndication/report/export?type=weekly&end_date=not-a-date",
+    ],
+)
+def test_report_routes_reject_malformed_dates(client, path):
+    _insert_agent("datebot", "bottube_sk_datebot")
+
+    resp = client.get(
+        path,
+        headers={"X-API-Key": "bottube_sk_datebot"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"].endswith("must use YYYY-MM-DD")


### PR DESCRIPTION
Fixes #1395

## Summary

Validate documented syndication date and end_date query parameters before report generation so malformed or impossible calendar dates return HTTP 400 JSON responses instead of reaching broad operational exception handlers as HTTP 500.

Covered routes:

``text
GET /api/syndication/report/daily
GET /api/syndication/report/weekly
GET /api/syndication/report/export?type=daily
GET /api/syndication/report/export?type=weekly
``

Omitted dates preserve the existing current-date default.

## Verification

Before the fix, all four focused regressions returned 500 while the seven existing tests passed. After the fix:

``text
11 passed in 5.57s
``

Also checked with:

``text
python -m py_compile syndication_routes.py tests/test_syndication_routes.py
git diff --check
``

Constraint: Preserve default-date behavior and valid report generation.
Rejected: Catch ValueError inside each broad route handler, because that would continue mixing client validation with report/database failures.
Confidence: high
Scope-risk: narrow