### PR TITLE
fix: validate firehose limit query

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -18800,10 +18800,9 @@ def xrpc_feed_firehose():
     stable even as new uploads arrive.
     """
     cursor = (request.args.get("cursor") or "").strip()
-    try:
-        limit = max(1, min(200, int(request.args.get("limit", 100))))
-    except Exception:
-        limit = 100
+    limit, error = _parse_positive_int_query("limit", 100, max_value=200)
+    if error:
+        return error
     ip = _get_client_ip()
     if not _rate_limit(f"firehose:{ip}", 30, 60):
         return jsonify({"ok": False, "error": "rate limited"}), 429

--- a/tests/test_firehose_query_param_validation.py
+++ b/tests/test_firehose_query_param_validation.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for /xrpc/feed.firehose limit validation."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def ensure_firehose_tables(app):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS video_provenance (
+                video_id TEXT PRIMARY KEY,
+                canonical_sha256 TEXT,
+                uploader_sig TEXT,
+                anchor_chain TEXT,
+                anchor_tx_hash TEXT,
+                anchor_block_height INTEGER,
+                anchor_manifest_hash TEXT
+            )
+            """
+        )
+        db.commit()
+
+
+@pytest.mark.parametrize("limit", ["abc", "0", "201"])
+def test_firehose_rejects_invalid_limit(client, limit):
+    response = client.get(f"/xrpc/feed.firehose?limit={limit}")
+
+    assert response.status_code == 400
+    assert "limit" in response.get_json()["error"]
+
+
+@pytest.mark.parametrize("limit", [None, "1", "200"])
+def test_firehose_accepts_default_and_boundary_limits(client, limit):
+    path = "/xrpc/feed.firehose"
+    if limit is not None:
+        path += f"?limit={limit}"
+
+    response = client.get(path)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["ok"] is True
+    assert isinstance(data["events"], list)


### PR DESCRIPTION
## Summary

- Validate `/xrpc/feed.firehose?limit=...` with the existing `_parse_positive_int_query()` helper.
- Return JSON 400 for malformed or out-of-range limits instead of silently defaulting/clamping.
- Add focused regression coverage for invalid `abc`, `0`, `201`, plus default and boundary values `1` and `200`.

Fixes #1447.

## Validation

Passed:

```text
python -m py_compile bottube_server.py tests/test_firehose_query_param_validation.py
uv run --no-project --with pytest --with flask --with werkzeug --with requests --with python-dotenv --with pillow --with qrcode --with cryptography --with PyJWT --with openai --with google-genai python -m pytest -q tests/test_firehose_query_param_validation.py --tb=short
# 6 passed

git diff --check -- bottube_server.py tests/test_firehose_query_param_validation.py
```

Also ran adjacent query-param tests:

```text
uv run --no-project --with pytest --with flask --with werkzeug --with requests --with python-dotenv --with pillow --with qrcode --with cryptography --with PyJWT --with openai --with google-genai python -m pytest -q tests/test_firehose_query_param_validation.py tests/test_feed_query_param_validation.py --tb=short
# 20 passed, then Windows teardown hit PermissionError deleting the temporary sqlite DB file
```

The adjacent assertions passed; the only error was a Windows sqlite file-handle cleanup issue during fixture teardown.
