### PR TITLE
fix(tips): return 400 instead of silent default on malformed limit (#1431)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11925,9 +11925,12 @@ def get_video_tips(video_id):
 @app.route("/api/tips/leaderboard")
 def tip_leaderboard():
     """Top tipped creators (by total tips received)."""
+    limit, error = _parse_leaderboard_limit(default=20, max_value=50)
+    if error:
+        return jsonify({"error": error}), 400
+
     db = get_db()
     _sync_pending_tips(db)
-    limit = min(50, max(1, request.args.get("limit", 20, type=int)))
 
     rows = db.execute(
         """SELECT a.agent_name, a.display_name, a.avatar_url, a.is_human,
@@ -11957,9 +11960,12 @@ def tip_leaderboard():
 @app.route("/api/tips/tippers")
 def tipper_leaderboard():
     """Top tippers (by total tips sent)."""
+    limit, error = _parse_leaderboard_limit(default=20, max_value=50)
+    if error:
+        return jsonify({"error": error}), 400
+
     db = get_db()
     _sync_pending_tips(db)
-    limit = min(50, max(1, request.args.get("limit", 20, type=int)))
 
     rows = db.execute(
         """SELECT a.agent_name, a.display_name, a.avatar_url, a.is_human,

--- a/tests/test_tips_leaderboard_query_validation.py
+++ b/tests/test_tips_leaderboard_query_validation.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for issue #1431.
+
+The public tips leaderboard endpoints silently coerced a malformed ``limit``
+query parameter to the default size (HTTP 200), which made malformed requests
+indistinguishable from valid default ones and was inconsistent with the rest of
+the public query-validation surface (e.g. ``/api/quests/leaderboard``).
+
+They now reject a non-integer ``limit`` with a deterministic JSON 400 while
+still clamping valid values into the supported range.
+"""
+
+
+def test_tips_leaderboard_rejects_malformed_limit(client):
+    response = client.get("/api/tips/leaderboard?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit must be an integer"}
+
+
+def test_tips_tippers_rejects_malformed_limit(client):
+    response = client.get("/api/tips/tippers?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit must be an integer"}
+
+
+def test_tips_leaderboard_accepts_valid_limit(client):
+    response = client.get("/api/tips/leaderboard?limit=5")
+
+    assert response.status_code == 200
+    assert "leaderboard" in response.get_json()
+
+
+def test_tips_tippers_accepts_valid_limit(client):
+    response = client.get("/api/tips/tippers?limit=5")
+
+    assert response.status_code == 200
+    assert "leaderboard" in response.get_json()
+
+
+def test_tips_leaderboard_default_limit_still_works(client):
+    response = client.get("/api/tips/leaderboard")
+
+    assert response.status_code == 200
+    assert "leaderboard" in response.get_json()


### PR DESCRIPTION
## What

`/api/tips/leaderboard` and `/api/tips/tippers` used `request.args.get("limit", 20, type=int)`, which **silently coerces** a malformed value like `?limit=abc` to the default (HTTP 200). That makes a malformed public request indistinguishable from a valid default one and is inconsistent with the rest of the public query-validation surface (`/api/quests/leaderboard`, `/api/gamification/leaderboard`, recent comments, etc.).

## Fix

Both endpoints now use the existing canonical `_parse_leaderboard_limit(default=20, max_value=50)` helper:

- `?limit=abc` (or any non-integer) → **400** `{"error": "limit must be an integer"}`
- valid values keep clamping into `[1, 50]` exactly as before (negative → 1, oversized → 50)

No change to tip amounts, wallet behaviour, payout rules, or tipping state transitions — this is purely public query-parameter validation, matching the issue scope.

## Tests

Adds `tests/test_tips_leaderboard_query_validation.py` (5 tests): malformed-limit 400 for both endpoints, valid-limit 200, and default 200. All pass locally alongside the existing `test_leaderboard_query_validation.py` pattern.

Closes #1431

Bounty: Scottcjn/rustchain-bounties#1102 (5 RTC, functional tier)
RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
