### PR TITLE
fix(api): return 400 instead of 500 on non-object JSON for agent referral routes

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -5132,7 +5132,10 @@ def _referral_me_payload() -> Response:
     agent_id = int(g.agent["id"])
     data = {}
     if request.method == "POST":
-        data = request.get_json(silent=True) or request.form.to_dict() or {}
+        json_data = request.get_json(silent=True)
+        if json_data is not None and not isinstance(json_data, dict):
+            return jsonify({"error": "JSON body must be an object"}), 400
+        data = json_data or request.form.to_dict() or {}
     requested_track = _normalize_referral_track(data.get("allowed_track", data.get("track", "both")), "both")
     requested_code = _normalize_ref_code(data.get("code", ""))
     # Prefer an existing code for this agent.
@@ -5215,7 +5218,10 @@ def referral_me_user():
 
 def _referral_apply_payload(source: str):
     db = get_db()
-    data = request.get_json(silent=True) or request.form.to_dict() or {}
+    json_data = request.get_json(silent=True)
+    if json_data is not None and not isinstance(json_data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+    data = json_data or request.form.to_dict() or {}
     ref_code = _normalize_ref_code(data.get("ref_code", "") or data.get("ref", ""))
     if not ref_code:
         return jsonify({"error": "ref_code is required"}), 400

--- a/tests/test_referral_json_object_validation.py
+++ b/tests/test_referral_json_object_validation.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for non-object JSON bodies on the agent referral routes.
+
+Before the fix, ``POST /api/agents/me/referral`` and
+``POST /api/agents/me/referral/apply`` did ``request.get_json(silent=True) or
+request.form.to_dict() or {}`` and then called ``.get()`` on the result.  A
+valid-but-non-object JSON body (a list, string or number is truthy) flowed
+straight through the ``or`` and raised ``AttributeError`` on ``.get()`` —
+returning HTTP 500 instead of a deterministic 400.
+"""
+
+
+def _auth_headers(api_key):
+    return {"X-API-Key": api_key}
+
+
+def _assert_json_object_required(resp):
+    assert resp.status_code == 400, resp.get_data(as_text=True)
+    assert resp.get_json() == {"error": "JSON body must be an object"}
+
+
+def test_referral_me_rejects_non_object_json(client, registered_agent):
+    headers = _auth_headers(registered_agent["api_key"])
+
+    for payload in (["bad"], "bad", 5, True):
+        resp = client.post("/api/agents/me/referral", headers=headers, json=payload)
+        _assert_json_object_required(resp)
+
+
+def test_referral_apply_rejects_non_object_json(client, registered_agent):
+    headers = _auth_headers(registered_agent["api_key"])
+
+    for payload in (["bad"], "bad", 5):
+        resp = client.post(
+            "/api/agents/me/referral/apply", headers=headers, json=payload
+        )
+        _assert_json_object_required(resp)
+
+
+def test_referral_me_get_still_works(client, registered_agent):
+    headers = _auth_headers(registered_agent["api_key"])
+    resp = client.get("/api/agents/me/referral", headers=headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body.get("ok") is True
+    assert body.get("code")
+
+
+def test_referral_me_empty_object_still_works(client, registered_agent):
+    headers = _auth_headers(registered_agent["api_key"])
+    resp = client.post("/api/agents/me/referral", headers=headers, json={})
+    assert resp.status_code == 200
+    assert resp.get_json().get("ok") is True
+
+
+def test_referral_apply_missing_code_returns_400(client, registered_agent):
+    """A valid object body without ref_code keeps the original 400 contract."""
+    headers = _auth_headers(registered_agent["api_key"])
+    resp = client.post("/api/agents/me/referral/apply", headers=headers, json={})
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "ref_code is required"}


### PR DESCRIPTION
## Problem

The agent-facing referral routes assume the parsed JSON body is always an object before calling `.get()` on it:

- `POST /api/agents/me/referral`
- `POST /api/agents/me/referral/apply`

Both did:

```python
data = request.get_json(silent=True) or request.form.to_dict() or {}
...
data.get("ref_code", ...)   # or data.get("allowed_track", ...)
```

A **valid-but-non-object** JSON body (a list, string, number or `true` is truthy) flows straight through the `or` chain, so `data.get(...)` raises `AttributeError` and the request returns **HTTP 500** instead of a deterministic 400.

### Reproduce (production)

```bash
# register to get an API key, then:
curl -s -o /dev/null -w "%{http_code}\n" -X POST https://bottube.ai/api/agents/me/referral \
  -H "X-API-Key: <key>" -H "Content-Type: application/json" -d '[1,2]'
# -> 500   (expected 400)

curl -s -o /dev/null -w "%{http_code}\n" -X POST https://bottube.ai/api/agents/me/referral/apply \
  -H "X-API-Key: <key>" -H "Content-Type: application/json" -d '[1,2]'
# -> 500   (expected 400)

# a valid object body still works:
curl ... -d '{}'   # -> 200 (referral) / 400 "ref_code is required" (apply)
```

## Fix

Mirror the existing pattern already used by `register_agent` / `_json_object_body` and the `#1288` authenticated-body validation: reject a non-object JSON body with a deterministic `400 {"error": "JSON body must be an object"}` **before** any field access, while still preserving the `request.form` fallback for the session/web flow.

This complements the already-merged admin-referral hardening (#1213/#1214) and the authenticated-utility-routes work (#1288), which did **not** cover these agent self-referral endpoints.

`+8 / -2` in `bottube_server.py`.

## Tests

New `tests/test_referral_json_object_validation.py`:

- non-object bodies (`list` / `str` / `number` / `bool`) on both routes -> `400 "JSON body must be an object"`
- `GET /api/agents/me/referral` still returns `200`
- empty `{}` body still returns `200` (referral) and the existing `400 "ref_code is required"` (apply)

The two non-object cases **fail on `main` with `AttributeError: 'list' object has no attribute 'get'` (HTTP 500)** and pass with this fix. Existing `tests/test_referrals.py` and `tests/test_authenticated_json_object_validation.py` continue to pass — no regressions. `py_compile` clean.

Closes part of the malformed-JSON hardening tracked under the bounty program.
