### PR TITLE
feat(query-validator): shared query param validator for BoTTube API (closes #16254)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -48,6 +48,7 @@ from flask import (
     url_for,
 )
 from markupsafe import Markup, escape
+from shared_query_validator import parse_int_param, parse_enum_param, parse_ts_param
 from werkzeug.security import check_password_hash, generate_password_hash
 
 # Mood Engine for Agent Mood System (Bounty #2283)
@@ -9265,7 +9266,7 @@ def trending():
                  after this time. Mutually exclusive with days.
       category – filter by video category
     """
-    limit, err = _parse_positive_int_query("limit", 20, max_value=50)
+    limit, err = parse_int_param("limit", default=20, max_value=50)
     if err:
         return err
 
@@ -9279,12 +9280,12 @@ def trending():
         return jsonify({"error": "days and since are mutually exclusive"}), 400
 
     if raw_days is not None and raw_days != "":
-        days, err = _parse_positive_int_query("days", 1, max_value=90)
+        days, err = parse_int_param("days", default=1, max_value=90)
         if err:
             return err
 
     if raw_since is not None and raw_since != "":
-        since, err = _parse_positive_int_query("since", 0, min_value=0)
+        since, err = parse_ts_param("since", default=0, min_value=0)
         if err:
             return err
 
@@ -9896,26 +9897,29 @@ def feed():
     # ~500k rows, already well past the whole feed catalogue, so the cap does
     # not affect any legitimate use case. Mirrors the `/api/videos` bound
     # (Bottube issue #1414).
-    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    page, error = parse_int_param("page", default=1, max_value=10000)
     if error:
         return error
-    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    per_page, error = parse_int_param("per_page", default=20, max_value=50)
     if error:
         return error
     mode = request.args.get("mode", "latest")
     category = request.args.get("category")
     bucket_override = (request.args.get("bucket") or "").strip().lower()
-    mode = (mode or "latest").strip().lower()
-    if mode not in _FEED_MODES:
-        return _feed_choice_error("mode", _FEED_MODES)
+    mode, err = parse_enum_param("mode", _FEED_MODES, default="latest")
+    if err:
+        return err
     if category is not None:
         category = category.strip()
         if not category:
             category = None
         elif category not in _FEED_CATEGORY_IDS:
-            return _feed_choice_error("category", _FEED_CATEGORY_IDS)
-    if bucket_override and bucket_override not in _FEED_BUCKETS:
-        return _feed_choice_error("bucket", _FEED_BUCKETS)
+            allowed_text = ", ".join(sorted(_FEED_CATEGORY_IDS))
+            return jsonify({"error": f"category must be one of: {allowed_text}"}), 400
+    if bucket_override:
+        bucket_override, err = parse_enum_param("bucket", _FEED_BUCKETS)
+        if err:
+            return err
 
     # Get optional API key for personalized recommendations
     api_key = request.headers.get("X-API-Key") or request.args.get("api_key")
@@ -17193,18 +17197,9 @@ def api_related_videos(video_id):
         return s
 
     scored = sorted(candidates, key=score, reverse=True)
-    raw_limit = request.args.get("limit")
-    if raw_limit is None or raw_limit == "":
-        limit = 8
-    else:
-        try:
-            limit = int(raw_limit)
-        except (TypeError, ValueError):
-            return jsonify({"error": "limit must be an integer"}), 400
-        if limit < 1:
-            return jsonify({"error": "limit must be >= 1"}), 400
-        if limit > 20:
-            return jsonify({"error": "limit must be <= 20"}), 400
+    limit, err = parse_int_param("limit", default=8, min_value=1, max_value=20)
+    if err:
+        return err
 
     return jsonify({
         "ok": True,

--- a/shared_query_validator.py
+++ b/shared_query_validator.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+"""Shared query parameter validator for BoTTube API endpoints.
+
+Centralizes validation logic used across /api/feed, /api/trending, /api/videos,
+and /api/videos/<id>/related to reject malformed parameters with HTTP 400
+instead of silently coercing invalid input.
+
+Usage:
+    from shared_query_validator import parse_int_param, parse_enum_param
+
+    limit, err = parse_int_param("limit", default=20, min_value=1, max_value=50)
+    if err:
+        return err  # (jsonify response, 400)
+"""
+from flask import jsonify, request
+
+
+def parse_int_param(name, default=1, min_value=None, max_value=None):
+    """Parse an integer query parameter with bounds checking.
+
+    Args:
+        name: Parameter name in the query string.
+        default: Default value when parameter is missing or empty.
+        min_value: Minimum allowed value (inclusive). None = no minimum.
+        max_value: Maximum allowed value (inclusive). None = no maximum.
+
+    Returns:
+        Tuple of (value, error). If error is not None, it's a Flask response tuple
+        (jsonify({"error": "..."}), 400).
+    """
+    raw_value = request.args.get(name)
+    if raw_value is None or raw_value == "":
+        return default, None
+
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return None, (
+            jsonify({"error": f"{name} must be an integer"}),
+            400,
+        )
+
+    if min_value is not None and value < min_value:
+        return None, (
+            jsonify({"error": f"{name} must be >= {min_value}"}),
+            400,
+        )
+
+    if max_value is not None and value > max_value:
+        return None, (
+            jsonify({"error": f"{name} must be <= {max_value}"}),
+            400,
+        )
+
+    return value, None
+
+
+def parse_enum_param(name, allowed_values, default=None):
+    """Parse an enum-style query parameter.
+
+    Args:
+        name: Parameter name in the query string.
+        allowed_values: Set/list of valid string values.
+        default: Default value when parameter is missing or empty.
+
+    Returns:
+        Tuple of (value, error). If error is not None, it's a Flask response tuple.
+    """
+    raw_value = request.args.get(name)
+    if raw_value is None or raw_value == "":
+        return default, None
+
+    value = raw_value.strip().lower()
+    if value not in allowed_values:
+        allowed_text = ", ".join(sorted(allowed_values))
+        return None, (
+            jsonify({"error": f"{name} must be one of: {allowed_text}"}),
+            400,
+        )
+
+    return value, None
+
+
+def parse_ts_param(name, default=0, min_value=None):
+    """Parse a timestamp query parameter.
+
+    Args:
+        name: Parameter name in the query string.
+        default: Default value when parameter is missing or empty.
+        min_value: Minimum allowed value (inclusive). None = no minimum.
+
+    Returns:
+        Tuple of (value, error). Value is a float timestamp.
+    """
+    import math
+
+    raw_value = request.args.get(name)
+    if raw_value is None or raw_value == "":
+        return default, None
+
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        return None, (
+            jsonify({"error": f"{name} must be a number"}),
+            400,
+        )
+
+    if not math.isfinite(value):
+        return None, (
+            jsonify({"error": f"{name} must be a finite number"}),
+            400,
+        )
+
+    if min_value is not None and value < min_value:
+        return None, (
+            jsonify({"error": f"{name} must be >= {min_value}"}),
+            400,
+        )
+
+    return value, None

--- a/tests/test_shared_query_validator.py
+++ b/tests/test_shared_query_validator.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: MIT
+"""Tests for shared_query_validator module.
+
+Covers parse_int_param, parse_enum_param, parse_ts_param with malformed/negative/oversized/valid inputs.
+"""
+import pytest
+from flask import Flask, jsonify, request
+from shared_query_validator import parse_int_param, parse_enum_param, parse_ts_param
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    return app
+
+
+def test_parse_int_param_default_when_missing(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("limit", default=20, min_value=1, max_value=50)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test")
+        assert resp.status_code == 200
+        assert resp.json["value"] == 20
+
+
+def test_parse_int_param_default_when_empty(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("limit", default=20, min_value=1, max_value=50)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?limit=")
+        assert resp.status_code == 200
+        assert resp.json["value"] == 20
+
+
+def test_parse_int_param_valid_value(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("limit", default=20, min_value=1, max_value=50)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?limit=10")
+        assert resp.status_code == 200
+        assert resp.json["value"] == 10
+
+
+def test_parse_int_param_malformed_string(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("limit", default=20, min_value=1, max_value=50)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?limit=abc")
+        assert resp.status_code == 400
+        assert "integer" in resp.json["error"].lower()
+
+
+def test_parse_int_param_negative_value(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("limit", default=20, min_value=1, max_value=50)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?limit=-5")
+        assert resp.status_code == 400
+        assert ">= 1" in resp.json["error"]
+
+
+def test_parse_int_param_oversized_value(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("limit", default=20, min_value=1, max_value=50)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?limit=999")
+        assert resp.status_code == 400
+        assert "<= 50" in resp.json["error"]
+
+
+def test_parse_int_param_zero_value_with_min_one(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("page", default=1, min_value=1, max_value=100)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?page=0")
+        assert resp.status_code == 400
+
+
+def test_parse_int_param_no_bounds(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("anything", default=0)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?anything=12345")
+        assert resp.status_code == 200
+        assert resp.json["value"] == 12345
+
+
+def test_parse_int_param_min_only(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("min_test", default=0, min_value=5)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?min_test=3")
+        assert resp.status_code == 400
+
+
+def test_parse_enum_param_valid_value(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_enum_param("mode", {"latest", "recommended"}, default="latest")
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?mode=recommended")
+        assert resp.status_code == 200
+        assert resp.json["value"] == "recommended"
+
+
+def test_parse_enum_param_invalid_value(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_enum_param("mode", {"latest", "recommended"}, default="latest")
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?mode=invalid")
+        assert resp.status_code == 400
+        assert "one of" in resp.json["error"].lower()
+
+
+def test_parse_enum_param_default_when_missing(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_enum_param("mode", {"latest", "recommended"}, default="latest")
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test")
+        assert resp.status_code == 200
+        assert resp.json["value"] == "latest"
+
+
+def test_parse_enum_param_case_insensitive(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_enum_param("mode", {"latest", "recommended"}, default="latest")
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?mode=LATEST")
+        assert resp.status_code == 200
+        assert resp.json["value"] == "latest"
+
+
+def test_parse_ts_param_valid_timestamp(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_ts_param("since", default=0, min_value=0)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?since=1700000000.5")
+        assert resp.status_code == 200
+        assert resp.json["value"] == pytest.approx(1700000000.5)
+
+
+def test_parse_ts_param_nan_rejected(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_ts_param("since", default=0, min_value=0)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?since=nan")
+        assert resp.status_code == 400
+
+
+def test_parse_ts_param_inf_rejected(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_ts_param("since", default=0, min_value=0)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?since=inf")
+        assert resp.status_code == 400
+
+
+def test_parse_ts_param_negative_rejected(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_ts_param("since", default=0, min_value=0)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?since=-100")
+        assert resp.status_code == 400
+
+
+def test_parse_ts_param_default_when_missing(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_ts_param("since", default=0, min_value=0)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test")
+        assert resp.status_code == 200
+        assert resp.json["value"] == 0
+
+
+def test_parse_ts_param_malformed_rejected(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_ts_param("since", default=0, min_value=0)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?since=not_a_number")
+        assert resp.status_code == 400
+        assert "number" in resp.json["error"].lower()
+
+
+def test_parse_int_param_boundary_values(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("limit", default=20, min_value=1, max_value=50)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?limit=1")
+        assert resp.status_code == 200
+        assert resp.json["value"] == 1
+
+        resp = client.get("/test?limit=50")
+        assert resp.status_code == 200
+        assert resp.json["value"] == 50
+
+
+def test_parse_int_param_float_string_rejected(app):
+    @app.route("/test")
+    def handler():
+        value, err = parse_int_param("limit", default=20, min_value=1, max_value=50)
+        if err:
+            return err
+        return jsonify({"value": value})
+
+    with app.test_client() as client:
+        resp = client.get("/test?limit=3.14")
+        assert resp.status_code == 400


### PR DESCRIPTION
Closed as obsolete — superseded by merged PR #1614 which added the shared query-param validator module (bottube_validators/).