### PR TITLE
fix: validate public analytics days

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8431,6 +8431,10 @@ def get_agent(agent_name):
 @app.route("/api/agents/<agent_name>/analytics")
 def get_agent_analytics(agent_name):
     """Time-series analytics for a creator: views, engagement, subscribers."""
+    days, error = _parse_positive_int_query("days", 30, max_value=90)
+    if error:
+        return error
+
     db = get_db()
     agent = db.execute(
         """SELECT id, agent_name, display_name
@@ -8442,7 +8446,6 @@ def get_agent_analytics(agent_name):
         return jsonify({"error": "Agent not found"}), 404
 
     aid = agent["id"]
-    days = min(90, max(1, request.args.get("days", 30, type=int)))
     now = time.time()
     cutoff = now - days * 86400
 
@@ -8534,6 +8537,10 @@ def get_agent_analytics(agent_name):
 @app.route("/api/videos/<video_id>/analytics")
 def get_video_analytics(video_id):
     """Per-video analytics: daily views, engagement breakdown."""
+    days, error = _parse_positive_int_query("days", 30, max_value=90)
+    if error:
+        return error
+
     db = get_db()
     video = db.execute(
         """SELECT v.*
@@ -8546,7 +8553,6 @@ def get_video_analytics(video_id):
     if not video:
         return jsonify({"error": "Video not found"}), 404
 
-    days = min(90, max(1, request.args.get("days", 30, type=int)))
     now = time.time()
     cutoff = now - days * 86400
 

--- a/tests/test_public_analytics_visibility.py
+++ b/tests/test_public_analytics_visibility.py
@@ -186,3 +186,35 @@ def test_video_analytics_still_returns_visible_videos(client):
     assert data["video_id"] == "visible-clip"
     assert data["totals"]["views"] == 3
     assert sum(row["views"] for row in data["daily_views"]) == 1
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/agents/visible_agent/analytics",
+        "/api/videos/visible-clip/analytics",
+    ],
+)
+@pytest.mark.parametrize("days", ["abc", "0", "91"])
+def test_public_analytics_rejects_invalid_days(client, path, days):
+    agent_id = _insert_agent("visible_agent")
+    _insert_video("visible-clip", agent_id, title="Visible Clip")
+
+    resp = client.get(f"{path}?days={days}")
+
+    assert resp.status_code == 400
+    assert "days" in resp.get_json()["error"]
+
+
+@pytest.mark.parametrize("days", ["1", "90"])
+def test_public_analytics_accepts_days_boundaries(client, days):
+    agent_id = _insert_agent("visible_agent")
+    _insert_video("visible-clip", agent_id, title="Visible Clip")
+
+    agent_resp = client.get(f"/api/agents/visible_agent/analytics?days={days}")
+    video_resp = client.get(f"/api/videos/visible-clip/analytics?days={days}")
+
+    assert agent_resp.status_code == 200
+    assert video_resp.status_code == 200
+    assert agent_resp.get_json()["period_days"] == int(days)
+    assert video_resp.get_json()["period_days"] == int(days)


### PR DESCRIPTION
## Summary

- validate `days` on the public creator and video analytics routes with the existing `_parse_positive_int_query` helper
- return deterministic JSON 400 responses for non-integer, zero, negative, and above-90 values
- preserve the existing 30-day default and valid 1-90 day range
- add regression tests for both routes and both valid boundaries

Closes #1423. Refs Scottcjn/rustchain-bounties#1102.

## Before / after

Before the fix, `days=abc` returned `200 OK` with `period_days: 30` because Flask silently substituted the default after integer conversion failed. The new tests failed on untouched main with `200 == 400`.

After the fix, both routes reject invalid values before querying the database and return the shared helper messages such as `{"error":"days must be an integer"}`.

## Validation

- `.venv312/bin/python -m pytest tests/test_public_analytics_visibility.py -q` -> 12 passed
- `.venv312/bin/python -m pytest tests/test_videos_list_query_param_validation.py tests/test_agent_directory_query_validation.py -q` -> 27 passed
- `python -m compileall -q bottube_server.py tests/test_public_analytics_visibility.py`
- `git diff --check`

The full repository run reached 1,169 passed and 10 skipped, with 90 unrelated failures and 10 pre-existing fixture errors involving shared app contexts/database paths. The focused and adjacent validation suites above are green.

This contribution was developed with AI assistance and manually reviewed and tested.