### PR TITLE
fix(api): return 400 instead of 500 on overflowing /api/feed ?page (SQLite OFFSET)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9615,7 +9615,16 @@ def feed():
     Returns:
         JSON with videos list, page info, mode used, and the active bucket.
     """
-    page, error = _parse_positive_int_query("page", 1)
+    # `page` is bounded at 10000 so a malformed or malicious client cannot
+    # request an arbitrarily deep page. Without an upper bound, a value such
+    # as `page=9223372036854775807` makes `offset = (page - 1) * per_page`
+    # exceed SQLite's signed 64-bit INTEGER range, which raises
+    # `OverflowError` when bound into `LIMIT ? OFFSET ?` and surfaces as an
+    # HTTP 500 instead of a clean 400. 10000 pages of `per_page<=50` is
+    # ~500k rows, already well past the whole feed catalogue, so the cap does
+    # not affect any legitimate use case. Mirrors the `/api/videos` bound
+    # (Bottube issue #1414).
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
     if error:
         return error
     per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)

--- a/tests/test_feed_page_offset_overflow.py
+++ b/tests/test_feed_page_offset_overflow.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for GET /api/feed pagination OFFSET overflow.
+
+Bug: ``page`` was parsed with ``_parse_positive_int_query("page", 1)`` without
+an upper bound. Type and sign validation already returned 400 for ``page=abc``
+or ``page=-1`` (issue #1456 / PR #1402), but an in-range *positive* integer that
+is astronomically large still slipped through. Such a ``?page`` makes
+``offset = (page - 1) * per_page`` exceed SQLite's signed 64-bit INTEGER range,
+which raises ``OverflowError`` ("Python int too large to convert to SQLite
+INTEGER") on the ``LIMIT ? OFFSET ?`` query and surfaces as an HTTP 500.
+
+Verified on production before the fix (unauthenticated):
+    GET https://bottube.ai/api/feed?page=9223372036854775807 -> 500
+    GET https://bottube.ai/api/feed?page=999999999999999     -> 200  (safe offset)
+
+Fix: bound ``page`` at 10000 (mirroring the existing ``/api/videos`` cap from
+issue #1414) so an out-of-range page returns a clean 400 before any offset is
+computed, while ordinary pagination is untouched.
+"""
+
+_SQLITE_MAX_SIGNED_INT = 2 ** 63 - 1
+
+
+def test_feed_max_int_page_returns_400_not_500(client):
+    """A page at SQLite's 64-bit ceiling must 400 cleanly, never 500."""
+    resp = client.get(f"/api/feed?page={_SQLITE_MAX_SIGNED_INT}")
+    assert resp.status_code == 400, f"expected 400, got {resp.status_code}"
+    assert "page" in resp.get_json()["error"]
+
+
+def test_feed_overflowing_page_returns_400(client):
+    """A page beyond 64 bits (offset overflow) must 400, never 500."""
+    resp = client.get("/api/feed?page=99999999999999999999999999")
+    assert resp.status_code == 400
+
+
+def test_feed_v1_alias_overflowing_page_returns_400(client):
+    """The /api/v1/feed alias shares the handler and must also 400."""
+    resp = client.get(f"/api/v1/feed?page={_SQLITE_MAX_SIGNED_INT}")
+    assert resp.status_code == 400
+
+
+def test_feed_normal_page_still_ok(client):
+    """The fix must not regress ordinary pagination."""
+    resp = client.get("/api/feed?page=1")
+    assert resp.status_code == 200
+    assert "videos" in resp.get_json()
+
+
+def test_feed_page_at_bound_ok(client):
+    """The maximum allowed page (10000) is still accepted."""
+    resp = client.get("/api/feed?page=10000")
+    assert resp.status_code == 200
+    assert "videos" in resp.get_json()
+
+
+def test_feed_page_just_over_bound_returns_400(client):
+    """One past the cap is rejected with a clean 400."""
+    resp = client.get("/api/feed?page=10001")
+    assert resp.status_code == 400
+    assert "page" in resp.get_json()["error"]


### PR DESCRIPTION
## Summary

`GET /api/feed` (and its `/api/v1/feed` alias) returns an unhandled **HTTP 500**
when `?page` is a positive integer large enough that the resulting SQLite
`OFFSET` overflows the signed 64-bit range.

Type and sign validation are already in place (`page=abc`, `page=0`, `page=-1`
all return a clean 400 — issue #1456 / PR #1402). What is still missing is an
**upper bound**, so an in-range positive value such as
`page=9223372036854775807` slips through validation and then crashes.

## Production reproduction (unauthenticated)

```
GET https://bottube.ai/api/feed?page=9223372036854775807  -> 500  (text/html error page)
GET https://bottube.ai/api/feed?page=999999999999999      -> 200  (offset still inside 64-bit range)
GET https://bottube.ai/api/feed?page=1                     -> 200
```

## Root cause

`feed()` parses the page with `_parse_positive_int_query("page", 1)` — no
`max_value`. Later `offset = (page - 1) * per_page` is bound into
`... LIMIT ? OFFSET ?`. When `offset` exceeds `2**63 - 1`, SQLite raises
`OverflowError: Python int too large to convert to SQLite INTEGER`, which is
unhandled and surfaces as a 500.

## Fix

Bound `page` at `10000`, mirroring the existing `/api/videos` cap (issue #1414)
which uses the very same `_parse_positive_int_query(..., max_value=...)` helper.
10000 pages of `per_page <= 50` is ~500k rows — already well past the whole feed
catalogue — so the cap rejects only abusive input and never affects legitimate
pagination. An out-of-range page now returns the helper's standard
`400 {"error": "page must be <= 10000"}` before any DB query runs.

Diff: **+10 / -1** in `bottube_server.py` (one changed line + an explanatory
comment).

## Tests

New `tests/test_feed_page_offset_overflow.py` (6 tests): max-int / overflow page
on both `/api/feed` and `/api/v1/feed` -> 400; `page=1` and `page=10000` -> 200;
`page=10001` -> 400. The four overflow assertions **fail on the unpatched code
with the exact production 500** and pass with the fix. The existing
`tests/test_feed_query_param_validation.py` (14 tests, the #1402 type-validation
suite) still passes — no regression.

This is distinct from the type-coercion reports: #1456 / PR #1458 covered
malformed *types* (already fixed in main); this fixes the remaining
integer-overflow 500 on an otherwise-valid `page`.

RTC wallet: reward to `Vyacheslav-Tomashevskiy` on merge.
