### PR TITLE
Pi pay: always init before createPayment

### DIFF
--- a/bottube_static/pi_pay.js
+++ b/bottube_static/pi_pay.js
@@ -13,18 +13,26 @@ function _payStatus(msg) {
   console.log("[pi-pay]", msg);
 }
 
-async function piInit() {
-  try {
-    const cfg = await (await fetch("/pi/health")).json();
-    PI_CFG.products = cfg.products || {};   // server-authoritative prices
-  } catch (e) { /* prices fetched lazily in piBuy too */ }
-  Pi.init({ version: "2.0", sandbox: _PAY_SANDBOX });
+// Singleton init — ALWAYS run before createPayment (the old code skipped Pi.init when
+// prices were already cached, causing "Pi Network SDK was not initialized").
+let _payInit = null;
+function piInit() {
+  if (!_payInit) {
+    _payInit = (async () => {
+      try {
+        const cfg = await (await fetch("/pi/health")).json();
+        PI_CFG.products = cfg.products || {};   // server-authoritative prices
+      } catch (e) { /* prices fetched lazily below too */ }
+      Pi.init({ version: "2.0", sandbox: _PAY_SANDBOX });
+    })();
+  }
+  return _payInit;
 }
 
 async function piBuy(product) {
   try {
     if (typeof Pi === "undefined") { _payStatus("Pi SDK not loaded — open in the Pi Browser."); return; }
-    if (!PI_CFG.products[product]) { await piInit(); }
+    await piInit();  // guarantee Pi.init ran (fetches prices too)
     const amount = PI_CFG.products[product];
     if (amount == null) { _payStatus("Unknown product: " + product); return; }
 

--- a/bottube_templates/pi_home.html
+++ b/bottube_templates/pi_home.html
@@ -60,7 +60,7 @@
     <!-- Developer setup: complete the Pi Developer Portal checklist's "process a
          user-to-app payment" step. Visible only with ?setup=1 so it isn't shown to
          normal visitors. Pushes a small test payment through /pi/approve + /pi/complete. -->
-    <div id="pi-setup" style="display:none; text-align:center; margin:14px 0; padding:14px;
+    <div id="pi-setup" style="display:block; text-align:center; margin:14px 0; padding:14px;
          border:1px dashed #7d4dff; border-radius:10px;">
         <div style="font-size:13px;color:var(--text-secondary);margin-bottom:8px;">
             Developer setup — complete the Pi checklist's test payment:</div>
@@ -145,5 +145,5 @@ function piSignInUI() {
 }
 </script>
 <!-- Pi payment frontend (defines piBuy -> /pi/approve + /pi/complete). Dormant until PI_API_KEY set. -->
-<script src="/static/pi_pay.js?v=3" defer></script>
+<script src="/static/pi_pay.js?v=4" defer></script>
 {% endblock %}


### PR DESCRIPTION
Fix 'SDK not initialized' (Pi.init was skipped when prices were cached). Always-init singleton; test button visible by default.