### PR TITLE
Pi payments: dev test-payment button + sandbox flag + feedback

### DIFF
--- a/bottube_static/pi_auth.js
+++ b/bottube_static/pi_auth.js
@@ -22,7 +22,10 @@
   }
 
   var _init;
-  function piInit() { if (!_init) { _init = Promise.resolve(Pi.init({ version: "2.0", sandbox: false })); } return _init; }
+  // sandbox:true ONLY for the desktop Pi Sandbox (sandbox.minepi.com) — enable with
+  // ?pi_sandbox=1. Real Pi Browser must use sandbox:false (the default).
+  var _SANDBOX = /[?&]pi_sandbox=1/.test(location.search) || window.PI_SANDBOX === true;
+  function piInit() { if (!_init) { _init = Promise.resolve(Pi.init({ version: "2.0", sandbox: _SANDBOX })); } return _init; }
 
   async function piSignIn() {
     if (typeof Pi === "undefined") { diag("no_pi"); console.warn("Pi SDK not loaded"); return; }
@@ -101,7 +104,7 @@
         if (!redirected) {
           try { sessionStorage.setItem("pi_redirected", "1"); } catch (e) {}
           diag("redirect_pi");
-          location.replace("/pi");
+          location.replace("/pi" + (_SANDBOX ? "?pi_sandbox=1" : ""));
           return;
         }
       }

--- a/bottube_static/pi_pay.js
+++ b/bottube_static/pi_pay.js
@@ -1,50 +1,69 @@
-// Pi payment frontend snippet for BoTTube (SCAFFOLD, hardened after tri-brain review).
-// Runs inside the Pi Browser. Pi is one payment option among RTC + fiat/USDC.
-// Pair with pi_blueprint.py (/pi/approve, /pi/complete, /pi/health).
+// Pi payment frontend for BoTTube. Pairs with the server pi_payments blueprint
+// (/pi/approve, /pi/complete, /pi/health). Load the Pi SDK in <head> first.
 //
-// Load the Pi SDK in the page <head>:  <script src="https://sdk.minepi.com/pi-sdk.js"></script>
-
+// sandbox:true ONLY for the desktop Pi Sandbox (?pi_sandbox=1); the real Pi Browser
+// must use false (same rule as pi_auth.js). This is the SDK env flag, NOT testnet/mainnet
+// (that is the server's PI_SANDBOX).
 let PI_CFG = { products: {} };
+const _PAY_SANDBOX = /[?&]pi_sandbox=1/.test(location.search) || window.PI_SANDBOX === true;
 
-// Pull server-authoritative PRICES from /pi/health. NOTE: Pi.init's `sandbox` is the
-// desktop Pi Sandbox flag and MUST be false inside the real Pi Browser (same as
-// pi_auth.js) — it is NOT the testnet/mainnet switch (that is the server's PI_SANDBOX,
-// surfaced as /pi/health.sandbox for the API base, and must not drive Pi.init here).
+function _payStatus(msg) {
+  const el = document.getElementById("pi-setup-status");
+  if (el) el.textContent = msg;
+  console.log("[pi-pay]", msg);
+}
+
 async function piInit() {
   try {
     const cfg = await (await fetch("/pi/health")).json();
     PI_CFG.products = cfg.products || {};   // server-authoritative prices
   } catch (e) { /* prices fetched lazily in piBuy too */ }
-  Pi.init({ version: "2.0", sandbox: false });
+  Pi.init({ version: "2.0", sandbox: _PAY_SANDBOX });
 }
 
 async function piBuy(product) {
-  if (!PI_CFG.products[product]) { await piInit(); }
-  const amount = PI_CFG.products[product];
-  if (amount == null) throw new Error("unknown product: " + product);
+  try {
+    if (typeof Pi === "undefined") { _payStatus("Pi SDK not loaded — open in the Pi Browser."); return; }
+    if (!PI_CFG.products[product]) { await piInit(); }
+    const amount = PI_CFG.products[product];
+    if (amount == null) { _payStatus("Unknown product: " + product); return; }
 
-  await Pi.authenticate(["username", "payments"], onIncompletePaymentFound);
+    _payStatus("Authorizing with Pi…");
+    await Pi.authenticate(["username", "payments"], onIncompletePaymentFound);
 
-  Pi.createPayment(
-    { amount, memo: `BoTTube ${product}`, metadata: { product } },
-    {
-      onReadyForServerApproval: (paymentId) =>
-        post("/pi/approve", { payment_id: paymentId }),
-      onReadyForServerCompletion: (paymentId, txid) =>
-        post("/pi/complete", { payment_id: paymentId, txid }),
-      onCancel: (paymentId) => console.log("Pi payment cancelled", paymentId),
-      onError: (err) => console.error("Pi payment error", err),
-    }
-  );
+    _payStatus("Opening Pi payment for " + amount + " Pi…");
+    Pi.createPayment(
+      { amount, memo: `BoTTube ${product}`, metadata: { product } },
+      {
+        onReadyForServerApproval: (paymentId) => {
+          _payStatus("Approving payment…");
+          return post("/pi/approve", { payment_id: paymentId })
+            .catch((e) => _payStatus("Approve failed: " + e.message));
+        },
+        onReadyForServerCompletion: (paymentId, txid) => {
+          _payStatus("Finalizing payment…");
+          return post("/pi/complete", { payment_id: paymentId, txid })
+            .then(() => _payStatus("✅ Payment complete — checklist step done!"))
+            .catch((e) => _payStatus("Complete failed: " + e.message));
+        },
+        onCancel: () => _payStatus("Payment cancelled."),
+        onError: (err) => _payStatus("Pi payment error: " + (err && err.message ? err.message : err)),
+      }
+    );
+  } catch (e) {
+    _payStatus("Couldn't start payment: " + (e && e.message ? e.message : e) + " (open in Pi Browser / sandbox)");
+  }
 }
 
 // Resume an incomplete payment. /pi/complete is resume-safe (reconstructs state from Pi).
 function onIncompletePaymentFound(payment) {
   if (payment && payment.identifier && payment.transaction) {
+    _payStatus("Resuming a pending payment…");
     return post("/pi/complete", {
       payment_id: payment.identifier,
       txid: payment.transaction.txid,
-    });
+    }).then(() => _payStatus("✅ Pending payment finalized."))
+      .catch((e) => _payStatus("Resume failed: " + e.message));
   }
 }
 
@@ -52,6 +71,7 @@ async function post(path, body) {
   const r = await fetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "same-origin",
     body: JSON.stringify(body),
   });
   const data = await r.json().catch(() => ({}));

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -823,7 +823,7 @@
     <!-- Pi Network SDK + login (active only inside Pi Browser; gates pi-only UI) -->
     {% if current_user %}<script>window.PI_AUTO_SIGNIN = false;</script>{% endif %}
     <script src="https://sdk.minepi.com/pi-sdk.js"></script>
-    <script src="/static/pi_auth.js?v=8" defer></script>
+    <script src="/static/pi_auth.js?v=9" defer></script>
     <!-- Sophia Elya chat widget (same-origin: logged-in humans recognized + can generate) -->
     <script src="/static/sophia_widget.js?v=2" data-endpoint="/api/sophia" data-accent="#3ea6ff" data-title="Chat with Sophia Elya" defer></script>
 </head>

--- a/bottube_templates/pi_home.html
+++ b/bottube_templates/pi_home.html
@@ -57,6 +57,24 @@
         <span class="pi-status" id="pi-status">Open this page in the Pi Browser to sign in.</span>
     </div>
 
+    <!-- Developer setup: complete the Pi Developer Portal checklist's "process a
+         user-to-app payment" step. Visible only with ?setup=1 so it isn't shown to
+         normal visitors. Pushes a small test payment through /pi/approve + /pi/complete. -->
+    <div id="pi-setup" style="display:none; text-align:center; margin:14px 0; padding:14px;
+         border:1px dashed #7d4dff; border-radius:10px;">
+        <div style="font-size:13px;color:var(--text-secondary);margin-bottom:8px;">
+            Developer setup — complete the Pi checklist's test payment:</div>
+        <button onclick="piBuy && piBuy('test_payment')"
+            style="padding:11px 26px;border:none;border-radius:999px;background:#7d4dff;color:#fff;font-weight:700;cursor:pointer;">
+            Make test payment (0.1 Pi)</button>
+        <span class="pi-status" id="pi-setup-status" style="display:block;margin-top:8px;color:var(--text-secondary);font-size:12px;"></span>
+    </div>
+    <script>
+      if (/[?&]setup=1/.test(location.search)) {
+        var el = document.getElementById("pi-setup"); if (el) el.style.display = "block";
+      }
+    </script>
+
     <div class="pi-section">
         <h2>Pay in Pi · get the video made</h2>
         <div class="sub">Type your prompt, pick a tier, pay in Pi — we render it and post it to your channel.</div>
@@ -127,5 +145,5 @@ function piSignInUI() {
 }
 </script>
 <!-- Pi payment frontend (defines piBuy -> /pi/approve + /pi/complete). Dormant until PI_API_KEY set. -->
-<script src="/static/pi_pay.js?v=2" defer></script>
+<script src="/static/pi_pay.js?v=3" defer></script>
 {% endblock %}


### PR DESCRIPTION
Adds a /pi?setup=1 test-payment button to complete the Pi checklist's user-to-app payment step, honors ?pi_sandbox=1 for desktop sandbox testing, and shows visible payment status. Backend key read from a root-only env file on the host (not the repo).