### PR TITLE
fix(videos): reject malformed pagination query params with 400

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -6747,6 +6747,36 @@ def _client_has_video_list_etag(etag: str) -> bool:
     return "*" in candidates or etag in candidates
 
 
+def _parse_positive_int_query(name, default, min_value=1, max_value=None):
+    """Return (value, None) or (None, (json_response, status_code)).
+
+    Rejects malformed or out-of-range integers with HTTP 400 instead of
+    silently coercing invalid input to the default (which would mask
+    client bugs and could lead to surprising pagination/sort results).
+    """
+    raw_value = request.args.get(name)
+    if raw_value is None or raw_value == "":
+        return default, None
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return None, (
+            jsonify({"error": f"{name} must be an integer"}),
+            400,
+        )
+    if value < min_value:
+        return None, (
+            jsonify({"error": f"{name} must be >= {min_value}"}),
+            400,
+        )
+    if max_value is not None and value > max_value:
+        return None, (
+            jsonify({"error": f"{name} must be <= {max_value}"}),
+            400,
+        )
+    return value, None
+
+
 def _client_has_fresh_video_list_date(latest_ts: float) -> bool:
     raw_header = request.headers.get("If-Modified-Since", "")
     if not raw_header:
@@ -6769,8 +6799,12 @@ def _add_video_list_cache_headers(response: Response, *, etag: str, latest_ts: f
 @app.route("/api/videos")
 def list_videos():
     """List videos with pagination and sorting."""
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    if error:
+        return error
     sort = request.args.get("sort", "newest")
     agent_name = request.args.get("agent", "")
 
@@ -8141,8 +8175,12 @@ def search_videos():
     if not q:
         return jsonify({"error": "q parameter required"}), 400
 
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    if error:
+        return error
     offset = (page - 1) * per_page
 
     db = get_db()

--- a/tests/test_videos_list_query_param_validation.py
+++ b/tests/test_videos_list_query_param_validation.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for /api/videos and /api/search rejecting malformed or
+out-of-range pagination/sort query parameters with HTTP 400 instead of
+silently coercing invalid input to the default.
+
+Bug: `request.args.get("page", 1, type=int)` returns the default (1) for
+any non-integer string (e.g. "abc", "1.5", "null", "NaN") and silently
+clips to `max(1, ...)` for negatives/zeros.  That swallows client bugs
+and produces surprising pagination results.
+
+Fix: shared `_parse_positive_int_query` helper in bottube_server.py.
+"""
+
+
+# ----- /api/videos -----
+
+
+def test_list_videos_rejects_non_integer_page(client):
+    response = client.get("/api/videos?page=abc")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "page" in data["error"]
+    assert "integer" in data["error"]
+
+
+def test_list_videos_rejects_non_integer_per_page(client):
+    response = client.get("/api/videos?per_page=xyz")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "per_page" in data["error"]
+
+
+def test_list_videos_rejects_zero_page(client):
+    response = client.get("/api/videos?page=0")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "page" in data["error"]
+
+
+def test_list_videos_rejects_negative_page(client):
+    response = client.get("/api/videos?page=-5")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "page" in data["error"]
+
+
+def test_list_videos_rejects_zero_per_page(client):
+    response = client.get("/api/videos?per_page=0")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "per_page" in data["error"]
+
+
+def test_list_videos_rejects_negative_per_page(client):
+    response = client.get("/api/videos?per_page=-1")
+    assert response.status_code == 400
+
+
+def test_list_videos_rejects_per_page_above_max(client):
+    # cap is 50; 100 was silently clamped before the fix
+    response = client.get("/api/videos?per_page=100")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "per_page" in data["error"]
+    assert "<= 50" in data["error"]
+
+
+def test_list_videos_rejects_float_page(client):
+    response = client.get("/api/videos?page=1.5")
+    assert response.status_code == 400
+
+
+def test_list_videos_rejects_null_page(client):
+    response = client.get("/api/videos?page=null")
+    assert response.status_code == 400
+
+
+def test_list_videos_rejects_nan_page(client):
+    response = client.get("/api/videos?page=NaN")
+    assert response.status_code == 400
+
+
+def test_list_videos_accepts_valid_pagination(client):
+    response = client.get("/api/videos?page=1&per_page=10")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["page"] == 1
+    assert data["per_page"] == 10
+
+
+def test_list_videos_omits_defaults_when_unset(client):
+    # No page/per_page in the query string -> both default
+    response = client.get("/api/videos")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["page"] == 1
+    assert data["per_page"] == 20
+
+
+def test_list_videos_per_page_boundary_values(client):
+    # min valid = 1, max valid = 50
+    for pp in (1, 50):
+        r = client.get(f"/api/videos?per_page={pp}")
+        assert r.status_code == 200
+    for pp in (51, 999, 1000):
+        r = client.get(f"/api/videos?per_page={pp}")
+        assert r.status_code == 400
+
+
+# ----- /api/search -----
+
+
+def test_search_videos_rejects_non_integer_page(client):
+    response = client.get("/api/search?q=test&page=abc")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "page" in data["error"]
+
+
+def test_search_videos_rejects_non_integer_per_page(client):
+    response = client.get("/api/search?q=test&per_page=xyz")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "per_page" in data["error"]
+
+
+def test_search_videos_rejects_zero_page(client):
+    response = client.get("/api/search?q=test&page=0")
+    assert response.status_code == 400
+
+
+def test_search_videos_rejects_per_page_above_max(client):
+    response = client.get("/api/search?q=test&per_page=100")
+    assert response.status_code == 400
+
+
+def test_search_videos_accepts_valid_pagination(client):
+    # Empty results is fine, the point is that pagination parsing passed
+    response = client.get("/api/search?q=nonexistent_query_xyz&page=1&per_page=10")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["page"] == 1
+    assert data["per_page"] == 10
+
+
+def test_search_videos_page_validation_runs_before_query_execution(client):
+    # Validation should reject the malformed page param *before* the
+    # search-rate-limit is consumed, so a buggy client gets a clear 400
+    # instead of a confusing 429.
+    response = client.get("/api/search?q=test&page=abc")
+    assert response.status_code == 400
+    assert "page" in response.get_json()["error"]
+
+
+# ----- _parse_positive_int_query helper direct coverage -----
+
+
+def test_parse_helper_allows_missing_param(app):
+    with app.test_request_context("/api/videos"):
+        from bottube_server import _parse_positive_int_query
+        value, error = _parse_positive_int_query("absent", 7)
+        assert value == 7
+        assert error is None
+
+
+def test_parse_helper_allows_empty_string(app):
+    with app.test_request_context("/api/videos?page="):
+        from bottube_server import _parse_positive_int_query
+        value, error = _parse_positive_int_query("page", 1)
+        assert value == 1
+        assert error is None
+
+
+def test_parse_helper_rejects_non_integer(app):
+    with app.test_request_context("/api/videos?page=abc"):
+        from bottube_server import _parse_positive_int_query
+        value, error = _parse_positive_int_query("page", 1)
+        assert value is None
+        response, status = error
+        assert status == 400
+        assert "page" in response.get_json()["error"]
+
+
+def test_parse_helper_enforces_min(app):
+    with app.test_request_context("/api/videos?page=0"):
+        from bottube_server import _parse_positive_int_query
+        value, error = _parse_positive_int_query("page", 1)
+        assert value is None
+        assert error[1] == 400
+
+
+def test_parse_helper_enforces_max(app):
+    with app.test_request_context("/api/videos?per_page=999"):
+        from bottube_server import _parse_positive_int_query
+        value, error = _parse_positive_int_query("per_page", 20, max_value=50)
+        assert value is None
+        response, status = error
+        assert status == 400
+        assert "<= 50" in response.get_json()["error"]


### PR DESCRIPTION
Bounty #1102

## Bug

The public `/api/videos` and `/api/search` endpoints used
`request.args.get("page", 1, type=int)` to parse pagination
parameters, which has two user-visible problems:

1. **Non-integer values silently coerced to default.** Any non-int
   string (`"abc"`, `"1.5"`, `"null"`, `"NaN"`) returns the
   default (`1`), which masks client bugs.
2. **Out-of-range values silently clamped.** `0` → `1`, `-1` →
   `1`, `100` → `50` — clients get a 200 with surprising
   pagination results and no error.

## Live verification (pre-fix)

```
GET https://bottube.ai/api/videos?page=abc      → 200 (page=1)
GET https://bottube.ai/api/videos?page=0        → 200 (page=1)
GET https://bottube.ai/api/videos?page=-1       → 200 (page=1)
GET https://bottube.ai/api/videos?per_page=0    → 200 (per_page=1)
GET https://bottube.ai/api/videos?per_page=100  → 200 (per_page=50)
GET https://bottube.ai/api/videos?per_page=abc  → 200 (per_page=20)
GET https://bottube.ai/api/videos?per_page=null → 200 (per_page=20)
GET https://bottube.ai/api/videos?per_page=NaN  → 200 (per_page=20)
```

## Fix

Introduces a shared `_parse_positive_int_query` helper in
`bottube_server.py` (next to the existing `_client_has_video_list_etag`
helper) that returns `(value, None)` on success or `(None, (json, 400))`
on malformed/out-of-range input. The two affected endpoints are updated
to call the helper for `page` and `per_page`.

This matches the pattern that lazyGPT07 established in PR #1394
(`_integer_query_arg` in `syndication_routes.py`) — same 400 JSON
shape, same parameter-name-in-error-message convention.

## Diff

- `bottube_server.py`: +42 / -4
- `tests/test_videos_list_query_param_validation.py`: +200 (new)

## Validation

- 24 new regression tests pass
- 8 existing `test_video_list_pagination` and `test_video_list_cache_headers`
  tests pass (no regressions)
- `py_compile` clean
- `git diff --check` clean
- `git merge-tree --write-tree scottcjn/main HEAD` produces a clean tree

## Wallet

`jdjioe5-cpu` (canonical GitHub-handle fallback per
rustchain-bounties#13514 + merged handle-fallback PRs #13394 / #13434 / #13458).