### PR TITLE
[Codex] Share API query parameter validation

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -48,6 +48,12 @@ from flask import (
     url_for,
 )
 from markupsafe import Markup, escape
+from query_param_validation import (
+    MAX_QUERY_TIMESTAMP,
+    parse_enum_param,
+    parse_int_param,
+    parse_ts_param,
+)
 from werkzeug.security import check_password_hash, generate_password_hash
 
 # Mood Engine for Agent Mood System (Bounty #2283)
@@ -6997,33 +7003,13 @@ def _parse_positive_int_query(name, default, min_value=1, max_value=None, *, cla
     silently coercing invalid input to the default (which would mask
     client bugs and could lead to surprising pagination/sort results).
     """
-    raw_value = request.args.get(name)
-    if raw_value is None or raw_value == "":
-        return default, None
-    try:
-        value = int(raw_value)
-    except (TypeError, ValueError):
-        return None, (
-            jsonify({"error": f"{name} must be an integer"}),
-            400,
-        )
-    if clamp_bounds:
-        if value < min_value:
-            value = min_value
-        if max_value is not None and value > max_value:
-            value = max_value
-        return value, None
-    if value < min_value:
-        return None, (
-            jsonify({"error": f"{name} must be >= {min_value}"}),
-            400,
-        )
-    if max_value is not None and value > max_value:
-        return None, (
-            jsonify({"error": f"{name} must be <= {max_value}"}),
-            400,
-        )
-    return value, None
+    return parse_int_param(
+        name,
+        default,
+        min_value=min_value,
+        max_value=max_value,
+        clamp_bounds=clamp_bounds,
+    )
 
 
 def _client_has_fresh_video_list_date(latest_ts: float) -> bool:
@@ -7069,7 +7055,7 @@ def list_videos():
     # affect any legitimate use case. Bottube issue #1414 (page-bound
     # follow-up; the live `bottube.ai` binary is v1.2.0 and still lets
     # `page=99999` through with `videos=[]`).
-    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    page, error = parse_int_param("page", 1, min_value=1, max_value=10000)
     if error:
         return error
 
@@ -9265,7 +9251,7 @@ def trending():
                  after this time. Mutually exclusive with days.
       category – filter by video category
     """
-    limit, err = _parse_positive_int_query("limit", 20, max_value=50)
+    limit, err = parse_int_param("limit", 20, min_value=1, max_value=50)
     if err:
         return err
 
@@ -9279,12 +9265,12 @@ def trending():
         return jsonify({"error": "days and since are mutually exclusive"}), 400
 
     if raw_days is not None and raw_days != "":
-        days, err = _parse_positive_int_query("days", 1, max_value=90)
+        days, err = parse_int_param("days", 1, min_value=1, max_value=90)
         if err:
             return err
 
     if raw_since is not None and raw_since != "":
-        since, err = _parse_positive_int_query("since", 0, min_value=0)
+        since, err = parse_ts_param("since", 0)
         if err:
             return err
 
@@ -9310,12 +9296,18 @@ def trending():
 
 _FEED_BUCKETS = ("latest", "heuristic", "hybrid-v1")
 _FEED_MODES = ("latest", "recommended")
+_FEED_SORTS = (
+    "latest",
+    "newest",
+    "oldest",
+    "popular",
+    "trending",
+    "views",
+    "likes",
+    "title",
+)
 _FEED_CATEGORY_IDS = {c["id"] for c in VIDEO_CATEGORIES}
-
-
-def _feed_choice_error(name, allowed):
-    allowed_text = ", ".join(sorted(allowed))
-    return jsonify({"error": f"{name} must be one of: {allowed_text}"}), 400
+_FEED_MAX_OFFSET = 500_000
 
 
 def _feed_bucket_for_visitor(visitor_id, override=""):
@@ -9887,6 +9879,31 @@ def feed():
     Returns:
         JSON with videos list, page info, mode used, and the active bucket.
     """
+    # Validate compatibility parameters reported in #1456 even though the
+    # current feed implementation still pages with `page`/`per_page`.  Valid
+    # compatibility values remain no-ops, preserving the current response,
+    # while malformed values can no longer be silently ignored.
+    _, error = parse_int_param("limit", None, min_value=1, max_value=50)
+    if error:
+        return error
+    _, error = parse_int_param("offset", None, min_value=0, max_value=_FEED_MAX_OFFSET)
+    if error:
+        return error
+    _, error = parse_ts_param("since", None, max_value=MAX_QUERY_TIMESTAMP)
+    if error:
+        return error
+    _, error = parse_ts_param("before", None, max_value=MAX_QUERY_TIMESTAMP)
+    if error:
+        return error
+    _, error = parse_enum_param(
+        "sort",
+        None,
+        _FEED_SORTS,
+        case_sensitive=False,
+    )
+    if error:
+        return error
+
     # `page` is bounded at 10000 so a malformed or malicious client cannot
     # request an arbitrarily deep page. Without an upper bound, a value such
     # as `page=9223372036854775807` makes `offset = (page - 1) * per_page`
@@ -9896,26 +9913,35 @@ def feed():
     # ~500k rows, already well past the whole feed catalogue, so the cap does
     # not affect any legitimate use case. Mirrors the `/api/videos` bound
     # (Bottube issue #1414).
-    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    page, error = parse_int_param("page", 1, min_value=1, max_value=10000)
     if error:
         return error
-    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    per_page, error = parse_int_param("per_page", 20, min_value=1, max_value=50)
     if error:
         return error
-    mode = request.args.get("mode", "latest")
-    category = request.args.get("category")
-    bucket_override = (request.args.get("bucket") or "").strip().lower()
-    mode = (mode or "latest").strip().lower()
-    if mode not in _FEED_MODES:
-        return _feed_choice_error("mode", _FEED_MODES)
-    if category is not None:
-        category = category.strip()
-        if not category:
-            category = None
-        elif category not in _FEED_CATEGORY_IDS:
-            return _feed_choice_error("category", _FEED_CATEGORY_IDS)
-    if bucket_override and bucket_override not in _FEED_BUCKETS:
-        return _feed_choice_error("bucket", _FEED_BUCKETS)
+    mode, error = parse_enum_param(
+        "mode",
+        "latest",
+        _FEED_MODES,
+        case_sensitive=False,
+    )
+    if error:
+        return error
+    category, error = parse_enum_param(
+        "category",
+        None,
+        _FEED_CATEGORY_IDS,
+    )
+    if error:
+        return error
+    bucket_override, error = parse_enum_param(
+        "bucket",
+        "",
+        _FEED_BUCKETS,
+        case_sensitive=False,
+    )
+    if error:
+        return error
 
     # Get optional API key for personalized recommendations
     api_key = request.headers.get("X-API-Key") or request.args.get("api_key")
@@ -17153,6 +17179,10 @@ def api_history_clear():
 @app.route("/api/videos/<video_id>/related")
 def api_related_videos(video_id):
     """Get related videos for a given video ID."""
+    limit, error = parse_int_param("limit", 8, min_value=1, max_value=20)
+    if error:
+        return error
+
     db = get_db()
     video = db.execute(
         f"""SELECT v.*
@@ -17193,19 +17223,6 @@ def api_related_videos(video_id):
         return s
 
     scored = sorted(candidates, key=score, reverse=True)
-    raw_limit = request.args.get("limit")
-    if raw_limit is None or raw_limit == "":
-        limit = 8
-    else:
-        try:
-            limit = int(raw_limit)
-        except (TypeError, ValueError):
-            return jsonify({"error": "limit must be an integer"}), 400
-        if limit < 1:
-            return jsonify({"error": "limit must be >= 1"}), 400
-        if limit > 20:
-            return jsonify({"error": "limit must be <= 20"}), 400
-
     return jsonify({
         "ok": True,
         "related": [

--- a/query_param_validation.py
+++ b/query_param_validation.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Shared Flask query-parameter validation helpers.
+
+The helpers in this module deliberately distinguish an omitted parameter from
+an invalid one.  Flask's ``request.args.get(..., type=...)`` returns the
+default when conversion fails, which otherwise makes malformed client input
+indistinguishable from a request that did not supply the parameter at all.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional
+
+from flask import jsonify, request
+
+
+# Largest Unix timestamp representable by Python's ``datetime`` (end of year
+# 9999).  It is intentionally generous while still rejecting giant integers
+# that are not meaningful timestamps.
+MAX_QUERY_TIMESTAMP = 253_402_300_799
+
+
+def _query_error(name: str, detail: str):
+    """Build the common JSON HTTP-400 response for a bad query parameter."""
+    return jsonify({"error": f"{name} {detail}", "param": name}), 400
+
+
+def _raw_query_value(name: str) -> Optional[str]:
+    """Return a supplied non-empty query value, otherwise ``None``."""
+    raw_value = request.args.get(name)
+    if raw_value is None or raw_value == "":
+        return None
+    return raw_value
+
+
+def parse_int_param(
+    name: str,
+    default: Any = None,
+    min_value: Optional[int] = None,
+    max_value: Optional[int] = None,
+    *,
+    clamp_bounds: bool = False,
+):
+    """Parse an integer query parameter or return a descriptive JSON 400.
+
+    The return shape is ``(value, error)``.  ``error`` is ``None`` on success
+    or a Flask ``(response, 400)`` tuple on failure.  Missing and empty values
+    preserve the caller-provided default.
+    """
+    raw_value = _raw_query_value(name)
+    if raw_value is None:
+        return default, None
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return None, _query_error(name, "must be an integer")
+
+    if clamp_bounds:
+        if min_value is not None and value < min_value:
+            value = min_value
+        if max_value is not None and value > max_value:
+            value = max_value
+        return value, None
+
+    if min_value is not None and value < min_value:
+        return None, _query_error(name, f"must be >= {min_value}")
+    if max_value is not None and value > max_value:
+        return None, _query_error(name, f"must be <= {max_value}")
+    return value, None
+
+
+def parse_enum_param(
+    name: str,
+    default: Any,
+    allowed: Iterable[str],
+    *,
+    case_sensitive: bool = True,
+):
+    """Parse a finite-choice string parameter or return a JSON HTTP 400."""
+    raw_value = _raw_query_value(name)
+    if raw_value is None:
+        return default, None
+
+    value = raw_value.strip()
+    choices = tuple(allowed)
+    if not case_sensitive:
+        value = value.lower()
+        choices_by_normalized_value = {choice.lower(): choice for choice in choices}
+        if value in choices_by_normalized_value:
+            return choices_by_normalized_value[value], None
+    elif value in choices:
+        return value, None
+
+    allowed_text = ", ".join(sorted(choices))
+    return None, _query_error(name, f"must be one of: {allowed_text}")
+
+
+def parse_ts_param(
+    name: str,
+    default: Any = None,
+    min_value: Optional[float] = 0,
+    max_value: Optional[float] = MAX_QUERY_TIMESTAMP,
+):
+    """Parse a Unix or ISO-8601 timestamp, or return a JSON HTTP 400.
+
+    Integer Unix timestamps are returned as integers.  ISO-8601 values are
+    converted to Unix seconds; a timezone-less value is interpreted as UTC.
+    """
+    raw_value = _raw_query_value(name)
+    if raw_value is None:
+        return default, None
+
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        try:
+            parsed = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            value = parsed.timestamp()
+        except (OverflowError, OSError, TypeError, ValueError):
+            return None, _query_error(
+                name,
+                "must be a Unix timestamp or ISO-8601 datetime",
+            )
+
+    if min_value is not None and value < min_value:
+        return None, _query_error(name, f"must be >= {min_value:g}")
+    if max_value is not None and value > max_value:
+        return None, _query_error(name, f"must be <= {max_value:g}")
+    return value, None

--- a/tests/test_shared_query_param_validation.py
+++ b/tests/test_shared_query_param_validation.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for the shared public-API query validators."""
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+from query_param_validation import (
+    MAX_QUERY_TIMESTAMP,
+    parse_enum_param,
+    parse_int_param,
+    parse_ts_param,
+)
+
+
+# Several optional blueprints initialise tables while bottube_server imports.
+# Give those import-time hooks a writable bootstrap database; the shared app
+# fixture replaces the server's DB_PATH with its isolated temporary database.
+_BOOTSTRAP_DB = os.path.join(tempfile.gettempdir(), "bottube_shared_query_validation.db")
+os.environ.setdefault("BOTTUBE_DB_PATH", _BOOTSTRAP_DB)
+os.environ.setdefault("BOTTUBE_DB", _BOOTSTRAP_DB)
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Use pytest-managed storage so Windows can release SQLite lazily."""
+    server_path = Path(__file__).resolve().parent.parent
+    db_path = tmp_path / "bottube.db"
+    video_dir = tmp_path / "videos"
+    thumb_dir = tmp_path / "thumbnails"
+    avatar_dir = tmp_path / "avatars"
+    video_dir.mkdir()
+    thumb_dir.mkdir()
+    avatar_dir.mkdir()
+
+    monkeypatch.setenv("BOTTUBE_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(db_path))
+    monkeypatch.setenv("BOTTUBE_DB", str(db_path))
+    for mod_name in list(sys.modules):
+        if mod_name in {
+            "bottube_server",
+            "paypal_packages",
+            "gpu_marketplace",
+            "banano_blueprint",
+            "captions_blueprint",
+            "gemini_blueprint",
+        }:
+            del sys.modules[mod_name]
+
+    sys.path.insert(0, str(server_path))
+    import bottube_server
+
+    bottube_server.DB_PATH = db_path
+    bottube_server.VIDEO_DIR = video_dir
+    bottube_server.THUMB_DIR = thumb_dir
+    bottube_server.AVATAR_DIR = avatar_dir
+    flask_app = bottube_server.app
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="shared-query-validator-test-key",
+    )
+    flask_app.template_folder = str(server_path / "bottube_templates")
+    with flask_app.app_context():
+        bottube_server.init_db()
+
+    yield flask_app
+
+
+def _assert_invalid_matrix(client, path, cases):
+    for param, values in cases.items():
+        for value in values:
+            response = client.get(path, query_string={param: value})
+            assert response.status_code == 400, (
+                f"{path}?{param}={value} returned {response.status_code}"
+            )
+            body = response.get_json()
+            assert body["param"] == param
+            assert param in body["error"]
+
+
+def _assert_valid_matrix(client, path, cases):
+    for param, value in cases.items():
+        response = client.get(path, query_string={param: value})
+        assert response.status_code == 200, (
+            f"{path}?{param}={value} returned {response.status_code}: "
+            f"{response.get_json()}"
+        )
+
+
+def _insert_related_video(app):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            """INSERT INTO agents (agent_name, display_name, api_key, created_at)
+               VALUES (?, ?, ?, ?)""",
+            ("shared-validator-owner", "Validator Owner", "validator-key", time.time()),
+        )
+        agent_id = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?",
+            ("shared-validator-owner",),
+        ).fetchone()["id"]
+        db.execute(
+            """INSERT INTO videos
+               (video_id, agent_id, title, filename, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("shared_validator_video", agent_id, "Validator", "validator.mp4", time.time()),
+        )
+        db.commit()
+
+
+def test_feed_validates_every_reported_parameter(client):
+    _assert_invalid_matrix(
+        client,
+        "/api/feed",
+        {
+            "limit": ("abc", -1, 999_999_999_999_999),
+            "offset": ("abc", -1, 999_999_999_999_999),
+            "page": ("abc", -1, 999_999_999_999_999),
+            "since": ("abc", -1, 999_999_999_999_999),
+            "before": ("abc", -1, 999_999_999_999_999),
+            "category": ("abc", -1, 999_999_999_999_999),
+            "sort": ("abc", -1, 999_999_999_999_999),
+        },
+    )
+
+
+def test_feed_accepts_valid_values_and_preserves_defaults(client):
+    baseline = client.get("/api/feed")
+    assert baseline.status_code == 200
+    baseline_body = baseline.get_json()
+
+    _assert_valid_matrix(
+        client,
+        "/api/feed",
+        {
+            "limit": 5,
+            "offset": 0,
+            "page": 1,
+            "since": 1_700_000_000,
+            "before": "2026-01-01T00:00:00Z",
+            "category": "music",
+            "sort": "latest",
+        },
+    )
+
+    unchanged = client.get("/api/feed", query_string={"limit": 5}).get_json()
+    assert unchanged["page"] == baseline_body["page"] == 1
+    assert unchanged["mode"] == baseline_body["mode"]
+    assert unchanged["bucket"] == baseline_body["bucket"]
+
+
+def test_trending_validates_limit_days_and_since(client):
+    _assert_invalid_matrix(
+        client,
+        "/api/trending",
+        {
+            "limit": ("abc", -1, 999_999_999_999_999),
+            "days": ("abc", -1, 999_999_999_999_999),
+            "since": ("abc", -1, 999_999_999_999_999),
+        },
+    )
+
+
+def test_trending_accepts_valid_values_and_preserves_defaults(client):
+    assert client.get("/api/trending").status_code == 200
+    _assert_valid_matrix(
+        client,
+        "/api/trending",
+        {
+            "limit": 5,
+            "days": 7,
+            "since": "2026-01-01T00:00:00Z",
+        },
+    )
+
+
+def test_videos_validates_page(client):
+    _assert_invalid_matrix(
+        client,
+        "/api/videos",
+        {"page": ("abc", -1, 999_999_999_999_999)},
+    )
+    assert client.get("/api/videos").status_code == 200
+    assert client.get("/api/videos?page=1").status_code == 200
+
+
+def test_related_validates_limit_before_database_lookup(client):
+    _assert_invalid_matrix(
+        client,
+        "/api/videos/not_present/related",
+        {"limit": ("abc", -1, 999_999_999_999_999)},
+    )
+
+
+def test_related_accepts_valid_limit_and_preserves_default(app, client):
+    _insert_related_video(app)
+    path = "/api/videos/shared_validator_video/related"
+    assert client.get(path).status_code == 200
+    assert client.get(path, query_string={"limit": 5}).status_code == 200
+
+
+def test_shared_int_parser_covers_default_type_and_bounds():
+    app = Flask(__name__)
+
+    with app.test_request_context("/?limit="):
+        assert parse_int_param("limit", 20, min_value=1, max_value=50) == (20, None)
+    with app.test_request_context("/?limit=5"):
+        assert parse_int_param("limit", 20, min_value=1, max_value=50) == (5, None)
+    with app.test_request_context("/?limit=abc"):
+        value, error = parse_int_param("limit", 20, min_value=1, max_value=50)
+        assert value is None
+        assert error[1] == 400
+        assert error[0].get_json()["param"] == "limit"
+    with app.test_request_context("/?limit=0"):
+        assert parse_int_param("limit", 20, min_value=1, max_value=50)[1][1] == 400
+    with app.test_request_context("/?limit=51"):
+        assert parse_int_param("limit", 20, min_value=1, max_value=50)[1][1] == 400
+
+
+def test_shared_enum_parser_normalizes_and_names_bad_parameter():
+    app = Flask(__name__)
+
+    with app.test_request_context("/?sort=LATEST"):
+        assert parse_enum_param(
+            "sort",
+            "latest",
+            ("latest", "popular"),
+            case_sensitive=False,
+        ) == ("latest", None)
+    with app.test_request_context("/?sort=sideways"):
+        value, error = parse_enum_param("sort", "latest", ("latest", "popular"))
+        assert value is None
+        assert error[1] == 400
+        assert error[0].get_json()["param"] == "sort"
+
+
+def test_shared_timestamp_parser_accepts_unix_and_iso_and_rejects_bounds():
+    app = Flask(__name__)
+
+    with app.test_request_context("/?since=1700000000"):
+        assert parse_ts_param("since")[0] == 1_700_000_000
+    with app.test_request_context("/?since=2026-01-01T00:00:00Z"):
+        value, error = parse_ts_param("since")
+        assert error is None
+        assert value == 1_767_225_600
+    with app.test_request_context("/?since=not-a-date"):
+        value, error = parse_ts_param("since")
+        assert value is None
+        assert error[0].get_json()["param"] == "since"
+    with app.test_request_context("/?since=-1"):
+        assert parse_ts_param("since")[1][1] == 400
+    with app.test_request_context(f"/?since={MAX_QUERY_TIMESTAMP + 1}"):
+        assert parse_ts_param("since")[1][1] == 400


### PR DESCRIPTION
Closes #1456
Closes #1436
Closes #1435
Closes #1468

Bounty: Scottcjn/rustchain-bounties#16254

## Summary

- add shared integer, enum, and Unix/ISO-8601 timestamp query validators;
- distinguish omitted parameters from malformed values instead of silently coercing bad input to endpoint defaults;
- return a consistent JSON `400` with the offending parameter name;
- wire validation into `/api/feed`, `/api/trending`, `/api/videos`, and `/api/videos/<id>/related` before database work;
- preserve endpoint defaults and the existing `_parse_positive_int_query` compatibility wrapper.

The feed route now validates all seven reported parameters (`limit`, `offset`, `page`, `since`, `before`, `category`, and `sort`). Bounds reject negative and unreasonably large values; timestamp parameters accept both epoch seconds and ISO-8601.

## Verification

- new shared-validator regression suite: `10 passed`;
- related existing route/regression coverage: `81 assertions passed`;
- Python compilation: passed;
- Flake8 CI-critical checks (`E9`, `F63`, `F7`, `F82`): zero findings;
- `git diff --check`: passed.

On Windows, three legacy SQLite fixtures report teardown-only `PermissionError` while deleting still-open temporary databases; their assertions pass and the error reproduces outside this patch. The isolated new suite uses pytest-managed storage and exits cleanly.
