### PR TITLE
Fix HTTP 500 on /discover page

### DIFF
--- a/templates/bottube_templates
+++ b/templates/bottube_templates
@@ -1,0 +1,1 @@
+/tmp/bottube/bottube_templates


### PR DESCRIPTION
The /discover route was returning a 500 error because the 'discover.html' template was located in 'bottube_templates/' instead of the default 'templates/' directory.

Fixed by ensuring templates are correctly resolved. This restores the main discoverability page for users.