### PR TITLE
Fix semantic provider failure metrics

### DIFF
--- a/generation/reliability.py
+++ b/generation/reliability.py
@@ -99,18 +99,38 @@ def provider_metrics_snapshot() -> Dict[str, dict]:
     return {name: metrics.to_dict() for name, metrics in _PROVIDER_METRICS.items()}
 
 
-def run_with_retries(provider: str, operation: str, func: Callable[[], T], policy: RetryPolicy = RetryPolicy()) -> Tuple[bool, Optional[T], str, float, int]:
+def run_with_retries(
+    provider: str,
+    operation: str,
+    func: Callable[[], T],
+    policy: RetryPolicy = RetryPolicy(),
+    success_predicate: Optional[Callable[[T], bool]] = None,
+) -> Tuple[bool, Optional[T], str, float, int]:
     """Run a provider operation with bounded retries for transient categories.
 
     Returns: (ok, value, category_or_ok, total_latency_s, attempts_used)
     """
     start = time.monotonic()
     last_category = "permanent"
+    last_value: Optional[T] = None
     attempts = max(1, policy.attempts)
     for attempt_index in range(attempts):
         try:
             value = func()
+            last_value = value
             latency = time.monotonic() - start
+            if success_predicate is not None and not success_predicate(value):
+                last_category = classify_error(value)
+                retry = attempt_index + 1 < attempts and is_retryable(last_category)
+                log.warning(
+                    "provider_attempt provider=%s operation=%s attempt=%d success=false category=%s retry=%s result=%s",
+                    provider, operation, attempt_index + 1, last_category, retry, str(value)[:300],
+                )
+                if not retry:
+                    record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
+                    return False, value, last_category, latency, attempt_index + 1
+                time.sleep(policy.delay_for(attempt_index))
+                continue
             record_provider_metric(provider, success=True, latency_s=latency)
             log.info(
                 "provider_attempt provider=%s operation=%s attempt=%d success=true latency_s=%.3f",
@@ -132,4 +152,4 @@ def run_with_retries(provider: str, operation: str, func: Callable[[], T], polic
 
     latency = time.monotonic() - start
     record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
-    return False, None, last_category, latency, attempts
+    return False, last_value, last_category, latency, attempts

--- a/generation/reliability.py
+++ b/generation/reliability.py
@@ -112,12 +112,10 @@ def run_with_retries(
     """
     start = time.monotonic()
     last_category = "permanent"
-    last_value: Optional[T] = None
     attempts = max(1, policy.attempts)
     for attempt_index in range(attempts):
         try:
             value = func()
-            last_value = value
             latency = time.monotonic() - start
             if success_predicate is not None and not success_predicate(value):
                 last_category = classify_error(value)
@@ -152,4 +150,4 @@ def run_with_retries(
 
     latency = time.monotonic() - start
     record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
-    return False, last_value, last_category, latency, attempts
+    return False, None, last_category, latency, attempts

--- a/generation/reliability.py
+++ b/generation/reliability.py
@@ -82,6 +82,12 @@ def is_retryable(category: str) -> bool:
     return category in {"transient", "throttled"}
 
 
+def _semantic_failure_detail(value: object) -> object:
+    if isinstance(value, (tuple, list)) and len(value) >= 2:
+        return value[1]
+    return value
+
+
 def record_provider_metric(provider: str, *, success: bool, latency_s: float, category: Optional[str] = None) -> dict:
     metrics = _PROVIDER_METRICS.setdefault(provider, ProviderMetrics())
     metrics.attempts += 1
@@ -110,15 +116,15 @@ def run_with_retries(
 
     Returns: (ok, value, category_or_ok, total_latency_s, attempts_used)
     """
-    start = time.monotonic()
+    wall_start = time.monotonic()
     last_category = "permanent"
     attempts = max(1, policy.attempts)
     for attempt_index in range(attempts):
         try:
             value = func()
-            latency = time.monotonic() - start
+            latency = time.monotonic() - wall_start
             if success_predicate is not None and not success_predicate(value):
-                last_category = classify_error(value)
+                last_category = classify_error(_semantic_failure_detail(value))
                 retry = attempt_index + 1 < attempts and is_retryable(last_category)
                 log.warning(
                     "provider_attempt provider=%s operation=%s attempt=%d success=false category=%s retry=%s result=%s",
@@ -143,11 +149,11 @@ def run_with_retries(
                 provider, operation, attempt_index + 1, last_category, retry, str(exc)[:300],
             )
             if not retry:
-                latency = time.monotonic() - start
+                latency = time.monotonic() - wall_start
                 record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
                 return False, None, last_category, latency, attempt_index + 1
             time.sleep(policy.delay_for(attempt_index))
 
-    latency = time.monotonic() - start
+    latency = time.monotonic() - wall_start
     record_provider_metric(provider, success=False, latency_s=latency, category=last_category)
     return False, None, last_category, latency, attempts

--- a/generation/worker.py
+++ b/generation/worker.py
@@ -247,8 +247,9 @@ def _run_pipeline(
             provider_name,
             "submit",
             lambda: provider.submit(req, work_dir),
+            success_predicate=lambda result: bool(result and result[0]),
         )
-        if not ok or submit_result is None:
+        if submit_result is None:
             detail = f"submit {category} after {tries} attempt(s) in {latency_s:.2f}s"
             log.error("Provider %s %s", provider_name, detail)
             _record_attempt(job_id, provider_name, attempt_num, False, detail, category, latency_s)
@@ -256,8 +257,8 @@ def _run_pipeline(
 
         success, external_id = submit_result
 
-        if not success:
-            category = classify_error(external_id)
+        if not ok or not success:
+            category = category if category != "ok" else classify_error(external_id)
             log.warning("Provider %s failed: %s (%s)", provider_name, external_id, category)
             _record_attempt(job_id, provider_name, attempt_num, False, external_id, category, latency_s)
             continue

--- a/generation/worker.py
+++ b/generation/worker.py
@@ -25,7 +25,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Tuple
 
 from generation.models import GenerationRequest, JobStatus
 from generation.quality_gate import check_quality, QualityGateResult
@@ -53,6 +53,17 @@ for _d in (_VIDEO_DIR, _THUMB_DIR, _GEN_WORK_DIR):
 
 _POLL_INTERVAL = 3        # seconds between async polls
 _POLL_TIMEOUT = 300       # 5 minutes max wait per provider
+
+
+def _submit_succeeded(result: object) -> bool:
+    return isinstance(result, tuple) and len(result) == 2 and bool(result[0])
+
+
+def _as_submit_result(result: object) -> Optional[Tuple[bool, object]]:
+    if isinstance(result, tuple) and len(result) == 2:
+        return bool(result[0]), result[1]
+    return None
+
 
 # ---------------------------------------------------------------------------
 # In-memory job store (small -- jobs expire after 2 hours)
@@ -247,7 +258,7 @@ def _run_pipeline(
             provider_name,
             "submit",
             lambda: provider.submit(req, work_dir),
-            success_predicate=lambda result: bool(result and result[0]),
+            success_predicate=_submit_succeeded,
         )
         if submit_result is None:
             detail = f"submit {category} after {tries} attempt(s) in {latency_s:.2f}s"
@@ -255,7 +266,14 @@ def _run_pipeline(
             _record_attempt(job_id, provider_name, attempt_num, False, detail, category, latency_s)
             continue
 
-        success, external_id = submit_result
+        normalized_submit = _as_submit_result(submit_result)
+        if normalized_submit is None:
+            detail = f"submit returned invalid result shape after {tries} attempt(s) in {latency_s:.2f}s"
+            log.error("Provider %s %s: %r", provider_name, detail, submit_result)
+            _record_attempt(job_id, provider_name, attempt_num, False, detail, category, latency_s)
+            continue
+
+        success, external_id = normalized_submit
 
         if not ok or not success:
             category = category if category != "ok" else classify_error(external_id)

--- a/tests/test_generation_reliability.py
+++ b/tests/test_generation_reliability.py
@@ -79,3 +79,31 @@ def test_run_with_retries_records_semantic_false_result_as_failure():
     assert metrics["successes"] == 0
     assert metrics["failures"] == 1
     assert metrics["error_categories"]["throttled"] == 1
+
+
+def test_run_with_retries_does_not_reuse_stale_semantic_failure_after_exception():
+    calls = {"count": 0}
+
+    def semantic_then_exception():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return (False, "quota exhausted")
+        raise TimeoutError("temporary provider timeout")
+
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_semantic_then_exception",
+        "submit",
+        semantic_then_exception,
+        RetryPolicy(attempts=2, base_delay_s=0.0, max_delay_s=0.0, jitter_s=0.0),
+        success_predicate=lambda result: result[0],
+    )
+
+    assert ok is False
+    assert value is None
+    assert category == "transient"
+    assert attempts == 2
+    assert latency_s >= 0
+    metrics = provider_metrics_snapshot()["unit_provider_semantic_then_exception"]
+    assert metrics["successes"] == 0
+    assert metrics["failures"] == 1
+    assert metrics["error_categories"]["transient"] == 1

--- a/tests/test_generation_reliability.py
+++ b/tests/test_generation_reliability.py
@@ -81,6 +81,53 @@ def test_run_with_retries_records_semantic_false_result_as_failure():
     assert metrics["error_categories"]["throttled"] == 1
 
 
+def test_run_with_retries_classifies_semantic_failure_reason_not_tuple_repr():
+    class NoisyFalse:
+        def __bool__(self):
+            return False
+
+        def __repr__(self):
+            return "api key noise"
+
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_semantic_reason",
+        "submit",
+        lambda: (NoisyFalse(), "validation failed"),
+        RetryPolicy(attempts=1, base_delay_s=0.0, max_delay_s=0.0, jitter_s=0.0),
+        success_predicate=lambda result: result[0],
+    )
+
+    assert ok is False
+    assert value[1] == "validation failed"
+    assert category == "permanent"
+    assert attempts == 1
+    assert latency_s >= 0
+
+
+def test_run_with_retries_latency_includes_semantic_retry_sleep():
+    calls = {"count": 0}
+
+    def semantic_then_permanent():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return (False, "quota exhausted")
+        return (False, "validation failed")
+
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_semantic_sleep_latency",
+        "submit",
+        semantic_then_permanent,
+        RetryPolicy(attempts=2, base_delay_s=0.01, max_delay_s=0.01, jitter_s=0.0),
+        success_predicate=lambda result: result[0],
+    )
+
+    assert ok is False
+    assert value == (False, "validation failed")
+    assert category == "permanent"
+    assert attempts == 2
+    assert latency_s >= 0.01
+
+
 def test_run_with_retries_does_not_reuse_stale_semantic_failure_after_exception():
     calls = {"count": 0}
 

--- a/tests/test_generation_reliability.py
+++ b/tests/test_generation_reliability.py
@@ -59,3 +59,23 @@ def test_run_with_retries_does_not_retry_auth_errors():
     metrics = provider_metrics_snapshot()["unit_provider_auth"]
     assert metrics["failures"] >= 1
     assert metrics["error_categories"]["auth"] >= 1
+
+
+def test_run_with_retries_records_semantic_false_result_as_failure():
+    ok, value, category, latency_s, attempts = run_with_retries(
+        "unit_provider_semantic_false",
+        "submit",
+        lambda: (False, "quota exhausted"),
+        RetryPolicy(attempts=1, base_delay_s=0.0, max_delay_s=0.0, jitter_s=0.0),
+        success_predicate=lambda result: result[0],
+    )
+
+    assert ok is False
+    assert value == (False, "quota exhausted")
+    assert category == "throttled"
+    assert attempts == 1
+    assert latency_s >= 0
+    metrics = provider_metrics_snapshot()["unit_provider_semantic_false"]
+    assert metrics["successes"] == 0
+    assert metrics["failures"] == 1
+    assert metrics["error_categories"]["throttled"] == 1


### PR DESCRIPTION
Follow-up for #1430 review feedback.

This patch updates run_with_retries() to accept an optional success_predicate so semantic submit failures such as (False, "quota exhausted") are recorded as provider metric failures instead of successes. The generation worker now passes that predicate for submit calls and the reliability test covers the reviewer reproduction case.

Validation run locally:
- python3 -m py_compile generation/reliability.py generation/worker.py tests/test_generation_reliability.py
- direct invocation of all functions in tests/test_generation_reliability.py (pytest is not installed in this local environment)
- git diff --check