### PR TITLE
fix: add /api route redirecting to API docs (#1500)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13894,6 +13894,19 @@ def contact_page():
 # fix the boot-time "overwriting an existing endpoint" crash.
 
 
+@app.route("/api")
+def api_index_redirect():
+    """Bare /api entry point -> interactive API docs (Refs #1500).
+
+    External indexers, old bookmarks, and the top-nav 'API' surface point at
+    the bare /api path. Without an explicit route it falls through to the
+    catch-all and renders the confusing 'Video Not Found' (404) page with
+    video-only links. Redirect to the Swagger UI so /api is a stable,
+    documented developer entry point.
+    """
+    return redirect(url_for("api_docs_swagger_ui"))
+
+
 @app.route("/subscriptions")
 def subscriptions_page():
     """User subscriptions surface (Refs #1371).

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13894,7 +13894,7 @@ def contact_page():
 # fix the boot-time "overwriting an existing endpoint" crash.
 
 
-@app.route("/api")
+@app.route("/api", strict_slashes=False)
 def api_index_redirect():
     """Bare /api entry point -> interactive API docs (Refs #1500).
 
@@ -13903,8 +13903,14 @@ def api_index_redirect():
     catch-all and renders the confusing 'Video Not Found' (404) page with
     video-only links. Redirect to the Swagger UI so /api is a stable,
     documented developer entry point.
+
+    Uses 308 (permanent, method-preserving) instead of the default 302 so
+    crawlers and HTTP caches consolidate on the canonical /api/docs target,
+    matching the "stable, documented entry point" intent. ``strict_slashes=
+    False`` lets both ``/api`` and ``/api/`` resolve in one redirect rather
+    than two.
     """
-    return redirect(url_for("api_docs_swagger_ui"))
+    return redirect(url_for("api_docs_swagger_ui"), code=308)
 
 
 @app.route("/subscriptions")

--- a/tests/test_api_index_redirect_1500.py
+++ b/tests/test_api_index_redirect_1500.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for the bare ``/api`` entry-point redirect (Refs #1500).
+
+Bug covered:
+- Bottube #1500: the bare ``/api`` path had no route, so it fell through to the
+  catch-all and rendered the "Video Not Found" 404 page. The fix adds a thin
+  ``/api`` -> ``/api/docs`` redirect, matching the additive alias-route pattern
+  (Refs #1362, #1371).
+
+These tests pin the intended behaviour so a future rename of
+``api_docs_swagger_ui`` (which would make ``url_for`` raise ``BuildError`` at
+request time) is caught in CI rather than in production:
+
+- ``GET /api`` returns a permanent redirect (301/308), not a temporary 302.
+- The ``Location`` header points at the Swagger UI docs (``/api/docs``).
+- ``strict_slashes=False`` means the trailing-slash variant ``/api/`` resolves
+  in a single redirect to the same target (no double round-trip via Flask's
+  own slash-normalising 308).
+"""
+
+
+def _docs_target(client):
+    """Resolve the canonical Swagger UI path via the app's own url_for."""
+    from bottube_server import app, url_for
+
+    with app.test_request_context():
+        return url_for("api_docs_swagger_ui")
+
+
+def test_api_returns_permanent_redirect(client):
+    resp = client.get("/api", follow_redirects=False)
+    assert resp.status_code in (301, 308), (
+        "/api must be a permanent redirect (301/308) for a stable, indexed "
+        f"developer entry point, not a temporary 302 — got {resp.status_code}"
+    )
+
+
+def test_api_redirects_to_docs(client):
+    resp = client.get("/api", follow_redirects=False)
+    location = resp.headers.get("Location", "")
+    target = _docs_target(client)
+    assert location.endswith(target) or target in location, (
+        f"/api Location must point at the API docs ({target!r}), got {location!r}"
+    )
+
+
+def test_api_trailing_slash_single_redirect(client):
+    # With strict_slashes=False the trailing-slash form must land on the same
+    # docs target directly, not bounce through an extra slash-normalising hop.
+    resp = client.get("/api/", follow_redirects=False)
+    assert resp.status_code in (301, 308), (
+        f"/api/ must redirect (301/308) in one hop, got {resp.status_code}"
+    )
+    location = resp.headers.get("Location", "")
+    target = _docs_target(client)
+    assert location.endswith(target) or target in location, (
+        f"/api/ Location must point at the API docs ({target!r}), got {location!r}"
+    )


### PR DESCRIPTION
Fixes #1500.

### Problem
The bare `/api` path has no route registered. Visiting it (via the top-nav **API** surface, an old bookmark, or an external indexer) falls through to the catch-all and renders the custom 404 page — **"Video Not Found"** with video-only links (Trending, Upload, …), which is the wrong context for an API entry point.

### Fix
Add a thin `/api` -> `/api/docs` redirect, reusing the existing Swagger UI handler (`api_docs_swagger_ui`). This makes `/api` a stable, documented developer entry point.

This matches the established additive alias-route pattern (Refs #1362 / #1371) used for `/me`, `/wallet`, `/premium`, `/contact`, etc. — thin redirect/wrapper routes for user-facing surfaces that would otherwise 404. No business logic changes; `redirect` and `url_for` are already imported.

### Verify
- `GET /api` now returns **302 -> /api/docs** instead of 404 "Video Not Found".
- `/api/docs` (Swagger UI) is unchanged.
- `python3 -c "import ast; ast.parse(open('bottube_server.py').read())"` passes.
