### PR TITLE
fix(ci): label fork pull requests safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,15 +84,3 @@ jobs:
       continue-on-error: true
       run: |
         safety check || true
-
-  auto-label:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/labeler@v5
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: Auto Label Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          sync-labels: false


### PR DESCRIPTION
## Summary

- move automatic labeling out of the general `pull_request` CI workflow
- run the labeler from a dedicated `pull_request_target` workflow with `pull-requests: write`
- avoid checking out or executing contributor code in the privileged workflow

## Why

GitHub downgrades `GITHUB_TOKEN` to read-only for pull requests from forks, so the existing labeler fails with `Resource not accessible by integration` even though the job requests write permission. Some open contributor PRs hide that infrastructure failure with `continue-on-error`; this fixes the underlying permission boundary instead.

## Security

The privileged workflow only invokes `actions/labeler` against the base-branch configuration. It has no checkout step and runs no pull request code.

## Validation

- `git diff --check`
- parsed both workflow files with Ruby Psych
- reviewed the privileged workflow for checkout and script execution paths

`actionlint` is not installed in the local environment.