### PR TITLE
fix(stars): render native star sprint page

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13516,11 +13516,8 @@ def community_page():
 
 @app.route("/stars")
 def stars_page():
-    """Legacy star sprint landing page.
-
-    Kept as a redirect so old links don't 404, but the campaign lives on GitHub.
-    """
-    return redirect("https://github.com/Scottcjn/Rustchain/issues/47", code=302)
+    """Star sprint landing page."""
+    return render_template("stars.html")
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_user_route_aliases_1362_1371.py
+++ b/tests/test_user_route_aliases_1362_1371.py
@@ -45,6 +45,18 @@ def test_contact_returns_200_for_anonymous(client):
     assert resp.content_type.startswith("text/html")
 
 
+def test_stars_returns_native_page_for_anonymous(client):
+    resp = client.get("/stars", follow_redirects=False)
+    html = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert resp.content_type.startswith("text/html")
+    assert "7-Day Star Sprint" in html
+    assert "https://github.com/Scottcjn/Rustchain" in html
+    assert "githubassets" not in html
+    assert 'data-color-mode="auto"' not in html
+
+
 # --- Auth-required surfaces (must 302 -> /login?next=...) -------------------
 
 


### PR DESCRIPTION
## Summary
- render `/stars` with the existing BoTTube `stars.html` template instead of redirecting to GitHub
- add regression coverage that `/stars` returns native BoTTube HTML and not GitHub document markup

Closes #1485

## Tests
- `/tmp/bottube-pytest-venv/bin/python -m pytest tests/test_user_route_aliases_1362_1371.py`
- `python3 -m py_compile bottube_server.py tests/test_user_route_aliases_1362_1371.py`
- `git diff --check`