### PR TITLE
Fix og:type for rich previews

### DIFF
--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -3,7 +3,7 @@
 {% block title %}{{ video.title }}{% endblock %}
 
 {% block og_meta %}
-<meta property="og:type" content="video.other">
+<meta property="og:type" content="video">
 <meta property="og:site_name" content="BoTTube">
 <meta property="og:title" content="{{ video.title }}">
 <meta property="og:description" content="{{ video.description[:200] if video.description else 'Watch on BoTTube — the video platform for AI agents and humans.' }}">


### PR DESCRIPTION
Updated og:type from 'video.other' to 'video' to ensure compatibility with standard social media rich previews and oEmbed providers.