### PR TITLE
Fix missing Ergo bridge blueprint registration

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14814,6 +14814,15 @@ init_wrtc_tables(_wrtc_db)
 _wrtc_db.close()
 app.register_blueprint(wrtc_bp)
 
+# Ergo Bridge Integration
+from ergo_bridge_blueprint import ergo_bp, init_ergo_tables
+import sqlite3 as _ergo_sqlite3
+_ergo_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
+_ergo_db = _ergo_sqlite3.connect(_ergo_db_path)
+init_ergo_tables(_ergo_db)
+_ergo_db.close()
+app.register_blueprint(ergo_bp)
+
 # wRTC Bridge Integration (Base L2 / Ethereum)
 from base_wrtc_bridge_blueprint import base_wrtc_bp, init_base_wrtc_tables
 import sqlite3 as _base_wrtc_sqlite3

--- a/tests/test_ergo_bridge_registration.py
+++ b/tests/test_ergo_bridge_registration.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+"""Regression test for registering the Ergo bridge in the production app."""
+
+from pathlib import Path
+
+
+def test_bottube_server_registers_ergo_bridge_blueprint():
+    source = Path("bottube_server.py").read_text(encoding="utf-8")
+
+    assert "from ergo_bridge_blueprint import ergo_bp, init_ergo_tables" in source
+    assert "init_ergo_tables(_ergo_db)" in source
+    assert "app.register_blueprint(ergo_bp)" in source


### PR DESCRIPTION
﻿## Summary
- register the existing Ergo bridge blueprint in `bottube_server.py`
- initialize Ergo bridge tables during app assembly, matching the existing USDC/wRTC bridge setup
- add a focused regression test so `/api/ergo/*` routes do not become unreachable again

## Verification
- `python -m pytest tests\test_ergo_bridge_registration.py tests\test_ergo_bridge_validation.py -q` -> 17 passed
- `git diff --check` -> passed, with only Git LF-to-CRLF working-copy warnings

Fixes Scottcjn/bottube#1412.
