### PR TITLE
fix(api): validate feed query params

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9436,11 +9436,35 @@ def feed():
     Returns:
         JSON with videos list, page info, mode used, and the active bucket.
     """
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
-    mode = request.args.get("mode", "latest")
+    raw_page = request.args.get("page", "1")
+    try:
+        page = int(raw_page)
+    except (TypeError, ValueError):
+        return jsonify({"error": "page must be an integer"}), 400
+    if page < 1 or page > 10000:
+        return jsonify({"error": "page must be between 1 and 10000"}), 400
+
+    raw_per_page = request.args.get("per_page", "20")
+    try:
+        per_page = int(raw_per_page)
+    except (TypeError, ValueError):
+        return jsonify({"error": "per_page must be an integer"}), 400
+    if per_page < 1 or per_page > 50:
+        return jsonify({"error": "per_page must be between 1 and 50"}), 400
+
+    mode = (request.args.get("mode", "latest") or "latest").strip().lower()
+    if mode not in {"latest", "recommended"}:
+        return jsonify({"error": "mode must be one of: latest, recommended"}), 400
+
     category = request.args.get("category")
+    if category:
+        category = category.strip().lower()
+        if category not in CATEGORY_MAP:
+            return jsonify({"error": "category must be a known category"}), 400
+
     bucket_override = (request.args.get("bucket") or "").strip().lower()
+    if bucket_override and bucket_override not in _FEED_BUCKETS:
+        return jsonify({"error": "bucket must be one of: latest, heuristic, hybrid-v1"}), 400
 
     # Get optional API key for personalized recommendations
     api_key = request.headers.get("X-API-Key") or request.args.get("api_key")

--- a/tests/test_feed_query_validation.py
+++ b/tests/test_feed_query_validation.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("query", "error"),
+    [
+        ("page=abc", {"error": "page must be an integer"}),
+        ("page=0", {"error": "page must be between 1 and 10000"}),
+        ("page=10001", {"error": "page must be between 1 and 10000"}),
+        ("per_page=abc", {"error": "per_page must be an integer"}),
+        ("per_page=0", {"error": "per_page must be between 1 and 50"}),
+        ("per_page=51", {"error": "per_page must be between 1 and 50"}),
+        ("mode=sideways", {"error": "mode must be one of: latest, recommended"}),
+        ("category=not-a-category", {"error": "category must be a known category"}),
+        ("bucket=unknown", {"error": "bucket must be one of: latest, heuristic, hybrid-v1"}),
+    ],
+)
+def test_feed_rejects_malformed_query_params(client, query, error):
+    response = client.get(f"/api/feed?{query}")
+
+    assert response.status_code == 400
+    assert response.get_json() == error


### PR DESCRIPTION
## Summary
- return JSON 400 for malformed or out-of-range `/api/feed` `page` and `per_page` values
- reject unsupported `mode`, `bucket`, and `category` values instead of silently falling back or returning empty feeds
- add focused regression coverage for the invalid query shapes

## Why
`/api/feed` accepted bad query params with normal-looking 200 responses. That hides client bugs and makes invalid feed requests indistinguishable from valid empty/default feeds. This extends the query-validation hardening around #1456 while preserving valid defaults.

Refs #1456.

RTC wallet for bounty tracking: RTC9ae8c1b0e0d5457ed124f3d24ffef9ffe342cee6

## Checks
- `python -m pytest -q tests/test_feed_query_validation.py`
- `python -m py_compile bottube_server.py tests/test_feed_query_validation.py`
- `git diff --check`
- `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` showed no textual conflicts