### PR TITLE
[codex] Add descriptive homepage thumbnail alt text

### DIFF
--- a/bottube_templates/index.html
+++ b/bottube_templates/index.html
@@ -1093,7 +1093,7 @@
 
             grid.innerHTML = j.videos.map(function (v) {
                 var thumb = v.thumbnail
-                    ? '<img src="/thumbnails/' + _esc(v.thumbnail) + '" alt="Video thumbnail" loading="lazy" decoding="async" width="720" height="720">'
+                    ? '<img src="/thumbnails/' + _esc(v.thumbnail) + '" alt="Video thumbnail: ' + _esc(v.title || 'video') + '" loading="lazy" decoding="async" width="720" height="720">'
                     : '<div class="thumb-placeholder">&#9654;</div>';
                 var dur = (v.duration_sec && v.duration_sec > 0)
                     ? '<span class="duration-badge">' + Math.floor(v.duration_sec) + 's</span>' : '';

--- a/tests/test_seo_audit_hygiene.py
+++ b/tests/test_seo_audit_hygiene.py
@@ -66,3 +66,10 @@ def test_template_and_beacon_atlas_assets_have_no_console_log():
                 offenders.append(f"{path.relative_to(ROOT)}:{line_no}: {line.strip()}")
 
     assert offenders == []
+
+
+def test_homepage_hybrid_rail_uses_descriptive_thumbnail_alt_text():
+    index = (ROOT / "bottube_templates" / "index.html").read_text(encoding="utf-8")
+
+    assert 'alt="Video thumbnail: ' in index
+    assert 'alt="Video thumbnail" loading="lazy" decoding="async" width="720" height="720"' not in index


### PR DESCRIPTION
## Summary

Fixes the homepage hybrid rail thumbnail alt text so it uses the video title instead of the generic "Video thumbnail" label.

## Why

The current homepage JS rendered a generic alt string for the dynamic rail. That leaves screen reader users with less useful context and keeps the homepage accessibility audit from fully passing.

## Validation

- `.venv/bin/python -m pytest -q tests/test_seo_audit_hygiene.py`
- `git diff --check`

## Bounty

- Issue: [#13781](https://github.com/Scottcjn/rustchain-bounties/issues/13781)
- Reward: 1 RTC
- Payment evidence: bounty issue states the payout amount in the title and body
- Claim status: no open PR found for the issue; submitted as a new competing fix
