### PR TITLE
fix(a11y): label verify video id input

### DIFF
--- a/bottube_templates/verify.html
+++ b/bottube_templates/verify.html
@@ -26,6 +26,10 @@
     border-radius: 6px; cursor: pointer; font-weight: 600;
   }
   .vrf-form button:disabled { opacity: 0.55; cursor: wait; }
+  .vrf-sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+  }
   .vrf-out {
     margin-top: 22px; background: var(--bg-card); border: 1px solid var(--border);
     border-radius: var(--radius); padding: 18px;
@@ -78,6 +82,7 @@
   </p>
 
   <form id="vrf-form" class="vrf-form" onsubmit="event.preventDefault(); runVerify();">
+    <label for="vrf-vid" class="vrf-sr-only">Video ID</label>
     <input type="text" id="vrf-vid" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus>
     <button type="submit" id="vrf-btn" aria-label="Verify video provenance">Verify</button>
     <button type="button" id="vrf-asset-btn" style="background:#999;color:#000" title="Stream the canonical asset bytes and re-hash" onclick="runVerify(true)">+ check asset bytes</button>

--- a/tests/test_verify_template_accessibility.py
+++ b/tests/test_verify_template_accessibility.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_verify_video_id_input_has_programmatic_label():
+    template = (ROOT / "bottube_templates" / "verify.html").read_text(encoding="utf-8")
+
+    assert '<label for="vrf-vid" class="vrf-sr-only">Video ID</label>' in template
+    assert 'id="vrf-vid"' in template
+
+
+def test_verify_primary_submit_has_descriptive_accessible_name():
+    template = (ROOT / "bottube_templates" / "verify.html").read_text(encoding="utf-8")
+
+    assert 'id="vrf-btn" aria-label="Verify video provenance"' in template


### PR DESCRIPTION
## Summary
- add a programmatically-associated label for the `/verify` video ID input
- keep the label visually hidden so the existing compact form layout does not change
- add a focused template regression test for the input label and submit button accessible name

Refs #1434

## Tests
- `/tmp/bottube-pytest-venv/bin/python -m pytest tests/test_verify_template_accessibility.py`
- `python3 -m py_compile tests/test_verify_template_accessibility.py`
- `git diff --check`