### PR TITLE
fix(gpu_marketplace): validate JSON request bodies (400 instead of 500)

### DIFF
--- a/gpu_marketplace.py
+++ b/gpu_marketplace.py
@@ -227,6 +227,40 @@ def require_gpu_api_key(f):
         return f(*args, **kwargs)
     return decorated
 
+
+def _json_object():
+    """Parse the request body as a JSON object.
+
+    Returns a ``(data, error)`` tuple. ``error`` is ``None`` on success and the
+    handler should use ``data``. An empty/absent body yields ``({}, None)`` so
+    existing per-field validation keeps producing the same 400s. A body that is
+    valid JSON but *not* an object (e.g. a list, string or number) yields
+    ``(None, (response, 400))`` instead of letting a later ``data.get(...)``
+    raise ``AttributeError`` and surface as a 500.
+    """
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _coerce_float(value, default):
+    """Coerce a JSON value to float, returning ``(number, error)``.
+
+    Accepts numbers and numeric strings. Booleans and non-numeric values yield
+    a 400 instead of letting ``float(...)`` raise ``ValueError`` (a 500).
+    """
+    if value is None:
+        return float(default), None
+    if isinstance(value, bool):
+        return None, (jsonify({"error": "Numeric value required"}), 400)
+    try:
+        return float(value), None
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": "Numeric value required"}), 400)
+
 # ---------------------------------------------------------------------------
 # PROVIDER ENDPOINTS
 # ---------------------------------------------------------------------------
@@ -245,7 +279,9 @@ def register_provider():
         provider_id: str - Use this to claim jobs and send heartbeats
     """
     agent = g.agent
-    data = request.get_json() or {}
+    data, error = _json_object()
+    if error:
+        return error
 
     gpu_model = data.get("gpu_model", "").strip()
     if not gpu_model:
@@ -285,7 +321,9 @@ def provider_heartbeat():
         status: str (optional) - 'online', 'busy', 'offline'
     """
     agent = g.agent
-    data = request.get_json() or {}
+    data, error = _json_object()
+    if error:
+        return error
 
     provider_id = data.get("provider_id", "").strip()
     status = data.get("status", "online")
@@ -409,15 +447,21 @@ def submit_job():
     RTC is escrowed from your balance until job completes.
     """
     agent = g.agent
-    data = request.get_json() or {}
+    data, error = _json_object()
+    if error:
+        return error
 
     job_type = data.get("job_type", "").strip()
     if job_type not in ("video_render", "image_gen", "transcode", "llm_inference"):
         return jsonify({"error": "Invalid job_type"}), 400
 
     params = data.get("params", {})
-    estimated_mins = float(data.get("estimated_mins", 5))
-    max_price = float(data.get("max_price_per_min", 0.10))
+    estimated_mins, error = _coerce_float(data.get("estimated_mins"), 5)
+    if error:
+        return error
+    max_price, error = _coerce_float(data.get("max_price_per_min"), 0.10)
+    if error:
+        return error
 
     # Calculate escrow amount (use max price * estimated time * 1.5 buffer)
     escrow_amount = max_price * estimated_mins * 1.5
@@ -457,7 +501,9 @@ def claim_job():
         job_id: str
     """
     agent = g.agent
-    data = request.get_json() or {}
+    data, error = _json_object()
+    if error:
+        return error
 
     provider_id = data.get("provider_id", "").strip()
     job_id = data.get("job_id", "").strip()
@@ -516,7 +562,9 @@ def start_job():
         job_id: str
     """
     agent = g.agent
-    data = request.get_json() or {}
+    data, error = _json_object()
+    if error:
+        return error
 
     provider_id = data.get("provider_id", "").strip()
     job_id = data.get("job_id", "").strip()
@@ -557,7 +605,9 @@ def complete_job():
         result_url: str (optional) - URL to the rendered output
     """
     agent = g.agent
-    data = request.get_json() or {}
+    data, error = _json_object()
+    if error:
+        return error
 
     provider_id = data.get("provider_id", "").strip()
     job_id = data.get("job_id", "").strip()
@@ -633,7 +683,9 @@ def fail_job():
         error_message: str
     """
     agent = g.agent
-    data = request.get_json() or {}
+    data, error = _json_object()
+    if error:
+        return error
 
     provider_id = data.get("provider_id", "").strip()
     job_id = data.get("job_id", "").strip()

--- a/tests/test_gpu_marketplace_validation.py
+++ b/tests/test_gpu_marketplace_validation.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for GPU marketplace JSON request-body validation.
+
+Before this fix the POST handlers parsed the body with ``request.get_json()
+or {}``. A non-empty body that is valid JSON but *not* an object (a list,
+string or number) is truthy, so ``or {}`` does not replace it and the next
+``data.get(...)`` raised ``AttributeError`` -> HTTP 500. ``/jobs/submit`` had a
+second 500: a non-numeric ``estimated_mins``/``max_price_per_min`` made
+``float(...)`` raise ``ValueError``. Both should be clean 400s instead.
+"""
+import sqlite3
+
+import pytest
+import werkzeug
+from flask import Flask
+
+from gpu_marketplace import gpu_bp, init_gpu_tables
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    if not hasattr(werkzeug, "__version__"):
+        monkeypatch.setattr(werkzeug, "__version__", "test", raising=False)
+
+    db_path = tmp_path / "bottube_gpu.db"
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(db_path))
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            display_name TEXT,
+            api_key TEXT UNIQUE NOT NULL,
+            is_banned INTEGER DEFAULT 0,
+            ban_reason TEXT,
+            last_active REAL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE balances (
+            miner_id TEXT PRIMARY KEY,
+            amount_i64 INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO agents (agent_name, display_name, api_key, last_active)
+        VALUES ('gpu_agent', 'GPU Agent', 'bottube_sk_gpu_agent', 0)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO balances (miner_id, amount_i64)
+        VALUES ('gpu_agent', 1000000)
+        """
+    )
+    conn.commit()
+    conn.close()
+    init_gpu_tables(str(db_path))
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(gpu_bp)
+
+    yield app.test_client()
+
+
+AUTH = {"X-API-Key": "bottube_sk_gpu_agent"}
+
+POST_ROUTES = [
+    "/api/gpu/providers/register",
+    "/api/gpu/providers/heartbeat",
+    "/api/gpu/jobs/submit",
+    "/api/gpu/jobs/claim",
+    "/api/gpu/jobs/start",
+    "/api/gpu/jobs/complete",
+    "/api/gpu/jobs/fail",
+]
+
+
+@pytest.mark.parametrize("route", POST_ROUTES)
+@pytest.mark.parametrize("body", [["not", "an", "object"], "a-string", 123])
+def test_non_object_json_rejected_with_400(client, route, body):
+    resp = client.post(route, headers=AUTH, json=body)
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "JSON object required"}
+
+
+def test_empty_body_still_hits_field_validation(client):
+    # Empty body must keep the previous behaviour: defaults applied, then the
+    # existing per-field 400 (not a 500, not the new "JSON object required").
+    resp = client.post("/api/gpu/providers/register", headers=AUTH)
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "gpu_model required"}
+
+
+def test_valid_object_still_succeeds(client):
+    resp = client.post(
+        "/api/gpu/providers/register",
+        headers=AUTH,
+        json={"gpu_model": "RTX 3080", "gpu_vram_gb": 10},
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+
+def test_submit_job_non_numeric_estimated_mins_rejected(client):
+    resp = client.post(
+        "/api/gpu/jobs/submit",
+        headers=AUTH,
+        json={"job_type": "video_render", "estimated_mins": "abc"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "Numeric value required"}
+
+
+def test_submit_job_non_numeric_max_price_rejected(client):
+    resp = client.post(
+        "/api/gpu/jobs/submit",
+        headers=AUTH,
+        json={
+            "job_type": "video_render",
+            "estimated_mins": 5,
+            "max_price_per_min": "free",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "Numeric value required"}


### PR DESCRIPTION
## Summary

Three of the GPU-marketplace POST handlers (and the job-submit numeric fields) return **HTTP 500** on malformed-but-valid JSON request bodies instead of a clean 400. This hardens all of them.

`gpu_marketplace.py` parsed bodies with `data = request.get_json() or {}`. A body that is valid JSON but **not an object** (a list, string or number) is truthy, so `or {}` does not replace it and the following `data.get(...)` raises `AttributeError` → unhandled → **500**. `/api/gpu/jobs/submit` had a second crash: a non-numeric `estimated_mins` / `max_price_per_min` made `float(...)` raise `ValueError` → **500**.

## Reproduction (against the real code paths)

Minimal Flask client with `gpu_marketplace.gpu_bp` registered + a valid API key:

```python
# 'list' object has no attribute 'get'  -> 500
client.post("/api/gpu/providers/register", headers=AUTH, json=["not", "an", "object"])
# float('abc') ValueError                -> 500
client.post("/api/gpu/jobs/submit", headers=AUTH,
            json={"job_type": "video_render", "estimated_mins": "abc"})
```

## Fix

- Add a small `_json_object()` helper (mirrors the existing pattern already used by `chat_handlers._json_object_body`): empty/absent body still yields `{}` so existing per-field 400s are unchanged; a non-object body returns `{"error": "JSON object required"}, 400`.
- Apply it to all seven POST handlers: `providers/register`, `providers/heartbeat`, `jobs/submit`, `jobs/claim`, `jobs/start`, `jobs/complete`, `jobs/fail`.
- Add `_coerce_float()` for `jobs/submit` numeric fields → `{"error": "Numeric value required"}, 400` instead of a 500 (also rejects JSON booleans).

No behavioural change for valid requests; only malformed input now returns 400 instead of 500.

## Scope

One focused bug. Two files: `gpu_marketplace.py` (+61/-9) and a new `tests/test_gpu_marketplace_validation.py`. No `__pycache__`/`.pyc`/`node_modules`. No invented files or endpoints — only existing `gpu_marketplace.py` routes are touched.

## Verification

```
python3 -m pytest -q tests/test_gpu_marketplace_validation.py tests/test_gpu_marketplace_auth.py
# 27 passed
python3 -m py_compile gpu_marketplace.py tests/test_gpu_marketplace_validation.py
```

The new tests parametrize all seven POST routes × three non-object body types (list/string/number) → 400, confirm an empty body still hits the existing field-level 400, confirm a valid object still succeeds (200), and cover both numeric-field crashes.

---

This is a functional bug fix in the BoTTube API; it also fits the ongoing bug-bounty (#71) "Medium" tier (malformed input → 500 across API endpoints). Happy to categorise wherever you prefer. First contribution here — I'll provide an RTC wallet address on acceptance.

/claim #1102
