### PR TITLE
Pi: remove bottube.ai/pi -> canonicalize to onpi.bottube.ai

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -5123,7 +5123,13 @@ def pi_home():
     the Pi Developer Portal so Pioneers launch straight into the Pi experience
     (Sign in with Pi + pay-in-Pi video generation). The standard site stays RTC.
     Sets a pi_mode cookie so the server keeps Pi-launched users in Pi mode."""
-    from flask import make_response
+    from flask import make_response, redirect
+    # onpi.bottube.ai is the canonical Pi domain. If the Pi storefront is reached on any
+    # other host (e.g. legacy bottube.ai/pi), send it there. index() calls this for the
+    # onpi/4pi hosts (which pass), so those serve normally with no redirect loop.
+    _h = request.host.split(":")[0].lower()
+    if not (_h.startswith("onpi.") or _h.startswith("4pi.")):
+        return redirect("https://onpi.bottube.ai/", code=301)
     # Prices come from pi_payments.PI_PRODUCTS (single source of truth; the server
     # re-verifies amount on approve/complete). UI copy (name/desc/badge) lives here.
     try:

--- a/bottube_static/pi_auth.js
+++ b/bottube_static/pi_auth.js
@@ -88,32 +88,11 @@
     if (window.PI_AUTO_SIGNIN === false) { diag("skip_logged_in"); return; }
     if (typeof Pi === "undefined") { diag("no_pi_at_load"); return; }
     confirmPiBrowser().then(function () {
-      // Confirmed Pi Browser. Reveal pi-only UI everywhere.
+      // Confirmed Pi Browser. Reveal pi-only UI; sign in in place. No redirect:
+      // onpi.bottube.ai is the dedicated Pi domain and serves the storefront at root,
+      // so there is nothing to redirect to (the old home->/pi bounce is removed).
       document.body.classList.add("pi-browser");
       diag("pi_confirmed");
-      // Immediate routing: push Pioneers to the Pi-friendly storefront — but ONLY
-      // from the home page. Deep links inside Pi Browser (/watch, /search, /agent,
-      // account flows) must NOT be hijacked. The Pi app should also be registered to
-      // https://bottube.ai/pi so first launch lands there directly.
-      // Only redirect to /pi on the real apex host. If the app was opened via a Pi
-      // subdomain (e.g. *.pinet.com), a relative redirect to /pi may not be proxied —
-      // so stay put and just sign in in place.
-      // Redirect home -> /pi on bottube.ai AND on the Pi app host (*.pinet.com /
-      // *.minepi.com), which proxies our full paths (confirmed: /api/feed loads there).
-      if (location.pathname === "/" && (
-            /(^|\.)bottube\.ai$/i.test(location.hostname) ||
-            /\.pinet\.com$/i.test(location.hostname) ||
-            /\.minepi\.com$/i.test(location.hostname))) {
-        var redirected = false;
-        try { redirected = !!sessionStorage.getItem("pi_redirected"); } catch (e) {}
-        if (!redirected) {
-          try { sessionStorage.setItem("pi_redirected", "1"); } catch (e) {}
-          diag("redirect_pi");
-          location.replace("/pi" + (_SANDBOX ? "?pi_sandbox=1" : ""));
-          return;
-        }
-      }
-      // On /pi, or a deep link, or redirect already used -> sign in (no navigation).
       piSignIn().catch(function (e) { diag("auth_err", e && e.message); console.error("Pi auto sign-in:", e); });
     }).catch(function (e) {
       // Not Pi Browser (or bridge unavailable) -> standard RTC site, do nothing.

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -826,7 +826,7 @@
     <script>window.PI_SANDBOX = true;</script>
     {% if current_user %}<script>window.PI_AUTO_SIGNIN = false;</script>{% endif %}
     <script src="https://sdk.minepi.com/pi-sdk.js"></script>
-    <script src="/static/pi_auth.js?v=11" defer></script>
+    <script src="/static/pi_auth.js?v=12" defer></script>
     <!-- Sophia Elya chat widget (same-origin: logged-in humans recognized + can generate) -->
     <script src="/static/sophia_widget.js?v=2" data-endpoint="/api/sophia" data-accent="#3ea6ff" data-title="Chat with Sophia Elya" defer></script>
 </head>


### PR DESCRIPTION
onpi.bottube.ai is the dedicated Pi domain. /pi page redirects there; home->/pi auto-redirect removed. /pi/* API routes unchanged.