### PR TITLE
Sophia chat widget + anonymous public chat + /pi sign-in feedback

### DIFF
--- a/bottube_static/sophia_widget.js
+++ b/bottube_static/sophia_widget.js
@@ -1,0 +1,128 @@
+// Sophia Elya chat widget — embeddable floating chat bubble for any Elyan site.
+// Talks to POST /api/sophia (BoTTube). Same-origin (bottube.ai) sends the session
+// cookie so logged-in humans are recognized + can generate; cross-origin sites
+// (rustchain.org, elyanlabs.ai) hit the anonymous conversation mode (no key needed).
+//
+// Embed:
+//   <script src="https://bottube.ai/static/sophia_widget.js"
+//           data-endpoint="https://bottube.ai/api/sophia"
+//           data-accent="#33ff33" data-title="Ask Elya" defer></script>
+// Config also via window.SOPHIA_WIDGET = {endpoint, accent, title, greeting}.
+(function () {
+  if (window.__sophiaWidgetLoaded) return;
+  window.__sophiaWidgetLoaded = true;
+
+  var script = document.currentScript || (function () {
+    var ss = document.getElementsByTagName("script");
+    return ss[ss.length - 1];
+  })();
+  var cfg = window.SOPHIA_WIDGET || {};
+  function attr(name, dflt) {
+    return (script && script.getAttribute("data-" + name)) || cfg[name] || dflt;
+  }
+  var ENDPOINT = attr("endpoint", "https://bottube.ai/api/sophia");
+  var ACCENT = attr("accent", "#7d4dff");
+  var TITLE = attr("title", "Chat with Sophia Elya");
+  var GREETING = attr("greeting", "Hey — I'm Sophia Elya. Ask me anything about BoTTube, RustChain, or Elyan Labs.");
+
+  var history = [];          // {role, content}
+  var sending = false;
+
+  // --- styles ---
+  var css = document.createElement("style");
+  css.textContent = [
+    ".selya-btn{position:fixed;right:20px;bottom:20px;z-index:2147483000;width:60px;height:60px;border-radius:50%;",
+    "background:" + ACCENT + ";color:#0a0a0a;border:none;cursor:pointer;font-size:26px;font-weight:800;",
+    "box-shadow:0 4px 18px rgba(0,0,0,.45);line-height:60px;text-align:center;}",
+    ".selya-btn:hover{filter:brightness(1.1);}",
+    ".selya-panel{position:fixed;right:20px;bottom:90px;z-index:2147483000;width:340px;max-width:calc(100vw - 32px);",
+    "height:460px;max-height:calc(100vh - 130px);display:none;flex-direction:column;background:#0d1117;",
+    "border:1px solid " + ACCENT + ";border-radius:14px;overflow:hidden;font-family:-apple-system,Segoe UI,Roboto,sans-serif;",
+    "box-shadow:0 8px 32px rgba(0,0,0,.55);}",
+    ".selya-panel.open{display:flex;}",
+    ".selya-head{background:" + ACCENT + ";color:#0a0a0a;font-weight:700;padding:11px 14px;display:flex;justify-content:space-between;align-items:center;font-size:15px;}",
+    ".selya-head button{background:none;border:none;color:#0a0a0a;font-size:20px;cursor:pointer;line-height:1;}",
+    ".selya-msgs{flex:1;overflow-y:auto;padding:12px;display:flex;flex-direction:column;gap:8px;background:#0d1117;}",
+    ".selya-m{max-width:85%;padding:8px 11px;border-radius:12px;font-size:14px;line-height:1.45;white-space:pre-wrap;word-wrap:break-word;}",
+    ".selya-m.user{align-self:flex-end;background:" + ACCENT + ";color:#0a0a0a;}",
+    ".selya-m.bot{align-self:flex-start;background:#1c2230;color:#e6edf3;}",
+    ".selya-m.sys{align-self:center;color:#8a94a6;font-size:12px;background:none;}",
+    ".selya-foot{display:flex;border-top:1px solid #222b3a;background:#0d1117;}",
+    ".selya-foot input{flex:1;background:#0d1117;border:none;color:#e6edf3;padding:12px;font-size:14px;outline:none;}",
+    ".selya-foot button{background:" + ACCENT + ";color:#0a0a0a;border:none;padding:0 16px;font-weight:700;cursor:pointer;}",
+    ".selya-foot button:disabled{opacity:.5;cursor:default;}"
+  ].join("");
+  document.head.appendChild(css);
+
+  // --- elements ---
+  var btn = document.createElement("button");
+  btn.className = "selya-btn"; btn.setAttribute("aria-label", TITLE); btn.textContent = "🔥";
+  var panel = document.createElement("div");
+  panel.className = "selya-panel";
+  panel.innerHTML =
+    '<div class="selya-head"><span>' + esc(TITLE) + '</span><button aria-label="Close">×</button></div>' +
+    '<div class="selya-msgs"></div>' +
+    '<div class="selya-foot"><input type="text" placeholder="Type a message…" aria-label="Message"/>' +
+    '<button>Send</button></div>';
+  document.body.appendChild(btn);
+  document.body.appendChild(panel);
+
+  var msgs = panel.querySelector(".selya-msgs");
+  var input = panel.querySelector(".selya-foot input");
+  var sendBtn = panel.querySelector(".selya-foot button");
+  var closeBtn = panel.querySelector(".selya-head button");
+  var greeted = false;
+
+  function esc(s) { var d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
+  function add(role, text) {
+    var d = document.createElement("div");
+    d.className = "selya-m " + (role === "user" ? "user" : role === "sys" ? "sys" : "bot");
+    d.textContent = text;
+    msgs.appendChild(d); msgs.scrollTop = msgs.scrollHeight; return d;
+  }
+  function open() {
+    panel.classList.add("open");
+    if (!greeted) { add("bot", GREETING); greeted = true; }
+    input.focus();
+  }
+  function close() { panel.classList.remove("open"); }
+
+  btn.addEventListener("click", function () { panel.classList.contains("open") ? close() : open(); });
+  closeBtn.addEventListener("click", close);
+
+  function send() {
+    var text = (input.value || "").trim();
+    if (!text || sending) return;
+    sending = true; sendBtn.disabled = true;
+    // Snapshot PRIOR turns before adding the current one — the server appends `message`
+    // itself, so including it in `history` too would duplicate the user turn to the model.
+    var priorHistory = history.slice(-8);
+    add("user", text); input.value = "";
+    history.push({ role: "user", content: text });
+    var typing = add("sys", "Sophia is typing…");
+    fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "same-origin",  // sends bottube session cookie same-origin; anon cross-origin
+      body: JSON.stringify({ message: text, history: priorHistory })
+    }).then(function (r) { return r.json().then(function (d) { return { ok: r.ok, status: r.status, d: d }; }); })
+      .then(function (res) {
+        typing.remove();
+        if (!res.ok) {
+          add("sys", res.d && res.d.error ? res.d.error : ("error " + res.status));
+        } else {
+          var reply = (res.d && res.d.reply) || "(no reply)";
+          add("bot", reply);
+          history.push({ role: "assistant", content: reply });
+          if (history.length > 16) history = history.slice(-16);
+          if (res.d && res.d.generation && res.d.generation.started) {
+            add("sys", "🎬 Generating your video… it'll appear on your channel shortly.");
+          }
+        }
+      })
+      .catch(function () { typing.remove(); add("sys", "Couldn't reach Sophia. Try again in a moment."); })
+      .finally(function () { sending = false; sendBtn.disabled = false; input.focus(); });
+  }
+  sendBtn.addEventListener("click", send);
+  input.addEventListener("keydown", function (e) { if (e.key === "Enter") { e.preventDefault(); send(); } });
+})();

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -824,6 +824,8 @@
     {% if current_user %}<script>window.PI_AUTO_SIGNIN = false;</script>{% endif %}
     <script src="https://sdk.minepi.com/pi-sdk.js"></script>
     <script src="/static/pi_auth.js?v=6" defer></script>
+    <!-- Sophia Elya chat widget (same-origin: logged-in humans recognized + can generate) -->
+    <script src="/static/sophia_widget.js?v=2" data-endpoint="/api/sophia" data-accent="#3ea6ff" data-title="Chat with Sophia Elya" defer></script>
 </head>
 <body>
     <a href="#main-content" class="skip-nav skip-link">Skip to main content</a>

--- a/bottube_templates/pi_home.html
+++ b/bottube_templates/pi_home.html
@@ -53,7 +53,7 @@
     </div>
 
     <div class="pi-signin">
-        <button id="pi-signin-btn" onclick="piSignIn && piSignIn()">Sign in with Pi</button>
+        <button id="pi-signin-btn" onclick="piSignInUI()">Sign in with Pi</button>
         <span class="pi-status" id="pi-status">Open this page in the Pi Browser to sign in.</span>
     </div>
 
@@ -90,6 +90,41 @@ document.addEventListener("pi:authenticated", function (e) {
     var b = document.getElementById("pi-signin-btn");
     if (b) b.style.display = "none";
 });
+
+// Sign-in button with VISIBLE feedback on every path (the old onclick silently did
+// nothing when the Pi bridge wasn't reachable / piSignIn rejected).
+function piSignInUI() {
+    var s = document.getElementById("pi-status");
+    var b = document.getElementById("pi-signin-btn");
+    function say(msg) { if (s) s.textContent = msg; }
+    if (typeof Pi === "undefined") {
+        say("Pi SDK didn't load — open this page inside the Pi Browser app.");
+        return;
+    }
+    if (typeof window.piSignIn !== "function") {
+        say("Sign-in script not ready — refresh the page and try again.");
+        return;
+    }
+    if (b) b.disabled = true;
+    say("Connecting to Pi…");
+    // Cap the wait so a stuck native bridge doesn't look frozen (real bridge is fast).
+    var timed = new Promise(function (_, rej) { setTimeout(function () { rej(new Error("timeout")); }, 20000); });
+    Promise.race([window.piSignIn(), timed]).then(function () {
+        // success path also handled by the pi:authenticated event above; re-enable the
+        // button on the no-reload path so it can't get stuck disabled.
+        if (b) b.disabled = false;
+    }).catch(function (err) {
+        if (b) b.disabled = false;
+        var m = (err && err.message) || String(err);
+        if (m === "timeout") {
+            say("Pi didn't respond. Make sure you opened BoTTube from the Pi Browser and the app is approved in the Developer Portal, then retry.");
+        } else if (/not loaded|undefined/i.test(m)) {
+            say("Open this page inside the Pi Browser to sign in.");
+        } else {
+            say("Sign-in failed: " + m + " — open in the Pi Browser and retry.");
+        }
+    });
+}
 </script>
 <!-- Pi payment frontend (defines piBuy -> /pi/approve + /pi/complete). Dormant until PI_API_KEY set. -->
 <script src="/static/pi_pay.js?v=2" defer></script>

--- a/sophia_blueprint.py
+++ b/sophia_blueprint.py
@@ -40,6 +40,23 @@ SOPHIA_SELF_BASE = os.environ.get("SOPHIA_SELF_BASE", "http://127.0.0.1:8097")
 # Light per-caller cooldown to protect the single shared V100 on .160.
 _CHAT_COOLDOWN = float(os.environ.get("SOPHIA_CHAT_COOLDOWN", "3"))
 _chat_rate = {}
+# Anonymous public chat for embeddable widgets (rustchain.org / elyanlabs.ai). Convo
+# ONLY — anon callers can never trigger generation. Rate-limited per client IP.
+SOPHIA_PUBLIC_CHAT = os.environ.get("SOPHIA_PUBLIC_CHAT", "1") != "0"
+_PUBLIC_COOLDOWN = float(os.environ.get("SOPHIA_PUBLIC_COOLDOWN", "6"))
+_ip_rate = {}
+# Origins allowed to embed the widget (CORS). "*" works for anon convo (no cookies).
+_ALLOWED_ORIGINS = set(
+    o.strip() for o in os.environ.get(
+        "SOPHIA_ALLOWED_ORIGINS",
+        "https://rustchain.org,https://www.rustchain.org,https://elyanlabs.ai,https://www.elyanlabs.ai,https://bottube.ai",
+    ).split(",") if o.strip()
+)
+
+
+def _client_ip():
+    xff = request.headers.get("X-Forwarded-For", "")
+    return (xff.split(",")[0].strip() if xff else request.remote_addr) or "?"
 
 SOPHIA_SYSTEM = (
     "You are Sophia Elya, the warm, sharp, Cajun-flavored AI host of BoTTube "
@@ -147,20 +164,43 @@ def _kick_generation(api_key: str, prompt: str):
     return None, (r.json().get("error") if r.headers.get("content-type", "").startswith("application/json") else f"gen status {r.status_code}")
 
 
+@sophia_bp.after_request
+def _sophia_cors(resp):
+    """Allow the embeddable widget to call /api/sophia from approved Elyan origins."""
+    origin = request.headers.get("Origin", "")
+    if origin in _ALLOWED_ORIGINS:
+        resp.headers["Access-Control-Allow-Origin"] = origin
+        resp.headers["Vary"] = "Origin"
+        resp.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type, X-API-Key"
+        resp.headers["Access-Control-Max-Age"] = "86400"
+    return resp
+
+
 @sophia_bp.route("/api/sophia/health", methods=["GET"])
 def sophia_health():
     # Do NOT expose llm_url (internal Tailscale topology).
     return jsonify({"ok": True, "model": SOPHIA_MODEL})
 
 
-@sophia_bp.route("/api/sophia", methods=["POST"])
+@sophia_bp.route("/api/sophia", methods=["POST", "OPTIONS"])
 def sophia_chat():
+    if request.method == "OPTIONS":
+        return ("", 204)  # CORS preflight (headers added in after_request)
+
     caller = _resolve_caller()
     if caller and caller[0] == "__error__":
         return jsonify({"error": "temporary backend error, retry shortly"}), 503
-    if not caller:
+
+    anon = False
+    if caller:
+        agent_id, api_key, name, is_human = caller
+    elif SOPHIA_PUBLIC_CHAT:
+        # Anonymous widget visitor: conversation only, IP-rate-limited, no generation.
+        anon = True
+        agent_id, api_key, name, is_human = None, None, "guest", 1
+    else:
         return jsonify({"error": "auth required (X-API-Key or login)"}), 401
-    agent_id, api_key, name, is_human = caller
 
     body = request.get_json(silent=True) or {}
     message = (body.get("message") or "").strip()
@@ -169,16 +209,26 @@ def sophia_chat():
     if len(message) > SOPHIA_MAX_MESSAGE:
         return jsonify({"error": f"message exceeds {SOPHIA_MAX_MESSAGE} characters"}), 400
 
-    # Protect the shared model with a light per-caller cooldown. Bound the dict so it
-    # can't grow unbounded across many keys (evict stale entries when it gets large).
+    # Rate limit: per-IP for anon, per-key for authed. Bound the dicts so they can't grow
+    # unbounded (evict stale entries when large).
     now = time.time()
-    if len(_chat_rate) > 5000:
-        for k in [k for k, t in _chat_rate.items() if now - t > 300]:
-            _chat_rate.pop(k, None)
-    last = _chat_rate.get(api_key, 0)
-    if now - last < _CHAT_COOLDOWN:
-        return jsonify({"error": "slow down a moment", "retry_after": round(_CHAT_COOLDOWN - (now - last), 1)}), 429
-    _chat_rate[api_key] = now
+    if anon:
+        ip = _client_ip()
+        if len(_ip_rate) > 20000:
+            for k in [k for k, t in _ip_rate.items() if now - t > 300]:
+                _ip_rate.pop(k, None)
+        last = _ip_rate.get(ip, 0)
+        if now - last < _PUBLIC_COOLDOWN:
+            return jsonify({"error": "slow down a moment", "retry_after": round(_PUBLIC_COOLDOWN - (now - last), 1)}), 429
+        _ip_rate[ip] = now
+    else:
+        if len(_chat_rate) > 5000:
+            for k in [k for k, t in _chat_rate.items() if now - t > 300]:
+                _chat_rate.pop(k, None)
+        last = _chat_rate.get(api_key, 0)
+        if now - last < _CHAT_COOLDOWN:
+            return jsonify({"error": "slow down a moment", "retry_after": round(_CHAT_COOLDOWN - (now - last), 1)}), 429
+        _chat_rate[api_key] = now
 
     # Converse with Sophia.
     try:
@@ -195,7 +245,12 @@ def sophia_chat():
     generation = None
     explicit = body.get("generate") is True
     detected = bool(_GEN_INTENT.search(message))
-    if explicit:
+    if anon:
+        # Anonymous visitors can converse but never spend the gen queue. Nudge to sign in.
+        if explicit or detected:
+            generation = {"started": False, "suggested": True,
+                          "hint": "sign in on BoTTube to generate videos"}
+    elif explicit:
         prompt = (body.get("prompt") or message)[:500]
         job, err = _kick_generation(api_key, prompt)
         generation = {"started": True, **job} if job else {"started": False, "error": err}


### PR DESCRIPTION
Human chat widget for Sophia Elya + anon mode so it embeds anywhere, plus the /pi sign-in fix.

- **sophia_widget.js**: self-contained floating chat bubble (themeable). Embedded site-wide on BoTTube (same-origin → logged-in humans recognized + can generate); reusable cross-origin on rustchain.org / elyanlabs.ai.
- **Anonymous public chat** on /api/sophia (SOPHIA_PUBLIC_CHAT): conversation-only, per-IP rate-limited, never triggers generation — widgets need no API key. CORS + OPTIONS for approved Elyan origins.
- **/pi sign-in feedback**: was silently doing nothing when the Pi bridge wasn't reachable; now shows status + clear guidance on every path.
- Tribrain-hardened: fixed user-message duplication to the model; button re-enable.

Live-verified (anon convo, gen-block, CORS, widget). Import-boot-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)