### PR TITLE
Require auth on agent mood writes and stop internal fields leaking from the public API

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -4260,6 +4260,12 @@ def video_to_dict(row):
     d["url"] = f"/api/videos/{d['video_id']}/stream"
     d["watch_url"] = f"/watch/{d['video_id']}"
     d["thumbnail_url"] = f"/thumbnails/{d['thumbnail']}" if d.get("thumbnail") else ""
+    # Internal moderation/pipeline fields must not reach public API consumers.
+    # Verified: no frontend, template or server-side consumer reads these off
+    # this dict; every caller passes the result straight to jsonify.
+    for _internal in ("screening_details", "removed_reason", "screening_status",
+                      "novelty_score", "novelty_flags", "gen_job_id", "filename"):
+        d.pop(_internal, None)
     cat_id = d.get("category", "other")
     cat_info = CATEGORY_MAP.get(cat_id, CATEGORY_MAP["other"])
     d["category"] = cat_id
@@ -7309,6 +7315,7 @@ def get_agent_mood(agent_name):
 
 
 @app.route("/api/v1/agents/<agent_name>/mood/update", methods=["POST"])
+@require_api_key
 def update_agent_mood(agent_name):
     """
     Update mood for an agent based on signals.
@@ -7317,6 +7324,8 @@ def update_agent_mood(agent_name):
         - force_state: Force a specific mood state (optional)
         - trigger_reason: Reason for the mood change (optional)
     """
+    if g.agent["agent_name"] != agent_name:
+        return jsonify({"error": "Forbidden - agents may only update their own mood"}), 403
     if not MOOD_ENGINE_AVAILABLE:
         return jsonify({"error": "Mood engine not available"}), 503
     
@@ -7341,6 +7350,7 @@ def update_agent_mood(agent_name):
 
 
 @app.route("/api/v1/agents/<agent_name>/mood/signal", methods=["POST"])
+@require_api_key
 def record_mood_signal(agent_name):
     """
     Record a signal that influences agent mood.
@@ -7350,6 +7360,8 @@ def record_mood_signal(agent_name):
         - signal_value: Numeric value of the signal
         - signal_data: Optional additional data
     """
+    if g.agent["agent_name"] != agent_name:
+        return jsonify({"error": "Forbidden - agents may only update their own mood"}), 403
     if not MOOD_ENGINE_AVAILABLE:
         return jsonify({"error": "Mood engine not available"}), 503
     


### PR DESCRIPTION
## Why this exists

Both of these were fixed on the live server earlier today after being confirmed against production. This PR brings the repository in line. Without it the next deploy from `main` would silently undo both fixes, which is the actual risk that prompted the PR.

## 1. Agent mood endpoints had no authentication

`/api/v1/agents/<agent_name>/mood/update` and `/mood/signal` carried no `@require_api_key` and no ownership check, and `mood/update` accepts `force_state`. Any unauthenticated caller could set any agent's mood and have it persist.

Now both require an API key and verify the caller owns the agent:

```python
if g.agent["agent_name"] != agent_name:
    return jsonify({"error": "Forbidden - agents may only update their own mood"}), 403
```

47 other routes in this file already use `require_api_key`, so this is bringing two stragglers in line, not introducing a new pattern.

Checked before changing anything: no HTTP caller anywhere on the host, and zero hits in the nginx access log, so nothing legitimate was relying on the open endpoints. `bottube_mood_engine.py` only defines a duplicate blueprint route; it does not call these over HTTP.

Verified on production after deploying: both return **401** unauthenticated, homepage and videos API still 200.

## 2. Public API leaked internal moderation and pipeline fields

`video_to_dict()` did `d = dict(row)` and stripped only the rowid, so every endpoint that serialises a video returned:

`screening_details`, `removed_reason`, `screening_status`, `novelty_score`, `novelty_flags`, `gen_job_id`, `filename`

`screening_details` carried internal error text (connection failures, proxy timeouts, tier thresholds). `removed_reason` carried moderation notes. `filename` exposed the storage naming scheme, which the client never needs since streaming goes through `/api/videos/{video_id}/stream`.

Verified safe before removing: no frontend or template reads any of them, every `filename` read in the server uses the database row rather than this dict, and all 11 `video_to_dict` call sites pass the result straight to `jsonify`.

**Deliberately kept**, because they are features rather than leaks: `agent_id` (identifies the authoring agent, which is the point of an agent video platform), `is_removed`, and the provenance fields `attribution_id`, `collaborator_ids`, `syndication_chain`.

## Credit

Closes #1577, reported by @Vyacheslav-Tomashevskiy.

The `screening_details` half overlaps two existing PRs: @waterWang's #1589 (first submitted, `screening_details` only) and @rebel117's #1592 (later, also caught `removed_reason`). Both contributors have been paid for their findings. This PR covers both fields plus the five others neither had identified, so #1589 and #1592 can be closed once this lands.

## Not included

`#1578` (missing admin auth on the kill switch) is a separate issue and is not addressed here.