### PR TITLE
fix: validate transcript search limit query

### DIFF
--- a/tests/test_whisper_transcription.py
+++ b/tests/test_whisper_transcription.py
@@ -525,6 +525,18 @@ def test_search_endpoint_rejects_invalid_limit(flask_client, monkeypatch, limit)
     assert "limit" in resp.get_json()["error"]
 
 
+def test_parse_positive_int_arg_allows_unbounded_limit(flask_client):
+    import whisper_transcription_blueprint as wtb
+
+    with flask_client.application.test_request_context(
+        "/api/transcript/search?q=unicorn&limit=10000"
+    ):
+        value, error = wtb._parse_positive_int_arg("limit", 50)
+
+    assert error is None
+    assert value == 10000
+
+
 def test_search_endpoint_no_query(flask_client):
     resp = flask_client.get("/api/transcript/search")
     assert resp.status_code == 400

--- a/tests/test_whisper_transcription.py
+++ b/tests/test_whisper_transcription.py
@@ -485,6 +485,46 @@ def test_search_endpoint(tmp_db, flask_client, monkeypatch):
     assert "search_vid_001" in data["video_ids"]
 
 
+@pytest.mark.parametrize(
+    ("limit", "expected"),
+    [(None, 50), ("1", 1), ("500", 500)],
+)
+def test_search_endpoint_accepts_valid_limit(flask_client, monkeypatch, limit, expected):
+    import whisper_transcription_blueprint as wtb
+
+    seen = []
+
+    def fake_search(query, limit=50):
+        seen.append((query, limit))
+        return ["search_vid_limit"]
+
+    monkeypatch.setattr(wtb.wt, "search_transcripts", fake_search)
+
+    query_string = "q=unicorn"
+    if limit is not None:
+        query_string += f"&limit={limit}"
+    resp = flask_client.get(f"/api/transcript/search?{query_string}")
+
+    assert resp.status_code == 200
+    assert seen == [("unicorn", expected)]
+    assert resp.get_json()["video_ids"] == ["search_vid_limit"]
+
+
+@pytest.mark.parametrize("limit", ["abc", "0", "-1", "1.5", "501", ""])
+def test_search_endpoint_rejects_invalid_limit(flask_client, monkeypatch, limit):
+    import whisper_transcription_blueprint as wtb
+
+    def fail_search(*_args, **_kwargs):
+        raise AssertionError("invalid limit should not search transcripts")
+
+    monkeypatch.setattr(wtb.wt, "search_transcripts", fail_search)
+
+    resp = flask_client.get(f"/api/transcript/search?q=unicorn&limit={limit}")
+
+    assert resp.status_code == 400
+    assert "limit" in resp.get_json()["error"]
+
+
 def test_search_endpoint_no_query(flask_client):
     resp = flask_client.get("/api/transcript/search")
     assert resp.status_code == 400

--- a/whisper_transcription_blueprint.py
+++ b/whisper_transcription_blueprint.py
@@ -71,6 +71,36 @@ def _parse_positive_int(data, field_name: str, default: int):
     return parsed, None
 
 
+def _parse_positive_int_arg(field_name: str, default: int, max_value: int | None = None):
+    raw_value = request.args.get(field_name)
+    if raw_value is None:
+        return default, None
+    stripped = raw_value.strip()
+    if not stripped:
+        return None, (
+            jsonify({"error": f"{field_name} must be a positive integer"}),
+            400,
+        )
+    try:
+        parsed = int(stripped, 10)
+    except ValueError:
+        return None, (
+            jsonify({"error": f"{field_name} must be a positive integer"}),
+            400,
+        )
+    if parsed < 1:
+        return None, (
+            jsonify({"error": f"{field_name} must be a positive integer"}),
+            400,
+        )
+    if max_value is not None and parsed > max_value:
+        return None, (
+            jsonify({"error": f"{field_name} must be <= {max_value}"}),
+            400,
+        )
+    return parsed, None
+
+
 def _video_dir() -> str:
     return os.environ.get(
         "BOTTUBE_VIDEO_DIR",
@@ -200,7 +230,9 @@ def search_transcripts():
     query = request.args.get("q", "").strip()
     if not query:
         return jsonify({"error": "Query parameter 'q' is required"}), 400
-    limit = request.args.get("limit", 50, type=int)
+    limit, error = _parse_positive_int_arg("limit", 50, max_value=500)
+    if error:
+        return error
     video_ids = wt.search_transcripts(query, limit=limit)
     return jsonify({
         "query": query,

--- a/whisper_transcription_blueprint.py
+++ b/whisper_transcription_blueprint.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import Optional
 
 from flask import Blueprint, current_app, jsonify, request, Response
 
@@ -36,6 +37,7 @@ def _request_json_object():
 
 
 def _parse_positive_int(data, field_name: str, default: int):
+    """Parse positive integer fields from JSON request bodies."""
     value = data.get(field_name, default)
     if isinstance(value, bool):
         return None, (
@@ -71,7 +73,10 @@ def _parse_positive_int(data, field_name: str, default: int):
     return parsed, None
 
 
-def _parse_positive_int_arg(field_name: str, default: int, max_value: int | None = None):
+def _parse_positive_int_arg(field_name: str, default: int, max_value: Optional[int] = None):
+    """Parse positive integer fields from query-string arguments."""
+    if max_value is not None:
+        assert default <= max_value
     raw_value = request.args.get(field_name)
     if raw_value is None:
         return default, None


### PR DESCRIPTION
## Summary
- validate `/api/transcript/search?limit=` explicitly instead of relying on Flask `type=int` fallback
- return JSON 400 for malformed, non-positive, float, empty, and over-500 limits
- preserve the default limit of 50 and valid boundary values `1` and `500`

## Scope
This is limited to the existing Whisper transcript search endpoint. It does not touch blueprint registration, Gemini routes, transcript generation, downloads, or backfill behavior.

## Validation
- `python -m py_compile whisper_transcription_blueprint.py tests/test_whisper_transcription.py` -> passed
- `git diff --check -- whisper_transcription_blueprint.py tests/test_whisper_transcription.py` -> passed (Windows line-ending warnings only)
- `uv run --no-project --with pytest --with flask --with werkzeug python -m pytest -q tests/test_whisper_transcription.py -k "search_endpoint or transcript_search"` -> 11 passed, 38 deselected
- `uv run --no-project --with pytest --with flask --with werkzeug python -m pytest -q tests/test_whisper_transcription.py` -> 39 passed, 10 skipped

## AI assistance
Implemented with OpenAI Codex assistance. I reviewed the target route, existing backfill validation helper, and focused tests before making the small change.