### PR TITLE
fix: validate dashboard analytics days query

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13229,13 +13229,9 @@ def dashboard_analytics_api():
     db = get_db()
     uid = g.user["id"]
 
-    raw_days = request.args.get("days", 30)
-    try:
-        days = int(raw_days)
-    except (TypeError, ValueError):
-        return jsonify({"error": "days must be an integer"}), 400
-    if days < 7 or days > 90:
-        return jsonify({"error": "days must be between 7 and 90"}), 400
+    days, error = _parse_positive_int_query("days", 30, min_value=7, max_value=90)
+    if error:
+        return error
 
     now = time.time()
     day_sec = 86400

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -502,19 +502,30 @@ class TestAnalyticsApiPeriod:
     """Test analytics API period selection."""
 
     def test_analytics_api_period_bounds(self, client):
-        """Period should be bounded between 7 and 90 days."""
+        """Valid period boundaries should be accepted."""
         aid = _insert_agent("perioduser", "test-key-period")
         _login(client, "perioduser")
         
         # Test minimum bound
-        response = client.get("/api/dashboard/analytics?days=1")
+        response = client.get("/api/dashboard/analytics?days=7")
         data = response.get_json()
-        assert len(data["labels"]) >= 7
+        assert len(data["labels"]) == 7
         
         # Test maximum bound
-        response = client.get("/api/dashboard/analytics?days=200")
+        response = client.get("/api/dashboard/analytics?days=90")
         data = response.get_json()
-        assert len(data["labels"]) <= 90
+        assert len(data["labels"]) == 90
+
+    @pytest.mark.parametrize("days", ["abc", "0", "91"])
+    def test_analytics_api_rejects_invalid_days(self, client, days):
+        """Malformed or out-of-range periods should return JSON 400."""
+        _insert_agent("invalidperioduser", "test-key-invalid-period")
+        _login(client, "invalidperioduser")
+
+        response = client.get(f"/api/dashboard/analytics?days={days}")
+
+        assert response.status_code == 400
+        assert "days" in response.get_json()["error"]
 
     def test_analytics_api_default_period(self, client):
         """Default period should be 30 days."""


### PR DESCRIPTION
## Summary

- Reuse `_parse_positive_int_query()` for `/api/dashboard/analytics?days=...`.
- Return JSON 400 for malformed or out-of-range `days` values instead of silently defaulting/clamping.
- Update dashboard analytics period tests to cover valid 7/90 boundaries plus invalid `abc`, `0`, and `91` inputs.

Fixes #1445.

## Validation

Passed:

```text
python -m py_compile bottube_server.py tests/test_analytics_dashboard.py
uv run --no-project --with pytest --with flask --with werkzeug --with requests --with python-dotenv --with pillow --with qrcode --with cryptography --with PyJWT --with openai --with google-genai python -m pytest -q tests/test_analytics_dashboard.py::TestAnalyticsApiPeriod --tb=short
# 5 passed

git diff --check -- bottube_server.py tests/test_analytics_dashboard.py
```

Also ran the broader related suite:

```text
uv run --no-project --with pytest --with flask --with werkzeug --with requests --with python-dotenv --with pillow --with qrcode --with cryptography --with PyJWT --with openai --with google-genai python -m pytest -q tests/test_analytics_dashboard.py tests/test_public_analytics_visibility.py --tb=short
# 22 passed, 8 failed
```

The 8 failures are existing mismatches in the broader dashboard analytics tests (for example `/analytics` returning 308 instead of old 302/200 expectations, and old assertions expecting `thumbnail` / `trend` keys in top video rows). The focused period validation tests added/changed in this PR pass.
