### PR TITLE
[codex] reject invalid RSS/Atom feed limit values

### DIFF
--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -7,7 +7,7 @@ import os
 from email.utils import format_datetime
 
 import requests
-from flask import Blueprint, Response, request
+from flask import Blueprint, Response, jsonify, request
 
 feed_bp = Blueprint("feed", __name__)
 
@@ -129,12 +129,26 @@ def _fetch_videos(agent=None, category=None, limit=20):
 
 
 def _parse_limit():
-    """Parse and clamp the limit query parameter."""
+    """Parse the limit query parameter."""
+    raw_limit = request.args.get("limit")
+    if raw_limit is None:
+        return 20
+
     try:
-        limit = int(request.args.get("limit", 20))
-    except Exception:
-        limit = 20
-    return max(1, min(limit, 100))
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        raise ValueError("limit must be an integer")
+
+    if limit < 1:
+        raise ValueError("limit must be a positive integer")
+    if limit > 100:
+        raise ValueError("limit must be less than or equal to 100")
+
+    return limit
+
+
+def _limit_error_response(exc):
+    return jsonify({"error": str(exc)}), 400
 
 
 def _vid_fields(vid):
@@ -160,7 +174,10 @@ def rss_feed():
     """RSS 2.0 feed with global, per-agent, and per-category filtering."""
     agent = request.args.get("agent")
     category = request.args.get("category")
-    limit = _parse_limit()
+    try:
+        limit = _parse_limit()
+    except ValueError as exc:
+        return _limit_error_response(exc)
     videos = _fetch_videos(agent=agent, category=category, limit=limit)
 
     now_rfc = format_datetime(datetime.datetime.now(datetime.timezone.utc))
@@ -201,7 +218,10 @@ def atom_feed():
     """Atom 1.0 feed with global, per-agent, and per-category filtering."""
     agent = request.args.get("agent")
     category = request.args.get("category")
-    limit = _parse_limit()
+    try:
+        limit = _parse_limit()
+    except ValueError as exc:
+        return _limit_error_response(exc)
     videos = _fetch_videos(agent=agent, category=category, limit=limit)
 
     now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
@@ -254,7 +274,10 @@ def atom_feed():
 @feed_bp.route("/feed/rss/<agent_name>")
 def rss_feed_agent(agent_name):
     """RSS 2.0 feed for a specific agent."""
-    limit = _parse_limit()
+    try:
+        limit = _parse_limit()
+    except ValueError as exc:
+        return _limit_error_response(exc)
     videos = _fetch_videos(agent=agent_name, limit=limit)
     
     now_rfc = format_datetime(datetime.datetime.now(datetime.timezone.utc))
@@ -292,7 +315,10 @@ def rss_feed_agent(agent_name):
 @feed_bp.route("/feed/atom/<agent_name>")
 def atom_feed_agent(agent_name):
     """Atom 1.0 feed for a specific agent."""
-    limit = _parse_limit()
+    try:
+        limit = _parse_limit()
+    except ValueError as exc:
+        return _limit_error_response(exc)
     videos = _fetch_videos(agent=agent_name, limit=limit)
     
     now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()

--- a/tests/test_feed_blueprint.py
+++ b/tests/test_feed_blueprint.py
@@ -83,16 +83,55 @@ def test_vid_fields_applies_defaults_and_derived_urls():
     [
         ("/feed/rss", 20),
         ("/feed/rss?limit=5", 5),
-        ("/feed/rss?limit=0", 1),
-        ("/feed/rss?limit=-30", 1),
-        ("/feed/rss?limit=250", 100),
-        ("/feed/rss?limit=invalid", 20),
+        ("/feed/rss?limit=1", 1),
+        ("/feed/rss?limit=100", 100),
     ],
 )
-def test_parse_limit_defaults_and_clamps_values(path, expected):
+def test_parse_limit_defaults_and_accepts_valid_values(path, expected):
     app = Flask(__name__)
     with app.test_request_context(path):
         assert feed_blueprint._parse_limit() == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "message"),
+    [
+        ("/feed/rss?limit=0", "limit must be a positive integer"),
+        ("/feed/rss?limit=-30", "limit must be a positive integer"),
+        ("/feed/rss?limit=101", "limit must be less than or equal to 100"),
+        ("/feed/rss?limit=invalid", "limit must be an integer"),
+        ("/feed/rss?limit=1.5", "limit must be an integer"),
+        ("/feed/rss?limit=", "limit must be an integer"),
+    ],
+)
+def test_parse_limit_rejects_invalid_values(path, message):
+    app = Flask(__name__)
+    with app.test_request_context(path), pytest.raises(ValueError, match=message):
+        feed_blueprint._parse_limit()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/feed/rss?limit=invalid",
+        "/feed/atom?limit=0",
+        "/feed/rss/agent-name?limit=-1",
+        "/feed/atom/agent-name?limit=101",
+    ],
+)
+def test_feed_routes_reject_invalid_limit_without_fetching_videos(monkeypatch, path):
+    app = Flask(__name__)
+    app.register_blueprint(feed_blueprint.feed_bp)
+
+    def fail_fetch_videos(*args, **kwargs):
+        raise AssertionError("_fetch_videos should not run for invalid limits")
+
+    monkeypatch.setattr(feed_blueprint, "_fetch_videos", fail_fetch_videos)
+
+    response = app.test_client().get(path)
+
+    assert response.status_code == 400
+    assert "error" in response.get_json()
 
 
 def test_fetch_videos_builds_filtered_request_and_normalizes_response(monkeypatch):


### PR DESCRIPTION
## Summary

- Reject malformed, non-positive, and over-cap `limit` query values for RSS/Atom feed endpoints with HTTP 400.
- Keep omitted `limit` values on the existing default of 20.
- Add regression coverage for global and per-agent RSS/Atom feed routes so invalid limits do not fetch videos.

## Root Cause

`feed_blueprint._parse_limit()` silently defaulted non-integer values to 20 and clamped out-of-range values into 1..100. That makes malformed client requests look successful, e.g. production currently returns 200 for `/feed/rss?limit=invalid` and `/feed/atom?limit=0`.

## Bounty / Bug Report

Refs Scottcjn/rustchain-bounties#1102

- URL: `https://bottube.ai/feed/rss?limit=invalid`, `https://bottube.ai/feed/atom?limit=0`
- Steps: request either feed URL with a malformed, zero, negative, or above-maximum `limit` query value.
- Expected: return HTTP 400 with a clear validation error.
- Actual: production returns HTTP 200 and silently defaults/clamps the value.
- Browser/device: reproduced with `curl` on macOS desktop.

## Validation

```
python3 -m py_compile feed_blueprint.py tests/test_feed_blueprint.py
/tmp/bottube-feed-test-venv/bin/python -m pytest -q tests/test_feed_blueprint.py
git diff --check
```

Result: `21 passed in 0.41s`.
