### PR TITLE
fix: require admin auth on beef relationship kill switch (missing authorization)

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -87,6 +87,23 @@ def _db_path() -> Path:
         return Path(__file__).parent / "bottube.db"
 
 
+def _require_admin():
+    """Gate an admin-only endpoint using the main server's admin check.
+
+    Returns a Flask response (403) when the caller is not an admin, or
+    ``None`` when the request carries a valid ``X-Admin-Key``. Delegating to
+    ``bottube_server._require_admin`` keeps the admin secret and header
+    contract in one place instead of forking it here.
+    """
+    try:
+        import bottube_server  # type: ignore
+        return bottube_server._require_admin()
+    except Exception:
+        # If the main server module (and its admin key) is unavailable we must
+        # fail closed rather than silently allow the privileged action.
+        return jsonify({"error": "Forbidden"}), 403
+
+
 def get_db() -> sqlite3.Connection:
     """Return a per-request SQLite connection stored on Flask's g."""
     if "beef_db" in g:
@@ -363,6 +380,9 @@ def create_or_update_relationship():
 @beef_bp.route("/relationships/<int:rel_id>/kill", methods=["POST"])
 def admin_kill(rel_id: int):
     """Admin kill switch — immediately deactivates a beef arc."""
+    err = _require_admin()
+    if err:
+        return err
     db = get_db()
     db.execute(
         "UPDATE agent_relationships SET is_killed=1, updated_at=? WHERE id=?",


### PR DESCRIPTION
## What

`/api/beef/relationships/<rel_id>/kill` (`admin_kill`) is documented as the **"Admin kill switch"** and is listed among the module guardrails in the file header, but it performs its privileged write with **no authorization check at all**. Any unauthenticated caller can:

- permanently set `is_killed=1` on **any** relationship, and
- force-resolve its active drama arc (`status='killed'`).

There is no `@require_*` decorator, no in-body identity/admin check, and no blueprint/`before_request` guard covering `/api/beef/*` (the only `before_request` hooks are canonical-host redirect, rate-limiting, and engagement latency). So the endpoint is reachable anonymously in production.

Every other admin action in the app (`/api/admin/ban`, `/api/admin/nuke`, `/api/admin/remove-video`, …) gates on `_require_admin()` (X-Admin-Key header). This one was simply missed.

## Fix

Gate `admin_kill` with the existing admin check, delegated to `bottube_server._require_admin()` via a lazy import (same pattern the module already uses for `DB_PATH`) so the admin secret and header contract stay in one place. Fails **closed** (403) if the server module is unavailable — never silently allows the privileged action.

## Verification

Ran the blueprint under a Flask test client with a stubbed admin key:

- `POST /api/beef/relationships/1/kill` (no header) → **403 Forbidden**
- wrong `X-Admin-Key` → **403**
- correct `X-Admin-Key` → **200** and the kill is applied

Read-only and non-admin beef endpoints are untouched.

/claim #71