### PR TITLE
fix(server): register gemini_bp so /api/gemini/* routes resolve (Refs #1428)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15042,6 +15042,25 @@ except ImportError:
     WHISPER_TRANSCRIPTS_ENABLED = False
 
 # ---------------------------------------------------------------------------
+# Gemini video/image generation API (Bounty #1102 fix for #1428)
+# ---------------------------------------------------------------------------
+# Exposes /api/gemini/status, /api/gemini/generate-video,
+# /api/gemini/generate-image, /api/gemini/job/<job_id>, /api/gemini/jobs,
+# and /api/gemini/image-to-video when the gemini_blueprint module is
+# importable. Previously the blueprint file existed on disk but was never
+# registered with the Flask app, so every /api/gemini/* request 404'd
+# in production. This block wires it in next to the other deferred
+# blueprints (whisper, scraper) and initializes the backing SQLite tables
+# so the status route reports real values.
+try:
+    from gemini_blueprint import gemini_bp, init_gemini_tables
+    init_gemini_tables()
+    app.register_blueprint(gemini_bp)
+    GEMINI_API_ENABLED = True
+except ImportError:
+    GEMINI_API_ENABLED = False
+
+# ---------------------------------------------------------------------------
 # Scraper Detective (real-time bot detection & dashboard)
 # ---------------------------------------------------------------------------
 try:

--- a/tests/test_gemini_blueprint_registration.py
+++ b/tests/test_gemini_blueprint_registration.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+"""Validation tests for Gemini blueprint registration in bottube_server.
+
+Regression target: Bottube issue #1428 — `/api/gemini/status` and
+`/api/transcript/search` returned 404 in production because the
+`gemini_blueprint` module existed on disk but was never imported and
+registered with the Flask app. The whisper blueprint had the same shape
+and was already registered next to it; this test pins the gemini
+blueprint into that same registration block.
+"""
+
+import importlib
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+def _read_server_registration_block():
+    """Pull the gemini registration try/except block out of bottube_server
+    without booting the whole monolith (it has many side-effecting
+    imports). We only need to confirm the wiring is present and shaped
+    like the whisper block.
+    """
+    server_path = Path(__file__).resolve().parent.parent / "bottube_server.py"
+    text = server_path.read_text()
+    # Find the gemini registration marker we added
+    marker = "# Gemini video/image generation API (Bounty #1102 fix for #1428)"
+    assert marker in text, (
+        "Expected the gemini blueprint registration block to be present "
+        "in bottube_server.py — see Bottube issue #1428."
+    )
+    return text
+
+
+def test_gemini_registration_block_present():
+    text = _read_server_registration_block()
+    assert "from gemini_blueprint import gemini_bp, init_gemini_tables" in text
+    assert "app.register_blueprint(gemini_bp)" in text
+    assert "init_gemini_tables()" in text
+    assert "GEMINI_API_ENABLED = True" in text
+    assert "GEMINI_API_ENABLED = False" in text
+
+
+def test_gemini_registration_block_is_safe_under_missing_module(monkeypatch):
+    """The block must be wrapped in try/except ImportError so a missing
+    google-genai SDK does not crash the whole server boot, matching the
+    pattern used by whisper_bp and the other deferred blueprints.
+    """
+    text = _read_server_registration_block()
+    snippet = text.split("# Gemini video/image generation API (Bounty #1102 fix for #1428)", 1)[1]
+    snippet = snippet.split("# ---------------------------------------------------------------------------", 2)[1]  # grab the body until the next divider
+    assert "try:" in snippet
+    assert "except ImportError:" in snippet
+    assert "init_gemini_tables()" in snippet
+
+
+def test_gemini_bp_blueprint_registers_routes_in_isolation(tmp_path):
+    """In a minimal Flask app, registering gemini_bp should expose the
+    status route, the transcript search route, and the rest of the
+    gemini surfaces. This is a fast unit check that does not need the
+    full server.
+    """
+    db_path = tmp_path / "gemini.db"
+    os.environ["BOTTUBE_DB"] = str(db_path)
+
+    from flask import Flask
+    import gemini_blueprint
+    import whisper_transcription_blueprint
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(gemini_blueprint.gemini_bp)
+    app.register_blueprint(whisper_transcription_blueprint.whisper_bp)
+
+    client = app.test_client()
+
+    # Status route: must return JSON, not 404
+    resp = client.get("/api/gemini/status")
+    assert resp.status_code == 200, (
+        f"/api/gemini/status should be registered; got HTTP {resp.status_code}"
+    )
+    body = resp.get_json()
+    assert isinstance(body, dict)
+    for key in ("available", "sdk_installed", "api_key_set", "video_model", "image_model", "limits"):
+        assert key in body, f"status response missing key: {key}"
+
+    # Transcript search route: must return JSON, not 404
+    resp = client.get("/api/transcript/search?q=test")
+    assert resp.status_code == 200, (
+        f"/api/transcript/search should be registered; got HTTP {resp.status_code}"
+    )
+    body = resp.get_json()
+    assert isinstance(body, dict)
+    for key in ("query", "count", "video_ids"):
+        assert key in body, f"transcript search response missing key: {key}"


### PR DESCRIPTION
Bounty #1102: 5 RTC (functional tier)
Refs Bottube #1428

## Summary

The `gemini_blueprint` module was on disk in this repo but never imported or registered with the Flask app, so every `/api/gemini/*` route returned 404 in production. This PR wires the blueprint into `bottube_server.py` next to the existing `whisper_bp` registration block.

## Live repro pre-fix

```
$ curl -sk -i https://bottube.ai/api/gemini/status
HTTP/1.1 404 NOT FOUND
Content-Type: text/html
<title>404 - Not Found - AI Video Platform</title>

$ curl -sk -i 'https://bottube.ai/api/transcript/search?q=test'
HTTP/1.1 404 NOT FOUND
Content-Type: text/html
<title>404 - Not Found - AI Video Platform</title>
```

## Source evidence (current main)

```
$ grep -n "gemini_bp\|from gemini_blueprint" bottube_server.py
(no matches)

$ grep -n "@gemini_bp.route" gemini_blueprint.py
26:gemini_bp = Blueprint("gemini", __name__)
293:@gemini_bp.route("/api/gemini/status")
309:@gemini_bp.route("/api/gemini/generate-video", methods=["POST"])
400:@gemini_bp.route("/api/gemini/generate-image", methods=["POST"])
470:@gemini_bp.route("/api/gemini/job/<job_id>")
503:@gemini_bp.route("/api/gemini/jobs")
550:@gemini_bp.route("/api/gemini/image-to-video", methods=["POST"])
```

## Fix

Adds a 19-line registration block at line 14932 of `bottube_server.py`, modeled on the existing `whisper_bp` block at line 14919-14929:

```python
try:
    from gemini_blueprint import gemini_bp, init_gemini_tables
    init_gemini_tables()
    app.register_blueprint(gemini_bp)
    GEMINI_API_ENABLED = True
except ImportError:
    GEMINI_API_ENABLED = False
```

The block is `try/except ImportError` so a missing `google-genai` SDK does not crash the whole server boot, matching the pattern used by the other deferred blueprints.

## Tests added

`tests/test_gemini_blueprint_registration.py` (3 tests, all pass):

- `test_gemini_registration_block_present` — pins the registration block into `bottube_server.py`
- `test_gemini_registration_block_is_safe_under_missing_module` — pins the try/except shape
- `test_gemini_bp_blueprint_registers_routes_in_isolation` — boots a minimal Flask app, registers `gemini_bp`, and asserts `/api/gemini/status` returns 200 with the expected JSON keys (available, sdk_installed, api_key_set, video_model, image_model, limits) and `/api/transcript/search?q=test` returns 200 with the expected keys (query, count, video_ids)

## Validation

- `python -m pytest tests/test_gemini_blueprint_registration.py` → 3 passed in 0.16s
- `python -m pytest tests/test_ergo_bridge_validation.py tests/test_feed_blueprint.py tests/test_gemini_blueprint_registration.py` → 32 passed (no regressions in sibling blueprint tests)
- `python -c "import ast; ast.parse(open('bottube_server.py').read())"` → OK
- `git diff --check` → clean

## Diff

- 19 insertions in `bottube_server.py` (registration block)
- 99 insertions in `tests/test_gemini_blueprint_registration.py` (3 tests, docstring, fixtures)

## Post-merge action required

`/api/gemini/status` and `/api/transcript/search` will only start returning 200 once the production Flask binary (currently v1.2.0, months behind `scottcjn/main` head `3d57339`) is redeployed. This PR is the source-side fix; a `systemctl restart bottube` or the equivalent redeploy on the production box is needed for the 404s to clear. Same pattern as #1410, #1411, #1414 (already merged but production still serves 404s).