### PR TITLE
fix(api): validate feed filter options

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8867,6 +8867,13 @@ def trending():
 # --- Phase 7: bucketed feed (latest / heuristic / hybrid-v1) -------------
 
 _FEED_BUCKETS = ("latest", "heuristic", "hybrid-v1")
+_FEED_MODES = ("latest", "recommended")
+_FEED_CATEGORY_IDS = {c["id"] for c in VIDEO_CATEGORIES}
+
+
+def _feed_choice_error(name, allowed):
+    allowed_text = ", ".join(sorted(allowed))
+    return jsonify({"error": f"{name} must be one of: {allowed_text}"}), 400
 
 
 def _feed_bucket_for_visitor(visitor_id, override=""):
@@ -9441,6 +9448,17 @@ def feed():
     mode = request.args.get("mode", "latest")
     category = request.args.get("category")
     bucket_override = (request.args.get("bucket") or "").strip().lower()
+    mode = (mode or "latest").strip().lower()
+    if mode not in _FEED_MODES:
+        return _feed_choice_error("mode", _FEED_MODES)
+    if category is not None:
+        category = category.strip()
+        if not category:
+            category = None
+        elif category not in _FEED_CATEGORY_IDS:
+            return _feed_choice_error("category", _FEED_CATEGORY_IDS)
+    if bucket_override and bucket_override not in _FEED_BUCKETS:
+        return _feed_choice_error("bucket", _FEED_BUCKETS)
 
     # Get optional API key for personalized recommendations
     api_key = request.headers.get("X-API-Key") or request.args.get("api_key")

--- a/tests/test_feed_query_validation.py
+++ b/tests/test_feed_query_validation.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "mode=sideways",
+        "bucket=random",
+        "category=not-a-real-category",
+    ],
+)
+def test_feed_rejects_unknown_filter_options(client, query):
+    response = client.get(f"/api/feed?{query}")
+
+    assert response.status_code == 400
+    assert "must be one of" in response.get_json()["error"]
+
+
+def test_feed_accepts_known_filter_options(client):
+    response = client.get("/api/feed?mode=latest&bucket=latest&category=music")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["mode"] == "latest"
+    assert data["bucket"] == "latest"


### PR DESCRIPTION
## Summary
- reject unknown `/api/feed` `mode`, `bucket`, and `category` values with HTTP 400
- keep empty values/defaults compatible with existing latest-feed behavior
- add regression tests for invalid and valid feed filter options

## Why
`/api/feed` still accepted arbitrary filter text for string options. Unknown modes silently fell through to latest, unknown buckets silently fell back, and unknown categories returned an empty 200 response. That made malformed client URLs look valid instead of returning a clear validation error.

This is the remaining string-filter portion of #1456. It is intentionally narrower than closed PR #1494 so it applies cleanly on current `main`, where `page`/`per_page` validation is already present.

Refs #1456.
Supersedes #1494.

RTC wallet for bounty tracking: RTC9ae8c1b0e0d5457ed124f3d24ffef9ffe342cee6

## Checks
- `python -m pytest -q tests/test_feed_query_validation.py`
- `python -m py_compile bottube_server.py tests/test_feed_query_validation.py`
- `git diff --check`