### PR TITLE
Fix #1500: Redirect /api to /docs

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13058,6 +13058,12 @@ def developers_page():
     return render_template("developers.html")
 
 
+@app.route("/api")
+@app.route("/api/")
+def api_redirect():
+    """Redirect legacy /api routes to /docs."""
+    return redirect("/docs", code=301)
+
 @app.route("/docs")
 def docs_page():
     """API documentation page."""


### PR DESCRIPTION
Resolves the 404 Video Not Found error when visiting the /api link by redirecting to /docs. Include RTC address: RTCec4066ce7c28d7e0f7df50368efc469f4c04fab8 for bounty.