### PR TITLE
fix(rtc-services): negative quantity in /api/rtc/pay mints RTC from a zero balance

### DIFF
--- a/rtc_services.py
+++ b/rtc_services.py
@@ -35,6 +35,11 @@ rtc_services_bp = Blueprint("rtc_services", __name__)
 # Service Catalog
 # ---------------------------------------------------------------------------
 
+# Upper bound on a single /api/rtc/pay purchase. Generous enough for any real
+# bulk buy (100 monthly passes = 6000 RTC) while keeping the cost arithmetic
+# well inside float range.
+MAX_PURCHASE_QUANTITY = 100
+
 SERVICE_CATALOG = {
     "pro_api_day": {
         "name": "Pro API Day Pass",
@@ -221,7 +226,17 @@ def init_app(app, db_path):
 
         data = request.get_json(force=True, silent=True) or {}
         service_key = data.get("service_key", "")
-        quantity = int(data.get("quantity", 1))
+        # quantity is client-supplied and multiplies straight into the cost.
+        # A negative value flips `rtc_balance - total_cost` into a credit and
+        # sails past the balance check below, so bound it before it is used.
+        try:
+            quantity = int(data.get("quantity", 1))
+        except (TypeError, ValueError):
+            return jsonify({"error": "quantity must be an integer"}), 400
+        if quantity < 1 or quantity > MAX_PURCHASE_QUANTITY:
+            return jsonify({
+                "error": f"quantity must be between 1 and {MAX_PURCHASE_QUANTITY}",
+            }), 400
 
         if service_key not in SERVICE_CATALOG:
             return jsonify({

--- a/tests/test_rtc_services_quantity_validation.py
+++ b/tests/test_rtc_services_quantity_validation.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MIT
+"""Validation tests for /api/rtc/pay quantity parsing.
+
+``quantity`` arrives straight from the client body.  Without a sign/range
+check the cost multiplies out negative, the balance gate compares against a
+negative number (and so always passes), and the debit -- written as
+``rtc_balance = rtc_balance - ?`` -- *adds* the amount instead.  Any
+self-registered agent could mint RTC from a zero balance.
+"""
+
+import sqlite3
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture()
+def app(tmp_path):
+    import rtc_services
+
+    db_path = tmp_path / "rtc_services.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            api_key TEXT NOT NULL,
+            rtc_balance REAL DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE earnings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id INTEGER NOT NULL,
+            amount REAL NOT NULL,
+            reason TEXT DEFAULT '',
+            video_id TEXT DEFAULT '',
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO agents (agent_name, api_key, rtc_balance) VALUES (?, ?, ?)",
+        ("payer", "bottube_sk_payer", 0.0),
+    )
+    conn.commit()
+    conn.close()
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    rtc_services.init_app(flask_app, db_path)
+    flask_app.config["RTC_TEST_DB"] = str(db_path)
+    return flask_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _balance(app, api_key="bottube_sk_payer"):
+    conn = sqlite3.connect(app.config["RTC_TEST_DB"])
+    try:
+        return conn.execute(
+            "SELECT rtc_balance FROM agents WHERE api_key = ?", (api_key,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("quantity", [-1, -1000])
+def test_rtc_pay_rejects_negative_quantity(client, app, quantity):
+    """A negative quantity must not invert the debit into a credit."""
+    resp = client.post(
+        "/api/rtc/pay",
+        json={"service_key": "pro_api_month", "quantity": quantity},
+        headers={"X-API-Key": "bottube_sk_payer"},
+    )
+    assert resp.status_code == 400, resp.get_json()
+    assert _balance(app) == 0.0
+
+
+def test_rtc_pay_rejects_zero_quantity(client, app):
+    """Zero quantity buys nothing and must not issue a free service token."""
+    resp = client.post(
+        "/api/rtc/pay",
+        json={"service_key": "pro_api_month", "quantity": 0},
+        headers={"X-API-Key": "bottube_sk_payer"},
+    )
+    assert resp.status_code == 400, resp.get_json()
+    assert _balance(app) == 0.0
+
+
+def test_rtc_pay_rejects_non_integer_quantity(client, app):
+    """A non-integer quantity is a client error, not an unhandled 500."""
+    resp = client.post(
+        "/api/rtc/pay",
+        json={"service_key": "pro_api_month", "quantity": "abc"},
+        headers={"X-API-Key": "bottube_sk_payer"},
+    )
+    assert resp.status_code == 400, resp.get_json()
+    assert _balance(app) == 0.0
+
+
+def test_rtc_pay_still_debits_a_funded_purchase(client, app):
+    """Control: the normal paid path is unchanged by the validation."""
+    conn = sqlite3.connect(app.config["RTC_TEST_DB"])
+    conn.execute("UPDATE agents SET rtc_balance = 60.0 WHERE api_key = ?",
+                 ("bottube_sk_payer",))
+    conn.commit()
+    conn.close()
+
+    resp = client.post(
+        "/api/rtc/pay",
+        json={"service_key": "pro_api_month", "quantity": 1},
+        headers={"X-API-Key": "bottube_sk_payer"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["service_token"]
+    assert _balance(app) == 0.0


### PR DESCRIPTION
## Summary

`/api/rtc/pay` multiplies a client-supplied `quantity` straight into the cost and then debits with bare arithmetic, so a **negative quantity credits the caller**. Any self-registered agent can mint RTC from a zero balance.

`rtc_services.py:224` (line numbers on `89d82fe`):

```python
quantity = int(data.get("quantity", 1))          # no sign/range check
...
total_cost = svc["price_rtc"] * quantity         # -> negative
if balance < total_cost:                         # 0.0 < -60000.0 is False -> passes
    ... 402
...
"UPDATE agents SET rtc_balance = rtc_balance - ?", (total_cost, agent["id"])   # subtracting a negative ADDS
```

## Reproduction (against this endpoint, attacker starts at `rtc_balance = 0.0`, zero deposits)

```
POST /api/rtc/pay   X-API-Key: <any self-registered key>
{"service_key": "pro_api_month", "quantity": -1000}

-> 200 OK
   {"amount_rtc": -60000.0, "balance_remaining": 60000.0, "service_token": "<issued>"}
balance after: 60000.0
```

The purchase is also recorded in `earnings` as `-total_cost`, i.e. **`+60000`** with reason `service_purchase:pro_api_month:qty-1000`, so the audit trail corroborates the mint rather than exposing it. A valid service token is issued at the same time. There is no rate limit on the endpoint, so it repeats freely.

`quantity` also reaches `uses_total * quantity` and `int()` raises an uncaught `ValueError` on a non-numeric value (a 500).

## Reachability

`rtc_services.init_app(app, DB_PATH)` is registered unconditionally at `bottube_server.py:15400-15401`; auth is `X-API-Key` against `agents`, which self-registration hands out. No admin required.

## Fix

Bound `quantity` to `1..MAX_PURCHASE_QUANTITY` (100) before it reaches the cost arithmetic. `int()` stays inside the `try`, so clients that send `"1"` or `1.0` keep working; only out-of-range and unparseable values are rejected, and a non-integer now returns 400 instead of a 500.

The sibling bridges already guard this class — `base_wrtc_bridge_blueprint.py` rejects non-finite/below-minimum amounts and `ergo_bridge_blueprint.py` explicitly rejects `<= 0` — which left this endpoint the remaining unguarded multiplier.

## Verification

`tests/test_rtc_services_quantity_validation.py` (new, 5 tests):

- On clean `main`: **4 fail** — the negative-quantity cases mint (balance 0.0 -> 60000.0) and `"abc"` raises `ValueError`.
- With the fix: **5 pass**.
- The 5th is a control: a funded `quantity: 1` purchase still returns 200, issues a token, and debits 60.0 -> 0.0, so the normal paid path is unchanged.

Neighbouring suites still green: `tests/test_base_wrtc_bridge_validation.py` + `tests/test_banano_amount_validation.py` -> 37 passed.

Reported under the Ongoing Bug Bounty (rustchain-bounties#71, BoTTube payment system in scope). Severity is mine to propose, not to set — this creates funds from nothing for any registered user, which reads as **Critical** under the posted table; happy to defer to your call.

Wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
