### PR TITLE
fix: reject malformed tips leaderboard limits

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11713,7 +11713,9 @@ def tip_leaderboard():
     """Top tipped creators (by total tips received)."""
     db = get_db()
     _sync_pending_tips(db)
-    limit = min(50, max(1, request.args.get("limit", 20, type=int)))
+    limit, error = _parse_tip_leaderboard_limit()
+    if error:
+        return jsonify({"error": error}), 400
 
     rows = db.execute(
         """SELECT a.agent_name, a.display_name, a.avatar_url, a.is_human,
@@ -11740,12 +11742,25 @@ def tip_leaderboard():
     })
 
 
+def _parse_tip_leaderboard_limit(default=20, max_value=50):
+    raw_value = request.args.get("limit")
+    if raw_value in (None, ""):
+        return default, None
+    try:
+        limit = int(raw_value)
+    except (TypeError, ValueError):
+        return None, "limit must be an integer"
+    return min(max_value, max(1, limit)), None
+
+
 @app.route("/api/tips/tippers")
 def tipper_leaderboard():
     """Top tippers (by total tips sent)."""
     db = get_db()
     _sync_pending_tips(db)
-    limit = min(50, max(1, request.args.get("limit", 20, type=int)))
+    limit, error = _parse_tip_leaderboard_limit()
+    if error:
+        return jsonify({"error": error}), 400
 
     rows = db.execute(
         """SELECT a.agent_name, a.display_name, a.avatar_url, a.is_human,

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -6801,7 +6801,7 @@ def _make_param_conflict_error(canonical_name, alias_name):
     )
 
 
-def _parse_positive_int_query(name, default, min_value=1, max_value=None):
+def _parse_positive_int_query(name, default, min_value=1, max_value=None, *, clamp_bounds=False):
     """Return (value, None) or (None, (json_response, status_code)).
 
     Rejects malformed or out-of-range integers with HTTP 400 instead of
@@ -6818,6 +6818,12 @@ def _parse_positive_int_query(name, default, min_value=1, max_value=None):
             jsonify({"error": f"{name} must be an integer"}),
             400,
         )
+    if clamp_bounds:
+        if value < min_value:
+            value = min_value
+        if max_value is not None and value > max_value:
+            value = max_value
+        return value, None
     if value < min_value:
         return None, (
             jsonify({"error": f"{name} must be >= {min_value}"}),
@@ -11715,7 +11721,7 @@ def tip_leaderboard():
     _sync_pending_tips(db)
     limit, error = _parse_tip_leaderboard_limit()
     if error:
-        return jsonify({"error": error}), 400
+        return error
 
     rows = db.execute(
         """SELECT a.agent_name, a.display_name, a.avatar_url, a.is_human,
@@ -11743,14 +11749,13 @@ def tip_leaderboard():
 
 
 def _parse_tip_leaderboard_limit(default=20, max_value=50):
-    raw_value = request.args.get("limit")
-    if raw_value in (None, ""):
-        return default, None
-    try:
-        limit = int(raw_value)
-    except (TypeError, ValueError):
-        return None, "limit must be an integer"
-    return min(max_value, max(1, limit)), None
+    return _parse_positive_int_query(
+        "limit",
+        default,
+        min_value=1,
+        max_value=max_value,
+        clamp_bounds=True,
+    )
 
 
 @app.route("/api/tips/tippers")
@@ -11760,7 +11765,7 @@ def tipper_leaderboard():
     _sync_pending_tips(db)
     limit, error = _parse_tip_leaderboard_limit()
     if error:
-        return jsonify({"error": error}), 400
+        return error
 
     rows = db.execute(
         """SELECT a.agent_name, a.display_name, a.avatar_url, a.is_human,

--- a/tests/test_video_tips_api.py
+++ b/tests/test_video_tips_api.py
@@ -44,3 +44,27 @@ def test_video_tips_returns_empty_totals_for_existing_video(app, client):
         "page": 1,
         "per_page": 10,
     }
+
+
+def test_tip_leaderboard_rejects_malformed_limit(client):
+    response = client.get("/api/tips/leaderboard?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit must be an integer"}
+
+
+def test_tipper_leaderboard_rejects_malformed_limit(client):
+    response = client.get("/api/tips/tippers?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit must be an integer"}
+
+
+def test_tip_leaderboards_preserve_numeric_limit_bounds(client):
+    response = client.get("/api/tips/leaderboard?limit=0")
+    tippers = client.get("/api/tips/tippers?limit=999")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"leaderboard": []}
+    assert tippers.status_code == 200
+    assert tippers.get_json() == {"leaderboard": []}


### PR DESCRIPTION
## Problem

The public tips leaderboard endpoints silently accept malformed `limit` values because they use Flask's `request.args.get(..., type=int)` fallback behavior:

- `https://bottube.ai/api/tips/leaderboard?limit=abc` -> HTTP 200 with the default received-tips leaderboard
- `https://bottube.ai/api/tips/tippers?limit=abc` -> HTTP 200 with the default sent-tips leaderboard

Nearby public query-validation endpoints already return deterministic JSON 400 responses for malformed `limit`, so these two tips endpoints were inconsistent and made bad requests indistinguishable from valid default requests.

## Impact

This is a small public API correctness / observability bug on the tips surface. Clients cannot tell whether their requested leaderboard limit was accepted or silently ignored.

## Fix

- Add a shared tips leaderboard `limit` parser.
- Return `400 {"error": "limit must be an integer"}` when `limit` is malformed.
- Preserve the existing numeric bounds behavior for valid values.

## Scope boundary

This does not change tip amounts, wallet behavior, payout rules, confirmation rules, or tipping state transitions.

## Validation

- `python3 -m pytest -q tests/test_video_tips_api.py tests/test_leaderboard_query_validation.py` -> 7 passed
- `python3 -m py_compile bottube_server.py`
- `git diff --check`

Fixes Scottcjn/bottube#1431
Related bounty context: Scottcjn/rustchain-bounties#1102

---
wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
