### PR TITLE
fix(a11y): label bridge history limit inputs

### DIFF
--- a/bottube_templates/bridge_base.html
+++ b/bottube_templates/bridge_base.html
@@ -204,7 +204,7 @@
       <p>Latest deposits and withdrawals for your authenticated account on Base.</p>
       <div class="row">
         <button class="btn btn-dark" id="historyBtn" type="button" aria-label="Load transaction history">Load History</button>
-        <input id="historyLimitInput" type="number" min="1" max="200" value="50" style="max-width:100px;">
+        <input id="historyLimitInput" type="number" min="1" max="200" value="50" aria-label="History entries to load" style="max-width:100px;">
       </div>
       <div id="historyPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
     </div>

--- a/bottube_templates/bridge_wrtc.html
+++ b/bottube_templates/bridge_wrtc.html
@@ -171,7 +171,7 @@
       <p>Latest verified deposits and queued/sent withdrawals for the authenticated account.</p>
       <div class="row">
         <button class="btn btn-dark" id="historyBtn" type="button" aria-label="Load transaction history">Load History</button>
-        <input id="historyLimitInput" type="number" min="1" max="200" value="50" style="max-width:100px;">
+        <input id="historyLimitInput" type="number" min="1" max="200" value="50" aria-label="History entries to load" style="max-width:100px;">
       </div>
       <div id="historyPanel" class="panel" style="margin-top:10px;">No requests yet.</div>
     </div>

--- a/tests/test_bridge_history_limit_accessibility.py
+++ b/tests/test_bridge_history_limit_accessibility.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import re
+
+
+TEMPLATES_DIR = Path(__file__).parent.parent / "bottube_templates"
+
+
+def _history_limit_input(template_name):
+    html = (TEMPLATES_DIR / template_name).read_text(encoding="utf-8")
+    match = re.search(r'<input[^>]*id="historyLimitInput"[^>]*>', html)
+    assert match, f"{template_name} is missing the history limit input"
+    return match.group(0)
+
+
+def test_bridge_history_limit_inputs_have_accessible_names():
+    for template_name in ("bridge_wrtc.html", "bridge_base.html"):
+        input_markup = _history_limit_input(template_name)
+        assert 'aria-label="History entries to load"' in input_markup


### PR DESCRIPTION
## Summary
- add accessible names to the history limit number inputs on both bridge pages
- cover the Solana and Base bridge templates with a focused accessibility regression test

## Why
The history limit inputs beside "Load History" were unnamed spinbuttons for screen reader users. This gives each control the stable accessible name "History entries to load" without changing the visual layout.

Closes #1313.

RTC wallet for bounty tracking: RTC9ae8c1b0e0d5457ed124f3d24ffef9ffe342cee6

## Checks
- `python -m pytest -q tests/test_bridge_history_limit_accessibility.py tests/test_aria_labels.py`
- `git diff --check`