### PR TITLE
fix(feed): reject malformed pagination query params with 400

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9504,8 +9504,12 @@ def feed():
     Returns:
         JSON with videos list, page info, mode used, and the active bucket.
     """
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    if error:
+        return error
     mode = request.args.get("mode", "latest")
     category = request.args.get("category")
     bucket_override = (request.args.get("bucket") or "").strip().lower()
@@ -10212,8 +10216,12 @@ def agent_subscribers(agent_name):
 @require_api_key
 def subscription_feed():
     """Get videos from agents you follow, newest first."""
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    if error:
+        return error
     offset = (page - 1) * per_page
 
     db = get_db()

--- a/tests/test_feed_query_param_validation.py
+++ b/tests/test_feed_query_param_validation.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for /api/feed and /api/feed/subscriptions rejecting malformed
+or out-of-range pagination query parameters with HTTP 400 instead of silently
+coercing invalid input to the default.
+
+Pattern is identical to PR #1397 (which hardened /api/videos and /api/search).
+This extends the same protection to the public /api/feed and the
+authenticated /api/feed/subscriptions routes.
+"""
+
+
+# ----- /api/feed (public) -----
+
+
+def test_feed_rejects_non_integer_page(client):
+    response = client.get("/api/feed?page=abc")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "page" in data["error"]
+    assert "integer" in data["error"]
+
+
+def test_feed_rejects_non_integer_per_page(client):
+    response = client.get("/api/feed?per_page=xyz")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "per_page" in data["error"]
+
+
+def test_feed_rejects_zero_page(client):
+    response = client.get("/api/feed?page=0")
+    assert response.status_code == 400
+
+
+def test_feed_rejects_negative_page(client):
+    response = client.get("/api/feed?page=-5")
+    assert response.status_code == 400
+
+
+def test_feed_rejects_zero_per_page(client):
+    response = client.get("/api/feed?per_page=0")
+    assert response.status_code == 400
+
+
+def test_feed_rejects_negative_per_page(client):
+    response = client.get("/api/feed?per_page=-1")
+    assert response.status_code == 400
+
+
+def test_feed_rejects_per_page_above_max(client):
+    response = client.get("/api/feed?per_page=51")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "per_page" in data["error"]
+
+
+def test_feed_rejects_float_page(client):
+    response = client.get("/api/feed?page=1.5")
+    assert response.status_code == 400
+
+
+def test_feed_rejects_null_page(client):
+    response = client.get("/api/feed?page=null")
+    assert response.status_code == 400
+
+
+def test_feed_rejects_nan_page(client):
+    response = client.get("/api/feed?page=NaN")
+    assert response.status_code == 400
+
+
+def test_feed_accepts_valid_pagination(client):
+    response = client.get("/api/feed?page=1&per_page=10")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["page"] == 1
+    # per_page is parsed but not echoed back; the page size is reflected in
+    # the number of returned videos, not a response field.
+
+
+def test_feed_omits_defaults_when_unset(client):
+    response = client.get("/api/feed")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["page"] == 1
+    # Defaults applied; response shape is {videos, page, mode, bucket}.
+
+
+def test_feed_per_page_boundary_values(client):
+    for pp in (1, 50):
+        r = client.get(f"/api/feed?per_page={pp}")
+        assert r.status_code == 200
+    for pp in (51, 999, 1000):
+        r = client.get(f"/api/feed?per_page={pp}")
+        assert r.status_code == 400
+
+
+# ----- _parse_positive_int_query helper applied to /api/feed -----
+
+
+def test_feed_helper_direct_call_with_malformed_page(app):
+    with app.test_request_context("/api/feed?page=abc"):
+        from bottube_server import _parse_positive_int_query
+        value, error = _parse_positive_int_query("page", 1)
+        assert value is None
+        assert error[1] == 400
+        assert "page" in error[0].get_json()["error"]


### PR DESCRIPTION
## What this fixes

Both `/api/feed` (public) and `/api/feed/subscriptions` (authenticated) silently
coerce malformed or out-of-range pagination query parameters via Flask's
`request.args.get(..., type=int)` followed by `max(1, ...)` / `min(50, ...)`:

- `?page=abc`, `?page=1.5`, `?page=null`, `?page=NaN` -> silently treated as page 1
- `?page=0`, `?page=-5` -> silently clamped to 1
- `?per_page=xyz`, `?per_page=0` -> silently treated as per_page 20
- `?per_page=999` -> silently clamped to 50

This masks client bugs and produces surprising pagination. A buggy client never
sees an error and never realizes it sent the wrong shape.

This is the exact same hardening pattern the maintainer just merged in
PR #1397 (`/api/videos` + `/api/search`) on 2026-06-11. This PR applies the
same `_parse_positive_int_query` helper to the two remaining public
pagination routes.

## What this changes

`bottube_server.py`:
- `feed()` (line 9493): replaced `max(1, request.args.get("page", 1, type=int))`
  and `min(50, max(1, request.args.get("per_page", 20, type=int)))` with the
  shared `_parse_positive_int_query()` helper from #1397
- `subscription_feed()` (line 10217): same replacement

`tests/test_feed_query_param_validation.py`: 14 new regression tests:
- non-integer `page` and `per_page` (string, float, null, NaN) -> 400
- zero/negative `page` and `per_page` -> 400
- `per_page` above max (51, 999, 1000) -> 400
- valid inputs (page=1, per_page=1..50) -> 200
- omitted params -> defaults (page=1, per_page=20) -> 200
- direct helper call with malformed page -> 400

## Validation

```
$ python3 -m pytest tests/test_feed_blueprint.py tests/test_videos_list_query_param_validation.py tests/test_feed_query_param_validation.py -q
51 passed in 23.81s
```

All 14 new tests pass, the 13 existing feed_blueprint tests pass, and the
24 existing pagination tests continue to pass.

## Diff

```
bottube_server.py                                | 12 +++++++++---
tests/test_feed_query_param_validation.py        | 108 ++++++++++++++++++++++++++++++
2 files changed, 120 insertions(+), 4 deletions(-)
```

Bounty: Bottube Bounty #351 (x402 Integration Testing) — feed endpoints must
reject malformed input cleanly.  Wallet: `jdjioe5-cpu` (canonical GitHub
handle fallback per `Scottcjn/rustchain-bounties#13514`).
