### PR TITLE
Pi: redirect home->/pi on pinet app host

### DIFF
--- a/bottube_static/pi_auth.js
+++ b/bottube_static/pi_auth.js
@@ -98,7 +98,12 @@
       // Only redirect to /pi on the real apex host. If the app was opened via a Pi
       // subdomain (e.g. *.pinet.com), a relative redirect to /pi may not be proxied —
       // so stay put and just sign in in place.
-      if (location.pathname === "/" && /(^|\.)bottube\.ai$/i.test(location.hostname)) {
+      // Redirect home -> /pi on bottube.ai AND on the Pi app host (*.pinet.com /
+      // *.minepi.com), which proxies our full paths (confirmed: /api/feed loads there).
+      if (location.pathname === "/" && (
+            /(^|\.)bottube\.ai$/i.test(location.hostname) ||
+            /\.pinet\.com$/i.test(location.hostname) ||
+            /\.minepi\.com$/i.test(location.hostname))) {
         var redirected = false;
         try { redirected = !!sessionStorage.getItem("pi_redirected"); } catch (e) {}
         if (!redirected) {

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -823,7 +823,7 @@
     <!-- Pi Network SDK + login (active only inside Pi Browser; gates pi-only UI) -->
     {% if current_user %}<script>window.PI_AUTO_SIGNIN = false;</script>{% endif %}
     <script src="https://sdk.minepi.com/pi-sdk.js"></script>
-    <script src="/static/pi_auth.js?v=9" defer></script>
+    <script src="/static/pi_auth.js?v=10" defer></script>
     <!-- Sophia Elya chat widget (same-origin: logged-in humans recognized + can generate) -->
     <script src="/static/sophia_widget.js?v=2" data-endpoint="/api/sophia" data-accent="#3ea6ff" data-title="Chat with Sophia Elya" defer></script>
 </head>


### PR DESCRIPTION
App opens at *.pinet.com (proxies our paths); redirect was bottube.ai-only so users landed on home, not /pi. Allow pinet/minepi hosts.