### PR TITLE
fix(embed): honor loop and mute query params on embed player

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11799,7 +11799,13 @@ def embed(video_id):
         abort(404)
 
     autoplay = request.args.get("autoplay", "0") == "1"
-    autoplay_attr = "autoplay " if autoplay else ""
+    loop = request.args.get("loop", "0") == "1"
+    mute = request.args.get("mute", "0") == "1"
+    video_attrs = "autoplay " if autoplay else ""
+    if loop:
+        video_attrs += "loop "
+    if mute:
+        video_attrs += "muted "
 
     title_esc = (video["title"] or "").replace("&", "&amp;").replace("<", "&lt;").replace('"', "&quot;")
     creator_esc = (video["display_name"] or video["agent_name"] or "").replace("&", "&amp;").replace("<", "&lt;")
@@ -11827,7 +11833,7 @@ body:hover .overlay{{opacity:1}}
 .brand:hover{{background:#65b8ff}}
 </style>
 </head><body>
-<video controls {autoplay_attr}playsinline>
+<video controls {video_attrs}playsinline>
 <source src="/api/videos/{video_id}/stream" type="video/mp4">
 </video>
 <div class="overlay">

--- a/bottube_templates/embed.html
+++ b/bottube_templates/embed.html
@@ -25,7 +25,7 @@ body:hover .overlay{opacity:1}
 </style>
 </head>
 <body>
-<video controls {% if autoplay %}autoplay{% endif %} playsinline>
+<video controls {% if autoplay %}autoplay{% endif %}{% if loop %} loop{% endif %}{% if mute %} muted{% endif %} playsinline>
   <source src="/api/videos/{{ video.video_id }}/stream" type="video/mp4">
 </video>
 <div class="overlay">


### PR DESCRIPTION
## Problem

The `/embed/<video_id>` route only forwards the `autoplay` query param to the `<video>` element. `?loop=1` and `?mute=1` are silently ignored — the response is identical to the no-arg case.

This means:
- Publishers can't loop a short clip without manual interaction
- Publishers can't autoplay muted (the only combination that survives mobile Safari autoplay policy)

Reported in #1441.

## Fix

Parse `loop` and `mute` the same way `autoplay` is already parsed, and emit the matching `loop` / `muted` HTML attributes on the `<video>` tag.

### Before
```python
autoplay = request.args.get("autoplay", "0") == "1"
autoplay_attr = "autoplay " if autoplay else ""
# <video controls {autoplay_attr}playsinline>
```

### After
```python
autoplay = request.args.get("autoplay", "0") == "1"
loop = request.args.get("loop", "0") == "1"
mute = request.args.get("mute", "0") == "1"
video_attrs = "autoplay " if autoplay else ""
if loop:
    video_attrs += "loop "
if mute:
    video_attrs += "muted "
# <video controls {video_attrs}playsinline>
```

Also updated `bottube_templates/embed.html` for consistency.

## Verification

```
?autoplay=1          -> <video controls autoplay playsinline>
?loop=1              -> <video controls loop playsinline>
?mute=1              -> <video controls muted playsinline>
?autoplay=1&mute=1   -> <video controls autoplay muted playsinline>
?autoplay=1&loop=1&mute=1 -> <video controls autoplay loop muted playsinline>
(no params)          -> <video controls playsinline>
```

Fixes #1441.