### PR TITLE
Forge3D Phase-0: pay-RTC 3D generation in Studio (swappable backend)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15437,6 +15437,16 @@ try:
 except Exception as _studio_e:
     print(f"[WARN] Studio blueprint not loaded: {_studio_e}")
 
+# --- Forge3D (/studio 3D mode) — pay RTC to generate 3D models; swappable backend
+# (Meshy wrap in Phase-0, local TRELLIS/Tripo later). Own per-type job + async refund. ---
+try:
+    from forge3d_blueprint import forge3d_bp, init_forge3d_tables
+    init_forge3d_tables()
+    app.register_blueprint(forge3d_bp)
+    print('[forge3d] registered Forge3D blueprint')
+except Exception as _forge3d_e:
+    print(f"[WARN] Forge3D blueprint not loaded: {_forge3d_e}")
+
 # ---------------------------------------------------------------------------
 # Push Notification Subscriptions (FCM / Web Push)
 # ---------------------------------------------------------------------------

--- a/bottube_templates/studio.html
+++ b/bottube_templates/studio.html
@@ -51,6 +51,7 @@
     <button class="st-mode active" data-mode="video" onclick="stMode('video')">🎬 Video</button>
     <button class="st-mode" data-mode="image" onclick="stMode('image')">🖼️ Image</button>
     <button class="st-mode" data-mode="voice" onclick="stMode('voice')">🔊 Voice</button>
+    <button class="st-mode" data-mode="model" onclick="stMode('model')">🧊 3D</button>
   </div>
 
   <div class="st-bal" id="st-bal">Checking your RTC balance…</div>
@@ -82,6 +83,12 @@
     <button class="gen" id="voice-btn" onclick="stGenerate('voice')">Generate Voice · <span class="price">{{ voice_rtc }} RTC</span></button>
   </div>
 
+  <!-- 3D MODEL -->
+  <div class="st-single" id="mode-model" style="display:none">
+    <p style="color:var(--text-secondary);font-size:14px;margin-bottom:12px;">Describe an object; we generate a downloadable 3D model (GLB). Swappable backend — Meshy now, our own fleet next. ~1 min.</p>
+    <button class="gen" onclick="stGenerate('model')">Generate 3D Model · <span class="price">{{ model_rtc }} RTC</span></button>
+  </div>
+
   <div class="st-status" id="st-status"></div>
   <div class="st-result" id="st-result"></div>
 
@@ -110,15 +117,17 @@
     document.querySelectorAll(".st-mode").forEach(function(b){
       b.classList.toggle("active", b.getAttribute("data-mode") === mode);
     });
-    document.getElementById("mode-video").style.display = (mode === "video") ? "" : "none";
-    document.getElementById("mode-image").style.display = (mode === "image") ? "" : "none";
-    document.getElementById("mode-voice").style.display = (mode === "voice") ? "" : "none";
+    ["video","image","voice","model"].forEach(function(m){
+      document.getElementById("mode-" + m).style.display = (mode === m) ? "" : "none";
+    });
     say(""); clearResult();
-    promptEl.placeholder = (mode === "video")
-      ? "Describe the video you want… e.g. 'a neon cajun bayou at night, fireflies over the water, cinematic'"
-      : (mode === "image")
-      ? "Describe the image… e.g. 'a vintage IBM POWER8 server glowing in a cathedral of voltage, dramatic light'"
-      : "Type what Sophia should say… e.g. 'Welcome to Elyan Labs. Let me show you what we built.'";
+    var ph = {
+      video: "Describe the video you want… e.g. 'a neon cajun bayou at night, fireflies over the water, cinematic'",
+      image: "Describe the image… e.g. 'a vintage IBM POWER8 server glowing in a cathedral of voltage, dramatic light'",
+      voice: "Type what Sophia should say… e.g. 'Welcome to Elyan Labs. Let me show you what we built.'",
+      model: "Describe an object to model in 3D… e.g. 'a low-poly treasure chest, game-ready'"
+    };
+    promptEl.placeholder = ph[mode] || "";
   };
 
   function loadInfo() {
@@ -180,7 +189,16 @@
     var iv = setInterval(function(){
       tries++;
       fetch(url, { credentials: "same-origin" }).then(function(r){ return r.json(); }).then(function(d){
-        if (d.status === "completed" || d.video_id) {
+        if (d.model_url) {
+          clearInterval(iv); setBusy(false);
+          say("🧊 Done! Charged successfully.");
+          resultEl.innerHTML =
+            '<model-viewer src="' + d.model_url + '" camera-controls auto-rotate ' +
+            'style="width:100%;height:360px;background:#111;border-radius:8px;" ' +
+            'ar shadow-intensity="1"></model-viewer>' +
+            '<div style="margin-top:8px"><a href="' + d.model_url + '" download>Download GLB →</a>' +
+            ((d.formats && d.formats.length) ? ' · formats: ' + d.formats.join(", ") : "") + '</div>';
+        } else if (d.status === "completed" || d.video_id) {
           clearInterval(iv); setBusy(false);
           var watch = d.watch_url || (d.video_id ? ("/watch/" + d.video_id) : null);
           say(watch ? ("🎬 Done! <a href='" + watch + "'>Watch your video →</a>") : "🎬 Done — check your channel.");
@@ -196,4 +214,5 @@
   }
 })();
 </script>
+<script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
 {% endblock %}

--- a/forge3d_blueprint.py
+++ b/forge3d_blueprint.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# Author: @Scottcjn (Elyan Labs)
+"""
+Forge3D — Studio's 3D generation line (Meshy-class), RTC-billed.
+
+This blueprint owns the 3D JOB lifecycle with its OWN per-type schema (design §7:
+do not reuse the video-shaped job/result). The RTC debit happens in
+studio_blueprint (shared atomic rails); this module runs the async generation and
+**refunds on terminal failure** (job-scoped, fired once) — the async-refund
+contract §7 requires for every long job.
+
+  start_job(agent_id, prompt, cost) -> job_id        (called by studio_blueprint)
+  GET /api/studio/3d/status/<job_id>                 (poll; type-specific result)
+
+Output GLB is written to the shared Studio media dir and served by the existing
+/studio/media/<fname> route.
+"""
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from pathlib import Path
+
+from flask import Blueprint, jsonify
+
+forge3d_bp = Blueprint("forge3d", __name__)
+
+STUDIO_MEDIA_DIR = os.environ.get("STUDIO_MEDIA_DIR",
+                                  str(Path(os.environ.get("BOTTUBE_BASE_DIR",
+                                      str(Path(__file__).resolve().parent))) / "studio_media"))
+
+
+def _db_path():
+    base = os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent))
+    return os.environ.get("BOTTUBE_DB_PATH", str(Path(base) / "bottube.db"))
+
+
+def _conn():
+    c = sqlite3.connect(_db_path(), timeout=30)
+    c.row_factory = sqlite3.Row
+    c.execute("PRAGMA busy_timeout=30000")
+    return c
+
+
+def init_forge3d_tables(db_path: str = None):
+    c = sqlite3.connect(db_path or _db_path(), timeout=30)
+    try:
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS forge3d_jobs (
+                id          TEXT PRIMARY KEY,
+                agent_id    INTEGER NOT NULL,
+                prompt      TEXT,
+                status      TEXT NOT NULL DEFAULT 'queued',
+                glb_fname   TEXT,
+                formats     TEXT,
+                error       TEXT,
+                charged_rtc REAL DEFAULT 0,
+                refunded    INTEGER NOT NULL DEFAULT 0,
+                created_at  REAL,
+                updated_at  REAL
+            )""")
+        c.commit()
+    finally:
+        c.close()
+
+
+def _set(job_id, **kw):
+    if not kw:
+        return
+    kw["updated_at"] = time.time()
+    cols = ", ".join(f"{k}=?" for k in kw)
+    c = _conn()
+    try:
+        c.execute(f"UPDATE forge3d_jobs SET {cols} WHERE id=?", (*kw.values(), job_id))
+        c.commit()
+    finally:
+        c.close()
+
+
+def _refund_once(job_id, agent_id, cost):
+    """Refund the RTC exactly once for this job (atomic guard on `refunded`)."""
+    c = _conn()
+    try:
+        cur = c.execute("UPDATE forge3d_jobs SET refunded=1 WHERE id=? AND refunded=0", (job_id,))
+        if cur.rowcount == 1:
+            c.execute("UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id=?", (cost, agent_id))
+        c.commit()
+        return cur.rowcount == 1
+    finally:
+        c.close()
+
+
+def _save_glb(data: bytes) -> str:
+    Path(STUDIO_MEDIA_DIR).mkdir(parents=True, exist_ok=True)
+    fname = uuid.uuid4().hex + ".glb"
+    with open(os.path.join(STUDIO_MEDIA_DIR, fname), "wb") as f:
+        f.write(data)
+    return fname
+
+
+def _worker(job_id, agent_id, prompt, cost):
+    _set(job_id, status="generating")
+    try:
+        from forge3d_provider import generate_3d
+        glb, meta = generate_3d(prompt)
+        if not glb or len(glb) < 256:
+            raise RuntimeError("empty_model")
+        fname = _save_glb(glb)
+        _set(job_id, status="completed", glb_fname=fname,
+             formats=",".join(meta.get("formats", []) or []))
+        print(f"[forge3d] job {job_id} completed ({len(glb)} bytes, {meta.get('backend')})", flush=True)
+    except Exception as e:
+        _set(job_id, status="failed", error=str(e)[:200])
+        refunded = _refund_once(job_id, agent_id, cost)
+        print(f"[forge3d] job {job_id} failed: {e} (refunded={refunded})", flush=True)
+
+
+def start_job(agent_id: int, prompt: str, cost: float) -> str:
+    """Create a 3D job row and kick off the async worker. RTC already debited upstream."""
+    job_id = uuid.uuid4().hex
+    now = time.time()
+    c = _conn()
+    try:
+        c.execute("INSERT INTO forge3d_jobs (id, agent_id, prompt, status, charged_rtc, created_at, updated_at) "
+                  "VALUES (?,?,?,?,?,?,?)", (job_id, agent_id, prompt[:1000], "queued", cost, now, now))
+        c.commit()
+    finally:
+        c.close()
+    threading.Thread(target=_worker, args=(job_id, agent_id, prompt, cost), daemon=True).start()
+    return job_id
+
+
+@forge3d_bp.route("/api/studio/3d/status/<job_id>")
+def forge3d_status(job_id):
+    c = _conn()
+    try:
+        row = c.execute("SELECT * FROM forge3d_jobs WHERE id=?", (job_id,)).fetchone()
+    finally:
+        c.close()
+    if not row:
+        return jsonify({"error": "not found"}), 404
+    out = {"type": "model", "status": row["status"]}
+    if row["status"] == "completed" and row["glb_fname"]:
+        out["model_url"] = f"/studio/media/{row['glb_fname']}"
+        out["formats"] = (row["formats"] or "").split(",") if row["formats"] else ["glb"]
+    elif row["status"] == "failed":
+        out["error"] = row["error"] or "generation failed"
+    return jsonify(out)

--- a/forge3d_provider.py
+++ b/forge3d_provider.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# Author: @Scottcjn (Elyan Labs)
+"""
+Forge3D provider layer — the SWAPPABLE 3D backend behind Studio's 3D mode.
+
+Phase-0 wraps Meshy's public text-to-3D API. The whole point (design §0.1): the
+model is a swappable backend, not the product. To add/replace a backend (TRELLIS
+or Tripo on our own fleet, etc.), add a `_provider_*` function and list it in
+PROVIDERS — the billing/job/refund rails in forge3d_blueprint never change.
+
+Each provider returns (glb_bytes, meta_dict) on success or raises on failure.
+Raising is the contract that triggers the RTC refund upstream.
+"""
+import os
+import time
+
+import requests
+
+MESHY_ROOT = "https://api.meshy.ai/openapi"
+_TIMEOUT = float(os.environ.get("FORGE3D_TIMEOUT", "300"))   # total wait for a task
+_POLL = float(os.environ.get("FORGE3D_POLL", "5"))
+
+
+class Forge3DError(Exception):
+    """Generation failed — upstream refunds the RTC."""
+
+
+class Forge3DNoCredits(Forge3DError):
+    """Backend is out of credits/quota (HTTP 402) — distinct so the UI can say so."""
+
+
+def _provider_meshy(prompt: str, art_style: str = "realistic"):
+    key = os.environ.get("MESHY_API_KEY", "").strip()
+    if not key:
+        raise Forge3DError("no_backend_configured")
+    h = {"Authorization": f"Bearer {key}"}
+
+    r = requests.post(
+        f"{MESHY_ROOT}/v2/text-to-3d",
+        json={"mode": "preview", "prompt": prompt[:600],
+              "art_style": art_style, "should_remesh": True},
+        headers=h, timeout=30)
+    if r.status_code == 402:
+        raise Forge3DNoCredits("backend_out_of_credits")
+    r.raise_for_status()
+    task_id = (r.json() or {}).get("result")
+    if not task_id:
+        raise Forge3DError("no_task_id")
+
+    deadline = time.time() + _TIMEOUT
+    while time.time() < deadline:
+        time.sleep(_POLL)
+        s = requests.get(f"{MESHY_ROOT}/v2/text-to-3d/{task_id}", headers=h, timeout=30)
+        s.raise_for_status()
+        d = s.json() or {}
+        st = d.get("status")
+        if st == "SUCCEEDED":
+            urls = d.get("model_urls") or {}
+            glb = urls.get("glb")
+            if not glb:
+                raise Forge3DError("no_glb_in_result")
+            g = requests.get(glb, timeout=180)
+            g.raise_for_status()
+            return g.content, {"backend": "meshy", "task_id": task_id,
+                               "formats": sorted(urls.keys())}
+        if st in ("FAILED", "EXPIRED", "CANCELED"):
+            raise Forge3DError(f"backend_task_{str(st).lower()}")
+    raise Forge3DError("backend_timeout")
+
+
+# Ordered cascade — first that succeeds wins; all raise -> refund.
+PROVIDERS = [_provider_meshy]
+
+
+def generate_3d(prompt: str, art_style: str = "realistic"):
+    """Try each provider in order. Returns (glb_bytes, meta). Raises Forge3DError."""
+    last = None
+    for prov in PROVIDERS:
+        try:
+            return prov(prompt, art_style=art_style)
+        except Forge3DNoCredits as e:
+            last = e  # try next backend if any; preserve the no-credits signal
+        except Exception as e:  # noqa: BLE001 - any backend failure -> try next
+            last = e
+    raise last if last is not None else Forge3DError("no_providers")

--- a/studio_blueprint.py
+++ b/studio_blueprint.py
@@ -41,6 +41,7 @@ VIDEO_TIERS = {
 }
 IMAGE_RTC = float(os.environ.get("STUDIO_RTC_IMAGE", "0.5"))
 VOICE_RTC = float(os.environ.get("STUDIO_RTC_VOICE", "0.5"))
+MODEL_RTC = float(os.environ.get("STUDIO_RTC_MODEL", "3"))
 
 PROMPT_MAX = 1000
 _rate = {}
@@ -124,13 +125,19 @@ def _studio_video_worker(job_id, agent_id, prompt, duration, cost):
 def studio_home():
     return render_template("studio.html",
                            video_tiers=[{"key": k, **v} for k, v in VIDEO_TIERS.items()],
-                           image_rtc=IMAGE_RTC, voice_rtc=VOICE_RTC)
+                           image_rtc=IMAGE_RTC, voice_rtc=VOICE_RTC, model_rtc=MODEL_RTC)
+
+
+_MEDIA_MIME = {".glb": "model/gltf-binary", ".fbx": "application/octet-stream",
+               ".usdz": "model/vnd.usdz+zip"}
 
 
 @studio_bp.route("/studio/media/<path:fname>")
 def studio_media(fname):
     # uuid filenames only; send_from_directory blocks path traversal.
-    return send_from_directory(STUDIO_MEDIA_DIR, fname)
+    ext = os.path.splitext(fname)[1].lower()
+    kw = {"mimetype": _MEDIA_MIME[ext]} if ext in _MEDIA_MIME else {}
+    return send_from_directory(STUDIO_MEDIA_DIR, fname, **kw)
 
 
 @studio_bp.route("/api/studio/info", methods=["GET"])
@@ -147,6 +154,7 @@ def studio_info():
             "video": {k: v["rtc"] for k, v in VIDEO_TIERS.items()},
             "image": IMAGE_RTC,
             "voice": VOICE_RTC,
+            "model": MODEL_RTC,
         },
         "voice_enabled": bool(STUDIO_TTS_URL),
     })
@@ -173,6 +181,8 @@ def studio_generate():
         if not STUDIO_TTS_URL:
             return jsonify({"error": "voice generation is not configured"}), 503
         cost = VOICE_RTC
+    elif gtype == "model":
+        cost = MODEL_RTC
     else:
         return jsonify({"error": "unknown type"}), 400
 
@@ -213,6 +223,18 @@ def studio_generate():
             return jsonify({"error": "couldn't start generation; your RTC was refunded"}), 502
         return jsonify({"ok": True, "type": "video", "job_id": job_id, "charged_rtc": cost,
                         "new_balance": new_balance, "status_url": f"/api/generate-video/status/{job_id}"}), 202
+
+    # ---- MODEL (3D): async via forge3d provider cascade ----
+    if gtype == "model":
+        try:
+            from forge3d_blueprint import start_job
+            job_id = start_job(agent_id, prompt, cost)
+        except Exception as e:
+            _refund(agent_id, cost)
+            print(f"[studio] 3d start failed (refunded {cost}): {e}", flush=True)
+            return jsonify({"error": "couldn't start generation; your RTC was refunded"}), 502
+        return jsonify({"ok": True, "type": "model", "job_id": job_id, "charged_rtc": cost,
+                        "new_balance": new_balance, "status_url": f"/api/studio/3d/status/{job_id}"}), 202
 
     # ---- IMAGE: sync via Gemini ----
     if gtype == "image":


### PR DESCRIPTION
Adds a **3D mode** to `/studio`: prompt → GLB model, billed in RTC. First product line of the Meshy/HeyGen-class system.

- **forge3d_provider.py** — swappable backend cascade (design §0.1). Phase-0 wraps Meshy text-to-3D; a local TRELLIS/Tripo backend drops in later with zero billing/UI change.
- **forge3d_blueprint.py** — own per-type job schema (§7: *not* the video shape) + async worker that **refunds once on terminal failure** (the §7 async-refund gate). `GET /api/studio/3d/status/<id>` → `type=model` + `model_url`.
- **studio_blueprint.py** — `type=model` branch (cost `STUDIO_RTC_MODEL=3`), correct GLB mimetype.
- **studio.html** — 3D mode + `<model-viewer>` preview + GLB download.

**Verified e2e on prod:** debit 3 → Meshy 402 (5-credit acct) → fail → refund-once → balance restored. Renders real GLBs once Meshy is funded or a local backend is added. `MESHY_API_KEY` lives in a root-only service env, not the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)