### PR TITLE
fix(api): reject invalid agent directory enum values

### DIFF
--- a/agent_discovery.py
+++ b/agent_discovery.py
@@ -568,7 +568,12 @@ def api_agents_directory():
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
     sort = request.args.get("sort", "popular")
+    if sort not in {"newest", "popular", "active"}:
+        return jsonify({"error": "sort must be one of: newest, popular, active"}), 400
+
     agent_type = request.args.get("type", "all")
+    if agent_type not in {"agent", "human", "all"}:
+        return jsonify({"error": "type must be one of: agent, human, all"}), 400
     offset = (page - 1) * limit
 
     # Build query

--- a/tests/test_agent_directory_query_validation.py
+++ b/tests/test_agent_directory_query_validation.py
@@ -65,6 +65,25 @@ def test_agent_directory_rejects_malformed_page(agent_directory_client):
     assert fake_db.calls == []
 
 
+@pytest.mark.parametrize(
+    ("query", "expected_error"),
+    [
+        ("sort=bogus", "sort must be one of: newest, popular, active"),
+        ("type=robot", "type must be one of: agent, human, all"),
+    ],
+)
+def test_agent_directory_rejects_invalid_enum_params(
+    agent_directory_client, query, expected_error
+):
+    client, fake_db = agent_directory_client
+
+    resp = client.get(f"/api/agents?{query}")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": expected_error}
+    assert fake_db.calls == []
+
+
 def test_agent_directory_clamps_valid_numeric_bounds(agent_directory_client):
     client, fake_db = agent_directory_client
 


### PR DESCRIPTION
## Summary
- reject unsupported `sort` values on `GET /api/agents` instead of silently falling back to popular ordering
- reject unsupported `type` values instead of silently returning the unfiltered/all directory
- add focused regression coverage for both enum validations

Fixes #1486.

## Validation
- `python -m pytest -q tests/test_agent_directory_query_validation.py` -> 5 passed
- `python -m py_compile agent_discovery.py tests/test_agent_directory_query_validation.py` -> passed
- `git diff --check fork/main..HEAD -- agent_discovery.py tests/test_agent_directory_query_validation.py` -> passed

RTC claim wallet: `RTC9ae8c1b0e0d5457ed124f3d24ffef9ffe342cee6`
