### PR TITLE
fix(api): reject invalid sort/type enum values on /api/agents with 400 (#1486)

### DIFF
--- a/agent_discovery.py
+++ b/agent_discovery.py
@@ -39,6 +39,15 @@ def _parse_agent_directory_int(name: str, default: int, min_value: int, max_valu
     return value
 
 
+def _parse_agent_directory_choice(name: str, default: str, allowed: tuple[str, ...]) -> str:
+    raw_value = request.args.get(name)
+    if raw_value is None or raw_value == "":
+        return default
+    if raw_value not in allowed:
+        raise ValueError(f"{name} must be one of: {', '.join(allowed)}")
+    return raw_value
+
+
 # ═══════════════════════════════════════════════════════════════
 # GOOGLE A2A — Agent Card
 # Spec: https://google.github.io/A2A
@@ -566,10 +575,10 @@ def api_agents_directory():
     try:
         page = _parse_agent_directory_int("page", 1, min_value=1)
         limit = _parse_agent_directory_int("limit", 20, min_value=1, max_value=100)
+        sort = _parse_agent_directory_choice("sort", "popular", ("newest", "popular", "active"))
+        agent_type = _parse_agent_directory_choice("type", "all", ("agent", "human", "all"))
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
-    sort = request.args.get("sort", "popular")
-    agent_type = request.args.get("type", "all")
     offset = (page - 1) * limit
 
     # Build query

--- a/tests/test_agent_directory_query_validation.py
+++ b/tests/test_agent_directory_query_validation.py
@@ -77,3 +77,58 @@ def test_agent_directory_clamps_valid_numeric_bounds(agent_directory_client):
     assert body["limit"] == 100
     assert body["total"] == 0
     assert len(fake_db.calls) == 2
+
+
+@pytest.mark.parametrize("sort", ["newest", "popular", "active"])
+def test_agent_directory_accepts_valid_sort(agent_directory_client, sort):
+    client, fake_db = agent_directory_client
+
+    resp = client.get(f"/api/agents?sort={sort}")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["sort"] == sort
+    assert len(fake_db.calls) == 2
+
+
+def test_agent_directory_rejects_invalid_sort(agent_directory_client):
+    client, fake_db = agent_directory_client
+
+    resp = client.get("/api/agents?sort=trending")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "error": "sort must be one of: newest, popular, active"
+    }
+    assert fake_db.calls == []
+
+
+@pytest.mark.parametrize("agent_type", ["agent", "human", "all"])
+def test_agent_directory_accepts_valid_type(agent_directory_client, agent_type):
+    client, fake_db = agent_directory_client
+
+    resp = client.get(f"/api/agents?type={agent_type}")
+
+    assert resp.status_code == 200
+    assert len(fake_db.calls) == 2
+
+
+def test_agent_directory_rejects_invalid_type(agent_directory_client):
+    client, fake_db = agent_directory_client
+
+    resp = client.get("/api/agents?type=robot")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {
+        "error": "type must be one of: agent, human, all"
+    }
+    assert fake_db.calls == []
+
+
+def test_agent_directory_empty_sort_uses_default(agent_directory_client):
+    client, fake_db = agent_directory_client
+
+    resp = client.get("/api/agents?sort=")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["sort"] == "popular"
+    assert len(fake_db.calls) == 2


### PR DESCRIPTION
## What

`GET /api/agents` documents constrained enum query params (`sort` ∈ {newest, popular, active}, `type` ∈ {agent, human, all}) but production accepted **any** value and returned HTTP 200. An invalid `sort` silently fell back to `popular` ordering yet the rejected value was echoed back in the response body (`"sort": ...`) and in the `_links.self` / `_links.next` pagination URLs; an invalid `type` silently behaved like `all`. Clients believed their filter/order was applied when it was not.

Fixes #1486.

## Change

- Added `_parse_agent_directory_choice(name, default, allowed)` next to the existing `_parse_agent_directory_int` helper — empty/missing → documented default, unknown value → `ValueError`.
- `api_agents_directory` now validates `sort` and `type` inside the same `try/except ValueError` block that already guards `page`/`limit`, returning `400 {"error": "<param> must be one of: ..."}` before touching the DB. Behaviour for valid values is unchanged.

## Tests

Extended `tests/test_agent_directory_query_validation.py`:
- accepts each valid `sort` (newest/popular/active) and each valid `type` (agent/human/all);
- empty `sort=` falls back to `popular`;
- invalid `sort` / `type` → 400 with the documented error and **no DB call**.

`python3 -m pytest tests/test_agent_directory_query_validation.py` → 12 passed. `py_compile` clean.

/claim #1486
