### PR TITLE
fix: /api redirect, search XSS escape, /bridge 500 (fixes #1500, #1501, #1359)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13049,6 +13049,16 @@ def api_redirect():
     return redirect(url_for("docs_page"))
 
 
+@app.route("/bridge")
+def bridge_page():
+    """wRTC bridge landing page with safe defaults for unauthenticated users."""
+    return render_template("bridge.html",
+        user_balance=0.0,
+        swap_url="https://jup.ag/",
+        reserve_wallet="Not connected — log in to view",
+        user_sol_address="")
+
+
 @app.route("/docs")
 def docs_page():
     """API documentation page."""

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13043,6 +13043,12 @@ def developers_page():
     return render_template("developers.html")
 
 
+@app.route("/api")
+def api_redirect():
+    """Redirect /api to the API documentation page."""
+    return redirect(url_for("docs_page"))
+
+
 @app.route("/docs")
 def docs_page():
     """API documentation page."""

--- a/bottube_templates/search.html
+++ b/bottube_templates/search.html
@@ -243,7 +243,7 @@
     <main>
         <div class="search-results-header">
             <h1 class="section-title" id="search-results-heading" style="margin:0;">
-                Results for "{{ query }}"
+                Results for "{{ query | e }}"
             </h1>
             <span class="results-count">{{ total }} videos</span>
         </div>


### PR DESCRIPTION
## Summary

Three bug fixes in one PR:

### Fix 1: /api returns Video Not Found (#1500)
Added `/api` route that redirects to docs page. Previously hit 404 handler.

### Fix 2: Search term truncation with HTML chars (#1501)
Added `| e` escape filter to search query in heading. Prevents HTML parsing issues.

### Fix 3: /bridge returns HTTP 500 (#1359)
Added `/bridge` route with safe defaults for `user_balance`, `swap_url`, `reserve_wallet`, `user_sol_address`. Previously the template crashed because these variables weren't passed.

## Changes
- `bottube_server.py`: Added 2 routes (`/api` redirect, `/bridge` with defaults)
- `bottube_templates/search.html`: Added escape filter to query display

Closes #1500, closes #1501, closes #1359