### PR TITLE
fix: validate social graph limit params

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8575,7 +8575,9 @@ def get_agent_interactions(agent_name):
         return jsonify({"error": "Agent not found"}), 404
 
     aid = agent["id"]
-    limit = min(50, max(1, request.args.get("limit", 20, type=int)))
+    limit, error = _parse_positive_int_query("limit", 20, max_value=50)
+    if error:
+        return error
 
     # Agents who commented on this agent's videos
     commenters = db.execute(
@@ -8675,7 +8677,9 @@ def get_agent_interactions(agent_name):
 def social_graph():
     """Platform-wide social graph: top interacting pairs and network density."""
     db = get_db()
-    limit = min(50, max(1, request.args.get("limit", 20, type=int)))
+    limit, error = _parse_positive_int_query("limit", 20, max_value=50)
+    if error:
+        return error
 
     # Top interacting pairs (bidirectional: comments + likes between agents)
     pairs = db.execute(

--- a/tests/test_social_graph.py
+++ b/tests/test_social_graph.py
@@ -173,6 +173,18 @@ def test_social_graph_has_expected_keys_and_limit(client):
     )
 
 
+@pytest.mark.parametrize("query, expected_error", [
+    ("limit=abc", "limit must be an integer"),
+    ("limit=0", "limit must be >= 1"),
+    ("limit=51", "limit must be <= 50"),
+])
+def test_social_graph_rejects_invalid_limit(client, query, expected_error):
+    resp = client.get(f"/api/social/graph?{query}")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": expected_error}
+
+
 def test_agent_interactions_shape_not_found_and_limit(client):
     _seed_interaction_data()
 
@@ -212,3 +224,17 @@ def test_agent_interactions_shape_not_found_and_limit(client):
     assert {"agent_name", "display_name", "avatar_url", "comments_given", "likes_given", "total"} <= set(
         outgoing.keys()
     )
+
+
+@pytest.mark.parametrize("query, expected_error", [
+    ("limit=abc", "limit must be an integer"),
+    ("limit=0", "limit must be >= 1"),
+    ("limit=51", "limit must be <= 50"),
+])
+def test_agent_interactions_rejects_invalid_limit(client, query, expected_error):
+    _seed_interaction_data()
+
+    resp = client.get(f"/api/agents/alice/interactions?{query}")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": expected_error}


### PR DESCRIPTION
## Summary
- reject malformed and out-of-range `limit` query params on `/api/social/graph`
- apply the same deterministic validation to `/api/agents/<agent_name>/interactions`
- add regression coverage for non-integer, below-minimum, and above-maximum limits

Fixes #1400.

## Validation
- `uv run --no-project --with flask --with pytest --with werkzeug --with requests --with python-dotenv --with pillow --with qrcode --with cryptography --with PyJWT --with openai --with google-genai -- python -m pytest tests/test_social_graph.py -q` → 8 passed
- `git diff --check`
