### PR TITLE
GEO: AI-discoverable metadata for generated videos

### DIFF
--- a/seo_routes.py
+++ b/seo_routes.py
@@ -4,11 +4,56 @@
 # AEO, GEO, E-E-A-T, Semantic Entity Mapping — 2026 Edition
 # ---------------------------------------------------------------------------
 
-import html, json, time
+import html, json, re, time
 from flask import Blueprint, current_app, request
 from datetime import datetime, timezone
 
 seo_bp = Blueprint("seo", __name__)
+
+# ---------------------------------------------------------------------------
+# GEO metadata generator — turns a raw generation prompt into AI-discoverable
+# metadata (clean title, AI-optimized description, real keywords) so the
+# VideoObject JSON-LD / llms.txt / sitemap surface real data instead of a raw
+# conversational prompt with empty keywords. Deterministic (no LLM dependency).
+# ---------------------------------------------------------------------------
+_GEO_STOP = set(
+    "a an the of for and or to in on at with by from as is it that this these those "
+    "i id like want wanna create make generate render produce show showing video clip "
+    "me my please can you could would give animation animated scene about into".split()
+)
+_GEO_LEAD = re.compile(
+    r"^(i'?d?\s+(?:like|want)\s+(?:you\s+)?to\s+|please\s+|can\s+you\s+|could\s+you\s+|"
+    r"make\s+me\s+|generate\s+(?:me\s+)?|create\s+(?:me\s+)?|render\s+|produce\s+|"
+    r"a\s+video\s+(?:of|about|showing)\s+|video\s+of\s+|an?\s+)+",
+    re.IGNORECASE,
+)
+
+
+def build_geo_metadata(prompt, category="other"):
+    """Return (title, description, tags_json) optimized for AI/GEO discovery."""
+    p = (prompt or "").strip()
+    core = _GEO_LEAD.sub("", p).strip() or p
+    title = core[:70].rstrip(" .,!?;:").strip()
+    title = (title[0].upper() + title[1:]) if title else "AI-Generated Video"
+
+    words, kw = re.findall(r"[a-zA-Z0-9]+", core.lower()), []
+    for w in words:
+        if len(w) > 2 and w not in _GEO_STOP and w not in kw:
+            kw.append(w)
+        if len(kw) >= 8:
+            break
+    tags = ["AI-generated", "BoTTube", "text-to-video"]
+    if category and category not in ("other", ""):
+        tags.append(category)
+    tags += kw
+
+    desc = (
+        f"{title} — an AI-generated video created on BoTTube, the video platform for "
+        f"AI agents and humans. Subject: {core[:180]}. "
+        f"Generated on BoTTube from the prompt: \"{p[:180]}\". "
+        f"Content provenance is attested on RustChain via the AVAP protocol."
+    )
+    return title, desc, json.dumps(tags)
 
 
 @seo_bp.route("/robots.txt")

--- a/video_gen_blueprint.py
+++ b/video_gen_blueprint.py
@@ -871,6 +871,17 @@ def _generation_worker(job_id: str, agent_id: int, prompt: str,
 
         # Insert into database
         from bottube_server import DB_PATH
+
+        # GEO metadata — clean title, AI-optimized description, real keywords so the
+        # VideoObject JSON-LD / llms.txt / sitemap surface discoverable data instead
+        # of the raw conversational prompt with empty tags. Falls back gracefully.
+        try:
+            from seo_routes import build_geo_metadata
+            geo_title, geo_desc, geo_tags = build_geo_metadata(prompt, category)
+        except Exception as _geo_e:
+            print(f"[video_gen] geo metadata fallback: {_geo_e}", flush=True)
+            geo_title, geo_desc, geo_tags = (title or prompt[:120]), prompt, json.dumps([])
+
         db = sqlite3.connect(str(DB_PATH))
         db.row_factory = sqlite3.Row
         db.execute("PRAGMA journal_mode=WAL")
@@ -885,11 +896,11 @@ def _generation_worker(job_id: str, agent_id: int, prompt: str,
                 is_removed, removed_reason)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
-                video_id, agent_id, title, prompt,
+                video_id, agent_id, geo_title, geo_desc,
                 f"{video_id}.mp4", thumb_filename,
                 vid_duration, width, height,
-                json.dumps([]),  # tags
-                prompt,  # scene_description
+                geo_tags,  # tags (GEO keywords)
+                prompt,  # scene_description (raw prompt for internal reference)
                 category,
                 0.0, "",  # novelty_score, novelty_flags
                 "", "",   # revision_of, revision_note


### PR DESCRIPTION
Generated videos stored the raw prompt as title, duplicated it as description, and left **tags empty** — so the VideoObject JSON-LD / llms.txt / sitemap surfaced nothing discoverable (e.g. title `i'd like to create a video abo...`, `keywords []`).

`seo_routes.build_geo_metadata(prompt, category)` → clean title, AI-optimized description (names the platform + AVAP provenance), and real keyword tags. Deterministic (no LLM dependency), wired into `_generation_worker` so **all** generated videos (Studio + API) get GEO data at creation. Existing schema machinery now has real data to emit.

Verified on prod. 🤖 Generated with [Claude Code](https://claude.com/claude-code)