### PR TITLE
fix(a11y): label search and verify inputs

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -842,7 +842,8 @@
         </div>
 
         <form class="search-bar" action="{{ P }}/search" method="get" role="search" aria-label="{{ _('nav.search') }}">
-            <input type="text" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}" aria-label="{{ _('nav.search_placeholder') }}">
+            <label for="nav-search-input" class="sr-only">{{ _('nav.search') }}</label>
+            <input type="text" id="nav-search-input" name="q" placeholder="{{ _('nav.search_placeholder') }}" value="{{ request.args.get('q', '') }}" aria-label="{{ _('nav.search') }}">
             <button type="submit" aria-label="{{ _('nav.search') }}">{{ _('nav.search') }}</button>
         </form>
 

--- a/bottube_templates/verify.html
+++ b/bottube_templates/verify.html
@@ -26,10 +26,6 @@
     border-radius: 6px; cursor: pointer; font-weight: 600;
   }
   .vrf-form button:disabled { opacity: 0.55; cursor: wait; }
-  .vrf-sr-only {
-    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
-    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
-  }
   .vrf-out {
     margin-top: 22px; background: var(--bg-card); border: 1px solid var(--border);
     border-radius: var(--radius); padding: 18px;
@@ -82,8 +78,8 @@
   </p>
 
   <form id="vrf-form" class="vrf-form" onsubmit="event.preventDefault(); runVerify();">
-    <label for="vrf-vid" class="vrf-sr-only">Video ID</label>
-    <input type="text" id="vrf-vid" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus>
+    <label for="vrf-vid" class="sr-only">BoTTube video ID</label>
+    <input type="text" id="vrf-vid" aria-label="BoTTube video ID" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus>
     <button type="submit" id="vrf-btn" aria-label="Verify video provenance">Verify</button>
     <button type="button" id="vrf-asset-btn" style="background:#999;color:#000" title="Stream the canonical asset bytes and re-hash" onclick="runVerify(true)">+ check asset bytes</button>
   </form>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -159,6 +159,23 @@ class TestAccessibilityAttributes(unittest.TestCase):
             "Agents page search input missing associated label",
         )
 
+    def test_verify_page_video_id_input_has_accessible_name(self):
+        """The standalone verifier video-id field needs a programmatic label."""
+        content = self.read_file(self.TEMPLATE_DIR / 'verify.html')
+        input_match = re.search(r'<input[^>]*id="vrf-vid"[^>]*>', content)
+        self.assertIsNotNone(input_match, "Verify page video-id input not found")
+        input_markup = input_match.group(0)
+        self.assertIn('aria-label="BoTTube video ID"', input_markup,
+                      "Verify page video-id input missing aria-label")
+
+        label_match = re.search(r'<label[^>]*for="vrf-vid"[^>]*>BoTTube video ID</label>', content)
+        self.assertIsNotNone(label_match, "Verify page video-id input missing associated label")
+        label_markup = label_match.group(0)
+        self.assertIn('class="sr-only"', label_markup,
+                      "Verify page label should use the global screen-reader-only class")
+        self.assertNotIn('vrf-sr-only', content,
+                         "Verify page should not keep a page-local sr-only duplicate")
+
     def test_authenticated_form_inputs_have_associated_labels(self):
         """Collaboration and wallet text inputs need programmatic labels."""
         controls = (
@@ -231,6 +248,28 @@ class TestAccessibilityAttributes(unittest.TestCase):
                       "Skip link for keyboard navigation not found")
         self.assertIn('.sr-only', content,
                       "Screen reader only class not found")
+
+    def test_global_nav_search_input_has_accessible_name(self):
+        """The shared header search input must not rely on placeholder-only text."""
+        content = self.read_file(self.TEMPLATE_DIR / 'base.html')
+        label_match = re.search(
+            r"<label[^>]*>\{\{ _\('nav\.search'\) \}\}</label>",
+            content,
+        )
+        self.assertIsNotNone(label_match, "Global nav search input is missing a label")
+        label_markup = label_match.group(0)
+        self.assertIn('for="nav-search-input"', label_markup,
+                      "Global nav search label should target the search input")
+        self.assertIn('class="sr-only"', label_markup,
+                      "Global nav search label should use the screen-reader-only class")
+
+        input_match = re.search(r'<input[^>]*name="q"[^>]*>', content)
+        self.assertIsNotNone(input_match, "Global nav search input not found")
+        input_markup = input_match.group(0)
+        self.assertIn('id="nav-search-input"', input_markup,
+                      "Global nav search input should expose a stable id")
+        self.assertIn("aria-label=\"{{ _('nav.search') }}\"", input_markup,
+                      "Global nav search input should expose a stable aria-label")
     
     def test_focus_visible_styles_present(self):
         """Test that focus-visible styles are defined."""


### PR DESCRIPTION
Follow-up for #1449. The original PR is clean on checks but currently has a DIRTY merge state against main.

This patch merges current main into lea-a11y-fixes and resolves the only content conflict in bottube_templates/verify.html by preserving the PR accessibility fix: the verifier input keeps the BoTTube video ID label and aria-label, while duplicate sr-only CSS is removed.

Validation run locally:
- python3 -m unittest tests.test_accessibility.TestAccessibilityAttributes.test_verify_page_video_id_input_has_accessible_name tests.test_accessibility.TestAccessibilityAttributes.test_search_form_has_aria_label
- python3 -m py_compile tests/test_accessibility.py
- git diff --check