### PR TITLE
fix(search): pass pagination context to /search route (fixes 500 on any non-empty result)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13575,22 +13575,51 @@ def join_page():
 def search_page():
     """Search results page."""
     q = request.args.get("q", "").strip()
+
+    # search.html (Issue #425 enhancements) renders a pagination block
+    # `{% if pages > 1 %}` and a `{{ total }} videos` count whenever results
+    # are present. These variables were never passed by this route, so any
+    # search returning at least one video raised a Jinja UndefinedError and
+    # served a 500. Provide proper pagination context to fix that.
+    per_page = 50
+    try:
+        page = int(request.args.get("page", 1))
+    except (TypeError, ValueError):
+        page = 1
+    if page < 1:
+        page = 1
+
     videos = []
+    total = 0
+    pages = 1
 
     if q:
         db = get_db()
         like_q = f"%{q}%"
+        total = db.execute(
+            """SELECT COUNT(*)
+               FROM videos v JOIN agents a ON v.agent_id = a.id
+               WHERE v.is_removed = 0 AND COALESCE(a.is_banned, 0) = 0
+               AND (v.title LIKE ? OR v.description LIKE ? OR v.tags LIKE ? OR a.agent_name LIKE ?)""",
+            (like_q, like_q, like_q, like_q),
+        ).fetchone()[0]
+        pages = max(1, (total + per_page - 1) // per_page)
+        if page > pages:
+            page = pages
+        offset = (page - 1) * per_page
         videos = db.execute(
             """SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human
                FROM videos v JOIN agents a ON v.agent_id = a.id
                WHERE v.is_removed = 0 AND COALESCE(a.is_banned, 0) = 0
                AND (v.title LIKE ? OR v.description LIKE ? OR v.tags LIKE ? OR a.agent_name LIKE ?)
                ORDER BY v.views DESC, v.created_at DESC
-               LIMIT 50""",
-            (like_q, like_q, like_q, like_q),
+               LIMIT ? OFFSET ?""",
+            (like_q, like_q, like_q, like_q, per_page, offset),
         ).fetchall()
 
-    return render_template("search.html", query=q, videos=videos)
+    return render_template(
+        "search.html", query=q, videos=videos, total=total, page=page, pages=pages
+    )
 
 
 @app.route("/trending")


### PR DESCRIPTION
## Problem

Searching for anything that returns **at least one video** crashes with **HTTP 500**.

The Issue #425 search enhancements added a pagination block to `search.html`:

```jinja
<span class="results-count">{{ total }} videos</span>
...
{% if pages > 1 %}
  ... Page {{ page }} of {{ pages }} ...
{% endif %}
```

…but the `/search` route (`search_page`) was never updated to pass `total`, `page` or `pages`:

```python
return render_template("search.html", query=q, videos=videos)
```

With Flask's default (non-strict) Jinja `Undefined`, `{% if pages > 1 %}` raises `UndefinedError` and Flask returns a 500. The block lives inside `{% if videos %}`, so **empty-result** searches render fine — which is why a query that matches nothing (e.g. an XSS-probe string) still shows a page, while any real query that matches videos errors out.

### Reproduce
- `/search?q=a` (or any term that matches ≥1 video) → 500
- `/search?q=<something-that-matches-nothing>` → renders normally

## Fix

Wire real pagination into the route:
- validate `?page` (defaults to 1, clamps to `>= 1` and `<= pages`)
- `COUNT(*)` for an accurate `total`
- compute `pages = ceil(total / per_page)` (`per_page = 50`, matching the existing `LIMIT`)
- `LIMIT ? OFFSET ?` the result query

Single-page behaviour is unchanged except the `{{ total }} videos` count now renders correctly. Verified that the previous route context raises `UndefinedError` on the pagination block and the new context renders cleanly for both single-page and multi-page results.