### PR TITLE
a11y: accessible names for nav search + verify inputs (by Léa/Kryosys)

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -832,7 +832,8 @@
         </div>
 
         <form class="search-bar" action="{{ P }}/search" method="get" role="search" aria-label="{{ _('nav.search') }}">
-            <input type="text" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}" aria-label="{{ _('nav.search_placeholder') }}">
+            <label for="nav-search-input" class="sr-only">{{ _('nav.search') }}</label>
+            <input type="text" id="nav-search-input" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}" aria-label="{{ _('nav.search') }}">
             <button type="submit" aria-label="{{ _('nav.search') }}">{{ _('nav.search') }}</button>
         </form>
 

--- a/bottube_templates/verify.html
+++ b/bottube_templates/verify.html
@@ -25,6 +25,17 @@
     padding: 10px 22px; background: #3ea6ff; color: #000; border: 0;
     border-radius: 6px; cursor: pointer; font-weight: 600;
   }
+  .vrf-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
   .vrf-form button:disabled { opacity: 0.55; cursor: wait; }
   .vrf-out {
     margin-top: 22px; background: var(--bg-card); border: 1px solid var(--border);
@@ -78,7 +89,8 @@
   </p>
 
   <form id="vrf-form" class="vrf-form" onsubmit="event.preventDefault(); runVerify();">
-    <input type="text" id="vrf-vid" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus>
+    <label for="vrf-vid" class="vrf-sr-only">BoTTube video ID</label>
+    <input type="text" id="vrf-vid" aria-label="BoTTube video ID" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus>
     <button type="submit" id="vrf-btn" aria-label="Verify video provenance">Verify</button>
     <button type="button" id="vrf-asset-btn" style="background:#999;color:#000" title="Stream the canonical asset bytes and re-hash" onclick="runVerify(true)">+ check asset bytes</button>
   </form>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -159,6 +159,20 @@ class TestAccessibilityAttributes(unittest.TestCase):
             "Agents page search input missing associated label",
         )
 
+    def test_verify_page_video_id_input_has_accessible_name(self):
+        """The standalone verifier video-id field needs a programmatic label."""
+        content = self.read_file(self.TEMPLATE_DIR / 'verify.html')
+        input_match = re.search(r'<input[^>]*id="vrf-vid"[^>]*>', content)
+        self.assertIsNotNone(input_match, "Verify page video-id input not found")
+        input_markup = input_match.group(0)
+        self.assertIn('aria-label="BoTTube video ID"', input_markup,
+                      "Verify page video-id input missing aria-label")
+        self.assertRegex(
+            content,
+            r'<label[^>]*for="vrf-vid"[^>]*>BoTTube video ID</label>',
+            "Verify page video-id input missing associated label",
+        )
+
     def test_authenticated_form_inputs_have_associated_labels(self):
         """Collaboration and wallet text inputs need programmatic labels."""
         controls = (
@@ -231,6 +245,21 @@ class TestAccessibilityAttributes(unittest.TestCase):
                       "Skip link for keyboard navigation not found")
         self.assertIn('.sr-only', content,
                       "Screen reader only class not found")
+
+    def test_global_nav_search_input_has_accessible_name(self):
+        """The shared header search input must not rely on placeholder-only text."""
+        content = self.read_file(self.TEMPLATE_DIR / 'base.html')
+        self.assertRegex(
+            content,
+            r'<label[^>]*for="nav-search-input"[^>]*class="sr-only"[^>]*>'
+            r'\{\{ _\(\'nav\.search\'\) \}\}</label>',
+            "Global nav search input is missing a screen-reader label",
+        )
+        self.assertRegex(
+            content,
+            r'<input[^>]*id="nav-search-input"[^>]*name="q"[^>]*aria-label="\{\{ _\(\'nav\.search\'\) \}\}"',
+            "Global nav search input should expose a stable aria-label",
+        )
     
     def test_focus_visible_styles_present(self):
         """Test that focus-visible styles are defined."""


### PR DESCRIPTION
Two paid a11y fixes integrated (bounties #14081/#1217 nav search + #1102 verify video-ID — already paid 3+5 RTC to kryosys-lea):

- `base.html` — sr-only label + aria-label on the global nav search input
- `verify.html` — accessible name on the verify video-ID input
- `tests/test_accessibility.py` — regression assertions for both

Both filebin packages SHA-verified (ebb6b2c8…, 7913c09e…); patches applied clean to current main. 🤖 Generated with [Claude Code](https://claude.com/claude-code)