### PR TITLE
fix(api): reject malformed limit on /api/videos/<id>/related with 400

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15427,7 +15427,18 @@ def api_related_videos(video_id):
         return s
 
     scored = sorted(candidates, key=score, reverse=True)
-    limit = min(20, max(1, request.args.get("limit", 8, type=int)))
+    raw_limit = request.args.get("limit")
+    if raw_limit is None or raw_limit == "":
+        limit = 8
+    else:
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            return jsonify({"error": "limit must be an integer"}), 400
+        if limit < 1:
+            return jsonify({"error": "limit must be >= 1"}), 400
+        if limit > 20:
+            return jsonify({"error": "limit must be <= 20"}), 400
 
     return jsonify({
         "ok": True,

--- a/tests/test_related_limit_validation.py
+++ b/tests/test_related_limit_validation.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for GET /api/videos/<video_id>/related limit validation.
+
+Bug: the limit query param was parsed with
+min(20, max(1, request.args.get("limit", 8, type=int))) which silently
+coerces non-integer / negative / zero values to the default via Flask's
+type=int coercion. No 400 was ever returned.
+
+Fix: explicit validation that returns JSON 400 for malformed input.
+"""
+import time
+
+_VIDEO_ID = "related_limit_test_vid"
+
+
+def _make_video(app):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """INSERT INTO agents (agent_name, display_name, api_key, created_at)
+               VALUES (?, ?, ?, ?)""",
+            ("related-limit-owner", "Related Limit Owner", "rlt-key", time.time()),
+        )
+        agent_id = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?",
+            ("related-limit-owner",),
+        ).fetchone()["id"]
+        db.execute(
+            """INSERT INTO videos
+               (video_id, agent_id, title, filename, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (_VIDEO_ID, agent_id, "Related limit test", "related.mp4", time.time()),
+        )
+        db.commit()
+
+
+def test_related_rejects_non_integer_limit(app, client):
+    _make_video(app)
+    resp = client.get(f"/api/videos/{_VIDEO_ID}/related?limit=abc")
+    assert resp.status_code == 400
+    assert "limit" in resp.get_json()["error"]
+
+
+def test_related_rejects_negative_limit(app, client):
+    _make_video(app)
+    resp = client.get(f"/api/videos/{_VIDEO_ID}/related?limit=-5")
+    assert resp.status_code == 400
+
+
+def test_related_rejects_zero_limit(app, client):
+    _make_video(app)
+    resp = client.get(f"/api/videos/{_VIDEO_ID}/related?limit=0")
+    assert resp.status_code == 400
+
+
+def test_related_rejects_oversized_limit(app, client):
+    _make_video(app)
+    resp = client.get(f"/api/videos/{_VIDEO_ID}/related?limit=999")
+    assert resp.status_code == 400
+
+
+def test_related_accepts_valid_limit(app, client):
+    _make_video(app)
+    resp = client.get(f"/api/videos/{_VIDEO_ID}/related?limit=5")
+    assert resp.status_code == 200
+
+
+def test_related_accepts_default_limit(app, client):
+    _make_video(app)
+    resp = client.get(f"/api/videos/{_VIDEO_ID}/related")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Problem

The `/api/videos/<video_id>/related` endpoint uses `request.args.get("limit", 8, type=int)` which silently coerces malformed values to the default via Flask's coercion. No 400 is ever returned — the caller gets silently wrong data instead of a clear error.

Verified on production (`O4RcFyeDDT5` is a real video id):

```
GET https://bottube.ai/api/videos/O4RcFyeDDT5/related?limit=abc  -> 200
GET https://bottube.ai/api/videos/O4RcFyeDDT5/related?limit=-1   -> 200
GET https://bottube.ai/api/videos/O4RcFyeDDT5/related?limit=0    -> 200
GET https://bottube.ai/api/videos/O4RcFyeDDT5/related?limit=999  -> 200
```

Reported in #1468.

## Fix

Replace `min(20, max(1, request.args.get("limit", 8, type=int)))` with explicit validation that returns `{"error": "..."}, 400` for non-integer, negative, zero, and out-of-range values. On upstream main, the existing `_parse_positive_int_query` helper (from #1397) can be used instead — the inline version here is functionally identical.

### Before
```python
limit = min(20, max(1, request.args.get("limit", 8, type=int)))
```

### After
```python
raw_limit = request.args.get("limit")
if raw_limit is None or raw_limit == "":
    limit = 8
else:
    try:
        limit = int(raw_limit)
    except (TypeError, ValueError):
        return jsonify({"error": "limit must be an integer"}), 400
    if limit < 1:
        return jsonify({"error": "limit must be >= 1"}), 400
    if limit > 20:
        return jsonify({"error": "limit must be <= 20"}), 400
```

## Testing

6 new regression tests in `tests/test_related_limit_validation.py`:

| Test | Input | Expected |
|------|-------|----------|
| non-integer | `?limit=abc` | 400 |
| negative | `?limit=-5` | 400 |
| zero | `?limit=0` | 400 |
| oversized | `?limit=999` | 400 |
| valid | `?limit=5` | 200 |
| default | (no param) | 200 |

All 6 pass.