### PR TITLE
Pi: redirect to /pi only on apex host

### DIFF
--- a/bottube_static/pi_auth.js
+++ b/bottube_static/pi_auth.js
@@ -92,7 +92,10 @@
       // from the home page. Deep links inside Pi Browser (/watch, /search, /agent,
       // account flows) must NOT be hijacked. The Pi app should also be registered to
       // https://bottube.ai/pi so first launch lands there directly.
-      if (location.pathname === "/") {
+      // Only redirect to /pi on the real apex host. If the app was opened via a Pi
+      // subdomain (e.g. *.pinet.com), a relative redirect to /pi may not be proxied —
+      // so stay put and just sign in in place.
+      if (location.pathname === "/" && /(^|\.)bottube\.ai$/i.test(location.hostname)) {
         var redirected = false;
         try { redirected = !!sessionStorage.getItem("pi_redirected"); } catch (e) {}
         if (!redirected) {

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -823,7 +823,7 @@
     <!-- Pi Network SDK + login (active only inside Pi Browser; gates pi-only UI) -->
     {% if current_user %}<script>window.PI_AUTO_SIGNIN = false;</script>{% endif %}
     <script src="https://sdk.minepi.com/pi-sdk.js"></script>
-    <script src="/static/pi_auth.js?v=7" defer></script>
+    <script src="/static/pi_auth.js?v=8" defer></script>
     <!-- Sophia Elya chat widget (same-origin: logged-in humans recognized + can generate) -->
     <script src="/static/sophia_widget.js?v=2" data-endpoint="/api/sophia" data-accent="#3ea6ff" data-title="Chat with Sophia Elya" defer></script>
 </head>


### PR DESCRIPTION
When opened via a Pi subdomain (*.pinet.com), a relative /pi redirect may 404. Restrict it to bottube.ai; sign in in place elsewhere.