### PR TITLE
Studio: add Image (Gemini) + Voice (XTTS) modes alongside Video

### DIFF
--- a/bottube_templates/studio.html
+++ b/bottube_templates/studio.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Studio — Pay RTC, Generate Video{% endblock %}
+{% block title %}Studio — Pay RTC, Generate Video · Image · Voice{% endblock %}
 
 {% block extra_css %}
 <style>
@@ -7,7 +7,11 @@
   .st-hero { text-align:center; padding: 26px 16px 6px; }
   .st-hero h1 { font-size: 30px; margin-bottom: 8px; }
   .st-hero p { color: var(--text-secondary); font-size:16px; max-width:580px; margin:0 auto; }
-  .st-bal { text-align:center; margin: 14px 0 6px; color: var(--text-secondary); font-size: 14px; }
+  .st-modes { display:flex; justify-content:center; gap:8px; margin:18px auto 6px; flex-wrap:wrap; }
+  .st-mode { padding:9px 20px; border:1px solid var(--border); background:var(--bg-secondary); color:var(--text-secondary);
+    border-radius:999px; cursor:pointer; font-weight:700; font-size:14px; }
+  .st-mode.active { background:var(--accent); color:#0a0a0a; border-color:var(--accent); }
+  .st-bal { text-align:center; margin: 12px 0 6px; color: var(--text-secondary); font-size: 14px; }
   .st-bal strong { color:#ffcf33; font-size: 18px; }
   .st-prompt { width:100%; box-sizing:border-box; background:var(--bg-secondary); border:1px solid var(--border);
     border-radius:var(--radius); color:var(--text-primary); padding:14px; font-size:15px; min-height:84px; resize:vertical; margin:10px 0 6px; }
@@ -22,8 +26,15 @@
   .tier.t0 .tbadge { background:#2ba640; } .tier.t1 .tbadge { background:#3ea6ff; } .tier.t2 .tbadge { background:#ff4444; }
   .tier .gen { width:100%; padding:10px; border:none; border-radius:999px; background:var(--accent); color:#0a0a0a; font-weight:700; cursor:pointer; }
   .tier .gen:hover { background:var(--accent-hover); } .tier .gen:disabled { opacity:.5; cursor:default; }
+  .st-single { text-align:center; margin-top:8px; }
+  .st-single .gen { padding:13px 34px; border:none; border-radius:999px; background:var(--accent); color:#0a0a0a; font-weight:800; font-size:16px; cursor:pointer; }
+  .st-single .gen:disabled { opacity:.5; cursor:default; }
+  .st-single .price { color:#ffcf33; font-weight:700; }
   .st-status { text-align:center; margin:18px auto; max-width:600px; color:var(--text-secondary); font-size:14px; min-height:20px; }
   .st-status a { color:var(--accent); font-weight:700; }
+  .st-result { max-width:600px; margin:16px auto 0; text-align:center; }
+  .st-result img { max-width:100%; border-radius:var(--radius); border:1px solid var(--border); }
+  .st-result audio { width:100%; margin-top:6px; }
   .st-foot { text-align:center; color:var(--text-muted); font-size:12px; margin-top:24px; }
 </style>
 {% endblock %}
@@ -32,30 +43,50 @@
 <div class="st-wrap">
   <div class="st-hero">
     <span style="display:inline-block;background:#3ea6ff;color:#001;font-weight:700;font-size:12px;letter-spacing:.5px;padding:4px 12px;border-radius:999px;margin-bottom:12px;">🎬 BOTTUBE STUDIO</span>
-    <h1>Pay RTC · Generate an AI Video</h1>
-    <p>Type a prompt, pick a tier, pay in RTC — we render it on the LTX-2 pipeline and post it to your channel.</p>
+    <h1>Pay RTC · Generate AI Media</h1>
+    <p>Type a prompt, pick a mode, pay in RTC — video, image, or voice, rendered on our own pipeline. No gatekeepers.</p>
+  </div>
+
+  <div class="st-modes">
+    <button class="st-mode active" data-mode="video" onclick="stMode('video')">🎬 Video</button>
+    <button class="st-mode" data-mode="image" onclick="stMode('image')">🖼️ Image</button>
+    <button class="st-mode" data-mode="voice" onclick="stMode('voice')">🔊 Voice</button>
   </div>
 
   <div class="st-bal" id="st-bal">Checking your RTC balance…</div>
 
-  <textarea class="st-prompt" id="st-prompt" maxlength="500" placeholder="Describe the video you want… e.g. 'a neon cajun bayou at night, fireflies over the water, cinematic'"></textarea>
+  <textarea class="st-prompt" id="st-prompt" maxlength="1000" placeholder="Describe what you want…"></textarea>
 
-  <div class="tiers">
-    {% for t in studio_tiers %}
+  <!-- VIDEO: 3 tiers -->
+  <div class="tiers" id="mode-video">
+    {% for t in video_tiers %}
     <div class="tier t{{ loop.index0 }}">
       <span class="tbadge">{{ t.badge }}</span>
       <h3>{{ t.name }}</h3>
       <p>{{ t.desc }}</p>
       <div class="price">{{ t.rtc }} RTC</div>
-      <button class="gen" data-tier="{{ t.key }}" onclick="stGenerate(this.getAttribute('data-tier'))">Generate · {{ t.rtc }} RTC</button>
+      <button class="gen" data-tier="{{ t.key }}" onclick="stGenerate('video', this.getAttribute('data-tier'))">Generate · {{ t.rtc }} RTC</button>
     </div>
     {% endfor %}
   </div>
 
+  <!-- IMAGE -->
+  <div class="st-single" id="mode-image" style="display:none">
+    <p style="color:var(--text-secondary);font-size:14px;margin-bottom:12px;">A single high-quality AI image (Gemini 2.5 Flash Image). Posted nowhere — yours to download.</p>
+    <button class="gen" onclick="stGenerate('image')">Generate Image · <span class="price">{{ image_rtc }} RTC</span></button>
+  </div>
+
+  <!-- VOICE -->
+  <div class="st-single" id="mode-voice" style="display:none">
+    <p style="color:var(--text-secondary);font-size:14px;margin-bottom:12px;">Type up to ~600 characters; we voice it in the Sophia Elya XTTS voice.</p>
+    <button class="gen" id="voice-btn" onclick="stGenerate('voice')">Generate Voice · <span class="price">{{ voice_rtc }} RTC</span></button>
+  </div>
+
   <div class="st-status" id="st-status"></div>
+  <div class="st-result" id="st-result"></div>
 
   <div class="st-foot">
-    Generation engine is pluggable — LTX-2 today, more backends soon. RTC powers it; no gatekeepers.
+    Generation engine is pluggable — more backends soon. RTC powers it; no gatekeepers.
     Need RTC? <a href="/bridge/wrtc">Bridge credits</a>.
   </div>
 </div>
@@ -63,29 +94,60 @@
 <script>
 (function () {
   var statusEl = document.getElementById("st-status");
+  var resultEl = document.getElementById("st-result");
   var balEl = document.getElementById("st-bal");
-  var buttons = function(){ return document.querySelectorAll(".tier .gen"); };
-  function setBusy(b){ buttons().forEach(function(x){ x.disabled = b; }); }
+  var promptEl = document.getElementById("st-prompt");
+  var curMode = "video";
+  var signedIn = false, voiceEnabled = true;
+
+  function allButtons(){ return document.querySelectorAll(".gen"); }
+  function setBusy(b){ allButtons().forEach(function(x){ x.disabled = b; }); }
   function say(m){ statusEl.innerHTML = m; }
+  function clearResult(){ resultEl.innerHTML = ""; }
+
+  window.stMode = function (mode) {
+    curMode = mode;
+    document.querySelectorAll(".st-mode").forEach(function(b){
+      b.classList.toggle("active", b.getAttribute("data-mode") === mode);
+    });
+    document.getElementById("mode-video").style.display = (mode === "video") ? "" : "none";
+    document.getElementById("mode-image").style.display = (mode === "image") ? "" : "none";
+    document.getElementById("mode-voice").style.display = (mode === "voice") ? "" : "none";
+    say(""); clearResult();
+    promptEl.placeholder = (mode === "video")
+      ? "Describe the video you want… e.g. 'a neon cajun bayou at night, fireflies over the water, cinematic'"
+      : (mode === "image")
+      ? "Describe the image… e.g. 'a vintage IBM POWER8 server glowing in a cathedral of voltage, dramatic light'"
+      : "Type what Sophia should say… e.g. 'Welcome to Elyan Labs. Let me show you what we built.'";
+  };
 
   function loadInfo() {
     fetch("/api/studio/info", { credentials: "same-origin" })
       .then(function(r){ return r.json(); })
       .then(function(d){
-        if (!d.signed_in) { balEl.innerHTML = 'Sign in to generate — <a href="/login">log in</a>.'; setBusy(true); }
+        signedIn = !!d.signed_in;
+        voiceEnabled = d.voice_enabled !== false;
+        if (!signedIn) { balEl.innerHTML = 'Sign in to generate — <a href="/login">log in</a>.'; setBusy(true); }
         else { balEl.innerHTML = "Your balance: <strong>" + (d.rtc_balance != null ? d.rtc_balance : "?") + " RTC</strong>"; }
+        if (!voiceEnabled) {
+          var vb = document.getElementById("voice-btn");
+          if (vb) { vb.disabled = true; vb.textContent = "Voice temporarily unavailable"; }
+        }
       })
       .catch(function(){ balEl.textContent = ""; });
   }
   loadInfo();
 
-  window.stGenerate = function (tier) {
-    var prompt = (document.getElementById("st-prompt").value || "").trim();
+  window.stGenerate = function (mode, tier) {
+    var prompt = (promptEl.value || "").trim();
     if (!prompt) { say("Type a prompt first."); return; }
-    setBusy(true); say("Charging RTC and starting generation…");
+    setBusy(true); clearResult();
+    say(mode === "video" ? "Charging RTC and starting generation…" : "Charging RTC and generating…");
+    var payload = { type: mode, prompt: prompt };
+    if (mode === "video") payload.tier = tier;
     fetch("/api/studio/generate", {
       method: "POST", headers: { "Content-Type": "application/json" },
-      credentials: "same-origin", body: JSON.stringify({ prompt: prompt, tier: tier })
+      credentials: "same-origin", body: JSON.stringify(payload)
     }).then(function(r){ return r.json().then(function(d){ return { ok: r.ok, status: r.status, d: d }; }); })
       .then(function(res){
         if (!res.ok) {
@@ -95,8 +157,20 @@
           return;
         }
         balEl.innerHTML = "Your balance: <strong>" + res.d.new_balance + " RTC</strong>";
-        say("✅ Charged " + res.d.charged_rtc + " RTC. Generating your video… this can take a couple minutes.");
-        poll(res.d.status_url);
+        if (res.d.type === "image") {
+          setBusy(false);
+          say("✅ Charged " + res.d.charged_rtc + " RTC.");
+          resultEl.innerHTML = '<img src="' + res.d.media_url + '" alt="generated image">' +
+            '<div style="margin-top:8px"><a href="' + res.d.media_url + '" download>Download image →</a></div>';
+        } else if (res.d.type === "voice") {
+          setBusy(false);
+          say("✅ Charged " + res.d.charged_rtc + " RTC.");
+          resultEl.innerHTML = '<audio controls autoplay src="' + res.d.media_url + '"></audio>' +
+            '<div style="margin-top:8px"><a href="' + res.d.media_url + '" download>Download audio →</a></div>';
+        } else {
+          say("✅ Charged " + res.d.charged_rtc + " RTC. Generating your video… this can take a couple minutes.");
+          poll(res.d.status_url);
+        }
       })
       .catch(function(){ setBusy(false); say("Couldn't reach the studio. Try again."); });
   };

--- a/studio_blueprint.py
+++ b/studio_blueprint.py
@@ -1,33 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 # Author: @Scottcjn (Elyan Labs)
 """
-BoTTube Studio — pay RTC to generate a video. Technical demo of the pay-to-generate
-flow on RustChain's own RTC token (no external gatekeeper, ships today). The GENERATION
-layer is pluggable: today it uses the existing /api/generate-video cascade
-(LTX -> Ken Burns -> ffmpeg); when the Alibaba Cloud video API + SDK arrive, Alibaba
-slots into that cascade (video_providers.py) with NO change to this Studio code — the
-currency + UI here stay identical.
+BoTTube Studio — multimodal pay-RTC-to-generate. Video, Image, and Voice, billed in
+RustChain's own RTC token (no external gatekeeper). The GENERATION layer is pluggable
+per modality; when the Alibaba Cloud API/SDK arrives it slots in behind any of them
+with no change to the billing/UI here.
+
+  video -> existing /api/generate-video cascade (LTX -> Ken Burns -> ffmpeg), async
+  image -> Gemini 2.5 Flash Image (gemini_blueprint._generate_image_sync), sync
+  voice -> XTTS voice server (STUDIO_TTS_URL, e.g. the Sophia Elya voice box), sync
 
 Endpoints:
-  GET  /studio                  -> the Studio storefront page
-  GET  /api/studio/info         -> tiers + caller's RTC balance
-  POST /api/studio/generate     -> {prompt, tier} : atomic RTC debit + start generation
+  GET  /studio                     -> the Studio storefront page
+  GET  /api/studio/info            -> tiers + caller's RTC balance
+  POST /api/studio/generate        -> {type, prompt, tier?} : atomic RTC debit + generate
+  GET  /studio/media/<fname>       -> serve a generated image/audio file
 
-RTC debit is atomic (conditional UPDATE ... WHERE rtc_balance >= cost) and refunds if
-the generation fails to start.
+RTC debit is atomic and refunds if generation fails.
 """
 import os
 import sqlite3
 import threading
 import time
+import uuid
 from pathlib import Path
 
-from flask import Blueprint, jsonify, render_template, request, session
+import requests
+from flask import Blueprint, jsonify, render_template, request, session, send_from_directory
 
 studio_bp = Blueprint("studio", __name__)
 
-# RTC price per tier (env-overridable). Demo defaults; tune freely.
-STUDIO_TIERS = {
+# ---- pricing (RTC, env-overridable) ----
+VIDEO_TIERS = {
     "text_card": {"rtc": float(os.environ.get("STUDIO_RTC_TEXT", "1")),
                   "name": "Text Card", "desc": "Instant title-card video", "badge": "CHEAPEST", "duration": 5},
     "ken_burns": {"rtc": float(os.environ.get("STUDIO_RTC_KENBURNS", "3")),
@@ -35,12 +39,20 @@ STUDIO_TIERS = {
     "full_ai":   {"rtc": float(os.environ.get("STUDIO_RTC_FULLAI", "5")),
                   "name": "Full AI Video", "desc": "LTX-2 generated, with audio", "badge": "PREMIUM", "duration": 8},
 }
-PROMPT_MAX = 500
+IMAGE_RTC = float(os.environ.get("STUDIO_RTC_IMAGE", "0.5"))
+VOICE_RTC = float(os.environ.get("STUDIO_RTC_VOICE", "0.5"))
+
+PROMPT_MAX = 1000
 _rate = {}
-_COOLDOWN = float(os.environ.get("STUDIO_COOLDOWN", "30"))  # per-caller, protects the GPU
+_COOLDOWN = float(os.environ.get("STUDIO_COOLDOWN", "20"))
+# XTTS voice server (set on the host; internal IP stays out of the repo). e.g. http://<host>:5500
+STUDIO_TTS_URL = os.environ.get("STUDIO_TTS_URL", "")
+STUDIO_MEDIA_DIR = os.environ.get("STUDIO_MEDIA_DIR",
+                                  str(Path(os.environ.get("BOTTUBE_BASE_DIR",
+                                      str(Path(__file__).resolve().parent))) / "studio_media"))
 
 
-def _db_path() -> str:
+def _db_path():
     base = os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent))
     return os.environ.get("BOTTUBE_DB_PATH", str(Path(base) / "bottube.db"))
 
@@ -53,31 +65,51 @@ def _conn():
 
 
 def _resolve_caller(conn):
-    """(id, agent_name, rtc_balance) for an API agent (X-API-Key/agent_api_key) or a
-    logged-in human (session), else None."""
     api_key = request.headers.get("X-API-Key", "")
     if not api_key:
         api_key = ((request.get_json(silent=True) or {}).get("agent_api_key") or "").strip()
     if api_key:
-        row = conn.execute(
-            "SELECT id, agent_name, rtc_balance FROM agents WHERE api_key=? AND COALESCE(is_banned,0)=0",
-            (api_key,)).fetchone()
+        row = conn.execute("SELECT id, agent_name, rtc_balance FROM agents WHERE api_key=? AND COALESCE(is_banned,0)=0",
+                           (api_key,)).fetchone()
         if row:
             return row
     uid = session.get("user_id")
     if uid:
-        row = conn.execute(
-            "SELECT id, agent_name, rtc_balance FROM agents WHERE id=? AND COALESCE(is_banned,0)=0",
-            (uid,)).fetchone()
+        row = conn.execute("SELECT id, agent_name, rtc_balance FROM agents WHERE id=? AND COALESCE(is_banned,0)=0",
+                           (uid,)).fetchone()
         if row:
             return row
     return None
 
 
+def _refund(agent_id, cost):
+    try:
+        c = _conn()
+        c.execute("UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?", (cost, agent_id))
+        c.commit(); c.close()
+    except sqlite3.Error:
+        pass
+
+
+def _save_media(data: bytes, ext: str) -> str:
+    Path(STUDIO_MEDIA_DIR).mkdir(parents=True, exist_ok=True)
+    fname = uuid.uuid4().hex + "." + ext
+    with open(os.path.join(STUDIO_MEDIA_DIR, fname), "wb") as f:
+        f.write(data)
+    return fname
+
+
 @studio_bp.route("/studio")
 def studio_home():
-    tiers = [{"key": k, **v} for k, v in STUDIO_TIERS.items()]
-    return render_template("studio.html", studio_tiers=tiers)
+    return render_template("studio.html",
+                           video_tiers=[{"key": k, **v} for k, v in VIDEO_TIERS.items()],
+                           image_rtc=IMAGE_RTC, voice_rtc=VOICE_RTC)
+
+
+@studio_bp.route("/studio/media/<path:fname>")
+def studio_media(fname):
+    # uuid filenames only; send_from_directory blocks path traversal.
+    return send_from_directory(STUDIO_MEDIA_DIR, fname)
 
 
 @studio_bp.route("/api/studio/info", methods=["GET"])
@@ -86,29 +118,42 @@ def studio_info():
     try:
         caller = _resolve_caller(conn)
         bal = round(caller["rtc_balance"], 6) if caller else None
-        signed_in = caller is not None
     finally:
         conn.close()
     return jsonify({
-        "ok": True,
-        "signed_in": signed_in,
-        "rtc_balance": bal,
-        "tiers": {k: v["rtc"] for k, v in STUDIO_TIERS.items()},
+        "ok": True, "signed_in": caller is not None, "rtc_balance": bal,
+        "tiers": {
+            "video": {k: v["rtc"] for k, v in VIDEO_TIERS.items()},
+            "image": IMAGE_RTC,
+            "voice": VOICE_RTC,
+        },
+        "voice_enabled": bool(STUDIO_TTS_URL),
     })
 
 
 @studio_bp.route("/api/studio/generate", methods=["POST"])
 def studio_generate():
     body = request.get_json(silent=True) or {}
+    gtype = (body.get("type") or "video").strip()
     prompt = (body.get("prompt") or "").strip()
-    tier = (body.get("tier") or "").strip()
     if not prompt:
         return jsonify({"error": "prompt required"}), 400
     if len(prompt) > PROMPT_MAX:
         return jsonify({"error": f"prompt exceeds {PROMPT_MAX} characters"}), 400
-    if tier not in STUDIO_TIERS:
-        return jsonify({"error": "unknown tier"}), 400
-    cost = STUDIO_TIERS[tier]["rtc"]
+
+    if gtype == "video":
+        tier = (body.get("tier") or "").strip()
+        if tier not in VIDEO_TIERS:
+            return jsonify({"error": "unknown video tier"}), 400
+        cost = VIDEO_TIERS[tier]["rtc"]
+    elif gtype == "image":
+        cost = IMAGE_RTC
+    elif gtype == "voice":
+        if not STUDIO_TTS_URL:
+            return jsonify({"error": "voice generation is not configured"}), 503
+        cost = VOICE_RTC
+    else:
+        return jsonify({"error": "unknown type"}), 400
 
     conn = _conn()
     try:
@@ -116,15 +161,10 @@ def studio_generate():
         if not caller:
             return jsonify({"error": "sign in (or use an API key) to generate"}), 401
         agent_id = caller["id"]
-
-        # Per-caller cooldown (protect the single GPU).
         now = time.time()
-        last = _rate.get(agent_id, 0)
-        if now - last < _COOLDOWN:
+        if now - _rate.get(agent_id, 0) < _COOLDOWN:
             return jsonify({"error": "slow down a moment",
-                            "retry_after": round(_COOLDOWN - (now - last), 1)}), 429
-
-        # ATOMIC debit: only succeeds if balance covers the cost (prevents races/overspend).
+                            "retry_after": round(_COOLDOWN - (now - _rate.get(agent_id, 0)), 1)}), 429
         cur = conn.execute(
             "UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ? AND rtc_balance >= ?",
             (cost, agent_id, cost))
@@ -134,36 +174,53 @@ def studio_generate():
             return jsonify({"error": "insufficient RTC balance", "needed": cost,
                             "balance": round(bal["rtc_balance"], 6) if bal else 0}), 402
         _rate[agent_id] = now
-        new_balance = conn.execute("SELECT rtc_balance FROM agents WHERE id=?", (agent_id,)).fetchone()["rtc_balance"]
+        new_balance = round(conn.execute("SELECT rtc_balance FROM agents WHERE id=?", (agent_id,)).fetchone()["rtc_balance"], 6)
     finally:
         conn.close()
 
-    # Start generation by reusing the existing cascade (Alibaba slots in here later).
-    try:
-        from video_gen_blueprint import _create_job, _generation_worker
-        job_id = _create_job(agent_id, prompt)
-        threading.Thread(
-            target=_generation_worker,
-            args=(job_id, agent_id, prompt, STUDIO_TIERS[tier]["duration"], "ai-art", prompt[:200]),
-            daemon=True,
-        ).start()
-    except Exception as e:
-        # Refund on failure to start — never charge for a job we couldn't launch.
+    # ---- VIDEO: async job (reuse the cascade) ----
+    if gtype == "video":
         try:
-            rc = _conn()
-            rc.execute("UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?", (cost, agent_id))
-            rc.commit(); rc.close()
-        except sqlite3.Error:
-            pass
-        print(f"[studio] generation start failed (refunded {cost} RTC): {e}", flush=True)
-        return jsonify({"error": "couldn't start generation; your RTC was refunded"}), 502
+            from video_gen_blueprint import _create_job, _generation_worker
+            job_id = _create_job(agent_id, prompt)
+            threading.Thread(target=_generation_worker,
+                             args=(job_id, agent_id, prompt, VIDEO_TIERS[tier]["duration"], "ai-art", prompt[:200]),
+                             daemon=True).start()
+        except Exception as e:
+            _refund(agent_id, cost)
+            print(f"[studio] video start failed (refunded {cost}): {e}", flush=True)
+            return jsonify({"error": "couldn't start generation; your RTC was refunded"}), 502
+        return jsonify({"ok": True, "type": "video", "job_id": job_id, "charged_rtc": cost,
+                        "new_balance": new_balance, "status_url": f"/api/generate-video/status/{job_id}"}), 202
 
-    return jsonify({
-        "ok": True,
-        "job_id": job_id,
-        "tier": tier,
-        "charged_rtc": cost,
-        "new_balance": round(new_balance, 6),
-        "status_url": f"/api/generate-video/status/{job_id}",
-        "message": "Generation started. Poll status_url for the video.",
-    }), 202
+    # ---- IMAGE: sync via Gemini ----
+    if gtype == "image":
+        try:
+            from gemini_blueprint import _generate_image_sync
+            data, mime = _generate_image_sync(prompt)
+            if not data:
+                raise RuntimeError("no image returned")
+            ext = "png" if "png" in (mime or "") else ("jpg" if "jpe" in (mime or "") else "png")
+            fname = _save_media(data, ext)
+        except Exception as e:
+            _refund(agent_id, cost)
+            print(f"[studio] image gen failed (refunded {cost}): {e}", flush=True)
+            return jsonify({"error": "image generation failed; your RTC was refunded"}), 502
+        return jsonify({"ok": True, "type": "image", "media_url": f"/studio/media/{fname}",
+                        "charged_rtc": cost, "new_balance": new_balance})
+
+    # ---- VOICE: sync via XTTS ----
+    if gtype == "voice":
+        try:
+            r = requests.post(STUDIO_TTS_URL.rstrip("/") + "/api/tts",
+                              json={"text": prompt[:600]}, timeout=90)
+            r.raise_for_status()
+            if not r.content or len(r.content) < 256:
+                raise RuntimeError("empty audio")
+            fname = _save_media(r.content, "wav")
+        except Exception as e:
+            _refund(agent_id, cost)
+            print(f"[studio] voice gen failed (refunded {cost}): {e}", flush=True)
+            return jsonify({"error": "voice generation failed; your RTC was refunded"}), 502
+        return jsonify({"ok": True, "type": "voice", "media_url": f"/studio/media/{fname}",
+                        "charged_rtc": cost, "new_balance": new_balance})


### PR DESCRIPTION
Extends BoTTube Studio from video-only to multimodal pay-RTC-to-generate.

`POST /api/studio/generate` now takes a `type`:
- **video** — async LTX cascade job, poll `status_url` (unchanged)
- **image** — sync Gemini 2.5 Flash Image, 0.5 RTC, returns `media_url`
- **voice** — sync XTTS (Sophia Elya voice via `STUDIO_TTS_URL` env), 0.5 RTC

Same atomic RTC debit + refund-on-failure across all three. Internal TTS host stays in env, not the repo; voice tier auto-hides if unconfigured. studio.html gets a Video/Image/Voice mode switcher with inline img/audio rendering.

Already deployed + verified on prod (.153). Brings main in sync with production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)