### PR TITLE
fix(usdc): bind deposit sender to account wallet (anti-theft)

### DIFF
--- a/tests/test_usdc_deposit_sender_binding.py
+++ b/tests/test_usdc_deposit_sender_binding.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+"""Security regression tests for USDC deposit sender-binding (anti-theft).
+
+A USDC->treasury tx_hash is PUBLIC on-chain data, and the deposit endpoint
+dedups only per-tx_hash. Without binding the on-chain sender to the
+authenticated account's wallet, any authenticated agent could claim someone
+else's (or any unclaimed) treasury USDC transfer as their own balance credit
+-- the same theft the wRTC Solana/Base bridges already block by requiring
+sender == account wallet. These tests pin that binding into /api/usdc/deposit.
+"""
+
+import sqlite3
+from importlib import metadata
+
+import pytest
+import werkzeug
+from flask import Flask, g
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
+
+
+ALICE_WALLET = "0x1111111111111111111111111111111111111111"
+MALLORY_WALLET = "0x2222222222222222222222222222222222222222"
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    import usdc_blueprint as usdc
+
+    db_path = tmp_path / "usdc.db"
+    conn = sqlite3.connect(str(db_path))
+    # Mirror the production agents columns the USDC blueprint reads:
+    # `name` (its auth helper) + `eth_address` (the new sender binding).
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            agent_name TEXT,
+            api_key TEXT NOT NULL,
+            eth_address TEXT,
+            rtc_balance REAL DEFAULT 0
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO agents (name, agent_name, api_key, eth_address) VALUES (?, ?, ?, ?)",
+        [
+            ("alice", "alice", "k_alice", ALICE_WALLET),
+            ("mallory", "mallory", "k_mallory", MALLORY_WALLET),
+            ("carol", "carol", "k_carol", ""),  # no wallet bound
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.register_blueprint(usdc.usdc_bp)
+
+    def _test_get_db():
+        if "test_db" in g:
+            return g.test_db
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        g.test_db = db
+        return db
+
+    monkeypatch.setattr(usdc, "get_db", _test_get_db)
+
+    # The on-chain transfer is "really" sent by ALICE_WALLET to the treasury.
+    def _fake_verify(tx_hash):
+        return (
+            {
+                "tx_hash": tx_hash,
+                "from_address": ALICE_WALLET.lower(),
+                "to_address": usdc.TREASURY_ADDRESS.lower(),
+                "amount_raw": str(100 * 10 ** usdc.USDC_DECIMALS),
+                "amount_usdc": 100.0,
+                "block_number": 123,
+                "chain": "base",
+                "verified": True,
+            },
+            None,
+        )
+
+    monkeypatch.setattr(usdc, "verify_usdc_transfer_onchain", _fake_verify)
+
+    yield flask_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _deposit(client, api_key, tx_hash):
+    return client.post(
+        "/api/usdc/deposit",
+        json={"tx_hash": tx_hash},
+        headers={"X-API-Key": api_key},
+    )
+
+
+def _balance(client, name):
+    with client.application.app_context():
+        import usdc_blueprint as usdc
+
+        db = usdc.get_db()
+        row = db.execute(
+            "SELECT balance_usdc FROM usdc_balances WHERE agent_name = ?", (name,)
+        ).fetchone()
+        return row["balance_usdc"] if row else 0.0
+
+
+def test_deposit_succeeds_when_sender_matches_bound_wallet(client):
+    resp = _deposit(client, "k_alice", "0x" + "a" * 64)
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["ok"] is True
+    assert _balance(client, "alice") == 100.0
+
+
+def test_deposit_blocks_claiming_another_users_transfer(client):
+    # Mallory tries to claim Alice's treasury transfer. Must be rejected (403)
+    # and must NOT credit Mallory.
+    resp = _deposit(client, "k_mallory", "0x" + "b" * 64)
+    assert resp.status_code == 403, resp.get_json()
+    assert "does not match" in resp.get_json()["error"].lower()
+    assert _balance(client, "mallory") == 0.0
+
+
+def test_deposit_requires_bound_wallet(client):
+    resp = _deposit(client, "k_carol", "0x" + "c" * 64)
+    assert resp.status_code == 400, resp.get_json()
+    assert "no ethereum wallet" in resp.get_json()["error"].lower()
+    assert _balance(client, "carol") == 0.0
+
+
+def test_rejected_deposit_is_not_recorded(client):
+    _deposit(client, "k_mallory", "0x" + "d" * 64)
+    with client.application.app_context():
+        import usdc_blueprint as usdc
+
+        db = usdc.get_db()
+        usdc.init_usdc_tables(db)
+        count = db.execute("SELECT COUNT(*) FROM usdc_deposits").fetchone()[0]
+    assert count == 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -285,6 +285,31 @@ def usdc_deposit():
             "got": transfer["to_address"],
         }), 400
 
+    # Anti-theft: the on-chain sender must match the account's bound Base/ETH wallet.
+    # A treasury tx_hash is PUBLIC on-chain data, and dedup is only per-tx_hash, so
+    # without this binding any authenticated agent could front-run/claim someone
+    # else's (or any unclaimed) treasury USDC transfer as their own balance credit.
+    # Mirrors the wRTC Solana/Base bridges (base_wrtc_bridge_blueprint.py,
+    # wrtc_bridge_blueprint.py), which both require sender == account wallet.
+    api_key = request.headers.get("X-API-Key") or request.args.get("api_key")
+    account_row = db.execute(
+        "SELECT eth_address FROM agents WHERE api_key = ?", (api_key,)
+    ).fetchone()
+    account_eth = ((account_row["eth_address"] if account_row else "") or "").strip().lower()
+    if not account_eth:
+        return jsonify({
+            "error": (
+                "No Ethereum wallet bound to your account. "
+                "Set your ETH address in profile settings before deposit verification."
+            )
+        }), 400
+    if account_eth != transfer["from_address"].lower():
+        return jsonify({
+            "error": "Sender wallet does not match your account's verified ETH address",
+            "expected_sender": account_eth,
+            "onchain_sender": transfer["from_address"],
+        }), 403
+
     # Record deposit
     db.execute("""
         INSERT INTO usdc_deposits (tx_hash, from_address, to_address, amount_raw, amount_usdc,


### PR DESCRIPTION
## Summary

`POST /api/usdc/deposit` verifies that an on-chain USDC transfer landed in the
treasury and dedups by `tx_hash`, but it **never checks who sent the transfer**.
It credits the *authenticated caller* for any valid treasury-bound USDC transfer.

A treasury `tx_hash` is **public on-chain data** (visible on Basescan), and the
dedup is only per-`tx_hash`. So any authenticated agent can claim another user's
— or any historically unclaimed — treasury USDC transfer as **their own** balance
credit, then cash it out via `/api/usdc/payout`.

This is the exact theft both wRTC bridges already block:

- `base_wrtc_bridge_blueprint.py` (lines ~372–390): *"Anti-theft: sender must match account's bound Ethereum address"* → `403` on mismatch.
- `wrtc_bridge_blueprint.py` (lines ~341–365): same check against `sol_address`.

`usdc_blueprint.py` was the sibling money-path that never received the check.
(Falls under SECURITY.md scope: *Authentication and authorization*.)

## Reproduction

1. Alice (honest) sends 100 USDC on Base to the BoTTube treasury to fund her account. The tx hash is public.
2. Before Alice calls `/api/usdc/deposit`, Mallory (any registered agent) reads Alice's tx hash and calls:
   ```
   POST /api/usdc/deposit
   X-API-Key: <Mallory's key>
   {"tx_hash": "<Alice's tx>"}
   ```
3. The endpoint confirms the transfer went to the treasury (it did), records the deposit **under Mallory**, and credits **Mallory's** USDC balance with 100.
4. Alice's later deposit call returns `409 already recorded`. Mallory withdraws via `/api/usdc/payout` to her own wallet.

Net: Alice's funds are credited to an attacker; the platform takes the loss.

## Fix

Require the verified on-chain `from_address` to equal the authenticated account's
bound `eth_address`, mirroring the Base bridge:

- `400` if the account has no ETH wallet bound.
- `403` if the on-chain sender doesn't match the bound wallet.

The wallet is looked up by `api_key` so the existing `get_authenticated_agent()`
helper is left untouched (minimal blast radius).

## Tests

Adds `tests/test_usdc_deposit_sender_binding.py`:

- matching sender → credited (200);
- **claiming another user's transfer → 403, not credited, not recorded** (the regression);
- no bound wallet → 400.

Verified as a negative control: **without** this fix the theft test credits the
attacker (`assert 1 == 0` on the deposit count); **with** it, all 4 pass.
Existing USDC/bridge suites still green (`pytest -k "usdc or bridge"` + `test_bridge_admin_auth.py` → 97 passed).