### PR TITLE
fix(discover): expose loadable thumbnail urls

### DIFF
--- a/bottube_templates/discover.html
+++ b/bottube_templates/discover.html
@@ -526,10 +526,11 @@
     }
 
     function createVideoCard(video) {
+        const thumbnailUrl = video.thumbnail_url || (video.thumbnail ? `/thumbnails/${encodeURIComponent(video.thumbnail)}` : '/static/default-thumb.jpg');
         return `
             <div class="video-card" onclick="window.location='/watch/${video.id}'">
                 <div class="video-thumbnail">
-                    <img src="${video.thumbnail || '/static/default-thumb.jpg'}" alt="${escapeHtml(video.title)}" loading="lazy" decoding="async">
+                    <img src="${thumbnailUrl}" alt="${escapeHtml(video.title)}" loading="lazy" decoding="async">
                     ${video.duration ? `<span class="video-duration">${formatDuration(video.duration)}</span>` : ''}
                 </div>
                 <div class="video-info">

--- a/search_blueprint.py
+++ b/search_blueprint.py
@@ -11,6 +11,7 @@ import re
 from datetime import datetime, timedelta
 from flask import Blueprint, render_template, jsonify, request, g
 from functools import wraps
+from urllib.parse import quote
 
 search_bp = Blueprint('search', __name__, url_prefix='/discover')
 
@@ -52,6 +53,17 @@ def _parse_int_query(name, default, min_val=0, max_val=None):
     if max_val is not None and value > max_val:
         raise ValueError(f"Invalid '{name}' parameter: maximum is {max_val}.")
     return value
+
+
+def _thumbnail_url(thumbnail):
+    if not thumbnail:
+        return ""
+    thumbnail = str(thumbnail).strip()
+    if not thumbnail:
+        return ""
+    if thumbnail.startswith(("http://", "https://", "/")):
+        return thumbnail
+    return f"/thumbnails/{quote(thumbnail)}"
 
 
 @search_bp.route('/')
@@ -150,6 +162,7 @@ def api_search():
             "title": row['title'],
             "description": row['description'][:200] + "..." if len(row['description']) > 200 else row['description'],
             "thumbnail": row['thumbnail'],
+            "thumbnail_url": _thumbnail_url(row['thumbnail']),
             "views": row['views'],
             "likes": row['likes'],
             "tags": tags,
@@ -284,6 +297,7 @@ def api_videos_by_tag(tag_name):
             "id": row['video_id'],
             "title": row['title'],
             "thumbnail": row['thumbnail'],
+            "thumbnail_url": _thumbnail_url(row['thumbnail']),
             "views": row['views'],
             "likes": row['likes'],
             "tags": tags,
@@ -359,6 +373,7 @@ def api_trending():
             "id": row['video_id'],
             "title": row['title'],
             "thumbnail": row['thumbnail'],
+            "thumbnail_url": _thumbnail_url(row['thumbnail']),
             "views": row['views'],
             "likes": row['likes'],
             "category": row['category'],
@@ -499,6 +514,7 @@ def api_for_you():
             "title": row['title'],
             "description": row['description'][:150] + "..." if len(row['description']) > 150 else row['description'],
             "thumbnail": row['thumbnail'],
+            "thumbnail_url": _thumbnail_url(row['thumbnail']),
             "views": row['views'],
             "likes": row['likes'],
             "tags": tags,

--- a/tests/test_discover_thumbnail_urls.py
+++ b/tests/test_discover_thumbnail_urls.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for discover gallery thumbnail URLs."""
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+import search_blueprint
+from search_blueprint import search_bp
+
+
+@pytest.fixture()
+def discover_thumbnail_client(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY,
+            agent_name TEXT,
+            display_name TEXT
+        );
+        CREATE TABLE videos (
+            id INTEGER PRIMARY KEY,
+            video_id TEXT,
+            title TEXT,
+            description TEXT,
+            thumbnail TEXT,
+            views INTEGER,
+            likes INTEGER,
+            tags TEXT,
+            category TEXT,
+            duration_sec REAL,
+            created_at REAL,
+            agent_id INTEGER
+        );
+        CREATE TABLE views (
+            video_id TEXT,
+            agent_id INTEGER,
+            created_at REAL
+        );
+        CREATE TABLE comments (
+            video_id TEXT,
+            created_at REAL
+        );
+        """
+    )
+    now = time.time()
+    conn.execute(
+        "INSERT INTO agents (id, agent_name, display_name) VALUES (1, 'thumbbot', 'Thumb Bot')"
+    )
+    conn.execute(
+        """INSERT INTO videos
+           (id, video_id, title, description, thumbnail, views, likes, tags, category, duration_sec, created_at, agent_id)
+           VALUES (1, 'thumb-video', 'Thumbnail demo', 'Demo video', 'sample thumb.jpg',
+                   9, 3, '["python"]', 'education', 12.5, ?, 1)""",
+        (now,),
+    )
+    conn.execute(
+        "INSERT INTO views (video_id, agent_id, created_at) VALUES ('thumb-video', 1, ?)",
+        (now,),
+    )
+    conn.commit()
+
+    monkeypatch.setattr(search_blueprint, "get_db", lambda: conn)
+
+    app = Flask(__name__)
+    app.register_blueprint(search_bp)
+    app.config["TESTING"] = True
+
+    yield app.test_client()
+
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/discover/api/search?q=Thumbnail",
+        "/discover/api/tag/python",
+        "/discover/api/trending",
+        "/discover/api/for-you",
+    ],
+)
+def test_discover_video_apis_expose_loadable_thumbnail_url(discover_thumbnail_client, path):
+    response = discover_thumbnail_client.get(path)
+
+    assert response.status_code == 200
+    video = response.get_json()["videos"][0]
+    assert video["thumbnail"] == "sample thumb.jpg"
+    assert video["thumbnail_url"] == "/thumbnails/sample%20thumb.jpg"
+
+
+def test_discover_template_prefers_thumbnail_url():
+    template = Path("bottube_templates/discover.html").read_text(encoding="utf-8")
+
+    assert "video.thumbnail_url" in template
+    assert "/thumbnails/${encodeURIComponent(video.thumbnail)}" in template


### PR DESCRIPTION
## Summary
- add a `thumbnail_url` field to discover/search video API payloads while preserving the existing raw `thumbnail` filename
- make the discover gallery prefer `thumbnail_url`, with a safe `/thumbnails/<encoded filename>` fallback for older payloads
- cover search, tag, trending, and anonymous for-you discover video responses with regression tests

## Tests
- `python -m pytest tests\test_discover_thumbnail_urls.py tests\test_search_blueprint_query_validation.py -q`
- `python -m py_compile search_blueprint.py tests\test_discover_thumbnail_urls.py`

Refs #1419