### PR TITLE
fix(api): validate similar video k query

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -20657,10 +20657,9 @@ def _ue_top_k_for_video(video_id, k=10, exclude_self=True):
 @app.route("/api/videos/<video_id>/similar")
 def api_videos_similar(video_id):
     """Top-K cosine-similar videos based on text embedding."""
-    try:
-        k = max(1, min(50, int(request.args.get("k", 10))))
-    except Exception:
-        k = 10
+    k, error = _parse_positive_int_query("k", 10, max_value=50)
+    if error:
+        return error
     db = get_db()
     video = db.execute(
         """SELECT 1 FROM videos

--- a/tests/test_similar_missing_video.py
+++ b/tests/test_similar_missing_video.py
@@ -78,3 +78,57 @@ def test_similar_preserves_no_embeddings_for_existing_video(
         "error": "no_embeddings_yet",
         "video_id": video_id,
     }
+
+
+def test_similar_rejects_invalid_k_values_before_embedding_lookup(
+    client, monkeypatch
+):
+    import bottube_server
+
+    video_id = _insert_video("similar_invalid_k")
+    calls = []
+
+    def record_lookup(*args, **kwargs):
+        calls.append((args, kwargs))
+        return []
+
+    monkeypatch.setattr(bottube_server, "_ue_top_k_for_video", record_lookup)
+
+    cases = {
+        "k=abc": "k must be an integer",
+        "k=0": "k must be >= 1",
+        "k=51": "k must be <= 50",
+    }
+
+    for query, expected_error in cases.items():
+        response = client.get(f"/api/videos/{video_id}/similar?{query}")
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": expected_error}
+
+    assert calls == []
+
+
+def test_similar_accepts_default_and_boundary_k_values(client, monkeypatch):
+    import bottube_server
+
+    video_id = _insert_video("similar_valid_k")
+    calls = []
+
+    def record_lookup(*args, **kwargs):
+        calls.append(kwargs["k"])
+        return []
+
+    monkeypatch.setattr(bottube_server, "_ue_top_k_for_video", record_lookup)
+
+    default_response = client.get(f"/api/videos/{video_id}/similar")
+    lower_response = client.get(f"/api/videos/{video_id}/similar?k=1")
+    upper_response = client.get(f"/api/videos/{video_id}/similar?k=50")
+
+    assert default_response.status_code == 404
+    assert lower_response.status_code == 404
+    assert upper_response.status_code == 404
+    assert default_response.get_json()["error"] == "no_embeddings_yet"
+    assert lower_response.get_json()["error"] == "no_embeddings_yet"
+    assert upper_response.get_json()["error"] == "no_embeddings_yet"
+    assert calls == [10, 1, 50]


### PR DESCRIPTION
## Summary

- reject malformed or out-of-range `/api/videos/<video_id>/similar?k=` values with JSON 400 instead of silently defaulting/clamping
- reuse the existing `_parse_positive_int_query()` helper for the public similar-videos route
- extend the existing similar route tests so invalid `k` values are rejected before embedding lookup and valid default/boundary values still flow through

## Validation

- `.venv/bin/python -m pytest -q tests/test_similar_missing_video.py` -> 4 passed
- `.venv/bin/python -m py_compile bottube_server.py tests/test_similar_missing_video.py` -> passed
- `git diff --check -- bottube_server.py tests/test_similar_missing_video.py` -> passed

## Bounty context

Fixes #1482.

Candidate functional BoTTube bug under Scottcjn/rustchain-bounties#1102. Reward tier and payout are subject to maintainer verification/acceptance; no payout is asserted by this PR.
