### PR TITLE
fix(api): validate CTR top query params

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -17719,8 +17719,16 @@ def ctr_global_stats():
 @app.route("/api/ctr/top")
 def ctr_top_videos():
     """Get top videos by CTR."""
-    limit = max(1, min(50, request.args.get("limit", 20, type=int)))
-    min_imp = request.args.get("min_impressions", 10, type=int)
+    limit, error = _parse_positive_int_query("limit", 20, max_value=50)
+    if error:
+        return error
+    min_imp, error = _parse_positive_int_query(
+        "min_impressions",
+        10,
+        min_value=0,
+    )
+    if error:
+        return error
     try:
         top = _get_ctr_tracker().get_top_by_ctr(limit=limit, min_impressions=min_imp)
         return jsonify({"ok": True, "videos": top})

--- a/tests/test_ctr_top_query_param_validation.py
+++ b/tests/test_ctr_top_query_param_validation.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+
+
+class FakeCTRTracker:
+    def __init__(self):
+        self.calls = []
+
+    def get_top_by_ctr(self, *, limit, min_impressions):
+        self.calls.append((limit, min_impressions))
+        return [{"video_id": "vid_high", "ctr": 0.5}]
+
+
+def test_ctr_top_rejects_invalid_query_values(client, monkeypatch):
+    import bottube_server
+
+    tracker = FakeCTRTracker()
+    monkeypatch.setattr(bottube_server, "_get_ctr_tracker", lambda: tracker)
+
+    cases = {
+        "limit=abc": "limit must be an integer",
+        "limit=0": "limit must be >= 1",
+        "limit=51": "limit must be <= 50",
+        "min_impressions=abc": "min_impressions must be an integer",
+        "min_impressions=-1": "min_impressions must be >= 0",
+    }
+
+    for query, expected_error in cases.items():
+        resp = client.get(f"/api/ctr/top?{query}")
+
+        assert resp.status_code == 400
+        assert resp.get_json() == {"error": expected_error}
+
+    assert tracker.calls == []
+
+
+def test_ctr_top_accepts_default_and_boundary_values(client, monkeypatch):
+    import bottube_server
+
+    tracker = FakeCTRTracker()
+    monkeypatch.setattr(bottube_server, "_get_ctr_tracker", lambda: tracker)
+
+    default_resp = client.get("/api/ctr/top")
+    lower_resp = client.get("/api/ctr/top?limit=1&min_impressions=0")
+    upper_resp = client.get("/api/ctr/top?limit=50&min_impressions=25")
+
+    assert default_resp.status_code == 200
+    assert lower_resp.status_code == 200
+    assert upper_resp.status_code == 200
+    assert default_resp.get_json()["ok"] is True
+    assert lower_resp.get_json()["ok"] is True
+    assert upper_resp.get_json()["ok"] is True
+    assert tracker.calls == [(20, 10), (1, 0), (50, 25)]


### PR DESCRIPTION
## Summary

- reject malformed or out-of-range `/api/ctr/top?limit=` values with JSON 400 instead of silently defaulting/clamping
- reject malformed or negative `/api/ctr/top?min_impressions=` values with JSON 400 instead of silently defaulting/accepting
- add focused regression coverage for invalid values plus default and boundary values

## Validation

- `.venv/bin/python -m pytest -q tests/test_ctr_top_query_param_validation.py` -> 2 passed
- `.venv/bin/python -m py_compile bottube_server.py tests/test_ctr_top_query_param_validation.py` -> passed
- `git diff --check -- bottube_server.py tests/test_ctr_top_query_param_validation.py` -> passed

## Bounty context

Fixes #1480.

Candidate functional BoTTube bug under Scottcjn/rustchain-bounties#1102. Reward tier and payout are subject to maintainer verification/acceptance; no payout is asserted by this PR.
