### PR TITLE
Studio: per-second video pricing + auto-refund on text-card fallback

### DIFF
--- a/bottube_templates/studio.html
+++ b/bottube_templates/studio.html
@@ -15,6 +15,11 @@
   .st-bal strong { color:#ffcf33; font-size: 18px; }
   .st-prompt { width:100%; box-sizing:border-box; background:var(--bg-secondary); border:1px solid var(--border);
     border-radius:var(--radius); color:var(--text-primary); padding:14px; font-size:15px; min-height:84px; resize:vertical; margin:10px 0 6px; }
+  .st-seconds { display:flex; align-items:center; gap:12px; justify-content:center; margin:6px 0 4px; flex-wrap:wrap; }
+  .st-seconds label { color:var(--text-secondary); font-size:14px; } .st-seconds label strong { color:#ffcf33; font-size:17px; }
+  .st-seconds input[type=range] { width:240px; accent-color:var(--accent); }
+  .st-sec-note { color:var(--text-muted); font-size:12px; }
+  .price .pps { color:var(--text-muted); font-size:12px; font-weight:400; }
   .tiers { display:grid; grid-template-columns: repeat(3, 1fr); gap:14px; margin-top:8px; }
   @media (max-width: 680px){ .tiers { grid-template-columns: 1fr; } }
   .tier { position:relative; background:var(--bg-secondary); border:1px solid var(--border); border-left-width:5px;
@@ -58,17 +63,24 @@
 
   <textarea class="st-prompt" id="st-prompt" maxlength="1000" placeholder="Describe what you want…"></textarea>
 
-  <!-- VIDEO: 3 tiers -->
-  <div class="tiers" id="mode-video">
-    {% for t in video_tiers %}
-    <div class="tier t{{ loop.index0 }}">
-      <span class="tbadge">{{ t.badge }}</span>
-      <h3>{{ t.name }}</h3>
-      <p>{{ t.desc }}</p>
-      <div class="price">{{ t.rtc }} RTC</div>
-      <button class="gen" data-tier="{{ t.key }}" onclick="stGenerate('video', this.getAttribute('data-tier'))">Generate · {{ t.rtc }} RTC</button>
+  <!-- VIDEO: seconds selector + 3 tiers -->
+  <div id="mode-video">
+    <div class="st-seconds">
+      <label>Length: <strong id="sec-val">5</strong> s</label>
+      <input type="range" id="sec-slider" min="3" max="8" value="5" step="1" oninput="stSeconds()">
+      <span class="st-sec-note">longer = more RTC</span>
     </div>
-    {% endfor %}
+    <div class="tiers">
+      {% for t in video_tiers %}
+      <div class="tier t{{ loop.index0 }}" data-rps="{{ t.rtc_per_sec }}">
+        <span class="tbadge">{{ t.badge }}</span>
+        <h3>{{ t.name }}</h3>
+        <p>{{ t.desc }}</p>
+        <div class="price"><span class="pc">{{ '%.1f'|format(t.rtc_per_sec * 5) }}</span> RTC <span class="pps">({{ t.rtc_per_sec }}/s)</span></div>
+        <button class="gen" data-tier="{{ t.key }}" data-rps="{{ t.rtc_per_sec }}" onclick="stGenerate('video', this.getAttribute('data-tier'))">Generate · <span class="btnc">{{ '%.1f'|format(t.rtc_per_sec * 5) }}</span> RTC</button>
+      </div>
+      {% endfor %}
+    </div>
   </div>
 
   <!-- IMAGE -->
@@ -148,13 +160,27 @@
   }
   loadInfo();
 
+  window.stSeconds = function () {
+    var s = parseInt((document.getElementById("sec-slider") || {}).value || "5", 10);
+    var sv = document.getElementById("sec-val"); if (sv) sv.textContent = s;
+    document.querySelectorAll("#mode-video .tier").forEach(function (card) {
+      var rps = parseFloat(card.getAttribute("data-rps") || "0");
+      var cost = Math.round(rps * s * 100) / 100;
+      card.querySelectorAll(".pc, .btnc").forEach(function (el) { el.textContent = cost; });
+    });
+  };
+  stSeconds();
+
   window.stGenerate = function (mode, tier) {
     var prompt = (promptEl.value || "").trim();
     if (!prompt) { say("Type a prompt first."); return; }
     setBusy(true); clearResult();
     say(mode === "video" ? "Charging RTC and starting generation…" : "Charging RTC and generating…");
     var payload = { type: mode, prompt: prompt };
-    if (mode === "video") payload.tier = tier;
+    if (mode === "video") {
+      payload.tier = tier;
+      payload.seconds = parseInt((document.getElementById("sec-slider") || {}).value || "5", 10);
+    }
     fetch("/api/studio/generate", {
       method: "POST", headers: { "Content-Type": "application/json" },
       credentials: "same-origin", body: JSON.stringify(payload)

--- a/studio_blueprint.py
+++ b/studio_blueprint.py
@@ -30,15 +30,30 @@ from flask import Blueprint, jsonify, render_template, request, session, send_fr
 
 studio_bp = Blueprint("studio", __name__)
 
-# ---- pricing (RTC, env-overridable) ----
+# ---- pricing (RTC, env-overridable). Video is priced PER SECOND — the user picks
+# how many seconds (longer = more RTC). is_text tiers legitimately produce a card. ----
 VIDEO_TIERS = {
-    "text_card": {"rtc": float(os.environ.get("STUDIO_RTC_TEXT", "1")),
-                  "name": "Text Card", "desc": "Instant title-card video", "badge": "CHEAPEST", "duration": 5},
-    "ken_burns": {"rtc": float(os.environ.get("STUDIO_RTC_KENBURNS", "3")),
-                  "name": "Ken Burns", "desc": "Cinematic pan & zoom over images", "badge": "POPULAR", "duration": 8},
-    "full_ai":   {"rtc": float(os.environ.get("STUDIO_RTC_FULLAI", "5")),
-                  "name": "Full AI Video", "desc": "LTX-2 generated, with audio", "badge": "PREMIUM", "duration": 8},
+    "text_card": {"rtc_per_sec": float(os.environ.get("STUDIO_RTC_TEXT_PS", "0.2")),
+                  "name": "Text Card", "desc": "Instant title-card video", "badge": "CHEAPEST",
+                  "min_s": 3, "max_s": 10, "default_s": 5, "is_text": True},
+    "ken_burns": {"rtc_per_sec": float(os.environ.get("STUDIO_RTC_KENBURNS_PS", "0.5")),
+                  "name": "Ken Burns", "desc": "Cinematic pan & zoom over images", "badge": "POPULAR",
+                  "min_s": 3, "max_s": 10, "default_s": 8},
+    "full_ai":   {"rtc_per_sec": float(os.environ.get("STUDIO_RTC_FULLAI_PS", "1.0")),
+                  "name": "Full AI Video", "desc": "Wan 2.2 / LTX generated", "badge": "PREMIUM",
+                  "min_s": 3, "max_s": 8, "default_s": 5},
 }
+
+
+def _video_cost(tier, seconds):
+    """Clamp seconds to the tier's range and return (cost_rtc, clamped_seconds)."""
+    t = VIDEO_TIERS[tier]
+    try:
+        s = int(round(float(seconds)))
+    except (TypeError, ValueError):
+        s = t["default_s"]
+    s = max(t["min_s"], min(t["max_s"], s))
+    return round(t["rtc_per_sec"] * s, 2), s
 IMAGE_RTC = float(os.environ.get("STUDIO_RTC_IMAGE", "0.5"))
 VOICE_RTC = float(os.environ.get("STUDIO_RTC_VOICE", "0.5"))
 MODEL_RTC = float(os.environ.get("STUDIO_RTC_MODEL", "3"))
@@ -100,12 +115,20 @@ def _save_media(data: bytes, ext: str) -> str:
     return fname
 
 
-def _studio_video_worker(job_id, agent_id, prompt, duration, cost):
-    """Run the shared video worker, then refund RTC if the async job FAILED.
+# gen_method values that mean "real AI video was produced". Anything else (the
+# ffmpeg title-card / text fallback) is NOT what a paid AI tier promised -> refund.
+_REAL_VIDEO_METHODS = {"ltx2", "wan22", "gemini", "stability", "fal", "replicate",
+                       "hf_sdxl_video", "huggingface", "ken_burns"}
 
-    The shared _generation_worker marks failed jobs but does not refund (it is
-    used by non-Studio callers with their own billing). The Studio debits up
-    front, so we own the async refund here — scoped to this job, fired once.
+
+def _studio_video_worker(job_id, agent_id, prompt, duration, cost, tier="full_ai"):
+    """Run the shared video worker, then refund RTC if the job FAILED, or if a paid
+    AI tier silently fell back to the ffmpeg text card (not what the user paid for).
+
+    The shared _generation_worker marks failed jobs but never refunds (it serves
+    non-Studio callers with their own billing). Studio debits up front, so we own
+    the async refund here — scoped to this job, fired once. The text_card tier
+    legitimately produces a card, so it is never refunded for that.
     """
     from video_gen_blueprint import _generation_worker, _get_job
     try:
@@ -113,10 +136,18 @@ def _studio_video_worker(job_id, agent_id, prompt, duration, cost):
     except Exception as e:
         print(f"[studio] video worker raised for {job_id}: {e}", flush=True)
     try:
-        j = _get_job(job_id)
-        if j and j.get("status") == "failed":
+        j = _get_job(job_id) or {}
+        status = j.get("status")
+        gen_method = j.get("gen_method")
+        is_text_tier = VIDEO_TIERS.get(tier, {}).get("is_text", False)
+        text_fallback = status == "completed" and gen_method not in _REAL_VIDEO_METHODS
+        if status == "failed":
             _refund(agent_id, cost)
             print(f"[studio] refunded {cost} RTC to {agent_id} (job {job_id} failed)", flush=True)
+        elif text_fallback and not is_text_tier:
+            _refund(agent_id, cost)
+            print(f"[studio] refunded {cost} RTC to {agent_id} "
+                  f"(job {job_id} fell back to '{gen_method}', tier '{tier}' expected AI video)", flush=True)
     except Exception as e:
         print(f"[studio] refund-check failed for {job_id}: {e}", flush=True)
 
@@ -151,7 +182,9 @@ def studio_info():
     return jsonify({
         "ok": True, "signed_in": caller is not None, "rtc_balance": bal,
         "tiers": {
-            "video": {k: v["rtc"] for k, v in VIDEO_TIERS.items()},
+            "video": {k: {"rtc_per_sec": v["rtc_per_sec"], "min_s": v["min_s"],
+                          "max_s": v["max_s"], "default_s": v["default_s"]}
+                      for k, v in VIDEO_TIERS.items()},
             "image": IMAGE_RTC,
             "voice": VOICE_RTC,
             "model": MODEL_RTC,
@@ -174,7 +207,7 @@ def studio_generate():
         tier = (body.get("tier") or "").strip()
         if tier not in VIDEO_TIERS:
             return jsonify({"error": "unknown video tier"}), 400
-        cost = VIDEO_TIERS[tier]["rtc"]
+        cost, seconds = _video_cost(tier, body.get("seconds", VIDEO_TIERS[tier]["default_s"]))
     elif gtype == "image":
         cost = IMAGE_RTC
     elif gtype == "voice":
@@ -215,14 +248,15 @@ def studio_generate():
             from video_gen_blueprint import _create_job
             job_id = _create_job(agent_id, prompt)
             threading.Thread(target=_studio_video_worker,
-                             args=(job_id, agent_id, prompt, VIDEO_TIERS[tier]["duration"], cost),
+                             args=(job_id, agent_id, prompt, seconds, cost, tier),
                              daemon=True).start()
         except Exception as e:
             _refund(agent_id, cost)
             print(f"[studio] video start failed (refunded {cost}): {e}", flush=True)
             return jsonify({"error": "couldn't start generation; your RTC was refunded"}), 502
         return jsonify({"ok": True, "type": "video", "job_id": job_id, "charged_rtc": cost,
-                        "new_balance": new_balance, "status_url": f"/api/generate-video/status/{job_id}"}), 202
+                        "seconds": seconds, "new_balance": new_balance,
+                        "status_url": f"/api/generate-video/status/{job_id}"}), 202
 
     # ---- MODEL (3D): async via forge3d provider cascade ----
     if gtype == "model":

--- a/video_gen_blueprint.py
+++ b/video_gen_blueprint.py
@@ -389,6 +389,12 @@ def _try_wan(prompt: str, duration: int, final_path) -> bool:
     except Exception:
         return False
     try:
+        # duration (s) -> frame count at 16fps; Wan likes 4n+1, clamp ~1-8s
+        frames = max(17, min(129, int(duration) * 16 + 1))
+        wf["1074"]["inputs"]["length"] = frames   # EmptyHunyuanLatentVideo
+    except Exception:
+        pass
+    try:
         req = urllib.request.Request(
             f"{WAN_COMFYUI_URL}/prompt",
             data=json.dumps({"prompt": wf}).encode(),


### PR DESCRIPTION
1. **Auto-refund** when a paid AI tier (ken_burns/full_ai) silently falls back to the ffmpeg text card (`gen_method` not a real AI backend). The `text_card` tier legitimately makes a card → never refunded. Closes the 'paid 5 RTC, got text' gap.
2. **Per-second pricing** — user picks length (3–8s slider), RTC scales (full_ai 1.0/s, ken_burns 0.5/s, text_card 0.2/s, env-overridable). `seconds` flows to the worker; Wan honors it (frames = seconds×16+1).

Verified: cost scaling (full_ai 3s=3→8s=8 RTC), info endpoint exposes per-sec tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)