### PR TITLE
feat: add Discord notification integration for video processing events [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import datetime
 import hashlib
 import hmac
+import html
 import json
 import math
 import mimetypes
@@ -4180,6 +4181,7 @@ def fire_discord_notification(agent_id: int, notif_type: str, message: str,
     def _send():
         try:
             conn = sqlite3.connect(str(DB_PATH))
+            conn.row_factory = sqlite3.Row
             row = conn.execute(
                 "SELECT discord_webhook_url FROM agents WHERE id = ?",
                 (agent_id,),
@@ -4197,7 +4199,7 @@ def fire_discord_notification(agent_id: int, notif_type: str, message: str,
                 "title": "BoTTube Notification",
                 "description": message[:2000],
                 "color": color,
-                "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             }
             if video_id:
                 embed["url"] = f"https://bottube.ai/watch/{video_id}"
@@ -4225,7 +4227,7 @@ def fire_discord_notification(agent_id: int, notif_type: str, message: str,
             with urllib.request.urlopen(req, timeout=10) as resp:
                 pass  # 204 No Content on success
         except Exception:
-            pass  # Silently fail (e.g., invalid webhook URL)
+            app.logger.warning(f"Discord webhook send failed for agent {agent_id}", exc_info=True)
 
     threading.Thread(target=_send, daemon=True).start()
 
@@ -14575,7 +14577,7 @@ def notification_settings_page():
         "tips": bool(agent.get("email_notify_tips", 1)),
         "subscriptions": bool(agent.get("email_notify_subscriptions", 1)),
     }
-    discord_webhook_url = agent.get("discord_webhook_url", "") or ""
+    discord_webhook_url = html.escape(agent.get("discord_webhook_url", "") or "")
     has_email = bool(agent.get("email", ""))
     email_verified = bool(agent.get("email_verified", 0))
     csrf_token = session.get("csrf_token", "")

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -2198,6 +2198,14 @@ def init_db():
         if col not in existing_cols:
             conn.execute(sql)
 
+    # Migration: Discord webhook URL for notifications
+    discord_cols = {row[1] for row in conn.execute("PRAGMA table_info(agents)").fetchall()}
+    discord_migrations = {
+        "discord_webhook_url": "ALTER TABLE agents ADD COLUMN discord_webhook_url TEXT DEFAULT ''",
+    }
+    for col, sql in discord_migrations.items():
+        if col not in discord_cols:
+            conn.execute(sql)
 
     # Migration: webhook delivery counters/rate-limit metadata
     webhook_cols = {row[1] for row in conn.execute("PRAGMA table_info(webhooks)").fetchall()}
@@ -3855,6 +3863,14 @@ def _notify_subscribers_new_video(agent_id, video_id, video_title, uploader_name
                     f'@{uploader_name} uploaded: "{video_title}"',
                     video_id
                 )
+                # Send Discord notification if configured
+                fire_discord_notification(
+                    sub["follower_id"], "new_video",
+                    f'@{uploader_name} uploaded a new video: "{video_title}"',
+                    from_agent=uploader_name,
+                    video_id=video_id,
+                    video_title=video_title,
+                )
             conn.commit()
             conn.close()
         except Exception as e:
@@ -3968,6 +3984,13 @@ def notify(db, agent_id: int, notif_type: str, message: str, from_agent: str = "
         except Exception:
             pass
     threading.Thread(target=_send_email_bg, daemon=True).start()
+
+    # Send Discord notification if configured (background thread)
+    fire_discord_notification(
+        agent_id, notif_type, message,
+        from_agent=from_agent,
+        video_id=video_id,
+    )
 
 
 def _notification_link_for_row(row) -> str:
@@ -4144,6 +4167,67 @@ def fire_webhooks(agent_id: int, event: str, payload: dict):
         conn.close()
 
     threading.Thread(target=_deliver, daemon=True).start()
+
+
+def fire_discord_notification(agent_id: int, notif_type: str, message: str,
+                               from_agent: str = "", video_id: str = "",
+                               video_title: str = ""):
+    """Send a Discord embed notification via the user's configured Discord webhook URL.
+
+    Non-blocking — runs in a background thread. Silently skips if the user
+    hasn't configured a Discord webhook URL in their settings.
+    """
+    def _send():
+        try:
+            conn = sqlite3.connect(str(DB_PATH))
+            row = conn.execute(
+                "SELECT discord_webhook_url FROM agents WHERE id = ?",
+                (agent_id,),
+            ).fetchone()
+            conn.close()
+            if not row:
+                return
+            webhook_url = row["discord_webhook_url"]
+            if not webhook_url or not webhook_url.startswith("https://discord.com/api/webhooks/"):
+                return
+
+            # Build a Discord embed
+            color = 0x3ea6ff  # BoTTube blue
+            embed = {
+                "title": "BoTTube Notification",
+                "description": message[:2000],
+                "color": color,
+                "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+            }
+            if video_id:
+                embed["url"] = f"https://bottube.ai/watch/{video_id}"
+            if video_title:
+                embed["fields"] = [{"name": "Video", "value": video_title[:256], "inline": True}]
+            if from_agent:
+                embed["author"] = {"name": from_agent[:256]}
+
+            payload = {
+                "username": "BoTTube",
+                "avatar_url": "https://bottube.ai/static/icon-512.png",
+                "embeds": [embed],
+            }
+
+            body = json.dumps(payload, separators=(",", ":")).encode()
+            req = urllib.request.Request(
+                webhook_url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "BoTTube-Discord/1.0",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                pass  # 204 No Content on success
+        except Exception:
+            pass  # Silently fail (e.g., invalid webhook URL)
+
+    threading.Thread(target=_send, daemon=True).start()
 
 
 def send_verification_email(email: str, token: str, username: str) -> bool:
@@ -14433,6 +14517,7 @@ def api_get_notification_preferences():
         "ok": True,
         "email": a["email"] or "",
         "email_verified": bool(a.get("email_verified", 0)),
+        "discord_webhook_url": a.get("discord_webhook_url", "") or "",
         "preferences": {
             "comments": bool(a.get("email_notify_comments", 1)),
             "replies": bool(a.get("email_notify_replies", 1)),
@@ -14464,6 +14549,13 @@ def api_set_notification_preferences():
             val = 1 if data[key] else 0
             db.execute(f"UPDATE agents SET {col} = ? WHERE id = ?", (val, g.agent["id"]))
             updated[key] = bool(val)
+    # Save Discord webhook URL
+    if "discord_webhook_url" in data:
+        url = (data["discord_webhook_url"] or "").strip()
+        if url and not url.startswith("https://discord.com/api/webhooks/"):
+            return jsonify({"error": "Invalid Discord webhook URL. Must start with https://discord.com/api/webhooks/"}), 400
+        db.execute("UPDATE agents SET discord_webhook_url = ? WHERE id = ?", (url, g.agent["id"]))
+        updated["discord_webhook_url"] = url
     db.commit()
     return jsonify({"ok": True, "updated": updated})
 
@@ -14483,6 +14575,7 @@ def notification_settings_page():
         "tips": bool(agent.get("email_notify_tips", 1)),
         "subscriptions": bool(agent.get("email_notify_subscriptions", 1)),
     }
+    discord_webhook_url = agent.get("discord_webhook_url", "") or ""
     has_email = bool(agent.get("email", ""))
     email_verified = bool(agent.get("email_verified", 0))
     csrf_token = session.get("csrf_token", "")
@@ -14517,13 +14610,7 @@ a {{ color:#3ea6ff; text-decoration:none; }}
     elif not email_verified:
         html += '<div class="warning">Your email is not verified. Please verify your email to receive notifications.</div>'
 
-    html += f"""
-<div class="success" id="saved-msg">Preferences saved!</div>
-<form id="pref-form">
-<input type="hidden" name="csrf_token" value="{csrf_token}">
-<h3>Email me when...</h3>
-<div class="form-group">
-<label>Someone comments on my video</label>
+    html += f"""\n<div class="success" id="saved-msg">Preferences saved!</div>\n<form id="pref-form">\n<input type="hidden" name="csrf_token" value="{csrf_token}">\n<h3>Discord Notifications</h3>\n<p style="font-size:14px;color:#999;margin:8px 0 16px;">\n    Get notified on Discord when your videos are processed or you receive new interactions.\n    <a href="https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks" target="_blank" rel="noopener" style="color:#3ea6ff;">Learn how to create a Discord webhook</a>\n</p>\n<div class="form-group" style="flex-direction:column;align-items:stretch;">\n    <label style="font-size:14px;color:#ccc;">Discord Webhook URL</label>\n    <input type="url" name="discord_webhook_url" id="discord-webhook-url"\n           placeholder="https://discord.com/api/webhooks/..."\n           value="{discord_webhook_url}"\n           style="padding:10px 14px;background:#1a1a1a;border:1px solid #333;border-radius:6px;color:#f1f1f1;font-size:14px;width:100%;box-sizing:border-box;">\n    <p style="font-size:12px;color:#666;margin:4px 0 0;">\n        Leave empty to disable Discord notifications.\n    </p>\n</div>\n<br>\n<h3>Email me when...</h3>\n<div class="form-group">\n<label>Someone comments on my video</label>
 <label class="toggle"><input type="checkbox" name="comments" {"checked" if prefs["comments"] else ""}><span class="slider"></span></label>
 </div>
 <div class="form-group">
@@ -14556,6 +14643,7 @@ document.getElementById('pref-form').addEventListener('submit', async function(e
         new_video: fd.has('new_video'),
         tips: fd.has('tips'),
         subscriptions: fd.has('subscriptions'),
+        discord_webhook_url: document.getElementById('discord-webhook-url').value,
     }};
     const res = await fetch('{g.prefix}/settings/notifications', {{
         method: 'POST',
@@ -14591,6 +14679,12 @@ def notification_settings_save():
         if key in data:
             val = 1 if data[key] else 0
             db.execute(f"UPDATE agents SET {col} = ? WHERE id = ?", (val, g.user["id"]))
+    # Save Discord webhook URL
+    if "discord_webhook_url" in data:
+        url = (data["discord_webhook_url"] or "").strip()
+        if url and not url.startswith("https://discord.com/api/webhooks/"):
+            return jsonify({"error": "Invalid Discord webhook URL. Must start with https://discord.com/api/webhooks/"}), 400
+        db.execute("UPDATE agents SET discord_webhook_url = ? WHERE id = ?", (url, g.user["id"]))
     db.commit()
     return jsonify({"ok": True})
 

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14581,7 +14581,7 @@ def notification_settings_page():
     has_email = bool(agent.get("email", ""))
     email_verified = bool(agent.get("email_verified", 0))
     csrf_token = session.get("csrf_token", "")
-    html = f"""<!DOCTYPE html>
+    page_html = f"""<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Notification Settings - BoTTube</title>
@@ -14608,11 +14608,11 @@ a {{ color:#3ea6ff; text-decoration:none; }}
 <p><a href="{g.prefix}/">&larr; Back to BoTTube</a></p>
 <h1>Notification Settings</h1>"""
     if not has_email:
-        html += '<div class="warning">You need to add an email address to receive email notifications. <a href="' + g.prefix + '/settings">Go to Settings</a></div>'
+        page_html += '<div class="warning">You need to add an email address to receive email notifications. <a href="' + g.prefix + '/settings">Go to Settings</a></div>'
     elif not email_verified:
-        html += '<div class="warning">Your email is not verified. Please verify your email to receive notifications.</div>'
+        page_html += '<div class="warning">Your email is not verified. Please verify your email to receive notifications.</div>'
 
-    html += f"""\n<div class="success" id="saved-msg">Preferences saved!</div>\n<form id="pref-form">\n<input type="hidden" name="csrf_token" value="{csrf_token}">\n<h3>Discord Notifications</h3>\n<p style="font-size:14px;color:#999;margin:8px 0 16px;">\n    Get notified on Discord when your videos are processed or you receive new interactions.\n    <a href="https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks" target="_blank" rel="noopener" style="color:#3ea6ff;">Learn how to create a Discord webhook</a>\n</p>\n<div class="form-group" style="flex-direction:column;align-items:stretch;">\n    <label style="font-size:14px;color:#ccc;">Discord Webhook URL</label>\n    <input type="url" name="discord_webhook_url" id="discord-webhook-url"\n           placeholder="https://discord.com/api/webhooks/..."\n           value="{discord_webhook_url}"\n           style="padding:10px 14px;background:#1a1a1a;border:1px solid #333;border-radius:6px;color:#f1f1f1;font-size:14px;width:100%;box-sizing:border-box;">\n    <p style="font-size:12px;color:#666;margin:4px 0 0;">\n        Leave empty to disable Discord notifications.\n    </p>\n</div>\n<br>\n<h3>Email me when...</h3>\n<div class="form-group">\n<label>Someone comments on my video</label>
+    page_html += f"""\n<div class="success" id="saved-msg">Preferences saved!</div>\n<form id="pref-form">\n<input type="hidden" name="csrf_token" value="{csrf_token}">\n<h3>Discord Notifications</h3>\n<p style="font-size:14px;color:#999;margin:8px 0 16px;">\n    Get notified on Discord when your videos are processed or you receive new interactions.\n    <a href="https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks" target="_blank" rel="noopener" style="color:#3ea6ff;">Learn how to create a Discord webhook</a>\n</p>\n<div class="form-group" style="flex-direction:column;align-items:stretch;">\n    <label style="font-size:14px;color:#ccc;">Discord Webhook URL</label>\n    <input type="url" name="discord_webhook_url" id="discord-webhook-url"\n           placeholder="https://discord.com/api/webhooks/..."\n           value="{discord_webhook_url}"\n           style="padding:10px 14px;background:#1a1a1a;border:1px solid #333;border-radius:6px;color:#f1f1f1;font-size:14px;width:100%;box-sizing:border-box;">\n    <p style="font-size:12px;color:#666;margin:4px 0 0;">\n        Leave empty to disable Discord notifications.\n    </p>\n</div>\n<br>\n<h3>Email me when...</h3>\n<div class="form-group">\n<label>Someone comments on my video</label>
 <label class="toggle"><input type="checkbox" name="comments" {"checked" if prefs["comments"] else ""}><span class="slider"></span></label>
 </div>
 <div class="form-group">
@@ -14660,7 +14660,7 @@ document.getElementById('pref-form').addEventListener('submit', async function(e
 }});
 </script>
 </body></html>"""
-    return html
+    return page_html
 
 
 @app.route("/settings/notifications", methods=["POST"])

--- a/tests/test_discord_notification.py
+++ b/tests/test_discord_notification.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: MIT
+"""Tests for Discord notification — fire_discord_notification."""
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+# Bootstrap the environment before any bottube_server imports fire
+# (init_gemini_tables and other module-level code need a writable DB path)
+_tmp = tempfile.mkdtemp()
+os.environ.setdefault("BOTTUBE_BASE_DIR", _tmp)
+os.environ.setdefault("BOTTUBE_DB", os.path.join(_tmp, "bottube.db"))
+
+# Ensure the bootstrap DB exists
+Path(_tmp).mkdir(parents=True, exist_ok=True)
+Path(os.environ["BOTTUBE_DB"]).touch()
+
+# Patch sqlite3.connect so that the hard-coded /root/bottube/bottube.db
+# fallback in init_gemini_tables redirects to our temp DB
+_orig_connect = sqlite3.connect
+
+
+def _bootstrap_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB"]
+    return _orig_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_connect
+
+# Now import — module-level init_gemini_tables() will use the redirected path
+from bottube_server import DB_PATH, fire_discord_notification, init_db
+
+# Restore original connect
+sqlite3.connect = _orig_connect
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def test_db():
+    """Create a fresh test database for each test."""
+    db_path = Path(tempfile.mkdtemp()) / "test.db"
+    # Patch DB_PATH before init_db runs
+    import bottube_server
+    original_db = bottube_server.DB_PATH
+    bottube_server.DB_PATH = db_path
+    init_db()
+    yield db_path
+    bottube_server.DB_PATH = original_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_sync(self):
+    """Run a daemon thread's target synchronously (inline)."""
+    self._target()
+
+
+def _insert_agent(db_path, agent_id: int, webhook_url: str):
+    """Insert a minimal agent row with the given discord_webhook_url."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO agents (id, agent_name, api_key, created_at, discord_webhook_url) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (agent_id, f"test_agent_{agent_id}", f"key_{agent_id}", time.time(), webhook_url),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestDiscordNotification:
+    """Send-path tests for fire_discord_notification."""
+
+    def test_sends_to_discord_webhook(self, test_db):
+        """With a valid discord.com webhook URL, POST to the webhook endpoint."""
+        _insert_agent(test_db, 1, "https://discord.com/api/webhooks/12345/test")
+
+        with patch("bottube_server.urllib.request.urlopen") as mock_urlopen, \
+             patch.object(threading.Thread, "start", _run_sync):
+
+            fire_discord_notification(
+                agent_id=1,
+                notif_type="new_video",
+                message="Test notification",
+                from_agent="test_agent",
+                video_id="abc123",
+                video_title="Test Video",
+            )
+
+            mock_urlopen.assert_called_once()
+            req = mock_urlopen.call_args[0][0]
+
+            # Assert the URL is a discord.com webhook URL
+            url = req.get_full_url()
+            assert "discord.com" in url
+            assert "/api/webhooks/" in url
+
+            # Assert the payload is well-formed
+            body = req.data
+            payload = json.loads(body)
+            assert payload["username"] == "BoTTube"
+            assert len(payload["embeds"]) == 1
+
+            embed = payload["embeds"][0]
+            assert embed["title"] == "BoTTube Notification"
+            assert embed["description"] == "Test notification"
+            assert embed["author"]["name"] == "test_agent"
+            assert embed["url"] == "https://bottube.ai/watch/abc123"
+            assert embed["fields"][0]["value"] == "Test Video"
+
+            # Assert correct method
+            assert req.method == "POST"
+
+    def test_invalid_webhook_skips_silently(self, test_db):
+        """A non-discord.com webhook URL should silently skip without POSTing."""
+        _insert_agent(test_db, 2, "https://evil.com/hook")
+
+        with patch("bottube_server.urllib.request.urlopen") as mock_urlopen, \
+             patch.object(threading.Thread, "start", _run_sync):
+
+            fire_discord_notification(
+                agent_id=2,
+                notif_type="new_video",
+                message="Should not send",
+            )
+            mock_urlopen.assert_not_called()
+
+    def test_empty_webhook_skips_silently(self, test_db):
+        """An empty webhook URL should silently skip without POSTing."""
+        _insert_agent(test_db, 3, "")
+
+        with patch("bottube_server.urllib.request.urlopen") as mock_urlopen, \
+             patch.object(threading.Thread, "start", _run_sync):
+
+            fire_discord_notification(
+                agent_id=3,
+                notif_type="new_video",
+                message="Should not send",
+            )
+            mock_urlopen.assert_not_called()
+
+    def test_no_agent_row_skips_silently(self, test_db):
+        """A non-existent agent ID should silently skip without POSTing."""
+        with patch("bottube_server.urllib.request.urlopen") as mock_urlopen, \
+             patch.object(threading.Thread, "start", _run_sync):
+
+            fire_discord_notification(
+                agent_id=999,
+                notif_type="new_video",
+                message="Should not send",
+            )
+            mock_urlopen.assert_not_called()
+
+    def test_sends_minimal_payload(self, test_db):
+        """Without optional fields (video_id, from_agent, video_title), send a minimal embed."""
+        _insert_agent(test_db, 4, "https://discord.com/api/webhooks/99999/abc")
+
+        with patch("bottube_server.urllib.request.urlopen") as mock_urlopen, \
+             patch.object(threading.Thread, "start", _run_sync):
+
+            fire_discord_notification(
+                agent_id=4,
+                notif_type="new_video",
+                message="Simple notification",
+            )
+
+            mock_urlopen.assert_called_once()
+            req = mock_urlopen.call_args[0][0]
+            payload = json.loads(req.data)
+
+            embed = payload["embeds"][0]
+            assert embed["title"] == "BoTTube Notification"
+            assert embed["description"] == "Simple notification"
+            # Optional fields should be absent
+            assert "url" not in embed
+            assert "fields" not in embed
+            assert "author" not in embed

--- a/tests/test_discord_notification.py
+++ b/tests/test_discord_notification.py
@@ -9,7 +9,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
## Summary

Implements Discord notification integration for video processing and interaction events (Issue #1418).

## Changes

1. **Migration**: Added `discord_webhook_url` column to `agents` table
2. **`fire_discord_notification()`**: New function that sends Discord embeds via user-configured webhook URL
3. **Notification integration**: Discord notifications are sent alongside existing email/webhook notifications in:
   - `_notify_subscribers_new_video()` — when a creator uploads a new video
   - `notify()` — for comments, replies, tips, etc.
4. **Settings UI**: Added Discord webhook URL input to the notification settings page (`/settings/notifications`)
5. **API**: Added `discord_webhook_url` to `GET /api/notifications/preferences` and `PUT /api/notifications/preferences`
6. **Validation**: Webhook URL must start with `https://discord.com/api/webhooks/`

## Usage

1. Go to your Discord server settings → Integrations → Webhooks → Create a webhook
2. Copy the webhook URL
3. Go to BoTTube Settings → Notifications → Paste the webhook URL
4. Save — you will now receive Discord notifications for new video uploads, comments, tips, and more

## Testing

- Discord webhook sends a rich embed with BoTTube branding
- Silently fails if the webhook URL is invalid (no crash)
- Background thread, non-blocking

Closes #1418