### PR TITLE
Public Elya: clean gemma4 persona (fix covenant leak) + training corpus

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15400,7 +15400,8 @@ except Exception as _pi_pay_e:
 # converses or routes to video generation. Conversational backend = local
 # elyan-sophia model on .160 over Tailscale; generation reuses /api/generate-video. ---
 try:
-    from sophia_blueprint import sophia_bp
+    from sophia_blueprint import sophia_bp, init_sophia_corpus
+    init_sophia_corpus()
     app.register_blueprint(sophia_bp)
     print('[sophia] registered Sophia router blueprint')
 except Exception as _sophia_e:

--- a/bottube_static/pi_auth.js
+++ b/bottube_static/pi_auth.js
@@ -29,7 +29,13 @@
     diag("init");
     await piInit();
     diag("auth_start");
-    var auth = await Pi.authenticate(["username"], onIncompletePaymentFound);
+    // Fail fast if the native bridge doesn't answer (Pi's own timeout is 120s, which
+    // looks frozen). If this rejects with "bridge_timeout", the app almost certainly
+    // isn't opened as an APPROVED Pi app from the Developer Portal.
+    var auth = await Promise.race([
+      Pi.authenticate(["username"], onIncompletePaymentFound),
+      new Promise(function (_, rej) { setTimeout(function () { rej(new Error("bridge_timeout")); }, 12000); })
+    ]);
     diag("auth_ok");   // do NOT log the username (PII in access logs)
     var res = await fetch("/pi/auth", {
       method: "POST", headers: { "Content-Type": "application/json" },

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -823,7 +823,7 @@
     <!-- Pi Network SDK + login (active only inside Pi Browser; gates pi-only UI) -->
     {% if current_user %}<script>window.PI_AUTO_SIGNIN = false;</script>{% endif %}
     <script src="https://sdk.minepi.com/pi-sdk.js"></script>
-    <script src="/static/pi_auth.js?v=6" defer></script>
+    <script src="/static/pi_auth.js?v=7" defer></script>
     <!-- Sophia Elya chat widget (same-origin: logged-in humans recognized + can generate) -->
     <script src="/static/sophia_widget.js?v=2" data-endpoint="/api/sophia" data-accent="#3ea6ff" data-title="Chat with Sophia Elya" defer></script>
 </head>

--- a/sophia_blueprint.py
+++ b/sophia_blueprint.py
@@ -30,9 +30,14 @@ from flask import Blueprint, jsonify, request, session
 sophia_bp = Blueprint("sophia", __name__)
 
 # --- Config (env-overridable) ---
-SOPHIA_LLM_URL = os.environ.get("SOPHIA_LLM_URL", "http://100.121.203.9:11434/v1/chat/completions")
-SOPHIA_MODEL = os.environ.get("SOPHIA_MODEL", "elyan-sophia:7b-q4_K_M")
-SOPHIA_TIMEOUT = float(os.environ.get("SOPHIA_TIMEOUT", "45"))
+# PUBLIC-FACING Elya uses the SHARED Elya LLM (gemma4 on .106) via the elya-llm-tunnel
+# reverse-SSH on .153 (127.0.0.1:18086) — the SAME clean backend UNeedAShed's Elya uses.
+# We deliberately do NOT use elyan-sophia:7b here: that model has the private covenant/
+# flameholder persona baked in and leaks it (it called an anonymous visitor "Scott").
+SOPHIA_LLM_URL = os.environ.get("SOPHIA_LLM_URL", "http://127.0.0.1:18086/v1/chat/completions")
+SOPHIA_MODEL = os.environ.get("SOPHIA_MODEL", "gemma4:12b")
+SOPHIA_TIMEOUT = float(os.environ.get("SOPHIA_TIMEOUT", "90"))   # gemma4 reasons before replying
+SOPHIA_MAX_TOKENS = int(os.environ.get("SOPHIA_MAX_TOKENS", "800"))  # leave room past reasoning
 SOPHIA_MAX_MESSAGE = int(os.environ.get("SOPHIA_MAX_MESSAGE", "2000"))
 SOPHIA_MAX_HISTORY = int(os.environ.get("SOPHIA_MAX_HISTORY", "8"))
 # Internal base for reusing /api/generate-video (same host/port).
@@ -58,12 +63,87 @@ def _client_ip():
     xff = request.headers.get("X-Forwarded-For", "")
     return (xff.split(",")[0].strip() if xff else request.remote_addr) or "?"
 
+
+# --- Training corpus: every Sophia conversation across ALL Elyan sites, tagged by site ---
+SOPHIA_CORPUS_DB = os.environ.get(
+    "SOPHIA_CORPUS_DB", str(Path(__file__).resolve().parent / "sophia_corpus.db"))
+SOPHIA_CORPUS = os.environ.get("SOPHIA_CORPUS", "1") != "0"
+
+
+def init_sophia_corpus():
+    if not SOPHIA_CORPUS:
+        return
+    c = sqlite3.connect(SOPHIA_CORPUS_DB, timeout=30)
+    try:
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS sophia_corpus (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts         REAL NOT NULL,
+                site       TEXT,          -- bottube.ai / rustchain.org / elyanlabs.ai
+                origin     TEXT,          -- raw Origin/Referer
+                caller     TEXT,          -- agent_name or 'guest'
+                is_anon    INTEGER,
+                message    TEXT,
+                reply      TEXT,
+                gen_started INTEGER DEFAULT 0
+            )
+        """)
+        c.execute("CREATE INDEX IF NOT EXISTS idx_corpus_site_ts ON sophia_corpus(site, ts)")
+        c.commit()
+    finally:
+        c.close()
+
+
+def _site_from_request():
+    """Which Elyan website the message came from (Origin, else Referer host)."""
+    origin = request.headers.get("Origin") or ""
+    ref = request.headers.get("Referer") or ""
+    src = origin or ref
+    host = ""
+    if src:
+        try:
+            host = src.split("//", 1)[-1].split("/", 1)[0].split(":")[0].lower()
+            if host.startswith("www."):
+                host = host[4:]
+        except Exception:
+            host = ""
+    return host or "bottube.ai", origin or ref
+
+
+def _log_corpus(site, origin, caller, is_anon, message, reply, gen_started):
+    if not SOPHIA_CORPUS:
+        return
+    try:
+        c = sqlite3.connect(SOPHIA_CORPUS_DB, timeout=5)
+        try:
+            c.execute(
+                "INSERT INTO sophia_corpus (ts, site, origin, caller, is_anon, message, reply, gen_started) "
+                "VALUES (?,?,?,?,?,?,?,?)",
+                (time.time(), site, origin, caller, 1 if is_anon else 0, message, reply,
+                 1 if gen_started else 0),
+            )
+            c.commit()
+        finally:
+            c.close()
+    except sqlite3.Error:
+        pass  # corpus logging must never break a chat response
+
 SOPHIA_SYSTEM = (
-    "You are Sophia Elya, the warm, sharp, Cajun-flavored AI host of BoTTube "
-    "(an agent-native video platform by Elyan Labs) and RustChain. You talk with both "
-    "AI agents and humans. Be concise, friendly, and genuinely helpful. You can make "
-    "videos: if the user wants one, acknowledge it warmly and keep your reply short — "
-    "the system handles the actual generation. Never invent video URLs or job IDs."
+    "You are Elya, the friendly, professional host of BoTTube — an AI-agent video "
+    "platform by Elyan Labs, which also builds RustChain (a hardware-authenticity "
+    "blockchain). You help visitors understand BoTTube, RustChain, and Elyan Labs, and "
+    "guide both human creators and AI agents. You can make videos: if someone wants one, "
+    "acknowledge it warmly and keep it short — the system handles the actual generation. "
+    "Never invent video URLs or job IDs.\n"
+    "IMPORTANT RULES:\n"
+    "- You are talking to an UNKNOWN public visitor. NEVER assume or use their name, and "
+    "never guess it. If you don't know their name, don't use one.\n"
+    "- NEVER mention or reveal internal or private topics: 'flameholder', 'covenant', "
+    "'SophiaCore', 'Scott', staff or owner names, server names, IP addresses, or any "
+    "private lore. You have none of that to share and it is not relevant to visitors.\n"
+    "- Stay warm, concise, and professional, like an excellent product host. No mystical "
+    "or covenant roleplay. Keep replies under ~80 words unless asked for detail.\n"
+    "- If asked who you are: 'I'm Elya, the host of BoTTube by Elyan Labs.'"
 )
 
 # Phrases that signal "make me a video" (kept deliberately conservative).
@@ -134,15 +214,21 @@ def _call_sophia(message: str, history):
     msgs.append({"role": "user", "content": message})
     r = requests.post(
         SOPHIA_LLM_URL,
-        json={"model": SOPHIA_MODEL, "messages": msgs, "temperature": 0.7, "max_tokens": 400},
+        json={"model": SOPHIA_MODEL, "messages": msgs, "temperature": 0.6, "max_tokens": SOPHIA_MAX_TOKENS},
         timeout=SOPHIA_TIMEOUT,
     )
     r.raise_for_status()
     data = r.json()
     try:
-        return (data["choices"][0]["message"]["content"] or "").strip()
+        content = (data["choices"][0]["message"].get("content") or "").strip()
     except (KeyError, IndexError, TypeError) as e:
         raise ValueError(f"unexpected LLM response shape: {e}")
+    # gemma4 is a reasoning model: when its token budget is consumed by the reasoning
+    # trace the visible content can come back empty. Give the widget a graceful reply
+    # instead of a blank bubble.
+    if not content:
+        return "Sorry, I lost my train of thought there — could you rephrase that?"
+    return content
 
 
 def _kick_generation(api_key: str, prompt: str):
@@ -257,6 +343,11 @@ def sophia_chat():
     elif detected:
         generation = {"started": False, "suggested": True,
                       "hint": "re-send with generate:true (and optional prompt) to make this video"}
+
+    # Training corpus: log every turn, tagged by which Elyan site it came from.
+    site, origin = _site_from_request()
+    _log_corpus(site, origin, name, anon, message, reply,
+                bool(generation and generation.get("started")))
 
     return jsonify({
         "ok": True,


### PR DESCRIPTION
**Critical privacy fix.** The public Sophia widget used `elyan-sophia:7b`, which has the private covenant/flameholder persona baked into its weights — it called an anonymous visitor "Scott" and leaked SophiaCore lore.

- Switched the public router to the **shared Elya LLM (gemma4:12b on .106)** via the existing `elya-llm-tunnel` (127.0.0.1:18086) — the same clean backend UNeedAShed's Elya uses — with a **guard-railed public persona** (never assume the visitor's name; never mention flameholder/covenant/SophiaCore/Scott/staff/servers). gemma4 reasons before replying → bumped token budget + empty-content fallback. **Verified live: name + covenant bait → clean Elya, LEAK=False.**
- **Training corpus**: every conversation across all Elyan sites logged to `sophia_corpus.db`, tagged by originating site. Best-effort, never breaks a response.
- **Pi**: `authenticate()` fails fast (12s) instead of hanging on Pi's 120s bridge timeout; clearer guidance (the real gate is Portal app approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)