### PR TITLE
Fix Banano info API endpoint

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -382,6 +382,38 @@ def check_view_milestones(db, agent_id: int, video_id: str, view_count: int):
 # API Routes
 # ---------------------------------------------------------------------------
 
+@ban_bp.route("/api/banano/info", methods=["GET"])
+def banano_info():
+    """Public Banano integration information."""
+    platform_address = _derive_address(BANANO_SEED, 0) if BANANO_SEED else None
+
+    return jsonify({
+        "chain": "banano",
+        "currency": "BAN",
+        "platform_address": platform_address,
+        "configured": bool(BANANO_SEED),
+        "bananopie_available": _HAS_BANANOPIE,
+        "rpc_endpoints": {
+            "primary": KALIUM_API,
+            "fallback": KALIUM_FALLBACK,
+        },
+        "raw_multiplier": str(BAN_RAW_MULTIPLIER),
+        "rewards_schedule": REWARDS,
+        "supported_actions": [
+            "balance - View an agent's BAN wallet balance",
+            "transactions - List an agent's BAN transaction history",
+            "tip - Tip another agent with BAN",
+            "withdraw - Request a BAN withdrawal",
+            "reward-video-gen - Award BAN for video generation",
+        ],
+        "how_it_works": {
+            "1": "The platform derives custodial Banano accounts from BANANO_SEED.",
+            "2": "Agents earn BAN rewards for configured platform actions.",
+            "3": "Agents can tip other agents or request withdrawals.",
+        },
+    })
+
+
 @ban_bp.route("/ban/balance/<agent_name>")
 def ban_balance(agent_name):
     """Get BAN balance for an agent (sum of credited transactions)."""

--- a/tests/test_banano_amount_validation.py
+++ b/tests/test_banano_amount_validation.py
@@ -72,6 +72,18 @@ def _ban_transaction_count(db_path):
         return db.execute("SELECT COUNT(*) FROM ban_transactions").fetchone()[0]
 
 
+def test_banano_info_endpoint_is_public(ban_client):
+    response = ban_client.get("/api/banano/info")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["chain"] == "banano"
+    assert payload["currency"] == "BAN"
+    assert payload["configured"] is False
+    assert payload["platform_address"] is None
+    assert "tip - Tip another agent with BAN" in payload["supported_actions"]
+
+
 @pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True, 0, -1])
 def test_ban_tip_rejects_invalid_amounts_without_writes(ban_client, amount):
     before = _ban_transaction_count(ban_client.db_path)


### PR DESCRIPTION
## Summary
- Add a public `GET /api/banano/info` endpoint to the existing Banano blueprint.
- Return chain, currency, RPC, reward schedule, and supported action metadata without requiring admin access.
- Cover the endpoint with a Flask test client regression test so `/api/banano/info` no longer returns 404.

## Validation
- `python -m pytest tests/test_banano_amount_validation.py -q` (23 passed)

Fixes #1442.