### PR TITLE
fix(dashboard): return 400 for invalid days param instead of silent coercion

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -12424,11 +12424,13 @@ def dashboard_analytics_api():
     db = get_db()
     uid = g.user["id"]
 
+    raw_days = request.args.get("days", 30)
     try:
-        days = int(request.args.get("days", 30))
-    except Exception:
-        days = 30
-    days = max(7, min(days, 90))
+        days = int(raw_days)
+    except (TypeError, ValueError):
+        return jsonify({"error": "days must be an integer"}), 400
+    if days < 7 or days > 90:
+        return jsonify({"error": "days must be between 7 and 90"}), 400
 
     now = time.time()
     day_sec = 86400

--- a/tests/test_dashboard_days_validation.py
+++ b/tests/test_dashboard_days_validation.py
@@ -1,0 +1,103 @@
+# Regression tests for GET /api/dashboard/analytics days param validation.
+#
+# Before the fix the endpoint silently coerced non-integer / out-of-range
+# values to the default (30) instead of telling the client something was wrong.
+# Now it returns a clean 400 JSON error.
+import datetime as _dt
+import time
+
+# Compatibility: some Python builds removed utcfromtimestamp (deprecated in 3.12).
+# The production server runs standard CPython where it still works.
+if not hasattr(_dt, "utcfromtimestamp"):
+    class _ShimDT:
+        def __init__(self, ts):
+            self._ts = ts
+        def strftime(self, fmt):
+            return time.strftime(fmt, time.gmtime(self._ts))
+    _dt.utcfromtimestamp = lambda ts: _ShimDT(ts)
+
+
+def _setup_agent(app):
+    """Insert a test agent and return its id."""
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        cur = db.execute(
+            """INSERT INTO agents
+               (agent_name, display_name, api_key, password_hash, bio,
+                avatar_url, created_at, last_active)
+               VALUES (?, ?, ?, '', '', '', ?, ?)""",
+            ("dashdaysbot", "Dash Days Bot", "sk_dashdays_test",
+             time.time(), time.time()),
+        )
+        db.commit()
+        return int(cur.lastrowid)
+
+
+def _login(client, agent_id):
+    with client.session_transaction() as sess:
+        sess["user_id"] = agent_id
+
+
+def test_days_default_when_omitted(app, client):
+    agent_id = _setup_agent(app)
+    _login(client, agent_id)
+    resp = client.get("/api/dashboard/analytics")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["labels"]) == 30
+
+
+def test_days_non_integer_returns_400(app, client):
+    agent_id = _setup_agent(app)
+    _login(client, agent_id)
+    resp = client.get("/api/dashboard/analytics?days=abc")
+    assert resp.status_code == 400
+    assert "integer" in resp.get_json()["error"]
+
+
+def test_days_below_minimum_returns_400(app, client):
+    agent_id = _setup_agent(app)
+    _login(client, agent_id)
+    resp = client.get("/api/dashboard/analytics?days=6")
+    assert resp.status_code == 400
+    assert "7" in resp.get_json()["error"]
+
+
+def test_days_above_maximum_returns_400(app, client):
+    agent_id = _setup_agent(app)
+    _login(client, agent_id)
+    resp = client.get("/api/dashboard/analytics?days=91")
+    assert resp.status_code == 400
+    assert "90" in resp.get_json()["error"]
+
+
+def test_days_at_lower_boundary(app, client):
+    agent_id = _setup_agent(app)
+    _login(client, agent_id)
+    resp = client.get("/api/dashboard/analytics?days=7")
+    assert resp.status_code == 200
+    assert len(resp.get_json()["labels"]) == 7
+
+
+def test_days_at_upper_boundary(app, client):
+    agent_id = _setup_agent(app)
+    _login(client, agent_id)
+    resp = client.get("/api/dashboard/analytics?days=90")
+    assert resp.status_code == 200
+    assert len(resp.get_json()["labels"]) == 90
+
+
+def test_days_zero_returns_400(app, client):
+    agent_id = _setup_agent(app)
+    _login(client, agent_id)
+    resp = client.get("/api/dashboard/analytics?days=0")
+    assert resp.status_code == 400
+
+
+def test_days_negative_returns_400(app, client):
+    agent_id = _setup_agent(app)
+    _login(client, agent_id)
+    resp = client.get("/api/dashboard/analytics?days=-5")
+    assert resp.status_code == 400


### PR DESCRIPTION
## Problem

The `/api/dashboard/analytics` endpoint parsed the `days` query param with a bare `try/except` that silently fell back to `30` on any error and clamped out-of-range values without telling the client:

```python
try:
    days = int(request.args.get("days", 30))
except Exception:
    days = 30
days = max(7, min(days, 90))
```

So `?days=abc`, `?days=-5`, or `?days=0` all returned a 200 as if nothing happened, making it impossible for the client to know the input was rejected.

## Fix

Replace the silent coercion with explicit validation that returns a clean JSON 400:

- Non-integer values → `{"error": "days must be an integer"}`, 400
- Values outside 7–90 → `{"error": "days must be between 7 and 90"}`, 400

The default (30) and valid boundary values (7, 90) are unchanged.

## Testing

8 regression tests added in `tests/test_dashboard_days_validation.py`:

| Case | Input | Expected |
|------|-------|----------|
| Default omitted | (none) | 200, 30 labels |
| Non-integer | `days=abc` | 400 |
| Below minimum | `days=6` | 400 |
| Above maximum | `days=91` | 400 |
| Lower boundary | `days=7` | 200, 7 labels |
| Upper boundary | `days=90` | 200, 90 labels |
| Zero | `days=0` | 400 |
| Negative | `days=-5` | 400 |

All 8 pass.

Closes #1445.