### PR TITLE
video_gen: wire Wan 2.2 as a local t2v provider alongside LTX

### DIFF
--- a/video_gen_blueprint.py
+++ b/video_gen_blueprint.py
@@ -44,6 +44,18 @@ video_gen_bp = Blueprint("video_gen", __name__)
 COMFYUI_URL = os.environ.get("COMFYUI_URL", "http://100.95.77.124:8188")
 COMFYUI_TIMEOUT = int(os.environ.get("COMFYUI_TIMEOUT", "300"))  # 5 min max
 
+# Wan 2.2 text-to-video via ComfyUI (local, our V100). Separate URL — Wan lives on :8189.
+# Empty = disabled. Workflow is the flattened t2v subgraph (UNETLoaderGGUF + lightx2v LoRA).
+WAN_COMFYUI_URL = os.environ.get("WAN_COMFYUI_URL", "")
+WAN_WORKFLOW_PATH = os.environ.get(
+    "WAN_WORKFLOW_PATH",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "wan_t2v_api.json"))
+try:
+    with open(WAN_WORKFLOW_PATH) as _wf:
+        _WAN_WORKFLOW = json.load(_wf)
+except Exception:
+    _WAN_WORKFLOW = None
+
 # Free-tier video gen backends (cascade: try each in order)
 HF_API_TOKEN = os.environ.get("HF_API_TOKEN", "")
 HF_VIDEO_MODEL = os.environ.get("HF_VIDEO_MODEL", "ali-vilab/text-to-video-ms-1.7b")
@@ -86,6 +98,7 @@ _provider_registry = ProviderRegistry()
 
 def _init_provider_registry():
     """Register all backends. Called once after functions are defined (bottom of module)."""
+    _provider_registry.register("wan22", _try_wan)  # local V100 Wan 2.2 t2v (no API key)
     _provider_registry.register("hf_sdxl_video", _try_hf_image_to_video, requires_key_env="HF_API_TOKEN")
     _provider_registry.register("huggingface", _try_huggingface, requires_key_env="HF_API_TOKEN")
     _provider_registry.register("gemini", _try_gemini, requires_key_env="GEMINI_API_KEY")
@@ -361,6 +374,66 @@ def _try_comfyui(prompt: str, seed: int) -> Optional[Path]:
                 except Exception:
                     continue
     return None
+
+
+def _try_wan(prompt: str, duration: int, final_path) -> bool:
+    """Wan 2.2 text-to-video via ComfyUI (:8189, local V100). Writes mp4 to final_path.
+
+    Registry backend signature (prompt, duration, final_path)->bool. Disabled unless
+    WAN_COMFYUI_URL is set and the flattened workflow loaded."""
+    if not WAN_COMFYUI_URL or not _WAN_WORKFLOW:
+        return False
+    wf = json.loads(json.dumps(_WAN_WORKFLOW))
+    try:
+        wf["1089"]["inputs"]["text"] = prompt[:PROMPT_MAX_LEN]   # positive prompt node
+    except Exception:
+        return False
+    try:
+        req = urllib.request.Request(
+            f"{WAN_COMFYUI_URL}/prompt",
+            data=json.dumps({"prompt": wf}).encode(),
+            headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            prompt_id = json.loads(resp.read()).get("prompt_id")
+        if not prompt_id:
+            return False
+    except Exception:
+        return False
+    deadline = time.time() + COMFYUI_TIMEOUT
+    outs = None
+    while time.time() < deadline:
+        time.sleep(4)
+        try:
+            with urllib.request.urlopen(f"{WAN_COMFYUI_URL}/history/{prompt_id}", timeout=10) as resp:
+                hist = json.loads(resp.read())
+            if prompt_id in hist:
+                entry = hist[prompt_id]; status = entry.get("status", {})
+                if status.get("completed") or entry.get("outputs"):
+                    outs = entry.get("outputs", {}); break
+                if status.get("status_str") == "error":
+                    return False
+        except Exception:
+            continue
+    if not outs:
+        return False
+    for _nid, node_out in outs.items():
+        for key in ("videos", "gifs", "images"):
+            for v in node_out.get(key, []) or []:
+                fn = v.get("filename")
+                if not fn:
+                    continue
+                params = urllib.parse.urlencode({
+                    "filename": fn, "subfolder": v.get("subfolder", ""),
+                    "type": v.get("type", "output")})
+                try:
+                    with urllib.request.urlopen(f"{WAN_COMFYUI_URL}/view?{params}", timeout=90) as resp:
+                        data = resp.read()
+                    if data and len(data) > 1000:
+                        Path(final_path).write_bytes(data)
+                        return True
+                except Exception:
+                    continue
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/wan_t2v_api.json
+++ b/wan_t2v_api.json
@@ -1,0 +1,194 @@
+{
+ "1071": {
+  "class_type": "CLIPLoader",
+  "inputs": {
+   "clip_name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+   "type": "wan",
+   "device": "default"
+  }
+ },
+ "1073": {
+  "class_type": "VAELoader",
+  "inputs": {
+   "vae_name": "wan_2.1_vae.safetensors"
+  }
+ },
+ "1076": {
+  "class_type": "UnetLoaderGGUF",
+  "inputs": {
+   "unet_name": "wan2.2_t2v_low_noise_14B_Q8_0.gguf"
+  }
+ },
+ "1075": {
+  "class_type": "UnetLoaderGGUF",
+  "inputs": {
+   "unet_name": "wan2.2_t2v_high_noise_14B_Q8_0.gguf"
+  }
+ },
+ "1083": {
+  "class_type": "LoraLoaderModelOnly",
+  "inputs": {
+   "lora_name": "wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors",
+   "strength_model": 1.0000000000000002,
+   "model": [
+    "1075",
+    0
+   ]
+  }
+ },
+ "1085": {
+  "class_type": "LoraLoaderModelOnly",
+  "inputs": {
+   "lora_name": "wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors",
+   "strength_model": 1.0000000000000002,
+   "model": [
+    "1076",
+    0
+   ]
+  }
+ },
+ "1086": {
+  "class_type": "ModelSamplingSD3",
+  "inputs": {
+   "shift": 5.000000000000001,
+   "model": [
+    "1085",
+    0
+   ]
+  }
+ },
+ "1082": {
+  "class_type": "ModelSamplingSD3",
+  "inputs": {
+   "shift": 5.000000000000001,
+   "model": [
+    "1083",
+    0
+   ]
+  }
+ },
+ "1081": {
+  "class_type": "KSamplerAdvanced",
+  "inputs": {
+   "add_noise": "enable",
+   "noise_seed": 0,
+   "steps": 4,
+   "cfg": 1,
+   "sampler_name": "euler",
+   "scheduler": "simple",
+   "start_at_step": 0,
+   "end_at_step": 2,
+   "return_with_leftover_noise": "enable",
+   "model": [
+    "1082",
+    0
+   ],
+   "positive": [
+    "1089",
+    0
+   ],
+   "negative": [
+    "1072",
+    0
+   ],
+   "latent_image": [
+    "1074",
+    0
+   ]
+  }
+ },
+ "1074": {
+  "class_type": "EmptyHunyuanLatentVideo",
+  "inputs": {
+   "width": 640,
+   "height": 640,
+   "length": 81,
+   "batch_size": 1
+  }
+ },
+ "1078": {
+  "class_type": "KSamplerAdvanced",
+  "inputs": {
+   "add_noise": "disable",
+   "noise_seed": 0,
+   "steps": 4,
+   "cfg": 1,
+   "sampler_name": "euler",
+   "scheduler": "simple",
+   "start_at_step": 2,
+   "end_at_step": 4,
+   "return_with_leftover_noise": "disable",
+   "model": [
+    "1086",
+    0
+   ],
+   "positive": [
+    "1089",
+    0
+   ],
+   "negative": [
+    "1072",
+    0
+   ],
+   "latent_image": [
+    "1081",
+    0
+   ]
+  }
+ },
+ "1114": {
+  "class_type": "CreateVideo",
+  "inputs": {
+   "fps": 16,
+   "images": [
+    "1087",
+    0
+   ]
+  }
+ },
+ "1087": {
+  "class_type": "VAEDecode",
+  "inputs": {
+   "samples": [
+    "1078",
+    0
+   ],
+   "vae": [
+    "1073",
+    0
+   ]
+  }
+ },
+ "1072": {
+  "class_type": "CLIPTextEncode",
+  "inputs": {
+   "text": "\u8272\u8c03\u8273\u4e3d\uff0c\u8fc7\u66dd\uff0c\u9759\u6001\uff0c\u7ec6\u8282\u6a21\u7cca\u4e0d\u6e05\uff0c\u5b57\u5e55\uff0c\u98ce\u683c\uff0c\u4f5c\u54c1\uff0c\u753b\u4f5c\uff0c\u753b\u9762\uff0c\u9759\u6b62\uff0c\u6574\u4f53\u53d1\u7070\uff0c\u6700\u5dee\u8d28\u91cf\uff0c\u4f4e\u8d28\u91cf\uff0cJPEG\u538b\u7f29\u6b8b\u7559\uff0c\u4e11\u964b\u7684\uff0c\u6b8b\u7f3a\u7684\uff0c\u591a\u4f59\u7684\u624b\u6307\uff0c\u753b\u5f97\u4e0d\u597d\u7684\u624b\u90e8\uff0c\u753b\u5f97\u4e0d\u597d\u7684\u8138\u90e8\uff0c\u7578\u5f62\u7684\uff0c\u6bc1\u5bb9\u7684\uff0c\u5f62\u6001\u7578\u5f62\u7684\u80a2\u4f53\uff0c\u624b\u6307\u878d\u5408\uff0c\u9759\u6b62\u4e0d\u52a8\u7684\u753b\u9762\uff0c\u6742\u4e71\u7684\u80cc\u666f\uff0c\u4e09\u6761\u817f\uff0c\u80cc\u666f\u4eba\u5f88\u591a\uff0c\u5012\u7740\u8d70\uff0c\u88f8\u9732\uff0cNSFW",
+   "clip": [
+    "1071",
+    0
+   ]
+  }
+ },
+ "1089": {
+  "class_type": "CLIPTextEncode",
+  "inputs": {
+   "text": "a low-poly wooden treasure chest spinning, game asset, clean studio background",
+   "clip": [
+    "1071",
+    0
+   ]
+  }
+ },
+ "2000": {
+  "class_type": "SaveVideo",
+  "inputs": {
+   "filename_prefix": "wan_t2v",
+   "format": "auto",
+   "codec": "auto",
+   "video": [
+    "1114",
+    0
+   ]
+  }
+ }
+}


### PR DESCRIPTION
Adds **wan22** to the video provider registry (registered first, no API key) — Wan 2.2 text-to-video on our own V100 via ComfyUI.

- `_try_wan` posts the flattened t2v workflow (`wan_t2v_api.json`) to `WAN_COMFYUI_URL` (:8189), polls `/history`, fetches the mp4.
- The workflow was flattened from the UI subgraph blueprint: `UNETLoader`→`UnetLoaderGGUF` swap (only GGUF weights exist) + lightx2v LoRA fallback (only high-noise LoRA present).
- Internal host stays in env (`WAN_COMFYUI_URL`), not the repo.

**Verified e2e:** standalone Wan render produced a valid mp4; a Studio `full_ai` job failed over LTX(:8188 down)→wan22(:8189) and rendered on the V100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)