### PR TITLE
Pi: onpi.bottube.ai dedicated app domain (rebrand from 4pi)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -12307,7 +12307,7 @@ def index():
     itself — no redirect (the Pi Developer Portal App URL points straight at the
     subdomain). Same backend, different front door."""
     _host = request.host.split(":")[0].lower()
-    if _host.startswith("4pi.") or _host == "4pi.bottube.ai":
+    if _host.startswith("onpi.") or _host.startswith("4pi."):
         return pi_home()
 
     db = get_db()


### PR DESCRIPTION
onpi.bottube.ai serves the Pi storefront at root (matches 'BoTTube on Pi'). DNS + nginx + TLS live; 4pi kept as alias.