### PR TITLE
fix(server): register missing route aliases to resolve 404s (#1471, #1472)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -24193,6 +24193,41 @@ def admin_moderation_reports():
     return jsonify({"ok": True, "count": len(out), "reports": out})
 
 
+# ---------------------------------------------------------------------------
+# Route aliases — fix 404s from deployment drift (issues #1471, #1472)
+# ---------------------------------------------------------------------------
+# These aliases ensure documented endpoints resolve even when the canonical
+# route was registered under a slightly different URL pattern.
+
+app.add_url_rule(
+    "/api/videos/<video_id>/anchor",
+    endpoint="api_video_anchor_alias",
+    view_func=api_video_anchor_proof,
+)
+
+app.add_url_rule(
+    "/api/videos/<video_id>/anchor_proof",
+    endpoint="api_video_anchor_underscore_alias",
+    view_func=api_video_anchor_proof,
+)
+
+app.add_url_rule(
+    "/api/transparency/v2",
+    endpoint="api_transparency_v2",
+    view_func=api_transparency,
+)
+
+
+@app.route("/api/embed")
+def api_embed_discovery():
+    """JSON oEmbed discovery endpoint for external link previews.
+
+    Wraps the existing ``/oembed`` handler so consumers that expect the
+    conventional ``/api/embed`` path still receive a valid oEmbed response.
+    """
+    return oembed()
+
+
 if __name__ == "__main__":
     init_db()
     print(f"[BoTTube] Starting on port 8097 - v{APP_VERSION}")


### PR DESCRIPTION
## Summary

Register missing route aliases in `bottube_server.py` to resolve HTTP 404 errors for documented API endpoints (issues #1471 and #1472).

### Problem

Several documented routes return 404 in production despite being defined in source. This is caused by deployment drift and missing URL aliases for common endpoint variants.

### Changes

Added `add_url_rule` aliases and a new route to ensure documented endpoints resolve correctly:

**Issue #1471 — `/api/videos/<id>/*` route aliases:**
- `/api/videos/<video_id>/anchor` → `api_video_anchor_proof` (the canonical route uses hyphen `/anchor-proof`)
- `/api/videos/<video_id>/anchor_proof` → `api_video_anchor_proof` (underscore alias for compatibility)

**Issue #1472 — missing API surface endpoints:**
- `/api/transparency/v2` → `api_transparency` (versioned alias for the existing transparency endpoint)
- `/api/embed` → new handler wrapping `/oembed` discovery for the conventional `/api/*` path

**Note:** Routes `/api/videos/<id>/stream` (L7271), `/api/videos/<id>/view` (L7346), and `/api/v1/activity` (L14870) are already registered at module level in the current source. Their production 404s are a deployment artifact that will resolve when the server is restarted with the latest code.

### Testing

- `python3 -c "import ast; ast.parse(open('bottube_server.py').read())"` — syntax OK
- AST analysis confirms all 4 new URL rules are registered on the Flask app
- No existing routes are modified; only aliases are added

Refs: #1471, #1472, rustchain-bounties#1102