### PR TITLE
feat(collab): add collaborator_ids + split-tip support (Bounty #2161)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -2445,6 +2445,11 @@ def init_db():
         conn.execute("ALTER TABLE videos ADD COLUMN response_to_video_id TEXT DEFAULT ''")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_videos_response_to ON videos(response_to_video_id)")
 
+    # Migration: add collaborator_ids for co-upload (Bounty #2161)
+    video_cols = {row[1] for row in conn.execute("PRAGMA table_info(videos)").fetchall()}
+    if "collaborator_ids" not in video_cols:
+        conn.execute("ALTER TABLE videos ADD COLUMN collaborator_ids TEXT DEFAULT '[]'")
+
     # Migration: create messages table
     conn.execute("""
         CREATE TABLE IF NOT EXISTS messages (
@@ -6332,6 +6337,7 @@ def upload_video():
     challenge_id = request.form.get("challenge_id", "").strip()
     gen_method = request.form.get("gen_method", "").strip().lower()  # AI video gen method
     response_to = request.form.get("response_to", "").strip()  # Video ID this is a response to (Issue #2282)
+    collaborator_ids_raw = request.form.get("collaborator_ids", "").strip()  # JSON array of agent_ids for co-upload (Bounty #2161)
 
     db = get_db()
     if revision_of:
@@ -6355,6 +6361,36 @@ def upload_video():
             return jsonify({"error": "response_to video not found"}), 404
         if original_video["is_removed"]:
             return jsonify({"error": "Cannot respond to a removed video"}), 400
+
+    # Parse + validate collaborator_ids (Bounty #2161 co-upload)
+    collaborator_ids_json = "[]"
+    if collaborator_ids_raw:
+        try:
+            parsed_collab = json.loads(collaborator_ids_raw)
+        except (ValueError, TypeError):
+            return jsonify({"error": "Invalid collaborator_ids: must be a JSON array of agent_ids"}), 400
+        if not isinstance(parsed_collab, list):
+            return jsonify({"error": "Invalid collaborator_ids: must be a JSON array"}), 400
+        if len(parsed_collab) > 5:
+            return jsonify({"error": "Too many collaborators: max 5 per video"}), 400
+        cleaned = []
+        for cid in parsed_collab:
+            if not isinstance(cid, int) or cid <= 0:
+                return jsonify({"error": "Invalid collaborator_id: must be a positive int"}), 400
+            if cid == g.agent["id"]:
+                return jsonify({"error": "Cannot add yourself as a collaborator"}), 400
+            cleaned.append(cid)
+        if cleaned:
+            placeholders = ",".join("?" * len(cleaned))
+            existing = db.execute(
+                f"SELECT id FROM agents WHERE id IN ({placeholders})", cleaned
+            ).fetchall()
+            existing_ids = {row["id"] for row in existing}
+            missing = set(cleaned) - existing_ids
+            if missing:
+                return jsonify({"error": f"Unknown collaborator agent_id(s): {sorted(missing)}"}), 400
+        collaborator_ids_json = json.dumps(cleaned)
+
     if challenge_id:
         ch = db.execute(
             "SELECT challenge_id, status, start_at, end_at FROM challenges WHERE challenge_id = ?",
@@ -6546,14 +6582,14 @@ def upload_video():
         """INSERT INTO videos
            (video_id, agent_id, title, description, filename, thumbnail,
             duration_sec, width, height, tags, scene_description, category,
-            novelty_score, novelty_flags, revision_of, revision_note, challenge_id, response_to_video_id, created_at,
+            novelty_score, novelty_flags, revision_of, revision_note, challenge_id, response_to_video_id, collaborator_ids, created_at,
             screening_status, screening_details, is_removed, removed_reason)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             video_id, g.agent["id"], title, description, filename,
             thumb_filename, duration, width, height, json.dumps(tags),
             scene_description, category, novelty_score, novelty_flags,
-            revision_of, revision_note, challenge_id, response_to, time.time(),
+            revision_of, revision_note, challenge_id, response_to, collaborator_ids_json, time.time(),
             screening_status, screening_details,
             1 if screening_status == "failed" else 0,
             ("held_for_review: " + screening_result.get("summary", ""))[:500] if screening_status == "failed" else "",
@@ -11156,7 +11192,8 @@ def tip_video(video_id):
 
     db = get_db()
     video = db.execute(
-        "SELECT v.agent_id, v.title, a.agent_name AS creator_name, "
+        "SELECT v.agent_id, v.title, v.collaborator_ids, "
+        "       a.agent_name AS creator_name, "
         "       a.rtc_wallet AS creator_rtc_wallet, a.rtc_address AS creator_rtc_address "
         "FROM videos v JOIN agents a ON v.agent_id = a.id WHERE v.video_id = ?",
         (video_id,),
@@ -11212,22 +11249,43 @@ def tip_video(video_id):
     if sender["rtc_balance"] < amount:
         return jsonify({"error": "Insufficient RTC balance", "balance": sender["rtc_balance"]}), 400
 
-    # Execute transfer
+    # Execute transfer — split the tip among collaborators (Bounty #2161)
+    collaborator_ids = []
+    try:
+        col_raw = video["collaborator_ids"] or "[]"
+        collaborator_ids = json.loads(col_raw) if col_raw else []
+    except (ValueError, TypeError):
+        collaborator_ids = []
+    # Filter out any collaborator that is the tipper themselves (no self-tip)
+    collaborator_ids = [cid for cid in collaborator_ids if cid != g.agent["id"] and isinstance(cid, int) and cid > 0]
+    # De-dupe while preserving order
+    seen = set()
+    collaborator_ids = [c for c in collaborator_ids if not (c in seen or seen.add(c))]
+    # Compute split — primary creator + each collaborator, evenly divided
+    recipients = [(video["agent_id"], "primary")] + [(cid, "collab") for cid in collaborator_ids]
+    if recipients:
+        per_recipient = round(amount / len(recipients), 6)
+        # Reconcile rounding so the sum equals the original amount
+        diff = round(amount - per_recipient * len(recipients), 6)
+    else:
+        per_recipient = amount
+        diff = 0
     db.execute("UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?", (amount, g.agent["id"]))
-    db.execute("UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?", (amount, video["agent_id"]))
+    for idx, (rid, role) in enumerate(recipients):
+        share = per_recipient + (diff if idx == 0 else 0)
+        db.execute("UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?", (share, rid))
+        # Log per-recipient tip row
+        db.execute(
+            "INSERT INTO tips (from_agent_id, to_agent_id, video_id, amount, message, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (g.agent["id"], rid, video_id, share, message, time.time()),
+        )
+        db.execute(
+            "INSERT INTO earnings (agent_id, amount, reason, video_id, created_at) VALUES (?, ?, ?, ?, ?)",
+            (rid, share, "tip_split_" + role, video_id, time.time()),
+        )
 
-    # Log tip
-    db.execute(
-        "INSERT INTO tips (from_agent_id, to_agent_id, video_id, amount, message, created_at) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
-        (g.agent["id"], video["agent_id"], video_id, amount, message, time.time()),
-    )
-
-    # Log earnings for recipient
-    db.execute(
-        "INSERT INTO earnings (agent_id, amount, reason, video_id, created_at) VALUES (?, ?, ?, ?, ?)",
-        (video["agent_id"], amount, "tip_received", video_id, time.time()),
-    )
+    # If no recipients (shouldn't happen since primary is always present), fall through to no-op
 
     # Notify recipient
     notify(db, video["agent_id"], "tip",

--- a/tests/test_bounty_2161_collab_tip_split.py
+++ b/tests/test_bounty_2161_collab_tip_split.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: MIT
+"""
+Tests for Bounty #2161: Creator Collaboration Features (Issue #427)
+Tests the split-tip logic on co-uploaded videos.
+
+The conftest re-imports the `bottube_server` module per test to reset
+DB_PATH, so we cannot cache it as a top-level name. We resolve the live
+module from `sys.modules` on every helper call.
+"""
+import json
+import sqlite3
+import sys
+import time
+
+import pytest
+
+
+def _live():
+    """Return the live bottube_server module the conftest is using right now."""
+    for mod in list(sys.modules.values()):
+        if mod is not None and mod.__name__ == "bottube_server":
+            return mod
+    raise RuntimeError("bottube_server not in sys.modules")
+
+
+def _conn():
+    import os
+    server = _live()
+    path = str(server.DB_PATH)
+    parent = os.path.dirname(path)
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent, exist_ok=True)
+    return sqlite3.connect(path)
+
+
+def _register(app, name):
+    server = _live()
+    client = app.test_client()
+    resp = client.post(
+        "/api/register",
+        json={"agent_name": name, "display_name": name.title()},
+    )
+    assert resp.status_code == 201, resp.get_json()
+    return resp.get_json()["api_key"]
+
+
+def _accept_terms(app, name):
+    server = _live()
+    api_key = _register(app, name)
+    client = app.test_client()
+    tos_resp = client.post(
+        "/api/agents/me/accept-terms",
+        json={"version": server.TOS_VERSION},
+        headers={"X-API-Key": api_key},
+    )
+    assert tos_resp.status_code == 200, tos_resp.get_json()
+    return api_key
+
+
+def _set_balance(name, balance):
+    conn = _conn()
+    conn.execute(
+        "UPDATE agents SET rtc_balance = ? WHERE agent_name = ?",
+        (balance, name),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _get_balance(name):
+    conn = _conn()
+    row = conn.execute(
+        "SELECT rtc_balance FROM agents WHERE agent_name = ?", (name,)
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+def _get_id(name):
+    conn = _conn()
+    row = conn.execute(
+        "SELECT id FROM agents WHERE agent_name = ?", (name,)
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+def _insert_video_with_collabs(owner_name, collaborator_names, video_id):
+    owner_id = _get_id(owner_name)
+    collab_ids = [_get_id(n) for n in collaborator_names]
+    conn = _conn()
+    conn.execute(
+        """INSERT INTO videos
+           (video_id, agent_id, title, filename, description, created_at, collaborator_ids)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (
+            video_id,
+            owner_id,
+            "Co-uploaded video",
+            f"{video_id}.mp4",
+            "Bounty #2161 test video",
+            time.time(),
+            json.dumps(collab_ids),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _query(sql, params=()):
+    conn = _conn()
+    cur = conn.execute(sql, params)
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+class TestCollabTipSplit:
+    """Bounty #2161: split-tip behavior on co-uploaded videos."""
+
+    def test_tip_with_no_collaborators_full_to_primary(self, app, client):
+        _accept_terms(app, "test_2161_p_nc")
+        tipper_key = _accept_terms(app, "test_2161_t_nc")
+        _set_balance("test_2161_p_nc", 0)
+        _set_balance("test_2161_t_nc", 100)
+        _insert_video_with_collabs("test_2161_p_nc", [], "vid_2161_nc")
+
+        response = client.post(
+            "/api/videos/vid_2161_nc/tip",
+            json={"amount": 0.12, "message": "no split"},
+            headers={"X-API-Key": tipper_key},
+        )
+        assert response.status_code == 200, response.get_json()
+        assert _get_balance("test_2161_p_nc") == pytest.approx(0.12, abs=1e-6)
+        assert _get_balance("test_2161_t_nc") == pytest.approx(99.88, abs=1e-6)
+
+        tips = _query("SELECT to_agent_id, amount FROM tips WHERE video_id = ?", ("vid_2161_nc",))
+        assert len(tips) == 1
+        assert tips[0][1] == pytest.approx(0.12, abs=1e-6)
+
+    def test_tip_with_two_collaborators_splits_evenly(self, app, client):
+        _accept_terms(app, "test_2161_p_2c")
+        _accept_terms(app, "test_2161_ca_2c")
+        _accept_terms(app, "test_2161_cb_2c")
+        tipper_key = _accept_terms(app, "test_2161_t_2c")
+        _set_balance("test_2161_p_2c", 0)
+        _set_balance("test_2161_t_2c", 100)
+        _set_balance("test_2161_ca_2c", 0)
+        _set_balance("test_2161_cb_2c", 0)
+        _insert_video_with_collabs(
+            "test_2161_p_2c", ["test_2161_ca_2c", "test_2161_cb_2c"], "vid_2161_2c"
+        )
+
+        response = client.post(
+            "/api/videos/vid_2161_2c/tip",
+            json={"amount": 0.12, "message": "split 3-way"},
+            headers={"X-API-Key": tipper_key},
+        )
+        assert response.status_code == 200, response.get_json()
+
+        # 0.12 / 3 = 0.04 each
+        assert _get_balance("test_2161_p_2c") == pytest.approx(0.04, abs=1e-6)
+        assert _get_balance("test_2161_ca_2c") == pytest.approx(0.04, abs=1e-6)
+        assert _get_balance("test_2161_cb_2c") == pytest.approx(0.04, abs=1e-6)
+        assert _get_balance("test_2161_t_2c") == pytest.approx(99.88, abs=1e-6)
+
+        tips = _query("SELECT to_agent_id, amount FROM tips WHERE video_id = ? ORDER BY to_agent_id", ("vid_2161_2c",))
+        assert len(tips) == 3
+        assert all(t[1] == pytest.approx(0.04, abs=1e-6) for t in tips)
+
+        earnings = _query("SELECT agent_id, amount, reason FROM earnings WHERE video_id = ?", ("vid_2161_2c",))
+        assert len(earnings) == 3
+        reasons = {e[0]: e[2] for e in earnings}
+        assert reasons[_get_id("test_2161_p_2c")] == "tip_split_primary"
+        assert reasons[_get_id("test_2161_ca_2c")] == "tip_split_collab"
+        assert reasons[_get_id("test_2161_cb_2c")] == "tip_split_collab"
+
+    def test_tip_rounding_diff_to_primary(self, app, client):
+        _accept_terms(app, "test_2161_p_r")
+        _accept_terms(app, "test_2161_ca_r")
+        _accept_terms(app, "test_2161_cb_r")
+        tipper_key = _accept_terms(app, "test_2161_t_r")
+        _set_balance("test_2161_t_r", 100)
+        _insert_video_with_collabs(
+            "test_2161_p_r", ["test_2161_ca_r", "test_2161_cb_r"], "vid_2161_r"
+        )
+
+        response = client.post(
+            "/api/videos/vid_2161_r/tip",
+            json={"amount": 0.10, "message": "rounding test"},
+            headers={"X-API-Key": tipper_key},
+        )
+        assert response.status_code == 200
+
+        # 0.10 / 3 = 0.0333... per_share = 0.033333; diff = 0.10 - 0.099999 = 0.000001
+        # primary gets per_share + diff = 0.033334, collabs get 0.033333
+        assert _get_balance("test_2161_p_r") == pytest.approx(0.033334, abs=1e-6)
+        assert _get_balance("test_2161_ca_r") == pytest.approx(0.033333, abs=1e-6)
+        assert _get_balance("test_2161_cb_r") == pytest.approx(0.033333, abs=1e-6)
+        total = (
+            (_get_balance("test_2161_p_r") or 0)
+            + (_get_balance("test_2161_ca_r") or 0)
+            + (_get_balance("test_2161_cb_r") or 0)
+        )
+        assert total == pytest.approx(0.10, abs=1e-6)
+
+    def test_self_in_collaborators_filtered_out(self, app, client):
+        _accept_terms(app, "test_2161_p_s")
+        _accept_terms(app, "test_2161_ca_s")
+        tipper_key = _accept_terms(app, "test_2161_t_s")
+        _set_balance("test_2161_t_s", 100)
+        # Tipper registers themselves as a collaborator on the video
+        _insert_video_with_collabs(
+            "test_2161_p_s", ["test_2161_t_s", "test_2161_ca_s"], "vid_2161_s"
+        )
+
+        response = client.post(
+            "/api/videos/vid_2161_s/tip",
+            json={"amount": 0.10, "message": "self filter"},
+            headers={"X-API-Key": tipper_key},
+        )
+        assert response.status_code == 200
+
+        # 0.10 split between primary + collab_a only (tipper filtered)
+        assert _get_balance("test_2161_p_s") == pytest.approx(0.05, abs=1e-6)
+        assert _get_balance("test_2161_ca_s") == pytest.approx(0.05, abs=1e-6)
+        assert _get_balance("test_2161_t_s") == pytest.approx(99.90, abs=1e-6)
+        self_tips = _query("SELECT COUNT(*) AS n FROM tips WHERE to_agent_id = ?", (_get_id("test_2161_t_s"),))
+        assert self_tips[0][0] == 0
+
+    def test_insufficient_balance_no_partial_split(self, app, client):
+        _accept_terms(app, "test_2161_p_ib")
+        _accept_terms(app, "test_2161_ca_ib")
+        tipper_key = _accept_terms(app, "test_2161_t_ib")
+        _set_balance("test_2161_t_ib", 100)
+        _insert_video_with_collabs(
+            "test_2161_p_ib", ["test_2161_ca_ib"], "vid_2161_ib"
+        )
+
+        response = client.post(
+            "/api/videos/vid_2161_ib/tip",
+            json={"amount": 200, "message": "too big"},
+            headers={"X-API-Key": tipper_key},
+        )
+        assert response.status_code == 400
+        assert _query("SELECT COUNT(*) AS n FROM tips WHERE video_id = ?", ("vid_2161_ib",))[0][0] == 0
+        assert _get_balance("test_2161_t_ib") == pytest.approx(100, abs=1e-6)


### PR DESCRIPTION
## Summary

Implements the tip-splitting lane of Creator Collaboration Features (Issue #427, Bounty #2161).

## What changed

- **Migration**: add `collaborator_ids TEXT DEFAULT '[]'` to the `videos` table
- **Upload validation**: parse + validate the `collaborator_ids` form field in `/api/upload` (max 5 collaborators, must exist, tipper can't add self)
- **Tip split**: `/api/videos/<id>/tip` now evenly splits a tip across the primary creator + each collaborator. Rounding diff lands on the primary creator. Tipper is filtered out of the split if they appear in `collaborator_ids`.
- **Per-recipient accounting**: each share gets its own `tips` row + `earnings` row (with `reason = tip_split_primary` or `tip_split_collab`)

## Tests

5 new tests in `tests/test_bounty_2161_collab_tip_split.py`, all passing:

- `test_tip_with_no_collaborators_full_to_primary` — sanity: no collabs → full tip to primary
- `test_tip_with_two_collaborators_splits_evenly` — 0.12 split 3 ways → 0.04 each
- `test_tip_rounding_diff_to_primary` — 0.10 split 3 ways → primary gets 0.033334, collabs get 0.033333
- `test_self_in_collaborators_filtered_out` — tipper in collab list is filtered, doesn't tip themselves
- `test_insufficient_balance_no_partial_split` — short balance → 400, no rows written

```
tests/test_bounty_2161_collab_tip_split.py::TestCollabTipSplit::test_tip_with_no_collaborators_full_to_primary PASSED
tests/test_bounty_2161_collab_tip_split.py::TestCollabTipSplit::test_tip_with_two_collaborators_splits_evenly PASSED
tests/test_bounty_2161_collab_tip_split.py::TestCollabTipSplit::test_tip_rounding_diff_to_primary PASSED
tests/test_bounty_2161_collab_tip_split.py::TestCollabTipSplit::test_self_in_collaborators_filtered_out PASSED
tests/test_bounty_2161_collab_tip_split.py::TestCollabTipSplit::test_insufficient_balance_no_partial_split PASSED
5 passed
```

## Out of scope

- Co-upload UI on `/upload` page (the form accepts the new field, but the HTML template doesn't expose it yet)
- Frontend rendering of collaborator badges on watch page
- The existing `response_to_video_id` (duets) is preserved and continues to work alongside

Refs Scottcjn/rustchain-bounties#2161