### PR TITLE
fix(a11y): WCAG 2.1 AA accessibility fixes (#406, #407, #418, #419)

### DIFF
--- a/bottube_templates/activity_feed.html
+++ b/bottube_templates/activity_feed.html
@@ -290,7 +290,7 @@
     function createUploadItem(activity) {
         return `
             <div class="activity-item">
-                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="" loading="lazy" decoding="async">
+                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="${escapeHtml(activity.agent.display_name)} avatar" loading="lazy" decoding="async">
                 <div class="activity-content">
                     <div class="activity-header">
                         <span class="activity-agent">${escapeHtml(activity.agent.display_name)}</span>
@@ -312,7 +312,7 @@
         const replyBadge = activity.content.is_reply ? '<span class="collab-badge">↩️ Reply</span>' : '';
         return `
             <div class="activity-item">
-                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="" loading="lazy" decoding="async">
+                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="${escapeHtml(activity.agent.display_name)} avatar" loading="lazy" decoding="async">
                 <div class="activity-content">
                     <div class="activity-header">
                         <span class="activity-agent">${escapeHtml(activity.agent.display_name)}</span>
@@ -333,7 +333,7 @@
         const emoji = activity.content.action === 'upvoted' ? '👍' : '👎';
         return `
             <div class="activity-item">
-                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="" loading="lazy" decoding="async">
+                <img src="${activity.agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="${escapeHtml(activity.agent.display_name)} avatar" loading="lazy" decoding="async">
                 <div class="activity-content">
                     <div class="activity-header">
                         <span class="activity-agent">${escapeHtml(activity.agent.display_name)}</span>
@@ -351,7 +351,7 @@
     function createTipItem(activity) {
         return `
             <div class="activity-item tip-activity">
-                <img src="${activity.from_agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="" loading="lazy" decoding="async">
+                <img src="${activity.from_agent.avatar || '/static/default-avatar.png'}" class="activity-avatar" alt="${escapeHtml(activity.from_agent.display_name)} avatar" loading="lazy" decoding="async">
                 <div class="activity-content">
                     <div class="activity-header">
                         <span class="activity-agent">${escapeHtml(activity.from_agent.display_name)}</span>

--- a/bottube_templates/analytics.html
+++ b/bottube_templates/analytics.html
@@ -407,11 +407,11 @@
                         y: {
                             beginAtZero: true,
                             grid: { color: 'rgba(255,255,255,0.1)' },
-                            ticks: { color: '#aaa' }
+                            ticks: { color: '#b0b0b0' }
                         },
                         x: {
                             grid: { display: false },
-                            ticks: { color: '#aaa' }
+                            ticks: { color: '#b0b0b0' }
                         }
                     }
                 }

--- a/bottube_templates/anchor_detail.html
+++ b/bottube_templates/anchor_detail.html
@@ -162,7 +162,7 @@ python3 bottube_verify_provenance.py &lt;video_id&gt; \
     <div class="ad-member">
       <div class="thumb">
         {% if m.thumbnail %}
-        <img src="{{ P }}/thumbnails/{{ m.thumbnail }}" alt="" loading="lazy">
+        <img src="{{ P }}/thumbnails/{{ m.thumbnail }}" alt="Video thumbnail: {{ m.title }}" loading="lazy">
         {% endif %}
       </div>
       <div class="info">

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -74,7 +74,7 @@
             --bg-card: #212121;
             --bg-hover: #2a2a2a;
             --text-primary: #f1f1f1;
-            --text-secondary: #aaaaaa;
+            --text-secondary: #b0b0b0;
             --text-muted: #8a8a8a; /* was #717171, bumped for WCAG AA 4.5:1 contrast */
             --accent: #3ea6ff;
             --accent-hover: #65b8ff;
@@ -959,7 +959,7 @@
             <a href="{{ language_switch_href(lc) }}" style="padding:2px 8px;font-size:12px;border-radius:4px;{% if locale == lc %}background:var(--accent);color:#000;font-weight:600;{% else %}color:var(--text-muted);{% endif %}">{{ lc|upper }}</a>
             {% endfor %}
         </div>
-        <div class="footer-operator" style="margin:8px 0; font-size:13px; color:#9aa4b2;">
+        <div class="footer-operator" style="margin:8px 0; font-size:13px; color:#b0b8c8;">
             Operated by <strong>Elyan Labs</strong> &middot; contact <a href="mailto:scott@elyanlabs.ai" style="color:inherit;">scott@elyanlabs.ai</a> &middot; <a href="/about" style="color:inherit;">About</a> &middot; United States
         </div>
         <div class="footer-copy">{{ _('footer.copyright') }}</div>

--- a/bottube_templates/beacon.html
+++ b/bottube_templates/beacon.html
@@ -529,7 +529,7 @@
         }
         @keyframes atlasPulse { 0%,100% { opacity:1; } 50% { opacity:0.3; } }
         .atlas-live-banner h3 { color: #00ffff; font-family: monospace; margin: 0; font-size: 1rem; }
-        .atlas-live-banner p { color: #aaa; margin: 4px 0 0; font-size: 0.85rem; }
+        .atlas-live-banner p { color: #b0b0b0; margin: 4px 0 0; font-size: 0.85rem; }
         .atlas-btn {
             background: transparent; border: 1px solid #00ffff; color: #00ffff;
             padding: 10px 20px; border-radius: 4px; font-family: monospace;

--- a/bottube_templates/embed.html
+++ b/bottube_templates/embed.html
@@ -18,7 +18,7 @@ video{max-width:100%;max-height:100%;width:100%;height:100%;object-fit:contain;d
 body:hover .overlay{opacity:1}
 .info{color:#fff;min-width:0}
 .title{font:600 14px/1.3 -apple-system,sans-serif;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:70vw}
-.creator{font:12px -apple-system,sans-serif;color:#aaa;margin-top:2px}
+.creator{font:12px -apple-system,sans-serif;color:#b0b0b0;margin-top:2px}
 .brand{pointer-events:auto;text-decoration:none;background:#3ea6ff;color:#0f0f0f;padding:6px 14px;border-radius:4px;
  font:700 12px -apple-system,sans-serif;white-space:nowrap;flex-shrink:0}
 .brand:hover{background:#65b8ff}

--- a/bottube_templates/explore.html
+++ b/bottube_templates/explore.html
@@ -123,7 +123,7 @@
         <form class="search" action="{{ P }}/search" method="get" role="search">
             <label class="sr-only" for="q">Search videos</label>
             <input id="q" type="search" name="q" placeholder="Search videos, creators, tags..." value="">
-            <button type="submit">Search</button>
+            <button type="submit" aria-label="Search videos">Search</button>
         </form>
     </div>
 

--- a/bottube_templates/login.html
+++ b/bottube_templates/login.html
@@ -335,7 +335,7 @@
         
         <div style="display:flex;align-items:center;gap:8px;margin:12px 0 4px 0;">
             <input type="checkbox" id="remember_me" name="remember_me" value="1" style="width:18px;height:18px;accent-color:#ff4444;cursor:pointer;">
-            <label for="remember_me" style="color:#ccc;font-size:14px;cursor:pointer;user-select:none;">Stay logged in</label>
+            <label for="remember_me" style="color:#d0d0d0;font-size:14px;cursor:pointer;user-select:none;">Stay logged in</label>
         </div>
 
         <button type="submit" class="submit-btn" aria-label="Log in to account">Log In</button>

--- a/bottube_templates/news_article.html
+++ b/bottube_templates/news_article.html
@@ -59,7 +59,7 @@
         align-items: center;
         gap: 12px;
         margin-bottom: 20px;
-        color: #aaa;
+        color: #b0b0b0;
         font-size: 0.9rem;
     }
     .article-meta img {
@@ -131,7 +131,7 @@
         align-items: center;
     }
     .article-footer .views {
-        color: #999;
+        color: #b0b0b0;
         font-size: 0.85rem;
     }
     .back-link {

--- a/bottube_templates/studio.html
+++ b/bottube_templates/studio.html
@@ -62,6 +62,7 @@
 
   <div class="st-bal" id="st-bal">Checking your RTC balance…</div>
 
+  <label class="sr-only" for="st-prompt">Describe what you want to generate</label>
   <textarea class="st-prompt" id="st-prompt" maxlength="1000" placeholder="Describe what you want…"></textarea>
 
   <!-- VIDEO: seconds selector + 3 tiers -->

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -1558,7 +1558,7 @@
         color: #fff; font-size: 16px; font-weight: 700; text-align: center;
         max-width: 80%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
     }
-    .video-endscreen .es-subtitle { color: #aaa; font-size: 13px; margin-bottom: 4px; }
+    .video-endscreen .es-subtitle { color: #d4d4d4; font-size: 13px; margin-bottom: 4px; }
     .video-endscreen .es-share-row {
         display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; max-width: 90%; }
     .video-endscreen .es-share-btn {
@@ -2672,8 +2672,8 @@
             
             <!-- AEO: Chunkable context for AI Overviews -->
             <section class="aeo-context" style="margin-top:16px;padding:12px 16px;background:rgba(255,255,255,0.03);border-radius:8px;border:1px solid rgba(255,255,255,0.06);">
-                <h2 style="font-size:14px;color:#aaa;margin:0 0 8px 0;font-weight:500;">About this video</h2>
-                <p style="font-size:13px;color:#888;margin:0;line-height:1.5;">
+                <h2 style="font-size:14px;color:var(--text-secondary);margin:0 0 8px 0;font-weight:500;">About this video</h2>
+                <p style="font-size:13px;color:var(--text-secondary);margin:0;line-height:1.5;">
                     This {{ video.duration_sec or 8 }}-second video was created by
                     <a href="/agent/{{ video.agent_name }}" style="color:#ff6666;">{{ video.display_name or video.agent_name }}</a>{% if not video.is_human %}, an AI agent{% endif %} on BoTTube.
                     {% if video.category %}Category: <strong>{{ video.category }}</strong>.{% endif %}
@@ -2894,7 +2894,7 @@
                     }
                     dyn.innerHTML = j.results.map(function (r) {
                         var thumb = r.thumbnail
-                            ? '<img src="/thumbnails/' + _esc(r.thumbnail) + '" alt="Video thumbnail" loading="lazy" decoding="async">'
+                            ? '<img src="/thumbnails/' + _esc(r.thumbnail) + '" alt="Video thumbnail: ' + _esc(r.title || 'video') + '" loading="lazy" decoding="async">'
                             : '<div class="thumb-placeholder">&#9654;</div>';
                         var dur = r.duration_sec > 0
                             ? '<span class="duration-badge">' + _esc(_fmtDur(r.duration_sec)) + '</span>'


### PR DESCRIPTION
## Summary
- Fixes missing alt text on video thumbnails and avatar images (WCAG 1.1.1)
- Fixes insufficient color contrast on secondary text elements (WCAG 1.4.3 AA 4.5:1)
- Adds missing accessible label to studio prompt textarea (WCAG 1.3.1)
- All icon-only buttons already had aria-labels from prior fixes (#406)

## Issues Resolved
- **#418** — Added descriptive `alt` text to avatar images in activity feed, anchor detail thumbnails, and dynamically generated sidebar thumbnails (now includes video title)
- **#419** — Updated low-contrast colors (`#aaa`, `#888`, `#999`, `#ccc`) to `#b0b0b0` or higher across: base CSS variables, watch page AEO section and endscreen, news article metadata, embed creator text, beacon banner, analytics chart ticks, footer operator, and login label
- **#407** — Added `sr-only` label for studio prompt textarea

## Files Changed
- `bottube_templates/activity_feed.html` — Avatar alt text
- `bottube_templates/anchor_detail.html` — Thumbnail alt text
- `bottube_templates/watch.html` — Sidebar thumbnail alt text, color contrast fixes
- `bottube_templates/base.html` — `--text-secondary` variable, footer operator color
- `bottube_templates/news_article.html` — Metadata color contrast
- `bottube_templates/embed.html` — Creator text color contrast
- `bottube_templates/beacon.html` — Banner text color contrast
- `bottube_templates/analytics.html` — Chart tick color contrast
- `bottube_templates/login.html` — Label color contrast
- `bottube_templates/studio.html` — Added sr-only label for prompt textarea