### PR TITLE
fix(api): reject malformed trending query params

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8847,9 +8847,33 @@ def _get_trending_videos(db, limit=20, category=None):
 @app.route("/api/trending")
 def trending():
     """Get trending videos (weighted by recent views, likes, comments, recency)."""
+    raw_limit = request.args.get("limit", "20")
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit must be an integer"}), 400
+    if limit < 1 or limit > 50:
+        return jsonify({"error": "limit must be between 1 and 50"}), 400
+
+    if "days" in request.args:
+        try:
+            days = int(request.args.get("days", ""))
+        except (TypeError, ValueError):
+            return jsonify({"error": "days must be an integer"}), 400
+        if days < 1 or days > 90:
+            return jsonify({"error": "days must be between 1 and 90"}), 400
+
+    if "since" in request.args:
+        try:
+            since = float(request.args.get("since", ""))
+        except (TypeError, ValueError):
+            return jsonify({"error": "since must be a timestamp"}), 400
+        if not math.isfinite(since) or since < 0:
+            return jsonify({"error": "since must be a non-negative timestamp"}), 400
+
     db = get_db()
     category = _normalize_category_filter(request.args.get("category"))
-    rows = _get_trending_videos(db, limit=20, category=category)
+    rows = _get_trending_videos(db, limit=limit, category=category)
 
     videos = []
     for row in rows:

--- a/tests/test_discoverability.py
+++ b/tests/test_discoverability.py
@@ -166,6 +166,26 @@ class TestTrendingEnhancements:
         for video in data["videos"]:
             assert video["category"] == "music"
 
+    @pytest.mark.parametrize(
+        ("query", "error"),
+        [
+            ("limit=abc", {"error": "limit must be an integer"}),
+            ("limit=0", {"error": "limit must be between 1 and 50"}),
+            ("limit=51", {"error": "limit must be between 1 and 50"}),
+            ("days=abc", {"error": "days must be an integer"}),
+            ("days=-1", {"error": "days must be between 1 and 90"}),
+            ("days=99999", {"error": "days must be between 1 and 90"}),
+            ("since=invalid", {"error": "since must be a timestamp"}),
+            ("since=-1", {"error": "since must be a non-negative timestamp"}),
+        ],
+    )
+    def test_trending_rejects_malformed_query_params(self, client, query, error):
+        """Malformed trending query params should fail instead of falling back."""
+        resp = client.get(f"/api/trending?{query}")
+
+        assert resp.status_code == 400
+        assert resp.get_json() == error
+
     def test_trending_rising_endpoint(self, client, registered_agent):
         """Test rising videos API."""
         # Upload a recent video


### PR DESCRIPTION
## Summary
- return JSON 400 for malformed `/api/trending` `limit`, `days`, and `since` values
- reject out-of-range `limit` and `days` values instead of silently falling back
- use valid `limit` values when fetching trending rows
- add regression coverage for the malformed query cases

## Why
`/api/trending` ignored malformed query params, so clients received normal-looking 200 responses for invalid inputs such as `limit=abc`, `days=-1`, and `since=invalid`. This makes API bugs hard to detect and inconsistent with stricter query validation elsewhere.

Closes #1436.

RTC wallet for bounty tracking: RTC9ae8c1b0e0d5457ed124f3d24ffef9ffe342cee6

## Checks
- `python -m pytest -q tests/test_discoverability.py::TestTrendingEnhancements::test_trending_category_filter tests/test_discoverability.py::TestTrendingEnhancements::test_trending_rejects_malformed_query_params`
- `python -m py_compile bottube_server.py tests/test_discoverability.py`
- `git diff --check`

Note: running the whole `TestTrendingEnhancements` class on this fork base still shows pre-existing 404 failures for `/api/trending/rising`; the targeted tests above cover this change.