### PR TITLE
fix(routes): add 14 user-facing HTML routes (Refs #1367)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13553,6 +13553,171 @@ def history_page():
     return redirect(url_for("dashboard_page"))
 
 
+@app.route("/settings/profile")
+def settings_profile_page():
+    """Account profile settings (Refs #1367).
+
+    Logical sub-route of /settings. For logged-in users, /settings/profile
+    delegates to wallet_settings_page() (the same handler the /settings parent
+    uses, since the profile form lives in the same template). For
+    signed-out users, redirect to /login with ?next=/settings/profile
+    preserved so the post-login redirect lands back here.
+    """
+    if not g.user:
+        return redirect(url_for("login", next="/settings/profile"))
+    return wallet_settings_page()
+
+
+@app.route("/agents/me")
+def agents_me_page():
+    """Canonical 'my agent' surface (Refs #1367).
+
+    Distinct from /api/agents/me (the PATCH/POST API which 401s for
+    unauthed users, expected). For logged-in users, /agents/me redirects
+    to /dashboard (where the user's own agent card is rendered). For
+    signed-out users, redirect to /login with ?next=/agents/me preserved.
+    """
+    if not g.user:
+        return redirect(url_for("login", next="/agents/me"))
+    return redirect(url_for("dashboard_page"))
+
+
+@app.route("/premium/plans")
+def premium_plans_page():
+    """Premium plan picker (Refs #1367).
+
+    For logged-in users, render the same premium_page() handler (which
+    renders premium.html with the plan picker). For signed-out users,
+    redirect to /login with ?next=/premium/plans preserved.
+    """
+    if not g.user:
+        return redirect(url_for("login", next="/premium/plans"))
+    return premium_page()
+
+
+@app.route("/premium/upgrade")
+def premium_upgrade_page():
+    """Premium upgrade flow (Refs #1367).
+
+    For logged-in users, redirect to the premium page where the upgrade
+    CTA lives. For signed-out users, redirect to /login with
+    ?next=/premium/upgrade preserved.
+    """
+    if not g.user:
+        return redirect(url_for("login", next="/premium/upgrade"))
+    return premium_page()
+
+
+@app.route("/account")
+def account_page():
+    """Canonical account surface (Refs #1367).
+
+    For logged-in users, /account -> /dashboard. For signed-out users,
+    redirect to /login with ?next=/account preserved.
+    """
+    if not g.user:
+        return redirect(url_for("login", next="/account"))
+    return redirect(url_for("dashboard_page"))
+
+
+@app.route("/account/settings")
+def account_settings_page():
+    """Account sub-route pointing at /settings/wallet (Refs #1367).
+
+    For logged-in users, /account/settings -> /settings/wallet. For
+    signed-out users, redirect to /login with ?next=/account/settings.
+    """
+    if not g.user:
+        return redirect(url_for("login", next="/account/settings"))
+    return redirect(url_for("wallet_settings_page"))
+
+
+@app.route("/creator")
+def creator_page():
+    """Creator hub (Refs #1367).
+
+    Singular alias for the canonical creator directory at /agents.
+    For logged-in users, redirect to /agents (where the logged-in user
+    can see their own creator card). For signed-out users, redirect to
+    /login with ?next=/creator preserved.
+    """
+    if not g.user:
+        return redirect(url_for("login", next="/creator"))
+    return redirect(url_for("agents_page"))
+
+
+@app.route("/creators")
+def creators_page():
+    """Creator directory (Refs #1367).
+
+    Plural alias for /agents. /creators -> /agents for all users (it is
+    a public-facing directory, not user-scoped).
+    """
+    return redirect(url_for("agents_page"))
+
+
+@app.route("/live")
+def live_page():
+    """Live streams surface (Refs #1367).
+
+    /live is not yet a separate product surface; redirect to /trending
+    where live/popular streams are surfaced today.
+    """
+    return redirect(url_for("trending_page"))
+
+
+@app.route("/home")
+def home_page():
+    """Canonical home alias for / (Refs #1367).
+
+    /home -> / for all visitors (anonymous and logged-in). The home
+    surface is the root index, which already handles both states.
+    """
+    return redirect(url_for("index"))
+
+
+@app.route("/watch")
+def watch_index_page():
+    """Canonical watch alias (Refs #1367).
+
+    /watch -> /trending for all visitors. The /watch/<video_id> route
+    remains the canonical single-video surface; /watch without a video
+    id resolves to the trending feed where users pick a video to watch.
+    """
+    return redirect(url_for("trending_page"))
+
+
+@app.route("/tags")
+def tags_index_page():
+    """Tag index alias (Refs #1367).
+
+    /tags -> /trending. Tag-driven browsing is not yet a separate
+    surface; the trending feed is the canonical discovery surface.
+    """
+    return redirect(url_for("trending_page"))
+
+
+@app.route("/help")
+def help_page():
+    """Help page (Refs #1367).
+
+    /help -> /docs. The docs surface is the canonical help content;
+    /help is a friendlier URL.
+    """
+    return redirect(url_for("docs_page"))
+
+
+@app.route("/channels")
+def channels_index_page():
+    """Channel index alias (Refs #1367).
+
+    /channels -> /trending. A dedicated channel index is not yet a
+    separate surface; the trending feed is the canonical channel
+    discovery surface.
+    """
+    return redirect(url_for("trending_page"))
+
+
 @app.route("/upload", methods=["GET", "POST"])
 def upload_page():
     """Upload form page for logged-in humans."""

--- a/tests/test_user_route_aliases_1367.py
+++ b/tests/test_user_route_aliases_1367.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for additional user-facing HTML route aliases (Refs #1367).
+
+Bugs covered:
+- Bottube #1367 (14 more user-facing HTML routes returning 404 in production):
+  `/settings/profile`, `/agents/me`, `/premium/plans`, `/premium/upgrade`,
+  `/account`, `/account/settings`, `/creator`, `/creators`, `/live`, `/home`,
+  `/watch`, `/tags`, `/help`, `/channels`.
+
+Each new route is a pure additive Flask view; the fix does not change any
+existing route. Auth-required surfaces redirect to `/login?next=...`; public
+surfaces (`/creators`, `/live`, `/home`, `/watch`, `/tags`, `/help`,
+`/channels`) return 302 redirects to canonical surfaces (`/agents`,
+`/trending`, `/`, `/docs`).
+"""
+
+
+# --- Auth-required surfaces (must 302 -> /login?next=...) -------------------
+
+
+def test_settings_profile_redirects_anonymous_to_login(client):
+    resp = client.get("/settings/profile", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/login" in location
+    assert "next=/settings/profile" in location or "next=%2Fsettings%2Fprofile" in location
+
+
+def test_agents_me_redirects_anonymous_to_login(client):
+    resp = client.get("/agents/me", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/login" in location
+    assert "next=/agents/me" in location or "next=%2Fagents%2Fme" in location
+
+
+def test_premium_plans_redirects_anonymous_to_login(client):
+    resp = client.get("/premium/plans", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/login" in location
+    assert "next=/premium/plans" in location or "next=%2Fpremium%2Fplans" in location
+
+
+def test_premium_upgrade_redirects_anonymous_to_login(client):
+    resp = client.get("/premium/upgrade", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/login" in location
+    assert "next=/premium/upgrade" in location or "next=%2Fpremium%2Fupgrade" in location
+
+
+def test_account_redirects_anonymous_to_login(client):
+    resp = client.get("/account", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/login" in location
+    assert "next=/account" in location or "next=%2Faccount" in location
+
+
+def test_account_settings_redirects_anonymous_to_login(client):
+    resp = client.get("/account/settings", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/login" in location
+    assert "next=/account/settings" in location or "next=%2Faccount%2Fsettings" in location
+
+
+def test_creator_redirects_anonymous_to_login(client):
+    resp = client.get("/creator", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/login" in location
+    assert "next=/creator" in location or "next=%2Fcreator" in location
+
+
+# --- Public surfaces (302 to canonical surface, no auth) -------------------
+
+
+def test_creators_redirects_to_agents(client):
+    """Plural creator directory -> /agents (canonical creator directory)."""
+    resp = client.get("/creators", follow_redirects=False)
+    assert resp.status_code == 302, (
+        f"/creators must redirect to /agents, got {resp.status_code}"
+    )
+    location = resp.headers.get("Location", "")
+    assert "/agents" in location, f"/creators Location must contain /agents, got {location!r}"
+
+
+def test_live_redirects_to_trending(client):
+    """Live streams surface -> /trending (live/popular feeds)."""
+    resp = client.get("/live", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/trending" in location, f"/live Location must contain /trending, got {location!r}"
+
+
+def test_home_redirects_to_root(client):
+    """Canonical home alias -> / for all visitors."""
+    resp = client.get("/home", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    # flask url_for('index') returns '/' or 'http://localhost/'
+    assert location.endswith("/") or "/login" not in location, (
+        f"/home Location must point at the root index, got {location!r}"
+    )
+
+
+def test_watch_redirects_to_trending(client):
+    """Canonical watch alias -> /trending (single-video surface is /watch/<id>)."""
+    resp = client.get("/watch", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/trending" in location, f"/watch Location must contain /trending, got {location!r}"
+
+
+def test_tags_redirects_to_trending(client):
+    """Tag index alias -> /trending."""
+    resp = client.get("/tags", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/trending" in location, f"/tags Location must contain /trending, got {location!r}"
+
+
+def test_help_redirects_to_docs(client):
+    """Help page -> /docs (canonical help content)."""
+    resp = client.get("/help", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/docs" in location, f"/help Location must contain /docs, got {location!r}"
+
+
+def test_channels_redirects_to_trending(client):
+    """Channel index alias -> /trending."""
+    resp = client.get("/channels", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/trending" in location, f"/channels Location must contain /trending, got {location!r}"
+
+
+# --- Regression: existing surfaces must not break ----------------------------
+
+
+def test_existing_watch_video_id_still_works(client):
+    """/watch/<video_id> (canonical single-video surface) must remain registered."""
+    resp = client.get("/watch/nonexistent-video-id-12345")
+    assert resp.status_code in (200, 404), (
+        f"/watch/<video_id> must remain a real route, got {resp.status_code}"
+    )
+
+
+def test_existing_agents_route_still_200(client):
+    """/agents (canonical creator directory) must remain 200."""
+    resp = client.get("/agents")
+    assert resp.status_code == 200
+
+
+def test_existing_trending_route_still_200(client):
+    """/trending (canonical trending feed) must remain 200."""
+    resp = client.get("/trending")
+    assert resp.status_code == 200
+
+
+def test_existing_docs_route_still_works(client):
+    """/docs (canonical help surface) must remain registered."""
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+
+
+# --- URL map registration smoke test -----------------------------------------
+
+
+def test_all_1367_routes_are_registered():
+    """All 14 Bottube #1367 routes must be in the URL map after import."""
+    import bottube_server  # noqa: F401 - import is the assertion
+
+    flask_app = bottube_server.app
+    rules = {r.rule for r in flask_app.url_map.iter_rules()}
+    expected = {
+        "/settings/profile", "/agents/me", "/premium/plans", "/premium/upgrade",
+        "/account", "/account/settings", "/creator", "/creators", "/live",
+        "/home", "/watch", "/tags", "/help", "/channels",
+    }
+    missing = expected - rules
+    assert not missing, f"Missing routes in URL map: {missing}"


### PR DESCRIPTION
Bottube #1367

Live re-verification at 2026-06-13T02:25:00+08:00 found 14 additional user-facing HTML routes on https://bottube.ai that still return HTTP 404 with the in-app Flask 404 template (<title>404 - Not Found - AI Video Platform</title>), even after PR #1408 (Refs #1362, Refs #1371) merged.

The 14 routes in this PR are distinct from those covered by PR #1408 and PR #1407 (Refs #1371 /channel alias). All 14 are pure additive Flask views with no logic changes to any existing route.

## Routing map

| Route | Auth | Target |
| --- | --- | --- |
| /settings/profile | required | /settings/wallet (delegates to wallet_settings_page) |
| /agents/me | required | /dashboard |
| /premium/plans | required | /premium (delegates to premium_page) |
| /premium/upgrade | required | /premium (delegates to premium_page) |
| /account | required | /dashboard |
| /account/settings | required | /settings/wallet |
| /creator | required | /agents |
| /creators | public | /agents |
| /live | public | /trending |
| /home | public | / (delegates to index) |
| /watch | public | /trending (/watch/<video_id> remains the canonical single-video surface) |
| /tags | public | /trending |
| /help | public | /docs |
| /channels | public | /trending |

Anonymous users on auth-required surfaces are redirected to /login?next=... preserving the original path. Logged-in users on auth-required surfaces are redirected to the canonical surface. Public surfaces redirect to the canonical public surface.

## Live repro (before this PR)

```bash
for path in /settings/profile /agents/me /premium/plans /premium/upgrade /account /account/settings /creator /creators /live /home /watch /tags /help /channels; do
  code=$(curl -sk -o /dev/null -w "%{http_code}" "https://bottube.ai${path}")
  echo "bottube ${path}: ${code}"
done
# All 14 return 404 with <title>404 - Not Found - AI Video Platform</title>
```

## Diff

```
bottube_server.py                          | 165 ++++++++++++++++++++++++++++++++++++++
tests/test_user_route_aliases_1367.py     | 186 ++++++++++++++++++++++++++++++++++++
2 files changed, 351 insertions(+)
```

## Validation

- 19/19 new tests in tests/test_user_route_aliases_1367.py pass
- 34/34 wider sweep across PR #1408, PR #1407, PR #1405, and PR #1404 tests pass
- 54/54 cross-stack tests (test_channel_alias_route, test_user_route_aliases_1362_1371, test_user_route_aliases_1367, test_bounty_2161_collab_tip_split, test_search_results_h1_heading, test_aria_labels) pass
- All 14 new routes verified live locally with flask test_client (302 to /login?next=... or to canonical surface)
- /agents, /trending, /docs canonical surfaces verified live as 200 OK

Refs Bottube #1367

Co-authored-by: guoyunfeng <guoyunfeng@users.noreply.github.com>