### PR TITLE
fix(search): validate min_views query parameter

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8291,7 +8291,9 @@ def search_videos():
         params.append(before_ts)
 
     # Engagement threshold
-    min_views = request.args.get("min_views", 0, type=int)
+    min_views, error = _parse_positive_int_query("min_views", 0, min_value=0)
+    if error:
+        return error
     if min_views > 0:
         conditions.append("v.views >= ?")
         params.append(min_views)

--- a/tests/test_videos_list_query_param_validation.py
+++ b/tests/test_videos_list_query_param_validation.py
@@ -135,6 +135,36 @@ def test_search_videos_rejects_per_page_above_max(client):
     assert response.status_code == 400
 
 
+def test_search_videos_rejects_non_integer_min_views(client):
+    response = client.get("/api/search?q=test&min_views=abc")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "min_views" in data["error"]
+    assert "integer" in data["error"]
+
+
+def test_search_videos_rejects_negative_min_views(client):
+    response = client.get("/api/search?q=test&min_views=-1")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "min_views" in data["error"]
+    assert ">= 0" in data["error"]
+
+
+def test_search_videos_accepts_zero_min_views(client):
+    response = client.get("/api/search?q=nonexistent_query_xyz&min_views=0")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["filters"]["min_views"] is None
+
+
+def test_search_videos_accepts_positive_min_views(client):
+    response = client.get("/api/search?q=nonexistent_query_xyz&min_views=10")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["filters"]["min_views"] == 10
+
+
 def test_search_videos_accepts_valid_pagination(client):
     # Empty results is fine, the point is that pagination parsing passed
     response = client.get("/api/search?q=nonexistent_query_xyz&page=1&per_page=10")


### PR DESCRIPTION
## Summary

Fixes #1425 by routing `/api/search?min_views=...` through the same integer query validation helper already used for `page` and `per_page`.

Before this change, malformed values such as `min_views=abc` were silently converted to the default `0`, which disabled the engagement threshold and returned `200 OK`.

## Changes

- Validate `min_views` with `_parse_positive_int_query("min_views", 0, min_value=0)`.
- Return deterministic JSON `400` responses for malformed or negative values.
- Preserve existing behavior for omitted/zero values and positive thresholds.
- Add regression coverage for malformed, negative, zero, and positive `min_views` values.

## Validation

Production reproduction before fix:

```bash
curl -i 'https://bottube.ai/api/search?q=retro&min_views=abc'
# HTTP/2 200, filters.min_views=null
```

Local validation:

```bash
/tmp/bottube-minviews-py311-venv/bin/python -B -m pytest -q tests/test_videos_list_query_param_validation.py --tb=short
# 28 passed

/tmp/bottube-minviews-py311-venv/bin/python -B -m py_compile bottube_server.py tests/test_videos_list_query_param_validation.py agent_relationships.py
# passed

git diff --check -- bottube_server.py tests/test_videos_list_query_param_validation.py
# passed
```

## Duplicate check

Searched BoTTube and rustchain-bounties for `min_views`, `/api/search min_views`, and related validation reports. Found closed feature/filter work (#188, #1208), but no current report or PR for malformed `/api/search?min_views=...` validation.
