### PR TITLE
fix: validate referral leaderboard limit

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -5508,11 +5508,9 @@ def founding_page():
 @app.route("/api/referrals/leaderboard")
 def referrals_leaderboard_api():
     db = get_db()
-    limit = request.args.get("limit", "50")
-    try:
-        limit_i = int(limit)
-    except Exception:
-        limit_i = 50
+    limit_i, error = _parse_positive_int_query("limit", 50, max_value=200)
+    if error:
+        return error
     return jsonify({"ok": True, "leaderboard": _get_referral_leaderboard(db, limit=limit_i)})
 
 

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -97,6 +97,29 @@ def _lookup_agent(agent_name: str) -> sqlite3.Row:
         return row
 
 
+@pytest.mark.parametrize("limit", ["abc", "1.5", "0", "-1", "201"])
+def test_referral_leaderboard_rejects_invalid_limit(client, limit):
+    resp = client.get(f"/api/referrals/leaderboard?limit={limit}")
+
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "limit" in body["error"]
+
+
+@pytest.mark.parametrize("limit", [None, "1", "200"])
+def test_referral_leaderboard_accepts_default_and_boundary_limits(client, limit):
+    path = "/api/referrals/leaderboard"
+    if limit is not None:
+        path = f"{path}?limit={limit}"
+
+    resp = client.get(path)
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert isinstance(body["leaderboard"], list)
+
+
 def test_referral_dashboard_tracks_human_and_agent_funnels(client):
     referrer_id = _insert_agent("founder1337", "bottube_sk_founder", is_human=True)
 


### PR DESCRIPTION
## Summary

- validate `GET /api/referrals/leaderboard?limit=` with the existing positive integer query helper
- return JSON 400 for malformed, non-positive, or above-200 `limit` values instead of silently defaulting/clamping
- add regression coverage for invalid values and default/boundary values

Fixes #1478.

## Bounty context

Related standing bounty: Scottcjn/rustchain-bounties#1102.

This is a functional public API bug: production currently returns HTTP 200 for invalid `limit` inputs such as `abc`, `0`, and `100000`, while sibling public endpoints use deterministic 400 validation for bad query parameters.

## Validation

- `.venv/bin/python -m pytest -q tests/test_referrals.py::test_referral_leaderboard_rejects_invalid_limit tests/test_referrals.py::test_referral_leaderboard_accepts_default_and_boundary_limits` -> 8 passed
- `.venv/bin/python -m pytest -q tests/test_referrals.py` -> 11 passed
- `.venv/bin/python -m py_compile bottube_server.py tests/test_referrals.py` -> passed
- `git diff --check -- bottube_server.py tests/test_referrals.py` -> passed
