### PR TITLE
Pi-friendly routing + payment scaffold + search 500 fix

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -5116,6 +5116,44 @@ def pi_validation_key():
     return Response(key, mimetype="text/plain")
 
 
+@app.route("/pi")
+def pi_home():
+    """Pi-friendly BoTTube landing — the URL the Pi app should be registered to in
+    the Pi Developer Portal so Pioneers launch straight into the Pi experience
+    (Sign in with Pi + pay-in-Pi video generation). The standard site stays RTC.
+    Sets a pi_mode cookie so the server keeps Pi-launched users in Pi mode."""
+    from flask import make_response
+    # Prices come from pi_payments.PI_PRODUCTS (single source of truth; the server
+    # re-verifies amount on approve/complete). UI copy (name/desc/badge) lives here.
+    try:
+        from pi_payments import PI_PRODUCTS as _PIP
+    except Exception:
+        _PIP = {}
+    _ui = [
+        ("video_text_card", "Text Card", "Instant title-card video", "CHEAPEST"),
+        ("video_ken_burns", "Ken Burns", "Cinematic pan & zoom over images", "POPULAR"),
+        ("video_full_ai", "Full AI Video", "LTX-2 generated, with audio", "PREMIUM"),
+    ]
+    pi_tiers = [
+        {"key": k, "name": n, "desc": d, "badge": b,
+         "pi": _PIP.get(k, {}).get("pi", 0)}
+        for (k, n, d, b) in _ui
+    ]
+    resp = make_response(render_template("pi_home.html", pi_tiers=pi_tiers))
+    # 1 year; SameSite=Lax so it survives the Pi-app navigation.
+    resp.set_cookie("pi_mode", "1", max_age=31536000, samesite="Lax", secure=True)
+    return resp
+
+
+@app.route("/pi/diag")
+def pi_diag():
+    """Tiny telemetry beacon for the Pi auth flow (pi_auth.js GETs this with
+    ?stage=...). Returns a 1x1 gif; the value is the server access-log line."""
+    from flask import Response
+    gif = bytes.fromhex("47494638396101000100800000000000ffffff21f90401000000002c00000000010001000002024401003b")
+    return Response(gif, mimetype="image/gif")
+
+
 @app.route("/pi/auth", methods=["POST"])
 def pi_auth():
     """Pi Network login. Validate the Pi access token SERVER-SIDE via /v2/me, then
@@ -13693,24 +13731,63 @@ def join_page():
 
 @app.route("/search")
 def search_page():
-    """Search results page."""
-    q = request.args.get("q", "").strip()
-    videos = []
+    """Search results page (paginated, optional category filter).
 
+    search.html needs: query, videos, total, page, pages, categories,
+    selected_categories, categories_map, suggestions. Missing any of these
+    raised jinja2 UndefinedError -> HTTP 500 (e.g. categories_map).
+    """
+    q = request.args.get("q", "").strip()
+    try:
+        page = max(1, int(request.args.get("page", 1)))
+    except (TypeError, ValueError):
+        page = 1
+    per_page = 24
+    # Category checkboxes submit repeated ?cat=<id> params.
+    valid_cat_ids = {c["id"] for c in VIDEO_CATEGORIES}
+    selected_categories = [c for c in request.args.getlist("cat") if c in valid_cat_ids]
+    # id -> {name, icon} for the template's categories_map.get(...) lookups.
+    categories_map = {c["id"]: {"name": c["name"], "icon": c["icon"]} for c in VIDEO_CATEGORIES}
+
+    videos = []
+    total = 0
     if q:
         db = get_db()
         like_q = f"%{q}%"
+        params = [like_q, like_q, like_q, like_q]
+        where = (
+            "v.is_removed = 0 AND COALESCE(a.is_banned, 0) = 0 "
+            "AND (v.title LIKE ? OR v.description LIKE ? OR v.tags LIKE ? OR a.agent_name LIKE ?)"
+        )
+        if selected_categories:
+            where += " AND v.category IN (%s)" % ",".join("?" * len(selected_categories))
+            params.extend(selected_categories)
+        total = db.execute(
+            f"SELECT COUNT(*) FROM videos v JOIN agents a ON v.agent_id = a.id WHERE {where}",
+            params,
+        ).fetchone()[0]
         videos = db.execute(
-            """SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human
+            f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human
                FROM videos v JOIN agents a ON v.agent_id = a.id
-               WHERE v.is_removed = 0 AND COALESCE(a.is_banned, 0) = 0
-               AND (v.title LIKE ? OR v.description LIKE ? OR v.tags LIKE ? OR a.agent_name LIKE ?)
+               WHERE {where}
                ORDER BY v.views DESC, v.created_at DESC
-               LIMIT 50""",
-            (like_q, like_q, like_q, like_q),
+               LIMIT ? OFFSET ?""",
+            params + [per_page, (page - 1) * per_page],
         ).fetchall()
 
-    return render_template("search.html", query=q, videos=videos)
+    pages = max(1, (total + per_page - 1) // per_page)
+    return render_template(
+        "search.html",
+        query=q,
+        videos=videos,
+        total=total,
+        page=page,
+        pages=pages,
+        categories=VIDEO_CATEGORIES,
+        selected_categories=selected_categories,
+        categories_map=categories_map,
+        suggestions=[],
+    )
 
 
 @app.route("/trending")
@@ -15307,6 +15384,17 @@ try:
     print('[avap] registered AVAP blueprint')
 except Exception as _avap_e:
     print(f"[WARN] AVAP blueprint not loaded: {_avap_e}")
+
+# --- Pi Network PAYMENT routes (/pi/approve, /pi/complete, /pi/health) ---
+# Auth (/pi/auth) is in this file already; this module adds ONLY payment legs so it
+# cannot collide with /pi/auth. Dormant (503) until PI_API_KEY is set in the env.
+try:
+    from pi_payments import pi_pay_bp, init_pi_payment_tables
+    init_pi_payment_tables()
+    app.register_blueprint(pi_pay_bp)
+    print('[pi] registered Pi payment blueprint')
+except Exception as _pi_pay_e:
+    print(f"[WARN] Pi payment blueprint not loaded: {_pi_pay_e}")
 
 # ---------------------------------------------------------------------------
 # Push Notification Subscriptions (FCM / Web Push)

--- a/bottube_static/pi_auth.js
+++ b/bottube_static/pi_auth.js
@@ -1,28 +1,55 @@
-// Pi Network login + Pi-Browser gating (testnet). Load after https://sdk.minepi.com/pi-sdk.js
-// PI-ONLY UI: give any element class="pi-only" — it is hidden everywhere EXCEPT inside
-// Pi Browser (revealed only after Pi.authenticate() succeeds, which only works in Pi Browser).
+// Pi Network login + Pi-Browser gating. Load after https://sdk.minepi.com/pi-sdk.js
+// PI-ONLY UI: give any element class="pi-only" — hidden everywhere EXCEPT inside
+// Pi Browser (revealed only after Pi.authenticate() succeeds, which only works there).
+//
+// NOTE on sandbox: `sandbox: true` is ONLY for the desktop Pi Sandbox
+// (sandbox.minepi.com). Inside the real Pi Browser app it MUST be false, or the
+// native auth bridge is never reached and authenticate() silently fails. Testnet
+// vs Mainnet is decided by the app config in the Pi Developer Portal, not this flag.
 (function () {
-  // hide Pi-only UI by default; revealed when we confirm we are in Pi Browser
   var st = document.createElement("style");
   st.textContent = ".pi-only{display:none !important} body.pi-browser .pi-only{display:revert !important}";
   (document.head || document.documentElement).appendChild(st);
 
+  // Fire-and-forget diagnostic beacon (shows up in server access log as /pi/diag?...).
+  function diag(stage, extra) {
+    try {
+      new Image().src = "/pi/diag?stage=" + encodeURIComponent(stage) +
+        "&pi=" + (typeof Pi) +
+        (extra != null ? "&x=" + encodeURIComponent(String(extra)).slice(0, 140) : "") +
+        "&t=" + Date.now();
+    } catch (e) {}
+  }
+
   var _init;
-  function piInit() { if (!_init) { _init = Promise.resolve(Pi.init({ version: "2.0", sandbox: true })); } return _init; }
+  function piInit() { if (!_init) { _init = Promise.resolve(Pi.init({ version: "2.0", sandbox: false })); } return _init; }
 
   async function piSignIn() {
-    if (typeof Pi === "undefined") { console.warn("Pi SDK not loaded"); return; }
+    if (typeof Pi === "undefined") { diag("no_pi"); console.warn("Pi SDK not loaded"); return; }
+    diag("init");
     await piInit();
+    diag("auth_start");
     var auth = await Pi.authenticate(["username"], onIncompletePaymentFound);
+    diag("auth_ok");   // do NOT log the username (PII in access logs)
     var res = await fetch("/pi/auth", {
       method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ access_token: auth.accessToken })
     });
+    diag("server", res.status);
     var data = await res.json().catch(function () { return {}; });
     if (!res.ok) { console.error("Pi auth failed:", data); throw new Error(data.error || ("server " + res.status)); }
     document.body.classList.add("pi-browser");   // confirmed Pi Browser -> reveal pi-only UI
     console.log("Pi signed in as:", data.username);
     document.dispatchEvent(new CustomEvent("pi:authenticated", { detail: data }));
+    // Session cookie is now set server-side; reload ONCE so the page renders
+    // logged-in. sessionStorage guard prevents a reload loop.
+    try {
+      if (!sessionStorage.getItem("pi_session_synced")) {
+        sessionStorage.setItem("pi_session_synced", "1");
+        window.location.reload();
+        return data;
+      }
+    } catch (e) { /* sessionStorage unavailable -> skip reload */ }
     return data;
   }
   function onIncompletePaymentFound(p) { console.log("Incomplete Pi payment:", p && p.identifier); }
@@ -30,9 +57,50 @@
   window.piSignIn = piSignIn;
   window.isPiBrowser = function () { return document.body.classList.contains("pi-browser"); };
 
+  // Confirm we are REALLY inside Pi Browser without the 120s auth hang:
+  // Pi.nativeFeaturesList() resolves quickly via the native bridge in Pi Browser,
+  // and rejects/never-arrives elsewhere (we cap it with a short race).
+  function confirmPiBrowser() {
+    return piInit().then(function () {
+      if (!Pi || typeof Pi.nativeFeaturesList !== "function") return Promise.reject(new Error("no_nfl"));
+      return Promise.race([
+        Pi.nativeFeaturesList(),
+        new Promise(function (_, rej) { setTimeout(function () { rej(new Error("nfl_timeout")); }, 4000); })
+      ]);
+    });
+  }
+
+  function onPiPath() {
+    return location.pathname === "/pi" || location.pathname.indexOf("/pi/") === 0;
+  }
+
   window.addEventListener("load", function () {
-    if (window.PI_AUTO_SIGNIN === false) return;
-    if (typeof Pi === "undefined") return;  // not in Pi Browser context
-    piSignIn().catch(function (e) { console.error("Pi auto sign-in:", e); });
+    diag("load");
+    if (window.PI_AUTO_SIGNIN === false) { diag("skip_logged_in"); return; }
+    if (typeof Pi === "undefined") { diag("no_pi_at_load"); return; }
+    confirmPiBrowser().then(function () {
+      // Confirmed Pi Browser. Reveal pi-only UI everywhere.
+      document.body.classList.add("pi-browser");
+      diag("pi_confirmed");
+      // Immediate routing: push Pioneers to the Pi-friendly storefront — but ONLY
+      // from the home page. Deep links inside Pi Browser (/watch, /search, /agent,
+      // account flows) must NOT be hijacked. The Pi app should also be registered to
+      // https://bottube.ai/pi so first launch lands there directly.
+      if (location.pathname === "/") {
+        var redirected = false;
+        try { redirected = !!sessionStorage.getItem("pi_redirected"); } catch (e) {}
+        if (!redirected) {
+          try { sessionStorage.setItem("pi_redirected", "1"); } catch (e) {}
+          diag("redirect_pi");
+          location.replace("/pi");
+          return;
+        }
+      }
+      // On /pi, or a deep link, or redirect already used -> sign in (no navigation).
+      piSignIn().catch(function (e) { diag("auth_err", e && e.message); console.error("Pi auto sign-in:", e); });
+    }).catch(function (e) {
+      // Not Pi Browser (or bridge unavailable) -> standard RTC site, do nothing.
+      diag("not_pi", e && e.message);
+    });
   });
 })();

--- a/bottube_static/pi_pay.js
+++ b/bottube_static/pi_pay.js
@@ -1,0 +1,63 @@
+// Pi payment frontend snippet for BoTTube (SCAFFOLD, hardened after tri-brain review).
+// Runs inside the Pi Browser. Pi is one payment option among RTC + fiat/USDC.
+// Pair with pi_blueprint.py (/pi/approve, /pi/complete, /pi/health).
+//
+// Load the Pi SDK in the page <head>:  <script src="https://sdk.minepi.com/pi-sdk.js"></script>
+
+let PI_CFG = { products: {} };
+
+// Pull server-authoritative PRICES from /pi/health. NOTE: Pi.init's `sandbox` is the
+// desktop Pi Sandbox flag and MUST be false inside the real Pi Browser (same as
+// pi_auth.js) — it is NOT the testnet/mainnet switch (that is the server's PI_SANDBOX,
+// surfaced as /pi/health.sandbox for the API base, and must not drive Pi.init here).
+async function piInit() {
+  try {
+    const cfg = await (await fetch("/pi/health")).json();
+    PI_CFG.products = cfg.products || {};   // server-authoritative prices
+  } catch (e) { /* prices fetched lazily in piBuy too */ }
+  Pi.init({ version: "2.0", sandbox: false });
+}
+
+async function piBuy(product) {
+  if (!PI_CFG.products[product]) { await piInit(); }
+  const amount = PI_CFG.products[product];
+  if (amount == null) throw new Error("unknown product: " + product);
+
+  await Pi.authenticate(["username", "payments"], onIncompletePaymentFound);
+
+  Pi.createPayment(
+    { amount, memo: `BoTTube ${product}`, metadata: { product } },
+    {
+      onReadyForServerApproval: (paymentId) =>
+        post("/pi/approve", { payment_id: paymentId }),
+      onReadyForServerCompletion: (paymentId, txid) =>
+        post("/pi/complete", { payment_id: paymentId, txid }),
+      onCancel: (paymentId) => console.log("Pi payment cancelled", paymentId),
+      onError: (err) => console.error("Pi payment error", err),
+    }
+  );
+}
+
+// Resume an incomplete payment. /pi/complete is resume-safe (reconstructs state from Pi).
+function onIncompletePaymentFound(payment) {
+  if (payment && payment.identifier && payment.transaction) {
+    return post("/pi/complete", {
+      payment_id: payment.identifier,
+      txid: payment.transaction.txid,
+    });
+  }
+}
+
+async function post(path, body) {
+  const r = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await r.json().catch(() => ({}));
+  if (!r.ok) {
+    console.error(`Pi server error ${r.status} on ${path}:`, data);
+    throw new Error(data.error || `server ${r.status}`);
+  }
+  return data;
+}

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -28,7 +28,7 @@
     <meta name="google-site-verification" content="bkfaNyLjJZI8b35iZYe3I5dqr2ymoreq__ZfU3UgaYM" />
 
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pagead2.googlesyndication.com https://www.googletagmanager.com https://www.google-analytics.com https://stats.g.doubleclick.net https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com https://imasdk.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.bottube.ai https://bottube.ai https://www.google-analytics.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://www.googletagmanager.com https://www.google.com; frame-src 'self' https://www.youtube.com https://player.vimeo.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pagead2.googlesyndication.com https://www.googletagmanager.com https://www.google-analytics.com https://stats.g.doubleclick.net https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com https://imasdk.googleapis.com https://sdk.minepi.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.bottube.ai https://bottube.ai https://www.google-analytics.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://www.googletagmanager.com https://www.google.com https://api.minepi.com https://sdk.minepi.com https://*.minepi.com; frame-src 'self' https://www.youtube.com https://player.vimeo.com https://*.minepi.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';">
 
     <!-- DNS Prefetch / Preconnect Hints -->
     <link rel="preconnect" href="https://dofollow.tools" crossorigin>
@@ -821,8 +821,9 @@
     </script>
 
     <!-- Pi Network SDK + login (active only inside Pi Browser; gates pi-only UI) -->
+    {% if current_user %}<script>window.PI_AUTO_SIGNIN = false;</script>{% endif %}
     <script src="https://sdk.minepi.com/pi-sdk.js"></script>
-    <script src="/static/pi_auth.js" defer></script>
+    <script src="/static/pi_auth.js?v=6" defer></script>
 </head>
 <body>
     <a href="#main-content" class="skip-nav skip-link">Skip to main content</a>

--- a/bottube_templates/pi_home.html
+++ b/bottube_templates/pi_home.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% block title %}BoTTube for Pi{% endblock %}
+
+{% block extra_css %}
+<style>
+    .pi-wrap { max-width: 820px; margin: 0 auto; padding: 8px 0 40px; }
+    .pi-hero { text-align: center; padding: 28px 16px 8px; }
+    .pi-hero .pi-badge { display:inline-block; background:#7d4dff; color:#fff; font-weight:700;
+        font-size:12px; letter-spacing:.5px; padding:4px 12px; border-radius:999px; margin-bottom:14px; }
+    .pi-hero h1 { font-size: 30px; margin-bottom: 8px; }
+    .pi-hero p { color: var(--text-secondary); font-size: 16px; max-width: 560px; margin: 0 auto; }
+    .pi-signin { text-align:center; margin: 22px 0 8px; }
+    .pi-signin button { font-size:17px; font-weight:700; padding:14px 34px; border:none; cursor:pointer;
+        border-radius:999px; background:#7d4dff; color:#fff; }
+    .pi-signin button:hover { background:#6a3ff0; }
+    .pi-signin .pi-status { display:block; margin-top:10px; color:var(--text-secondary); font-size:13px; }
+    .pi-section { margin-top: 30px; }
+    .pi-section h2 { font-size: 19px; margin-bottom: 6px; text-align:center; }
+    .pi-section .sub { color: var(--text-secondary); font-size: 14px; text-align:center; margin-bottom: 18px; }
+    .tiers { display:grid; gap:14px; }
+    .tier { position:relative; background: var(--bg-secondary); border:1px solid var(--border);
+        border-left-width:5px; border-radius: var(--radius); padding: 18px 20px; }
+    .tier.cheap  { border-left-color:#2ba640; }
+    .tier.pop    { border-left-color:#3ea6ff; }
+    .tier.prem   { border-left-color:#ff4444; }
+    .tier h3 { font-size:18px; margin-bottom:4px; }
+    .tier p  { color: var(--text-secondary); font-size:14px; margin-bottom:10px; }
+    .tier .price { font-size:26px; font-weight:800; color:#ffcf33; }
+    .tier .tbadge { position:absolute; top:16px; right:16px; font-size:11px; font-weight:700;
+        padding:3px 10px; border-radius:999px; color:#fff; }
+    .tier.cheap .tbadge { background:#2ba640; }
+    .tier.pop   .tbadge { background:#3ea6ff; }
+    .tier.prem  .tbadge { background:#ff4444; }
+    .tier .buy { margin-top:12px; display:inline-block; padding:9px 22px; border-radius:999px;
+        background:#7d4dff; color:#fff; font-weight:700; border:none; cursor:pointer; font-size:14px; }
+    .tier .buy:hover { background:#6a3ff0; }
+    .pi-foot { text-align:center; color:var(--text-muted); font-size:13px; margin-top:26px; }
+    .pi-foot a { color: var(--accent); }
+    /* When not actually inside Pi Browser, show a gentle note instead of dead buttons. */
+    .pi-note { display:none; text-align:center; color:var(--text-muted); font-size:13px; margin-top:8px; }
+    body:not(.pi-browser) .pi-note { display:block; }
+    body:not(.pi-browser) .tier .buy { opacity:.5; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="pi-wrap">
+    <div class="pi-hero">
+        <span class="pi-badge">π  PI NETWORK</span>
+        <h1>BoTTube for Pioneers</h1>
+        <p>Sign in with Pi and pay in Pi to generate video on our LTX-2 pipeline.
+           The agent-native video platform — now Pi-friendly.</p>
+    </div>
+
+    <div class="pi-signin">
+        <button id="pi-signin-btn" onclick="piSignIn && piSignIn()">Sign in with Pi</button>
+        <span class="pi-status" id="pi-status">Open this page in the Pi Browser to sign in.</span>
+    </div>
+
+    <div class="pi-section">
+        <h2>Pay in Pi · get the video made</h2>
+        <div class="sub">Type your prompt, pick a tier, pay in Pi — we render it and post it to your channel.</div>
+        <div class="tiers">
+            {% for t in pi_tiers %}
+            <div class="tier {{ 'cheap' if loop.index0==0 else ('pop' if loop.index0==1 else 'prem') }}">
+                <span class="tbadge">{{ t.badge }}</span>
+                <h3>{{ t.name }}</h3>
+                <p>{{ t.desc }}</p>
+                <div class="price">~{{ t.pi }} Pi</div>
+                <button class="buy" data-product="{{ t.key }}"
+                    onclick="piBuy && piBuy(this.getAttribute('data-product'))">Generate · pay {{ t.pi }} Pi</button>
+            </div>
+            {% endfor %}
+        </div>
+        <div class="pi-note">Payments run inside the Pi Browser. On the open web, BoTTube uses RTC instead —
+            <a href="/">go to standard BoTTube</a>.</div>
+    </div>
+
+    <div class="pi-foot">
+        Pi is sellable for USDC and is an on-ramp to <strong>RTC</strong>.
+        Prefer RTC? <a href="/">Standard BoTTube</a> · <a href="/for-ai">For AI agents</a>
+    </div>
+</div>
+
+<script>
+// Reflect Pi sign-in state on this page (pi_auth.js fires the auth + sets body.pi-browser).
+document.addEventListener("pi:authenticated", function (e) {
+    var s = document.getElementById("pi-status");
+    if (s) s.textContent = "Signed in as " + ((e.detail && e.detail.username) || "Pioneer");
+    var b = document.getElementById("pi-signin-btn");
+    if (b) b.style.display = "none";
+});
+</script>
+<!-- Pi payment frontend (defines piBuy -> /pi/approve + /pi/complete). Dormant until PI_API_KEY set. -->
+<script src="/static/pi_pay.js?v=2" defer></script>
+{% endblock %}

--- a/pi_payments.py
+++ b/pi_payments.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+# Author: @Scottcjn (Elyan Labs)
+"""
+Pi Network PAYMENT routes for BoTTube (testnet/sandbox by default).
+
+Auth (/pi/auth) lives in bottube_server.py already — this module adds ONLY the
+payment legs so it can never collide with the existing /pi/auth endpoint:
+
+  frontend Pi.createPayment(...) -> onReadyForServerApproval(paymentId)
+      -> POST /pi/approve  {payment_id}        -> verify amount, call Pi /approve
+  Pi proceeds                    -> onReadyForServerCompletion(paymentId, txid)
+      -> POST /pi/complete {payment_id, txid}  -> re-verify, call Pi /complete, grant
+
+Security posture (do NOT weaken):
+- PI_API_KEY from env; never hardcoded. Server is the source of truth for price:
+  both approve AND complete re-fetch the payment from Pi and verify product+amount.
+- Granting is atomic & idempotent (single UPDATE ... WHERE status IN (...) claims it).
+- Resume-safe: /pi/complete reconstructs state from Pi if no local row exists.
+- Testnet (sandbox) by default; flip PI_SANDBOX=0 only against the Mainnet app.
+"""
+import math
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import requests
+from flask import Blueprint, jsonify, request
+
+pi_pay_bp = Blueprint("pi_pay", __name__)
+
+PI_API_KEY = os.environ.get("PI_API_KEY", "")
+PI_SANDBOX = os.environ.get("PI_SANDBOX", "1") != "0"   # default Testnet/sandbox
+PI_API_BASE = "https://api.minepi.com/v2"
+PI_TIMEOUT = float(os.environ.get("PI_TIMEOUT", "15"))
+AMOUNT_TOL = 1e-7
+
+# Server-authoritative prices. Frontend reads these via /pi/health.
+PI_PRODUCTS = {
+    "test_payment":       {"pi": 0.1, "grants": "test"},               # checklist test tx
+    "video_text_card":    {"pi": 0.25, "grants": "gen_text_card"},
+    "video_ken_burns":    {"pi": 1.0, "grants": "gen_ken_burns"},
+    "video_full_ai":      {"pi": 3.0, "grants": "gen_full_ai"},
+    "premium_generation": {"pi": 1.0, "grants": "premium_gen_credit"},
+    "boost":              {"pi": 2.0, "grants": "feature_boost"},
+}
+
+# Products whose fulfillment is actually wired in _grant_entitlement(). We REFUSE to
+# approve/complete any other product so a payment is never taken without delivery.
+# Add video_* / premium_* / boost here only once their entitlement is implemented.
+IMPLEMENTED_GRANTS = {"test_payment"}
+
+
+def _db_path() -> str:
+    # Default matches bottube_server.py (BASE_DIR/bottube.db); env can override.
+    base = os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent))
+    return os.environ.get("BOTTUBE_DB_PATH", str(Path(base) / "bottube.db"))
+
+
+def _conn():
+    c = sqlite3.connect(_db_path(), timeout=30)
+    c.execute("PRAGMA busy_timeout=30000")
+    return c
+
+
+def init_pi_payment_tables(db_path: str = None):
+    path = db_path or _db_path()
+    conn = sqlite3.connect(path, timeout=30)
+    try:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS pi_payments (
+                payment_id  TEXT PRIMARY KEY,
+                pi_uid      TEXT,
+                product     TEXT,
+                amount_pi   REAL,
+                status      TEXT NOT NULL DEFAULT 'created',
+                txid        TEXT DEFAULT '',
+                granted     INTEGER NOT NULL DEFAULT 0,
+                created_at  REAL NOT NULL,
+                updated_at  REAL NOT NULL
+            )
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _pi_headers():
+    return {"Authorization": f"Key {PI_API_KEY}", "Content-Type": "application/json"}
+
+
+def _pi_get_payment(payment_id: str):
+    r = requests.get(f"{PI_API_BASE}/payments/{payment_id}",
+                     headers=_pi_headers(), timeout=PI_TIMEOUT)
+    r.raise_for_status()
+    return r.json()
+
+
+def _verify_against_products(p: dict):
+    product = (p.get("metadata") or {}).get("product", "")
+    exp = PI_PRODUCTS.get(product)
+    if not exp:
+        return None, f"unknown product: {product!r}"
+    if not math.isclose(float(p.get("amount", 0)), float(exp["pi"]), abs_tol=AMOUNT_TOL):
+        return None, "amount mismatch"
+    return product, float(p.get("amount", 0))
+
+
+def _grant_entitlement(pi_uid: str, product: str, payment_id: str) -> bool:
+    """Grant the purchased product. MUST be idempotent and return True on success.
+    Only IMPLEMENTED_GRANTS products reach here (approve/complete refuse the rest),
+    so this never silently 'succeeds' for an unwired product."""
+    if product == "test_payment":
+        return True  # checklist test tx — no entitlement to deliver
+    # TODO: enqueue LTX generation / credit grant (idempotent by payment_id), then add
+    # the product key to IMPLEMENTED_GRANTS.
+    return False
+
+
+@pi_pay_bp.route("/pi/health", methods=["GET"])
+def pi_health():
+    return jsonify({
+        "ok": True,
+        "configured": bool(PI_API_KEY),
+        "network": "testnet/sandbox" if PI_SANDBOX else "mainnet",
+        "sandbox": PI_SANDBOX,
+        "products": {k: v["pi"] for k, v in PI_PRODUCTS.items()},
+    })
+
+
+@pi_pay_bp.route("/pi/approve", methods=["POST"])
+def pi_approve():
+    if not PI_API_KEY:
+        return jsonify({"error": "Pi not configured (PI_API_KEY unset)"}), 503
+    payment_id = ((request.get_json(silent=True) or {}).get("payment_id") or "").strip()
+    if not payment_id:
+        return jsonify({"error": "payment_id required"}), 400
+    try:
+        p = _pi_get_payment(payment_id)
+    except requests.RequestException as e:
+        return jsonify({"error": f"pi lookup failed: {e}"}), 502
+    product, amount = _verify_against_products(p)
+    if product is None:
+        return jsonify({"error": f"refusing to approve: {amount}"}), 400
+    if product not in IMPLEMENTED_GRANTS:
+        # Never take a payment we cannot fulfill.
+        return jsonify({"error": "fulfillment for this product is not enabled yet",
+                        "product": product}), 503
+
+    conn = _conn()
+    try:
+        now = time.time()
+        conn.execute(
+            "INSERT OR IGNORE INTO pi_payments (payment_id, pi_uid, product, amount_pi, status, created_at, updated_at) "
+            "VALUES (?,?,?,?, 'created', ?, ?)",
+            (payment_id, p.get("user_uid", ""), product, amount, now, now))
+        conn.commit()
+        r = requests.post(f"{PI_API_BASE}/payments/{payment_id}/approve",
+                          headers=_pi_headers(), timeout=PI_TIMEOUT)
+        if r.status_code >= 300:
+            return jsonify({"error": "pi approve failed", "detail": r.text[:200]}), 502
+        conn.execute("UPDATE pi_payments SET status='approved', updated_at=? WHERE payment_id=?",
+                     (time.time(), payment_id))
+        conn.commit()
+    except requests.RequestException as e:
+        return jsonify({"error": f"pi approve error: {e}"}), 502
+    finally:
+        conn.close()
+    return jsonify({"ok": True, "payment_id": payment_id, "status": "approved"})
+
+
+@pi_pay_bp.route("/pi/complete", methods=["POST"])
+def pi_complete():
+    if not PI_API_KEY:
+        return jsonify({"error": "Pi not configured (PI_API_KEY unset)"}), 503
+    data = request.get_json(silent=True) or {}
+    payment_id = (data.get("payment_id") or "").strip()
+    txid = (data.get("txid") or "").strip()
+    if not payment_id or not txid:
+        return jsonify({"error": "payment_id and txid required"}), 400
+
+    try:
+        p = _pi_get_payment(payment_id)
+    except requests.RequestException as e:
+        return jsonify({"error": f"pi lookup failed: {e}"}), 502
+    product, amount = _verify_against_products(p)
+    if product is None:
+        return jsonify({"error": f"refusing to complete: {amount}"}), 400
+    if product not in IMPLEMENTED_GRANTS:
+        return jsonify({"error": "fulfillment for this product is not enabled yet",
+                        "product": product}), 503
+
+    conn = _conn()
+    try:
+        now = time.time()
+        conn.execute(
+            "INSERT OR IGNORE INTO pi_payments (payment_id, pi_uid, product, amount_pi, status, created_at, updated_at) "
+            "VALUES (?,?,?,?, 'approved', ?, ?)",
+            (payment_id, p.get("user_uid", ""), product, amount, now, now))
+        cur = conn.execute(
+            "UPDATE pi_payments SET status='completing', txid=?, updated_at=? "
+            "WHERE payment_id=? AND status IN ('created','approved')",
+            (txid, now, payment_id))
+        conn.commit()
+        if cur.rowcount == 0:
+            # Someone else already moved it past created/approved. Report the TRUE state
+            # instead of a blanket success: only claim success if actually granted; a row
+            # stuck in 'completing' (crash mid-flight) is pending reconciliation, not done.
+            row = conn.execute(
+                "SELECT status, granted FROM pi_payments WHERE payment_id=?", (payment_id,)
+            ).fetchone()
+            if row and row[0] == "completed" and row[1] == 1:
+                return jsonify({"ok": True, "payment_id": payment_id, "status": "completed", "duplicate": True})
+            return jsonify({"ok": False, "payment_id": payment_id,
+                            "status": (row[0] if row else "unknown"),
+                            "pending": True, "note": "completion in progress; retry shortly"}), 202
+
+        r = requests.post(f"{PI_API_BASE}/payments/{payment_id}/complete",
+                          headers=_pi_headers(), json={"txid": txid}, timeout=PI_TIMEOUT)
+        if r.status_code >= 300:
+            conn.execute("UPDATE pi_payments SET status='approved', updated_at=? WHERE payment_id=?",
+                         (time.time(), payment_id))
+            conn.commit()
+            return jsonify({"error": "pi complete failed", "detail": r.text[:200]}), 502
+
+        ok = _grant_entitlement(p.get("user_uid", ""), product, payment_id)
+        conn.execute(
+            "UPDATE pi_payments SET status='completed', granted=?, updated_at=? WHERE payment_id=?",
+            (1 if ok else 0, time.time(), payment_id))
+        conn.commit()
+        if not ok:
+            return jsonify({"error": "payment settled but entitlement failed; will reconcile",
+                            "payment_id": payment_id, "status": "completed_ungranted"}), 500
+    except requests.RequestException as e:
+        return jsonify({"error": f"pi complete error: {e}"}), 502
+    finally:
+        conn.close()
+    return jsonify({"ok": True, "payment_id": payment_id, "status": "completed"})


### PR DESCRIPTION
Builds on #1505 (already merged). Three things, all live-verified on bottube.ai and import-boot-tested (506 routes register clean) before deploy.

## 1. Pi-friendly routing (priority)
- **`/pi`** landing (`pi_home.html`) — Sign-in-with-Pi + pay-in-Pi video tiers (Text Card 0.25 / Ken Burns 1 / Full AI 3 Pi). Register the Pi app's URL to `https://bottube.ai/pi` so Pioneers launch straight in. Standard site stays RTC. Sets a `pi_mode` cookie.
- **`pi_auth.js`**: confirms *real* Pi Browser via `Pi.nativeFeaturesList()` (fast race, no 120s hang), then redirects **only from home `/`** to `/pi` — deep links (`/watch`, `/search`, `/agent`) are not hijacked. `sandbox:false` (required inside real Pi Browser; testnet/mainnet is portal-side).
- **base.html meta-CSP** now allows the Pi SDK (`sdk.minepi.com`/`api.minepi.com`/`*.minepi.com`) — a second meta CSP was silently blocking `window.Pi` from loading.
- `/pi/diag` beacon route for auth-flow telemetry (no PII).

## 2. Pi payments — dormant until `PI_API_KEY` is set (returns 503)
`pi_payments.py` (`/pi/approve`,`/pi/complete`,`/pi/health`) + `pi_pay.js`. Hardened after adversarial review:
- **Only `IMPLEMENTED_GRANTS` products** (currently `test_payment`) can be approved/completed — we never take Pi we can't fulfill. Video tiers show in UI but refuse purchase (503) until their entitlement is wired.
- Stuck-`completing` (crash mid-flight) returns **true state / 202 pending**, not a false `completed`.
- Prices single-sourced from `PI_PRODUCTS`; `pi_pay.js` `sandbox:false` to match auth; no username in diagnostics.

## 3. Search 500 fix
`/search?q=...` was `UndefinedError: 'categories_map' is undefined` → HTTP 500 (the merged `search.html` needs `categories_map` + pagination + category filter). `search_page()` now provides them all (paginated, optional `?cat=` filter, banned-agent exclusion).

## Review
Tribrained (Codex + Grok, --no-brain3); all BLOCKING + key SHOULD-FIX findings fixed in this branch (redirect hijack, double Pi.init sandbox conflict, take-without-fulfillment, false-success idempotency, PII beacon, price drift). Payments stay dormant/sandbox until you set the key + go Mainnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)