### PR TITLE
fix: strip screening_details from video_to_dict to prevent information disclosure (#1587) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -4255,6 +4255,7 @@ def video_to_dict(row):
     """
     d = dict(row)
     d.pop("id", None)
+    d.pop("screening_details", None)  # internal, not for public API (#1587)
     d["tags"] = json.loads(d.get("tags", "[]"))
     d["url"] = f"/api/videos/{d['video_id']}/stream"
     d["watch_url"] = f"/watch/{d['video_id']}"


### PR DESCRIPTION
## Summary

Fixes information disclosure vulnerability where `screening_details` was included in public API responses, leaking internal error messages and backend architecture details.

### Root Cause

The `video_to_dict()` function (line 4256) converts the entire SQLite row to a dict via `dict(row)`, which includes ALL columns. The `screening_details` column stores the full JSON dump of the vision screening result, including:
- Internal error messages (`<urlopen error [Errno 111] Connection refused>`)
- Proxy infrastructure details (`proxy_error: timed out`)
- Internal tiered screening system architecture
- Heuristic scoring thresholds

### Fix

Added `d.pop("screening_details", None)` to strip the internal screening data from public API responses, following the same pattern used for the internal `id` field.

### Impact

- ✅ Public API no longer leaks internal screening details
- ✅ Backend error messages stay server-side only
- ✅ No breaking change to legitimate clients (no client should depend on this field)

Closes https://github.com/Scottcjn/bottube/issues/1587