### PR TITLE
feat(#307): BoTTube provider router hardening (by Léa/Kryosys)

### DIFF
--- a/docs/generation_provider_reliability.md
+++ b/docs/generation_provider_reliability.md
@@ -1,0 +1,86 @@
+# Generation provider reliability
+
+This document describes the production-hardening path for the BoTTube generation provider router/worker.
+
+## Retry and fallback behavior
+
+Provider operations are normalized through `generation.reliability.run_with_retries()`:
+
+- `auth` errors (`401`, `403`, invalid API key) fail fast and move to the next provider.
+- `permanent` errors fail fast and move to the next provider.
+- `transient` errors (timeouts, temporary network failures, `502`/`503`/`504`) retry with bounded exponential backoff.
+- `throttled` errors (`429`, quota/rate-limit responses) retry with bounded exponential backoff.
+
+Default retry policy:
+
+```text
+attempts=3
+base_delay_s=0.5
+max_delay_s=4.0
+jitter_s=0.2
+```
+
+The fallback chain remains deterministic: the worker retries only the current provider for retryable categories; if it still fails, it records the category and advances to the next provider selected by `GenerationRouter`.
+
+## Observability
+
+Each provider attempt records:
+
+- provider name
+- success/failure
+- error category (`ok`, `auth`, `throttled`, `transient`, `permanent`)
+- latency in seconds
+- timestamp
+- human-readable detail
+
+The in-memory job entry also exposes a `provider_metrics` snapshot with per-provider counters:
+
+```json
+{
+  "grok": {
+    "attempts": 12,
+    "successes": 10,
+    "failures": 2,
+    "avg_latency_s": 1.812,
+    "total_latency_s": 21.744,
+    "error_categories": {"throttled": 1, "transient": 1}
+  }
+}
+```
+
+The worker logs structured `provider_attempt` lines suitable for ingestion by journald, Docker logs, or a hosted log pipeline.
+
+## Environment examples
+
+Typical provider secrets should be supplied by environment variables or a secrets manager, never committed:
+
+```bash
+export GROK_API_KEY="..."
+export RUNWAY_API_KEY="..."
+export BOTTUBE_BASE_DIR=/srv/bottube
+python bottube_server.py
+```
+
+If a provider key is absent or invalid, the router/worker should classify it as `auth` and fall back without retry storms.
+
+## Troubleshooting
+
+1. Check the job's `attempts` list for provider-level categories and details.
+2. Check `provider_metrics` for repeated `throttled` or `transient` failures.
+3. Confirm that API keys are present in the runtime environment.
+4. If a provider is permanently failing validation, verify `GenerationRequest` mode, duration, style and capability matching.
+5. If all providers fail, confirm the local `ffmpeg_titlecard` fallback is registered and available.
+
+## Testing
+
+Run the targeted reliability tests:
+
+```bash
+python -m pytest tests/test_generation_reliability.py -q
+```
+
+Run the broader generation/worker test suite when available:
+
+```bash
+python -m pytest tests -q
+```

--- a/generation/reliability.py
+++ b/generation/reliability.py
@@ -82,6 +82,12 @@ def is_retryable(category: str) -> bool:
     return category in {"transient", "throttled"}
 
 
+def _semantic_failure_detail(value: object) -> object:
+    if isinstance(value, (tuple, list)) and len(value) >= 2:
+        return value[1]
+    return value
+
+
 def record_provider_metric(provider: str, *, success: bool, latency_s: float, category: Optional[str] = None) -> dict:
     metrics = _PROVIDER_METRICS.setdefault(provider, ProviderMetrics())
     metrics.attempts += 1
@@ -99,18 +105,36 @@ def provider_metrics_snapshot() -> Dict[str, dict]:
     return {name: metrics.to_dict() for name, metrics in _PROVIDER_METRICS.items()}
 
 
-def run_with_retries(provider: str, operation: str, func: Callable[[], T], policy: RetryPolicy = RetryPolicy()) -> Tuple[bool, Optional[T], str, float, int]:
+def run_with_retries(
+    provider: str,
+    operation: str,
+    func: Callable[[], T],
+    policy: RetryPolicy = RetryPolicy(),
+    success_predicate: Optional[Callable[[T], bool]] = None,
+) -> Tuple[bool, Optional[T], str, float, int]:
     """Run a provider operation with bounded retries for transient categories.
 
     Returns: (ok, value, category_or_ok, total_latency_s, attempts_used)
     """
-    start = time.monotonic()
+    wall_start = time.monotonic()
     last_category = "permanent"
     attempts = max(1, policy.attempts)
     for attempt_index in range(attempts):
         try:
             value = func()
-            latency = time.monotonic() - start
+            latency = time.monotonic() - wall_start
+            if success_predicate is not None and not success_predicate(value):
+                last_category = classify_error(_semantic_failure_detail(value))
+                retry = attempt_index + 1 < attempts and is_retryable(last_category)
+                log.warning(
+                    "provider_attempt provider=%s operation=%s attempt=%d success=false category=%s retry=%s result=%s",
+                    provider, operation, attempt_index + 1, last_category, retry, str(value)[:300],
+                )
+                if not retry:
+                    record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
+                    return False, value, last_category, latency, attempt_index + 1
+                time.sleep(policy.delay_for(attempt_index))
+                continue
             record_provider_metric(provider, success=True, latency_s=latency)
             log.info(
                 "provider_attempt provider=%s operation=%s attempt=%d success=true latency_s=%.3f",
@@ -125,11 +149,11 @@ def run_with_retries(provider: str, operation: str, func: Callable[[], T], polic
                 provider, operation, attempt_index + 1, last_category, retry, str(exc)[:300],
             )
             if not retry:
-                latency = time.monotonic() - start
+                latency = time.monotonic() - wall_start
                 record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
                 return False, None, last_category, latency, attempt_index + 1
             time.sleep(policy.delay_for(attempt_index))
 
-    latency = time.monotonic() - start
+    latency = time.monotonic() - wall_start
     record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
     return False, None, last_category, latency, attempts

--- a/generation/reliability.py
+++ b/generation/reliability.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+"""
+generation/reliability.py - retry, error classification and provider metrics
+===========================================================================
+Small, dependency-free helpers used by the generation worker.  The goal is to
+make provider fallback deterministic and observable without changing provider
+adapter APIs.
+"""
+from __future__ import annotations
+
+import logging
+import random
+import socket
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional, Tuple, TypeVar
+
+log = logging.getLogger("generation.reliability")
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Bounded exponential backoff policy for transient provider failures."""
+
+    attempts: int = 3
+    base_delay_s: float = 0.5
+    max_delay_s: float = 4.0
+    jitter_s: float = 0.2
+
+    def delay_for(self, attempt_index: int) -> float:
+        delay = min(self.max_delay_s, self.base_delay_s * (2 ** max(0, attempt_index)))
+        if self.jitter_s:
+            delay += random.uniform(0.0, self.jitter_s)
+        return delay
+
+
+@dataclass
+class ProviderMetrics:
+    """In-memory counters and timings for provider attempts."""
+
+    attempts: int = 0
+    successes: int = 0
+    failures: int = 0
+    total_latency_s: float = 0.0
+    error_categories: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def avg_latency_s(self) -> float:
+        return self.total_latency_s / self.attempts if self.attempts else 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "attempts": self.attempts,
+            "successes": self.successes,
+            "failures": self.failures,
+            "avg_latency_s": round(self.avg_latency_s, 3),
+            "total_latency_s": round(self.total_latency_s, 3),
+            "error_categories": dict(self.error_categories),
+        }
+
+
+_PROVIDER_METRICS: Dict[str, ProviderMetrics] = {}
+
+
+def classify_error(error: object) -> str:
+    """Classify provider errors for retry/fallback decisions and CLI output."""
+    text = str(error or "").lower()
+    if any(token in text for token in ("401", "403", "unauthorized", "forbidden", "api key", "auth")):
+        return "auth"
+    if any(token in text for token in ("429", "rate limit", "quota", "throttl", "too many")):
+        return "throttled"
+    if isinstance(error, (TimeoutError, socket.timeout)) or any(
+        token in text for token in ("timeout", "timed out", "temporar", "connection reset", "network", "unavailable", "502", "503", "504")
+    ):
+        return "transient"
+    return "permanent"
+
+
+def is_retryable(category: str) -> bool:
+    return category in {"transient", "throttled"}
+
+
+def record_provider_metric(provider: str, *, success: bool, latency_s: float, category: Optional[str] = None) -> dict:
+    metrics = _PROVIDER_METRICS.setdefault(provider, ProviderMetrics())
+    metrics.attempts += 1
+    metrics.total_latency_s += max(0.0, latency_s)
+    if success:
+        metrics.successes += 1
+    else:
+        metrics.failures += 1
+        if category:
+            metrics.error_categories[category] = metrics.error_categories.get(category, 0) + 1
+    return metrics.to_dict()
+
+
+def provider_metrics_snapshot() -> Dict[str, dict]:
+    return {name: metrics.to_dict() for name, metrics in _PROVIDER_METRICS.items()}
+
+
+def run_with_retries(provider: str, operation: str, func: Callable[[], T], policy: RetryPolicy = RetryPolicy()) -> Tuple[bool, Optional[T], str, float, int]:
+    """Run a provider operation with bounded retries for transient categories.
+
+    Returns: (ok, value, category_or_ok, total_latency_s, attempts_used)
+    """
+    start = time.monotonic()
+    last_category = "permanent"
+    attempts = max(1, policy.attempts)
+    for attempt_index in range(attempts):
+        try:
+            value = func()
+            latency = time.monotonic() - start
+            record_provider_metric(provider, success=True, latency_s=latency)
+            log.info(
+                "provider_attempt provider=%s operation=%s attempt=%d success=true latency_s=%.3f",
+                provider, operation, attempt_index + 1, latency,
+            )
+            return True, value, "ok", latency, attempt_index + 1
+        except Exception as exc:  # provider adapters vary; normalize here
+            last_category = classify_error(exc)
+            retry = attempt_index + 1 < attempts and is_retryable(last_category)
+            log.warning(
+                "provider_attempt provider=%s operation=%s attempt=%d success=false category=%s retry=%s error=%s",
+                provider, operation, attempt_index + 1, last_category, retry, str(exc)[:300],
+            )
+            if not retry:
+                latency = time.monotonic() - start
+                record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
+                return False, None, last_category, latency, attempt_index + 1
+            time.sleep(policy.delay_for(attempt_index))
+
+    latency = time.monotonic() - start
+    record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
+    return False, None, last_category, latency, attempts

--- a/generation/worker.py
+++ b/generation/worker.py
@@ -25,7 +25,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Tuple
 
 from generation.models import GenerationRequest, JobStatus
 from generation.quality_gate import check_quality, QualityGateResult
@@ -53,6 +53,17 @@ for _d in (_VIDEO_DIR, _THUMB_DIR, _GEN_WORK_DIR):
 
 _POLL_INTERVAL = 3        # seconds between async polls
 _POLL_TIMEOUT = 300       # 5 minutes max wait per provider
+
+
+def _submit_succeeded(result: object) -> bool:
+    return isinstance(result, tuple) and len(result) == 2 and bool(result[0])
+
+
+def _as_submit_result(result: object) -> Optional[Tuple[bool, object]]:
+    if isinstance(result, tuple) and len(result) == 2:
+        return bool(result[0]), result[1]
+    return None
+
 
 # ---------------------------------------------------------------------------
 # In-memory job store (small -- jobs expire after 2 hours)
@@ -247,17 +258,25 @@ def _run_pipeline(
             provider_name,
             "submit",
             lambda: provider.submit(req, work_dir),
+            success_predicate=_submit_succeeded,
         )
-        if not ok or submit_result is None:
+        if submit_result is None:
             detail = f"submit {category} after {tries} attempt(s) in {latency_s:.2f}s"
             log.error("Provider %s %s", provider_name, detail)
             _record_attempt(job_id, provider_name, attempt_num, False, detail, category, latency_s)
             continue
 
-        success, external_id = submit_result
+        normalized_submit = _as_submit_result(submit_result)
+        if normalized_submit is None:
+            detail = f"submit returned invalid result shape after {tries} attempt(s) in {latency_s:.2f}s"
+            log.error("Provider %s %s: %r", provider_name, detail, submit_result)
+            _record_attempt(job_id, provider_name, attempt_num, False, detail, category, latency_s)
+            continue
 
-        if not success:
-            category = classify_error(external_id)
+        success, external_id = normalized_submit
+
+        if not ok or not success:
+            category = category if category != "ok" else classify_error(external_id)
             log.warning("Provider %s failed: %s (%s)", provider_name, external_id, category)
             _record_attempt(job_id, provider_name, attempt_num, False, external_id, category, latency_s)
             continue

--- a/generation/worker.py
+++ b/generation/worker.py
@@ -31,6 +31,7 @@ from generation.models import GenerationRequest, JobStatus
 from generation.quality_gate import check_quality, QualityGateResult
 from generation.router import GenerationRouter
 from generation.provider import ProviderRegistry
+from generation.reliability import classify_error, provider_metrics_snapshot, run_with_retries
 
 log = logging.getLogger("generation.worker")
 
@@ -222,6 +223,7 @@ def _run_pipeline(
         if not provider:
             log.warning("Provider %s not found, skipping", provider_name)
             continue
+        assert provider is not None
 
         update_job(
             job_id,
@@ -237,18 +239,27 @@ def _run_pipeline(
             _record_attempt(job_id, provider_name, attempt_num, False, reason)
             continue
 
-        # Submit
+        # Submit with transient retry/backoff.  Auth/permanent errors fail fast;
+        # transient/throttled provider errors get bounded retries before the
+        # deterministic fallback chain advances to the next provider.
         update_job(job_id, status=JobStatus.generating.value, progress=30)
-        try:
-            success, external_id = provider.submit(req, work_dir)
-        except Exception as exc:
-            log.error("Provider %s submit error: %s", provider_name, exc)
-            _record_attempt(job_id, provider_name, attempt_num, False, str(exc))
+        ok, submit_result, category, latency_s, tries = run_with_retries(
+            provider_name,
+            "submit",
+            lambda: provider.submit(req, work_dir),
+        )
+        if not ok or submit_result is None:
+            detail = f"submit {category} after {tries} attempt(s) in {latency_s:.2f}s"
+            log.error("Provider %s %s", provider_name, detail)
+            _record_attempt(job_id, provider_name, attempt_num, False, detail, category, latency_s)
             continue
 
+        success, external_id = submit_result
+
         if not success:
-            log.warning("Provider %s failed: %s", provider_name, external_id)
-            _record_attempt(job_id, provider_name, attempt_num, False, external_id)
+            category = classify_error(external_id)
+            log.warning("Provider %s failed: %s (%s)", provider_name, external_id, category)
+            _record_attempt(job_id, provider_name, attempt_num, False, external_id, category, latency_s)
             continue
 
         # Determine result path
@@ -262,10 +273,10 @@ def _run_pipeline(
             result_path = _poll_provider(job_id, provider, external_id, work_dir)
 
         if not result_path or not result_path.exists():
-            _record_attempt(job_id, provider_name, attempt_num, False, "no output file")
+            _record_attempt(job_id, provider_name, attempt_num, False, "no output file", "permanent", latency_s)
             continue
 
-        _record_attempt(job_id, provider_name, attempt_num, True, "ok")
+        _record_attempt(job_id, provider_name, attempt_num, True, "ok", "ok", latency_s)
         update_job(job_id, progress=70)
 
         # --- Step 3: Transcode ---
@@ -280,7 +291,7 @@ def _run_pipeline(
             else:
                 log.warning("Transcode failed for provider %s", provider_name)
                 final_path.unlink(missing_ok=True)
-                _record_attempt(job_id, provider_name, attempt_num, False, "transcode failed")
+                _record_attempt(job_id, provider_name, attempt_num, False, "transcode failed", "permanent", 0.0)
                 continue
 
         update_job(job_id, video_path=str(final_path), video_id=video_id)
@@ -371,16 +382,19 @@ def _run_pipeline(
 # ---------------------------------------------------------------------------
 
 def _record_attempt(job_id: str, provider: str, attempt: int,
-                    success: bool, detail: str):
+                    success: bool, detail: str, category: str = "", latency_s: float = 0.0):
     with _jobs_lock:
         if job_id in _jobs:
             _jobs[job_id].setdefault("attempts", []).append({
                 "provider": provider,
                 "attempt": attempt,
                 "success": success,
+                "category": category,
+                "latency_s": round(max(0.0, latency_s), 3),
                 "detail": detail[:500],
                 "timestamp": time.time(),
             })
+            _jobs[job_id]["provider_metrics"] = provider_metrics_snapshot()
 
 
 def _poll_provider(job_id, provider, external_id, work_dir) -> Optional[Path]:
@@ -393,11 +407,32 @@ def _poll_provider(job_id, provider, external_id, work_dir) -> Optional[Path]:
             provider.cancel(external_id)
             return None
 
-        status_str, progress = provider.get_status(external_id)
+        ok, status_result, category, latency_s, tries = run_with_retries(
+            provider.get_name(),
+            "status",
+            lambda: provider.get_status(external_id),
+        )
+        if not ok or status_result is None:
+            log.warning(
+                "Provider %s status failed: category=%s attempts=%d latency_s=%.2f",
+                provider.get_name(), category, tries, latency_s,
+            )
+            return None
+        status_str, progress = status_result
         update_job(job_id, progress=int(30 + progress * 40))
 
         if status_str == "completed":
-            result_path = provider.get_result(external_id, work_dir)
+            ok, result_path, category, latency_s, tries = run_with_retries(
+                provider.get_name(),
+                "result",
+                lambda: provider.get_result(external_id, work_dir),
+            )
+            if not ok:
+                log.warning(
+                    "Provider %s result failed: category=%s attempts=%d latency_s=%.2f",
+                    provider.get_name(), category, tries, latency_s,
+                )
+                return None
             if result_path and result_path.exists():
                 return result_path
             return None

--- a/tests/test_generation_reliability.py
+++ b/tests/test_generation_reliability.py
@@ -1,0 +1,61 @@
+import time
+
+from generation.reliability import RetryPolicy, classify_error, provider_metrics_snapshot, run_with_retries
+
+
+def test_classify_error_categories():
+    assert classify_error("401 unauthorized api key") == "auth"
+    assert classify_error("429 rate limit exceeded") == "throttled"
+    assert classify_error(TimeoutError("request timed out")) == "transient"
+    assert classify_error("validation failed: bad prompt") == "permanent"
+
+
+def test_run_with_retries_retries_transient_then_succeeds():
+    calls = {"count": 0}
+
+    def flaky():
+        calls["count"] += 1
+        if calls["count"] < 2:
+            raise TimeoutError("temporary provider timeout")
+        return (True, "job-123")
+
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_retry",
+        "submit",
+        flaky,
+        RetryPolicy(attempts=3, base_delay_s=0.0, max_delay_s=0.0, jitter_s=0.0),
+    )
+
+    assert ok is True
+    assert value == (True, "job-123")
+    assert category == "ok"
+    assert attempts == 2
+    assert latency_s >= 0
+    metrics = provider_metrics_snapshot()["unit_provider_retry"]
+    assert metrics["attempts"] >= 1
+    assert metrics["successes"] >= 1
+
+
+def test_run_with_retries_does_not_retry_auth_errors():
+    calls = {"count": 0}
+
+    def auth_failure():
+        calls["count"] += 1
+        raise RuntimeError("403 forbidden: invalid API key")
+
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_auth",
+        "submit",
+        auth_failure,
+        RetryPolicy(attempts=3, base_delay_s=0.0, max_delay_s=0.0, jitter_s=0.0),
+    )
+
+    assert ok is False
+    assert value is None
+    assert category == "auth"
+    assert attempts == 1
+    assert calls["count"] == 1
+    assert latency_s >= 0
+    metrics = provider_metrics_snapshot()["unit_provider_auth"]
+    assert metrics["failures"] >= 1
+    assert metrics["error_categories"]["auth"] >= 1

--- a/tests/test_generation_reliability.py
+++ b/tests/test_generation_reliability.py
@@ -59,3 +59,98 @@ def test_run_with_retries_does_not_retry_auth_errors():
     metrics = provider_metrics_snapshot()["unit_provider_auth"]
     assert metrics["failures"] >= 1
     assert metrics["error_categories"]["auth"] >= 1
+
+
+def test_run_with_retries_records_semantic_false_result_as_failure():
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_semantic_false",
+        "submit",
+        lambda: (False, "quota exhausted"),
+        RetryPolicy(attempts=1, base_delay_s=0.0, max_delay_s=0.0, jitter_s=0.0),
+        success_predicate=lambda result: result[0],
+    )
+
+    assert ok is False
+    assert value == (False, "quota exhausted")
+    assert category == "throttled"
+    assert attempts == 1
+    assert latency_s >= 0
+    metrics = provider_metrics_snapshot()["unit_provider_semantic_false"]
+    assert metrics["successes"] == 0
+    assert metrics["failures"] == 1
+    assert metrics["error_categories"]["throttled"] == 1
+
+
+def test_run_with_retries_classifies_semantic_failure_reason_not_tuple_repr():
+    class NoisyFalse:
+        def __bool__(self):
+            return False
+
+        def __repr__(self):
+            return "api key noise"
+
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_semantic_reason",
+        "submit",
+        lambda: (NoisyFalse(), "validation failed"),
+        RetryPolicy(attempts=1, base_delay_s=0.0, max_delay_s=0.0, jitter_s=0.0),
+        success_predicate=lambda result: result[0],
+    )
+
+    assert ok is False
+    assert value[1] == "validation failed"
+    assert category == "permanent"
+    assert attempts == 1
+    assert latency_s >= 0
+
+
+def test_run_with_retries_latency_includes_semantic_retry_sleep():
+    calls = {"count": 0}
+
+    def semantic_then_permanent():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return (False, "quota exhausted")
+        return (False, "validation failed")
+
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_semantic_sleep_latency",
+        "submit",
+        semantic_then_permanent,
+        RetryPolicy(attempts=2, base_delay_s=0.01, max_delay_s=0.01, jitter_s=0.0),
+        success_predicate=lambda result: result[0],
+    )
+
+    assert ok is False
+    assert value == (False, "validation failed")
+    assert category == "permanent"
+    assert attempts == 2
+    assert latency_s >= 0.01
+
+
+def test_run_with_retries_does_not_reuse_stale_semantic_failure_after_exception():
+    calls = {"count": 0}
+
+    def semantic_then_exception():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return (False, "quota exhausted")
+        raise TimeoutError("temporary provider timeout")
+
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_semantic_then_exception",
+        "submit",
+        semantic_then_exception,
+        RetryPolicy(attempts=2, base_delay_s=0.0, max_delay_s=0.0, jitter_s=0.0),
+        success_predicate=lambda result: result[0],
+    )
+
+    assert ok is False
+    assert value is None
+    assert category == "transient"
+    assert attempts == 2
+    assert latency_s >= 0
+    metrics = provider_metrics_snapshot()["unit_provider_semantic_then_exception"]
+    assert metrics["successes"] == 0
+    assert metrics["failures"] == 1
+    assert metrics["error_categories"]["transient"] == 1


### PR DESCRIPTION
Bounty #307 — provider router reliability (paid 120 RTC to kryosys-lea / RTC31ede8c0…).

**New:**
- `generation/reliability.py` — `RetryPolicy`, `ProviderMetrics`, `classify_error` (auth/throttled/transient/permanent), `run_with_retries`, metrics snapshot
- `tests/test_generation_reliability.py` — 3 tests (retry/fallback/error-classification)
- `docs/generation_provider_reliability.md` — troubleshooting + env

**Modified:**
- `generation/worker.py` — integrates reliability into submit/status/result paths

Implements all 5 bounty asks. Verified original (reliability.py not previously in repo).

⚠️ **Reviewer note:** `worker.py` was submitted as a full file (604→639L) off an unknown base — please confirm it doesn't revert recent changes before merge. Test suite not re-run in-house (author claims 3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)