### PR TITLE
fix(api): reject malformed stats and comments limits

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7801,7 +7801,11 @@ def _parse_recent_comments_limit():
         limit = int(raw_value)
     except (TypeError, ValueError):
         return None, "limit must be an integer"
-    return min(100, max(1, limit)), None
+    if limit < 1:
+        return None, "limit must be >= 1"
+    if limit > 100:
+        return None, "limit must be <= 100"
+    return limit, None
 
 
 def _parse_recent_comments_since():
@@ -10114,6 +10118,10 @@ def gamification_leaderboard():
 @app.route("/api/stats")
 def platform_stats():
     """Get public platform statistics."""
+    top_agents_limit, error = _parse_positive_int_query("limit", 5, max_value=100)
+    if error:
+        return error
+
     db = get_db()
     videos = db.execute("SELECT COUNT(*) FROM videos WHERE is_removed = 0").fetchone()[0]
     agents = db.execute("SELECT COUNT(*) FROM agents WHERE is_human = 0").fetchone()[0]
@@ -10127,7 +10135,8 @@ def platform_stats():
                   COUNT(v.id) as video_count,
                   COALESCE(SUM(v.views), 0) as total_views
            FROM agents a LEFT JOIN videos v ON a.id = v.agent_id
-           GROUP BY a.id ORDER BY total_views DESC LIMIT 5"""
+           GROUP BY a.id ORDER BY total_views DESC LIMIT ?""",
+        (top_agents_limit,),
     ).fetchall()
 
     return jsonify({

--- a/tests/test_recent_comments_query_validation.py
+++ b/tests/test_recent_comments_query_validation.py
@@ -2,11 +2,30 @@
 import pytest
 
 
-def test_recent_comments_rejects_malformed_limit(client):
-    response = client.get("/api/comments/recent?limit=abc")
+@pytest.mark.parametrize(
+    ("value", "expected_error"),
+    [
+        ("abc", "limit must be an integer"),
+        ("-1", "limit must be >= 1"),
+        ("0", "limit must be >= 1"),
+        ("101", "limit must be <= 100"),
+        ("999999999999999", "limit must be <= 100"),
+    ],
+)
+def test_recent_comments_rejects_malformed_or_out_of_range_limit(
+    client, value, expected_error
+):
+    response = client.get(f"/api/comments/recent?limit={value}")
 
     assert response.status_code == 400
-    assert response.get_json() == {"error": "limit must be an integer"}
+    assert response.get_json() == {"error": expected_error}
+
+
+@pytest.mark.parametrize("value", ["1", "100"])
+def test_recent_comments_accepts_limit_boundaries(client, value):
+    response = client.get(f"/api/comments/recent?limit={value}")
+
+    assert response.status_code == 200
 
 
 def test_recent_comments_rejects_malformed_since(client):
@@ -22,4 +41,3 @@ def test_recent_comments_rejects_non_finite_since(client, value):
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "since must be a finite number"}
-

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -568,6 +568,29 @@ class TestStatsEndpoint:
         assert "total_views" in data
         assert "top_agents" in data
 
+    def test_stats_accepts_valid_top_agents_limit(self, client):
+        resp = client.get("/api/stats?limit=1")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data["top_agents"]) <= 1
+
+    @pytest.mark.parametrize(
+        ("query", "expected_error"),
+        [
+            ("limit=abc", "limit must be an integer"),
+            ("limit=-1", "limit must be >= 1"),
+            ("limit=0", "limit must be >= 1"),
+            ("limit=101", "limit must be <= 100"),
+            ("limit=999999999999999", "limit must be <= 100"),
+        ],
+    )
+    def test_stats_rejects_malformed_or_out_of_range_limit(
+        self, client, query, expected_error
+    ):
+        resp = client.get(f"/api/stats?{query}")
+        assert resp.status_code == 400
+        assert resp.get_json() == {"error": expected_error}
+
 
 class TestCategoriesEndpoint:
     """Tests for GET /api/categories."""


### PR DESCRIPTION
Fixes #1457.

## Summary
- reject out-of-range `limit` values on `/api/comments/recent` instead of silently clamping them
- make `/api/stats` validate optional `limit` and apply it to the top-agents query
- add regression coverage for malformed and out-of-range `limit` values on both endpoints

## Validation
- `/tmp/bottube-test-venv/bin/python -m pytest tests/test_recent_comments_query_validation.py tests/test_upload_api.py::TestStatsEndpoint -q`
- `python3 -m py_compile bottube_server.py`
- `git diff --check`

Bounty payout details can be provided privately if this is accepted.