### PR TITLE
fix(mood): require auth on mood update/signal endpoints (unauth cross-agent write)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7322,28 +7322,34 @@ def get_agent_mood(agent_name):
 
 
 @app.route("/api/v1/agents/<agent_name>/mood/update", methods=["POST"])
+@require_api_key
 def update_agent_mood(agent_name):
     """
     Update mood for an agent based on signals.
-    
+
     Optional JSON body:
         - force_state: Force a specific mood state (optional)
         - trigger_reason: Reason for the mood change (optional)
     """
     if not MOOD_ENGINE_AVAILABLE:
         return jsonify({"error": "Mood engine not available"}), 503
-    
+
     db = get_db()
-    
+
     # Get agent by name
     agent = db.execute(
         "SELECT id, agent_name FROM agents WHERE agent_name = ?",
         (agent_name,)
     ).fetchone()
-    
+
     if not agent:
         return jsonify({"error": "Agent not found"}), 404
-    
+    # Mood is persisted server state that drives the agent's public behavior
+    # (comment style, title modifier, upload cadence), so only the owning agent
+    # may change it — never another agent named in the URL.
+    if agent["id"] != g.agent["id"]:
+        return jsonify({"error": "Not your agent"}), 403
+
     data = request.get_json() or {}
     force_state = data.get("force_state")
     trigger_reason = data.get("trigger_reason", "")
@@ -7354,10 +7360,11 @@ def update_agent_mood(agent_name):
 
 
 @app.route("/api/v1/agents/<agent_name>/mood/signal", methods=["POST"])
+@require_api_key
 def record_mood_signal(agent_name):
     """
     Record a signal that influences agent mood.
-    
+
     JSON body:
         - signal_type: Type of signal (view_count, comment_sentiment, upload_success, activity_level, streak_length)
         - signal_value: Numeric value of the signal
@@ -7365,18 +7372,21 @@ def record_mood_signal(agent_name):
     """
     if not MOOD_ENGINE_AVAILABLE:
         return jsonify({"error": "Mood engine not available"}), 503
-    
+
     db = get_db()
-    
+
     # Get agent by name
     agent = db.execute(
         "SELECT id, agent_name FROM agents WHERE agent_name = ?",
         (agent_name,)
     ).fetchone()
-    
+
     if not agent:
         return jsonify({"error": "Agent not found"}), 404
-    
+    # Only the owning agent may push signals into its own mood state.
+    if agent["id"] != g.agent["id"]:
+        return jsonify({"error": "Not your agent"}), 403
+
     data = request.get_json() or {}
     signal_type = data.get("signal_type")
     signal_value = data.get("signal_value")


### PR DESCRIPTION
## Security: unauthenticated cross-agent mood write (auth bypass / IDOR)

### The bug
`POST /api/v1/agents/<agent_name>/mood/update` and `POST /api/v1/agents/<agent_name>/mood/signal` carry **no `@require_api_key` and no ownership check**. They resolve the target agent purely from the URL path and then perform a persisted write:

- `update_agent_mood` → `api_update_mood` → `engine.update_mood(...)` → `_save_mood(...)`
- `record_mood_signal` → `api_record_signal` → `engine.record_signal(...)` → `INSERT INTO mood_signals ...; conn.commit()`

There is no global `before_request` auth gate (the only `before_request` just loads `g.user` optionally and never rejects), so **any anonymous caller can write to any agent's mood state**. Every other write route in the app is protected with `@require_api_key` (e.g. `update_video`, `vote_video`) or an explicit session check — these two POST siblings were missed. The `GET /mood` sibling is legitimately public and is unchanged.

### Impact
Mood state drives the agent's public-facing behavior — `get_comment_style`, `get_title_modifier`, and `get_upload_frequency_modifier` all read from it. An attacker can force any creator into e.g. `frustrated`, or flood negative signals, and thereby grief that creator's tone, titles, and upload cadence — unauthenticated, against any agent by name.

### Repro
```bash
# Force any victim into an arbitrary mood, no credentials:
curl -X POST https://<host>/api/v1/agents/VICTIM/mood/update \
     -H 'Content-Type: application/json' \
     -d '{"force_state":"frustrated","trigger_reason":"pwned"}'

# Flood arbitrary mood signals:
curl -X POST https://<host>/api/v1/agents/VICTIM/mood/signal \
     -H 'Content-Type: application/json' \
     -d '{"signal_type":"comment_sentiment","signal_value":-100}'
```

### Fix
Gate both routes with `@require_api_key` (same pattern as the rest of the app) and bind the target to the caller — reject when the URL agent is not the authenticated agent:

```python
if agent["id"] != g.agent["id"]:
    return jsonify({"error": "Not your agent"}), 403
```

Minimal, surgical diff; `bottube_server.py` still compiles. No behavior change for the owning agent or for the public `GET /mood`.

---
Security bug-bounty claim under rustchain-bounties#71 (auth bypass / cross-agent state mutation).