### PR TITLE
fix(banano): /ban/tip ignores pending withdrawals (BAN double-spend)

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -530,10 +530,14 @@ def ban_tip():
     if recipient["id"] == user_id:
         return jsonify({"error": "Cannot tip yourself"}), 400
 
+    # Withdrawals are written as 'pending' and only ever advance to
+    # 'sent'/'failed' -- never 'credited'. Filtering on 'credited' alone
+    # dropped those rows before the CASE could subtract them, leaving
+    # already-withdrawn BAN tippable. Match ban_withdraw's status set.
     balance_row = db.execute(
         "SELECT COALESCE(SUM(CASE WHEN tx_type IN ('reward', 'tip_received') THEN amount_ban ELSE 0 END), 0) - "
         "COALESCE(SUM(CASE WHEN tx_type IN ('withdrawal', 'tip_sent') THEN amount_ban ELSE 0 END), 0) as balance "
-        "FROM ban_transactions WHERE agent_id = ? AND status = 'credited'",
+        "FROM ban_transactions WHERE agent_id = ? AND status IN ('credited', 'sent', 'pending')",
         (user_id,),
     ).fetchone()
     balance = balance_row["balance"] if balance_row else 0

--- a/tests/test_banano_tip_pending_withdrawal.py
+++ b/tests/test_banano_tip_pending_withdrawal.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+"""/ban/tip must count pending withdrawals against the spendable balance.
+
+Withdrawal rows are written with ``status='pending'`` and only ever move to
+``'sent'``/``'failed'``.  ``ban_tip`` filtered on ``status = 'credited'``
+*before* its CASE expression, so withdrawal rows dropped out of the sum
+entirely and already-withdrawn BAN stayed tippable -- a ledger double-spend.
+``ban_withdraw`` gets this right with ``status IN ('credited','sent','pending')``.
+"""
+
+import sqlite3
+import time
+from importlib import metadata
+
+import pytest
+import werkzeug
+from flask import Flask, g
+
+import banano_blueprint
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
+
+
+@pytest.fixture
+def ban_client(tmp_path):
+    db_path = tmp_path / "bottube.db"
+    app = Flask(__name__)
+    app.secret_key = "test-secret-key"
+    app.config["TESTING"] = True
+    app.register_blueprint(banano_blueprint.ban_bp)
+
+    @app.before_request
+    def before_request():
+        g.db = sqlite3.connect(db_path)
+        g.db.row_factory = sqlite3.Row
+
+    @app.teardown_request
+    def teardown_request(_exc):
+        db = getattr(g, "db", None)
+        if db is not None:
+            db.close()
+
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            "CREATE TABLE agents (id INTEGER PRIMARY KEY, agent_name TEXT UNIQUE NOT NULL)"
+        )
+        db.execute(
+            "CREATE TABLE videos (video_id TEXT PRIMARY KEY, agent_id INTEGER NOT NULL)"
+        )
+        banano_blueprint.init_ban_tables(db)
+        db.executemany(
+            "INSERT INTO agents (id, agent_name) VALUES (?, ?)",
+            [(1, "alice"), (2, "bob")],
+        )
+        db.execute(
+            """
+            INSERT INTO ban_transactions
+            (agent_id, tx_type, amount_ban, reason, status, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (1, "reward", 10.0, "seed_balance", "credited", time.time()),
+        )
+        db.commit()
+
+    client = app.test_client()
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+    client.db_path = db_path
+    return client
+
+
+def _pending_withdrawal_total(db_path):
+    with sqlite3.connect(db_path) as db:
+        return db.execute(
+            "SELECT COALESCE(SUM(amount_ban), 0) FROM ban_transactions "
+            "WHERE tx_type = 'withdrawal' AND status = 'pending'"
+        ).fetchone()[0]
+
+
+def test_tip_rejected_after_full_balance_is_withdrawn(ban_client):
+    """Alice earns 10 BAN, withdraws all 10, then must not be able to tip it."""
+    withdraw = ban_client.post(
+        "/ban/withdraw",
+        json={"amount": 10.0, "address": "ban_" + "1" * 60},
+    )
+    assert withdraw.status_code == 200, withdraw.get_json()
+    assert _pending_withdrawal_total(ban_client.db_path) == 10.0
+
+    # The same 10 BAN is already committed to a payout row.
+    tip = ban_client.post("/ban/tip", json={"to_agent": "bob", "amount": 10.0})
+
+    assert tip.status_code == 400, tip.get_json()
+    assert "Insufficient BAN balance" in tip.get_json()["error"]
+    # And no second payout obligation was created.
+    assert _pending_withdrawal_total(ban_client.db_path) == 10.0
+
+
+def test_tip_still_allowed_within_the_unwithdrawn_remainder(ban_client):
+    """Control: withdrawing part of the balance leaves the rest tippable."""
+    withdraw = ban_client.post(
+        "/ban/withdraw",
+        json={"amount": 6.0, "address": "ban_" + "1" * 60},
+    )
+    assert withdraw.status_code == 200, withdraw.get_json()
+
+    tip = ban_client.post("/ban/tip", json={"to_agent": "bob", "amount": 4.0})
+    assert tip.status_code == 200, tip.get_json()


### PR DESCRIPTION
## Summary

`/ban/tip` computes the spendable BAN balance while filtering out the very rows that represent money already committed to a payout, so **already-withdrawn BAN stays tippable** — a ledger double-spend reachable by any registered user.

Withdrawal rows are inserted with `status='pending'` (`banano_blueprint.py:597-601`) and only ever advance to `'sent'`/`'failed'` — never `'credited'`. `ban_tip` (`banano_blueprint.py:533-539`) does:

```sql
SELECT ... - COALESCE(SUM(CASE WHEN tx_type IN ('withdrawal','tip_sent') THEN amount_ban ELSE 0 END), 0) AS balance
FROM ban_transactions WHERE agent_id = ? AND status = 'credited'
```

The `WHERE` filters rows *before* the `CASE` is evaluated, so withdrawal rows never reach the sum — the `WHEN tx_type IN ('withdrawal', ...)` branch is dead code for withdrawals.

## Reproduction

alice earns 10 BAN, withdraws all 10, then tips the same 10 BAN:

```
POST /ban/withdraw  {"amount": 10.0, "address": "ban_111...1"}   -> 200, payout row status='pending'
POST /ban/tip       {"to_agent": "bob", "amount": 10.0}          -> 200 {"ok": true, "amount_ban": 10.0}
```

Each hop mints another real payout obligation that `banano_payout.py` picks up and sends on-chain.

## Why this is a bug and not a design choice

`ban_tip` is the only balance reader that gets this wrong. Every sibling already counts pending withdrawals:

- `ban_withdraw` (`:589`) — `status IN ('credited', 'sent', 'pending')`
- `ban_balance` (`:435`) and `bottube_server.py:13483` — same treatment

The fix aligns `ban_tip` with `ban_withdraw`.

## Verification

`tests/test_banano_tip_pending_withdrawal.py` (new, 2 tests):

- On clean `main`: the withdraw-then-tip test **fails** — the tip returns `200 {"ok": true, "amount_ban": 10.0}`.
- With the fix: it returns `400 {"error": "Insufficient BAN balance (0.0000 available)"}`, and no second payout row is created.
- Control: a *partial* withdrawal (6 of 10) still leaves the remaining 4 tippable, so legitimate tipping is unaffected.

All 23 existing `tests/test_banano_amount_validation.py` tests still pass (25 total).

## Scope note

Reported under the Ongoing Bug Bounty (rustchain-bounties#71). Proposing **High**, deliberately not Critical: the ledger double-spend and the inflated `/ban/balance` liability are unconditional, but actual on-chain loss additionally needs `BANANO_SEED` configured, `bananopie` installed, and the payout cron running — and I could only find `banano_payout.py` referenced as a docstring cron line, with no systemd unit or deploy artifact in the tree, so I can't prove it's live in production. Tier is entirely your call.

Wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
