### PR TITLE
fix(search): return 400 instead of 500 on overflowing ?page (SQLite OFFSET)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -6801,6 +6801,12 @@ def _make_param_conflict_error(canonical_name, alias_name):
     )
 
 
+# SQLite stores integers as signed 64-bit values. A query OFFSET/LIMIT larger
+# than this raises OperationalError ("Python int too large to convert to SQLite
+# INTEGER"), so pagination math must stay within this bound.
+_SQLITE_MAX_SIGNED_INT = 2 ** 63 - 1
+
+
 def _parse_positive_int_query(name, default, min_value=1, max_value=None):
     """Return (value, None) or (None, (json_response, status_code)).
 
@@ -8276,6 +8282,11 @@ def search_videos():
     if error:
         return error
     offset = (page - 1) * per_page
+    # An astronomically large ?page makes offset exceed SQLite's signed 64-bit
+    # INTEGER range, which raises OperationalError on "LIMIT ? OFFSET ?" and
+    # surfaces as an HTTP 500. Reject such pages with a clean 400 instead.
+    if offset > _SQLITE_MAX_SIGNED_INT:
+        return jsonify({"error": "page out of range"}), 400
 
     db = get_db()
     like_q = f"%{q}%"

--- a/tests/test_search_page_offset_overflow.py
+++ b/tests/test_search_page_offset_overflow.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for GET /api/search pagination OFFSET overflow.
+
+Bug: ``page`` was parsed with ``_parse_positive_int_query("page", 1)`` without
+an upper bound. An astronomically large ``?page`` made
+``offset = (page - 1) * per_page`` exceed SQLite's signed 64-bit INTEGER range,
+which raises ``OperationalError`` ("Python int too large to convert to SQLite
+INTEGER") on the ``LIMIT ? OFFSET ?`` query and surfaces as an HTTP 500.
+
+Verified on production before the fix:
+    GET https://bottube.ai/api/search?q=x&page=9223372036854775807 -> 500
+
+Fix: reject pages whose offset would overflow SQLite with a clean 400, while
+leaving normal (even large but safe) pagination untouched.
+"""
+
+_SQLITE_MAX_SIGNED_INT = 2 ** 63 - 1
+
+
+def test_search_max_int_page_returns_400_not_500(client):
+    """A page at SQLite's 64-bit ceiling must 400 cleanly, never 500."""
+    resp = client.get(f"/api/search?q=x&page={_SQLITE_MAX_SIGNED_INT}")
+    assert resp.status_code == 400, f"expected 400, got {resp.status_code}"
+    assert "page" in resp.get_json()["error"]
+
+
+def test_search_overflowing_page_returns_400(client):
+    """A page beyond 64 bits (offset overflow) must 400, never 500."""
+    resp = client.get("/api/search?q=x&page=99999999999999999999")
+    assert resp.status_code == 400
+
+
+def test_search_normal_page_still_ok(client):
+    """The fix must not regress ordinary pagination."""
+    resp = client.get("/api/search?q=x&page=1")
+    assert resp.status_code == 200
+    assert "videos" in resp.get_json()
+
+
+def test_search_large_but_safe_page_ok(client):
+    """A large page whose offset stays within 64 bits returns 200 (empty page)."""
+    # offset = (10**9 - 1) * 20 ~= 2e10, well inside SQLite's signed 64-bit range.
+    resp = client.get("/api/search?q=x&page=1000000000")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

`GET /api/search` returns **HTTP 500** when `?page` is large enough that the
computed SQL `OFFSET` overflows SQLite's signed 64-bit `INTEGER` range. This
fix rejects such pages with a clean `400` instead of crashing, and adds a
regression test.

## Reproduction (production, checked 2026-06-14 UTC)

```bash
curl -i 'https://bottube.ai/api/search?q=x&page=9223372036854775807'
```

Actual: `HTTP/2 500` (server error page).
Expected: a deterministic JSON `400`.

The threshold matches the overflow exactly — `?page=100000000000` returns `200`,
while `?page=9223372036854775807` (and above) returns `500`.

## Root cause

In `search_videos()` (`bottube_server.py`), `page` is parsed with
`_parse_positive_int_query("page", 1)` with **no upper bound**, then:

```python
offset = (page - 1) * per_page
...
LIMIT ? OFFSET ?  ->  params + [per_page, offset]
```

When `offset` exceeds `2**63 - 1`, sqlite3 raises
`OverflowError: Python int too large to convert to SQLite INTEGER`, which is
unhandled and surfaces as a 500. Confirmed locally:

```python
db.execute("SELECT * FROM v LIMIT ? OFFSET ?", [20, (2**63-1-1)*20])
# OverflowError: Python int too large to convert to SQLite INTEGER
```

## Fix

Guard the computed offset against SQLite's signed 64-bit ceiling and return a
clean `400` for out-of-range pages (consistent with the existing
`_parse_positive_int_query` 400 behaviour). Normal pagination — including large
but in-range pages — is unaffected.

```python
offset = (page - 1) * per_page
if offset > _SQLITE_MAX_SIGNED_INT:
    return jsonify({"error": "page out of range"}), 400
```

## Tests

New `tests/test_search_page_offset_overflow.py` (uses the existing `client`
fixture):
- `?page=2**63-1` and `?page=99999999999999999999` -> `400` (not 500)
- `?page=1` -> `200` (no regression)
- `?page=1000000000` (large but in-range offset) -> `200`

The test **fails on `main`** (returns 500) and **passes with this fix**. Full
suite green locally:

```
tests/test_api_v1_videos_search_alias.py tests/test_search_blueprint_query_validation.py
tests/test_video_list_pagination.py tests/test_videos_list_query_param_validation.py
tests/test_search_page_offset_overflow.py  ->  52 passed
```

Addresses the "Find and Report a BoTTube Bug" bounty (rustchain-bounties #1102).

/claim #1102
