### PR TITLE
fix(search): validate min_views query parameter (Refs #1425)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8291,7 +8291,9 @@ def search_videos():
         params.append(before_ts)
 
     # Engagement threshold
-    min_views = request.args.get("min_views", 0, type=int)
+    min_views, error = _parse_positive_int_query("min_views", 0, min_value=0)
+    if error is not None:
+        return error
     if min_views > 0:
         conditions.append("v.views >= ?")
         params.append(min_views)

--- a/tests/test_search_min_views_validation.py
+++ b/tests/test_search_min_views_validation.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for Bottube #1425 — `/api/search` silently ignores
+malformed `min_views` query parameter.
+
+Bug: `/api/search?q=retro&min_views=abc` returns HTTP 200 with the
+engagement threshold silently disabled (Flask's `type=int` falls back
+to the default 0 on parse failure). This hides client bugs and is
+inconsistent with the already-hardened `/api/search` pagination
+parameters.
+
+Fix: route `min_views` through the existing `_parse_positive_int_query`
+helper that `page` and `per_page` already use, so malformed values
+return `400 {"error": "min_views must be an integer"}` like the other
+parameters.
+
+Refs: https://github.com/Scottcjn/bottube/issues/1425
+"""
+
+
+def test_search_min_views_rejects_malformed_string(client):
+    """GET /api/search?min_views=abc must return 400 (was 200 silently)."""
+    resp = client.get("/api/search?q=retro&min_views=abc")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "min_views" in data["error"]
+    assert "integer" in data["error"]
+
+
+def test_search_min_views_rejects_malformed_negative(client):
+    """GET /api/search?min_views=-5 must return 400 (min_value=0 enforced)."""
+    resp = client.get("/api/search?q=retro&min_views=-5")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "min_views" in data["error"]
+
+
+def test_search_min_views_accepts_zero(client):
+    """GET /api/search?min_views=0 is a valid no-op filter, must return 200."""
+    resp = client.get("/api/search?q=retro&min_views=0")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["filters"]["min_views"] is None
+
+
+def test_search_min_views_accepts_positive(client):
+    """GET /api/search?min_views=10 must return 200 with the threshold echoed."""
+    resp = client.get("/api/search?q=retro&min_views=10")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["filters"]["min_views"] == 10
+
+
+def test_search_min_views_omitted_default(client):
+    """GET /api/search?q=retro (no min_views) must return 200 with null filter."""
+    resp = client.get("/api/search?q=retro")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["filters"]["min_views"] is None


### PR DESCRIPTION
## Summary

Fixes Bottube #1425: `/api/search` silently ignores malformed `min_views` query parameter.

## Bug

`GET https://bottube.ai/api/search?q=retro&min_views=abc` returns **HTTP 200** with `"filters": {"min_views": null}`, hiding client bugs and disabling the engagement threshold.

## Root cause

`search_videos()` validated `page`/`per_page` with `_parse_positive_int_query` but parsed `min_views` with `request.args.get("min_views", 0, type=int)`, which falls back to the default on parse failure.

## Fix

Route `min_views` through the same `_parse_positive_int_query` helper with `min_value=0`, so:
- `?min_views=abc` → 400 `{"error": "min_views must be an integer"}`
- `?min_views=-5` → 400 `{"error": "min_views must be >= 0"}`
- `?min_views=0` → 200 (valid no-op filter)
- `?min_views=10` → 200 (engagement threshold applied)
- (omitted) → 200 (default null filter)

## Validation

```
$ python3 -m pytest tests/test_search_min_views_validation.py tests/test_api_v1_videos_search_alias.py tests/test_videos_list_query_param_validation.py -q
.....................................                                   [100%]
37 passed in 22.53s
```

- 5/5 new regression tests pass
- 32/32 existing pagination tests pass (no regression)
- `py_compile` clean
- `git diff --check` clean

## Diff

```
bottube_server.py                          |  4 +++-
tests/test_search_min_views_validation.py  | 60 +++++++++++++++++++++ (new)
```

## Production impact

The bug is **live** on production at https://bottube.ai/api/search?q=retro&min_views=abc (returns 200 with null filter). Source-side fix is ready; only maintainer Flask service redeploy can resolve.

Refs Bounty #1102 (BoTTube functional tier) — fix is a focused single-parameter validation that does not duplicate any open PR.

Refs: https://github.com/Scottcjn/bottube/issues/1425
