### PR TITLE
fix(api): reject malformed tips leaderboard limit

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11485,9 +11485,14 @@ def get_video_tips(video_id):
 @app.route("/api/tips/leaderboard")
 def tip_leaderboard():
     """Top tipped creators (by total tips received)."""
+    raw_limit = request.args.get("limit", "20")
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit must be an integer"}), 400
+    limit = min(50, max(1, limit))
     db = get_db()
     _sync_pending_tips(db)
-    limit = min(50, max(1, request.args.get("limit", 20, type=int)))
 
     rows = db.execute(
         """SELECT a.agent_name, a.display_name, a.avatar_url, a.is_human,
@@ -11517,9 +11522,14 @@ def tip_leaderboard():
 @app.route("/api/tips/tippers")
 def tipper_leaderboard():
     """Top tippers (by total tips sent)."""
+    raw_limit = request.args.get("limit", "20")
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit must be an integer"}), 400
+    limit = min(50, max(1, limit))
     db = get_db()
     _sync_pending_tips(db)
-    limit = min(50, max(1, request.args.get("limit", 20, type=int)))
 
     rows = db.execute(
         """SELECT a.agent_name, a.display_name, a.avatar_url, a.is_human,

--- a/tests/test_video_tips_api.py
+++ b/tests/test_video_tips_api.py
@@ -43,3 +43,11 @@ def test_video_tips_returns_empty_totals_for_existing_video(app, client):
         "page": 1,
         "per_page": 10,
     }
+
+
+def test_tips_leaderboards_reject_malformed_limit(client):
+    for path in ("/api/tips/leaderboard", "/api/tips/tippers"):
+        response = client.get(f"{path}?limit=abc")
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "limit must be an integer"}


### PR DESCRIPTION
## Summary
- return JSON 400 for malformed `limit` values on `/api/tips/leaderboard`
- return JSON 400 for malformed `limit` values on `/api/tips/tippers`
- keep the existing numeric clamp for valid values outside the 1-50 range

## Why
Both endpoints used Flask's `type=int` fallback, so `limit=abc` silently became the default. This makes malformed requests look valid and inconsistent with stricter public API validation.

Closes #1431.

RTC wallet for bounty tracking: RTC9ae8c1b0e0d5457ed124f3d24ffef9ffe342cee6

## Checks
- `python -m pytest -q tests/test_video_tips_api.py`
- `python -m py_compile bottube_server.py tests/test_video_tips_api.py`
- `git diff --check`