### PR TITLE
Pi: sandbox=false for mobile Pi Browser

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -821,12 +821,13 @@
     </script>
 
     <!-- Pi Network SDK + login (active only inside Pi Browser; gates pi-only UI) -->
-    <!-- BoTTube's Pi app is TESTNET-only → init the Pi SDK in testnet/sandbox mode
-         site-wide so Pi-Browser detection + auth are network-consistent. Flip when Mainnet. -->
-    <script>window.PI_SANDBOX = true;</script>
+    <!-- Pi.init sandbox=false in the REAL mobile Pi Browser. sandbox:true is ONLY for the
+         desktop sandbox (sandbox.minepi.com); testnet vs mainnet is the app's network +
+         wallet, not this flag. sandbox:true here broke payments auth ("open in sandbox"). -->
+    <script>window.PI_SANDBOX = false;</script>
     {% if current_user %}<script>window.PI_AUTO_SIGNIN = false;</script>{% endif %}
     <script src="https://sdk.minepi.com/pi-sdk.js"></script>
-    <script src="/static/pi_auth.js?v=12" defer></script>
+    <script src="/static/pi_auth.js?v=13" defer></script>
     <!-- Sophia Elya chat widget (same-origin: logged-in humans recognized + can generate) -->
     <script src="/static/sophia_widget.js?v=2" data-endpoint="/api/sophia" data-accent="#3ea6ff" data-title="Chat with Sophia Elya" defer></script>
 </head>

--- a/bottube_templates/pi_home.html
+++ b/bottube_templates/pi_home.html
@@ -46,7 +46,7 @@
 {% block content %}
 <!-- TESTNET-only Pi app → init the Pi SDK in sandbox/testnet mode (matches server
      PI_SANDBOX=1). Set before the deferred pi_auth.js / pi_pay.js execute. -->
-<script>window.PI_SANDBOX = true;</script>
+<script>window.PI_SANDBOX = false;</script>
 <div class="pi-wrap">
     <div class="pi-hero">
         <span class="pi-badge">π  PI NETWORK</span>


### PR DESCRIPTION
sandbox:true is desktop-sandbox-only; in the real Pi Browser it breaks payments auth. Flip to false (testnet is app-config + wallet, not this flag).