### PR TITLE
fix(api): return 400 instead of 500 on overflowing firehose cursor

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -105,6 +105,10 @@ def _get_ab_manager():
 AVATAR_DIR = BASE_DIR / "avatars"
 TEMPLATE_DIR = BASE_DIR / "bottube_templates"
 
+# Largest value SQLite can store in an INTEGER column / accept as a bound
+# parameter. Larger Python ints raise OverflowError in the driver.
+_SQLITE_MAX_INT64 = (1 << 63) - 1
+
 MAX_VIDEO_SIZE = 500 * 1024 * 1024  # 500 MB upload limit
 MAX_VIDEO_DURATION = 8  # seconds - default for short-form content
 MAX_VIDEO_WIDTH = 720
@@ -18829,6 +18833,12 @@ def xrpc_feed_firehose():
             return jsonify({"ok": False, "error": "invalid cursor"}), 400
         after_ms = int(m.group(1))
         after_rowid = int(m.group(2))
+        # Cursor segments are bound directly as SQLite INTEGER parameters
+        # (v.id > ?). A value above the signed 64-bit ceiling raises
+        # OverflowError inside the driver -> 500. Reject it the same way as
+        # a structurally invalid cursor instead of crashing.
+        if after_ms > _SQLITE_MAX_INT64 or after_rowid > _SQLITE_MAX_INT64:
+            return jsonify({"ok": False, "error": "invalid cursor"}), 400
 
     db = get_db()
     after_secs = after_ms / 1000.0

--- a/tests/test_firehose_cursor_overflow.py
+++ b/tests/test_firehose_cursor_overflow.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for GET /xrpc/feed.firehose cursor 64-bit overflow.
+
+Bug: the firehose cursor has the form ``<created_at_ms>:<rowid>`` and both
+segments were parsed with ``int(...)`` without any upper bound. The second
+segment is bound directly as a SQLite INTEGER parameter (``v.id > ?``), so a
+value above SQLite's signed 64-bit ceiling raises ``OverflowError`` ("Python
+int too large to convert to SQLite INTEGER") inside the driver and surfaces as
+an HTTP 500 instead of a deterministic validation error.
+
+Verified on production before the fix:
+    GET https://bottube.ai/xrpc/feed.firehose?cursor=0:99999999999999999999999999 -> 500
+    GET https://bottube.ai/xrpc/feed.firehose?cursor=0:1                           -> 200
+
+The endpoint already rejects structurally invalid cursors with HTTP 400
+("invalid cursor"); this extends the same treatment to out-of-range segments.
+"""
+
+_SQLITE_MAX_INT64 = (1 << 63) - 1
+
+
+def _ensure_firehose_schema(app):
+    """The firehose query LEFT JOINs video_provenance, whose schema is created
+    lazily by the upload path rather than init_db(). Materialize it so the
+    success-path assertions exercise the real query."""
+    import bottube_server
+
+    with app.app_context():
+        bottube_server._ensure_provenance_schema()
+
+
+def test_firehose_overflowing_rowid_returns_400_not_500(app, client):
+    """A cursor rowid beyond 64 bits must 400 cleanly, never 500.
+
+    This is the production-confirmed crash: the rowid segment is bound as a
+    SQLite INTEGER (``v.id > ?``), so an out-of-range value raises
+    ``OverflowError`` on the original code -> HTTP 500.
+    """
+    _ensure_firehose_schema(app)
+    resp = client.get("/xrpc/feed.firehose?cursor=0:99999999999999999999999999")
+    assert resp.status_code == 400, f"expected 400, got {resp.status_code}"
+    assert "cursor" in resp.get_json()["error"]
+
+
+def test_firehose_overflowing_ms_returns_400(app, client):
+    """The timestamp segment is range-checked too, for consistency.
+
+    The ``ms`` segment is divided to a float before binding, so on the
+    original code an out-of-range value was silently accepted (200) rather
+    than crashing; the fix rejects both segments uniformly.
+    """
+    _ensure_firehose_schema(app)
+    huge = _SQLITE_MAX_INT64 + 1
+    resp = client.get(f"/xrpc/feed.firehose?cursor={huge}:1")
+    assert resp.status_code == 400
+
+
+def test_firehose_no_cursor_still_ok(app, client):
+    """The fix must not regress the default (cursorless) firehose read."""
+    _ensure_firehose_schema(app)
+    resp = client.get("/xrpc/feed.firehose?limit=2")
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+
+def test_firehose_normal_cursor_still_ok(app, client):
+    """A well-formed in-range cursor returns 200 (empty page on a fresh DB)."""
+    _ensure_firehose_schema(app)
+    resp = client.get("/xrpc/feed.firehose?cursor=0:1&limit=2")
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+
+def test_firehose_malformed_cursor_still_400(client):
+    """A structurally invalid cursor keeps returning the existing 400."""
+    resp = client.get("/xrpc/feed.firehose?cursor=notacursor")
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary

The public signed firehose endpoint `GET /xrpc/feed.firehose` returns **HTTP 500** when the `cursor` query parameter carries an out-of-range row id, instead of a deterministic validation error.

The cursor has the form `<created_at_ms>:<rowid>`. Both segments are parsed with `int(...)` and the `rowid` segment is bound **directly** as a SQLite `INTEGER` parameter (`v.id > ?`). A value above SQLite's signed 64-bit ceiling raises `OverflowError: Python int too large to convert to SQLite INTEGER` inside the driver and surfaces as an unhandled 500.

## Reproduction (production)

```
GET https://bottube.ai/xrpc/feed.firehose?cursor=0:99999999999999999999999999  -> 500
GET https://bottube.ai/xrpc/feed.firehose?cursor=0:1                            -> 200
GET https://bottube.ai/xrpc/feed.firehose?limit=2                               -> 200
```

The endpoint already returns a clean `400 {"ok": false, "error": "invalid cursor"}` for structurally invalid cursors, but never range-checked the parsed integers.

## Root cause

`bottube_server.py`, `xrpc_feed_firehose()`:

```python
after_ms = int(m.group(1))
after_rowid = int(m.group(2))
...
rows = db.execute("... WHERE ... v.id > ? ... LIMIT ?",
                  (after_secs, after_secs, after_rowid, limit + 1))
```

`after_rowid` has no upper bound, so a 24+ digit value overflows the SQLite bind.

## Fix

Range-check both cursor segments against the signed 64-bit ceiling immediately after parsing and reject out-of-range cursors with the **existing** `400 "invalid cursor"` response — consistent with how the malformed-cursor case is already handled. Normal in-range cursors and the default (cursorless) read are untouched.

- `bottube_server.py`: `+10 / -0` (one module constant `_SQLITE_MAX_INT64` + a 2-line guard)
- `tests/test_firehose_cursor_overflow.py`: `+78` new regression test

## Tests

`pytest tests/test_firehose_cursor_overflow.py` — **5 passed** with the fix. The `rowid`-overflow test fails on the unpatched code with exactly the production error (`OverflowError ... -> 500`); it returns a clean 400 with the fix. Adjacent feed/pagination suites (`test_feed_query_param_validation`, `test_feed_blueprint`, `test_social_feed_query_validation`) — 31 passed, no regressions. `py_compile` clean.

This is distinct from the open firehose `limit` reports (#1447/#1448): those concern the `limit` parameter being silently clamped, whereas this is a genuine 500 crash on the `cursor` parameter.

Bounty: rustchain-bounties #1102. RTC reward to `Vyacheslav-Tomashevskiy` on merge.
