### PR TITLE
fix: validate top videos limit range

### DIFF
--- a/analytics_blueprint.py
+++ b/analytics_blueprint.py
@@ -266,10 +266,11 @@ def api_top_videos():
     
     metric = request.args.get('metric', 'views')
     try:
-        limit = int(request.args.get('limit', 10))
-    except ValueError:
+        limit = int(request.args.get('limit', '10'))
+    except (TypeError, ValueError):
         return jsonify({"error": "Invalid limit, must be an integer"}), 400
-    limit = max(1, min(limit, 50))
+    if limit < 1 or limit > 50:
+        return jsonify({"error": "Invalid limit, must be between 1 and 50"}), 400
     
     db = get_db()
     

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -405,6 +405,35 @@ class TestAnalyticsApiTimeSeries:
 class TestAnalyticsApiTopVideos:
     """Test analytics API top videos ranking."""
 
+    @pytest.mark.parametrize("limit", ["0", "-1", "51"])
+    def test_analytics_api_top_videos_rejects_out_of_range_limit(self, client, limit):
+        """Top videos API should reject limits outside the supported 1..50 range."""
+        aid = _insert_agent("toplimit" + limit.replace("-", "neg"), "test-key-top-limit-" + limit)
+
+        response = client.get(f"/analytics/api/top-videos?agent_id={aid}&limit={limit}")
+
+        assert response.status_code == 400
+        assert "limit" in response.get_json()["error"]
+
+    def test_analytics_api_top_videos_rejects_non_integer_limit(self, client):
+        """Top videos API should reject malformed limit values."""
+        aid = _insert_agent("toplimitbad", "test-key-top-limit-bad")
+
+        response = client.get(f"/analytics/api/top-videos?agent_id={aid}&limit=abc")
+
+        assert response.status_code == 400
+        assert "limit" in response.get_json()["error"]
+
+    @pytest.mark.parametrize("limit", ["1", "50"])
+    def test_analytics_api_top_videos_accepts_boundary_limits(self, client, limit):
+        """Top videos API should accept the documented 1..50 boundary values."""
+        aid = _insert_agent("toplimitvalid" + limit, "test-key-top-limit-valid-" + limit)
+
+        response = client.get(f"/analytics/api/top-videos?agent_id={aid}&limit={limit}")
+
+        assert response.status_code == 200
+        assert response.get_json()["videos"] == []
+
     def test_analytics_api_top_videos_by_views(self, client):
         """Top videos should be ranked by views."""
         aid = _insert_agent("topuser", "test-key-top")


### PR DESCRIPTION
## Summary

- reject out-of-range `limit` values on `GET /analytics/api/top-videos` instead of silently clamping them
- preserve the valid `1..50` boundary values and existing non-integer JSON 400 behavior
- add regression coverage for malformed, below-minimum, above-maximum, and boundary limits

Closes #1475.

## Root Cause

`api_top_videos()` parsed `limit` with `int(...)`, then coerced the value via `max(1, min(limit, 50))`. That made invalid requests such as `limit=0`, `limit=-1`, or `limit=51` return normal `200` responses, so API clients could not distinguish invalid analytics queries from valid empty results.

## Production Repro

Checked on 2026-06-17 UTC:

```bash
curl -i "https://bottube.ai/analytics/api/top-videos?agent_id=1&limit=0"
curl -i "https://bottube.ai/analytics/api/top-videos?agent_id=1&limit=51"
```

Both currently return `HTTP 200` with an empty `videos` array.

## Validation

```bash
.venv/bin/python -m pytest tests/test_analytics_dashboard.py::TestAnalyticsApiTopVideos::test_analytics_api_top_videos_rejects_out_of_range_limit tests/test_analytics_dashboard.py::TestAnalyticsApiTopVideos::test_analytics_api_top_videos_rejects_non_integer_limit tests/test_analytics_dashboard.py::TestAnalyticsApiTopVideos::test_analytics_api_top_videos_accepts_boundary_limits -q
# 6 passed

.venv/bin/python -m py_compile analytics_blueprint.py tests/test_analytics_dashboard.py
git diff --check -- analytics_blueprint.py tests/test_analytics_dashboard.py
```

Broader note: `tests/test_analytics_dashboard.py -q` currently has existing failures outside this change area (`/analytics` 308 redirect expectations and older dashboard JSON-field assertions such as `thumbnail` / `trend`). The focused top-videos validation tests pass.

## Bounty

Submitted for Scottcjn/rustchain-bounties#1102 as one functional BoTTube API bug, subject to maintainer review. RTC payout address if accepted: `RTCde409a83a31e54f946144390eaeb9964a444d2e6`.
