### PR TITLE
fix(api): register Ergo bridge blueprint

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14352,6 +14352,15 @@ init_base_wrtc_tables(_base_wrtc_db)
 _base_wrtc_db.close()
 app.register_blueprint(base_wrtc_bp)
 
+# ERG Bridge Integration (Ergo)
+from ergo_bridge_blueprint import ergo_bp, init_ergo_tables
+import sqlite3 as _ergo_sqlite3
+_ergo_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
+_ergo_db = _ergo_sqlite3.connect(_ergo_db_path)
+init_ergo_tables(_ergo_db)
+_ergo_db.close()
+app.register_blueprint(ergo_bp)
+
 # ---------------------------------------------------------------------------
 # x402 Payment Protocol (HTTP 402 Standard for AI Agent Micropayments)
 # ---------------------------------------------------------------------------

--- a/tests/test_ergo_bridge_registration.py
+++ b/tests/test_ergo_bridge_registration.py
@@ -1,0 +1,6 @@
+def test_ergo_bridge_info_route_is_registered():
+    import bottube_server
+
+    routes = {rule.rule for rule in bottube_server.app.url_map.iter_rules()}
+
+    assert "/api/ergo/info" in routes


### PR DESCRIPTION
## Summary
- register the Ergo bridge blueprint in the main Flask app
- initialize Ergo bridge tables at startup alongside the other bridge integrations
- add a route registration regression test for `/api/ergo/info`

## Why
`ergo_bridge_blueprint.py` defines `/api/ergo/info`, but the blueprint was not registered in `bottube_server.py`, so production returned 404 for a public bridge metadata endpoint.

Closes #1412.

RTC wallet for bounty tracking: RTC9ae8c1b0e0d5457ed124f3d24ffef9ffe342cee6

## Checks
- `python -m pytest -q tests/test_ergo_bridge_registration.py tests/test_ergo_bridge_validation.py`
- `python -m py_compile bottube_server.py ergo_bridge_blueprint.py tests/test_ergo_bridge_registration.py`
- `git diff --check`