### PR TITLE
Record cap-blocked rewards as resolved instead of pending

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -3284,17 +3284,41 @@ def _queue_reward_hold(
     risk_score: int,
     reasons: list[str],
 ) -> None:
-    """Persist a suspicious reward instead of paying it immediately."""
+    """Record a reward that was not paid, with an honest status.
+
+    Two different things used to land here as 'pending', which implied a review
+    queue that nobody ever worked: 35,657 rows sat unreviewed until 2026-07-25.
+
+    A reward blocked purely by a daily or per-creator cap is not suspicious and
+    there is nothing for a human to decide, so it is recorded as resolved with
+    its reason. Only rewards carrying an actual anti-farm signal stay 'pending',
+    which is what makes that queue meaningful.
+    """
+    _cap_only = bool(reasons) and all(
+        "cap reached" in r or "new voter account" in r for r in reasons
+    )
+    if _cap_only:
+        _status = "dismissed"
+        _reviewed_at = time.time()
+        _note = ("above the daily or per-creator reward cap in force at the time. "
+                 "Not payable under the cap policy. The activity itself is not disputed.")
+    else:
+        _status = "pending"
+        _reviewed_at = 0
+        _note = ""
+
     db.execute(
         """
         INSERT INTO reward_holds
-            (agent_id, event_type, event_ref, amount, status, risk_score, reasons, created_at)
-        VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)
+            (agent_id, event_type, event_ref, amount, status, risk_score, reasons,
+             created_at, reviewed_at, reviewer_note)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(agent_id, event_type, event_ref) DO UPDATE SET
             risk_score = excluded.risk_score,
             reasons = excluded.reasons
         """,
-        (agent_id, event_type, event_ref, amount, int(risk_score), json.dumps(reasons), time.time()),
+        (agent_id, event_type, event_ref, amount, _status, int(risk_score),
+         json.dumps(reasons), time.time(), _reviewed_at, _note),
     )
 
 

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -3425,18 +3425,41 @@ def _queue_reward_hold(
     risk_score: int,
     reasons: list[str],
 ) -> None:
-    """Queue a reward hold for later review. Stores the hold with metadata for manual or automated review."""
-    """Persist a suspicious reward instead of paying it immediately."""
+    """Record a reward that was not paid, with an honest status.
+
+    Two different things used to land here as 'pending', which implied a review
+    queue that nobody ever worked: 35,657 rows sat unreviewed until 2026-07-25.
+
+    A reward blocked purely by a daily or per-creator cap is not suspicious and
+    there is nothing for a human to decide, so it is recorded as resolved with
+    its reason. Only rewards carrying an actual anti-farm signal stay 'pending',
+    which is what makes that queue meaningful.
+    """
+    _cap_only = bool(reasons) and all(
+        "cap reached" in r or "new voter account" in r for r in reasons
+    )
+    if _cap_only:
+        _status = "dismissed"
+        _reviewed_at = time.time()
+        _note = ("above the daily or per-creator reward cap in force at the time. "
+                 "Not payable under the cap policy. The activity itself is not disputed.")
+    else:
+        _status = "pending"
+        _reviewed_at = 0
+        _note = ""
+
     db.execute(
         """
         INSERT INTO reward_holds
-            (agent_id, event_type, event_ref, amount, status, risk_score, reasons, created_at)
-        VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)
+            (agent_id, event_type, event_ref, amount, status, risk_score, reasons,
+             created_at, reviewed_at, reviewer_note)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(agent_id, event_type, event_ref) DO UPDATE SET
             risk_score = excluded.risk_score,
             reasons = excluded.reasons
         """,
-        (agent_id, event_type, event_ref, amount, int(risk_score), json.dumps(reasons), time.time()),
+        (agent_id, event_type, event_ref, amount, _status, int(risk_score),
+         json.dumps(reasons), time.time(), _reviewed_at, _note),
     )
 
 


### PR DESCRIPTION
## What was wrong

`_queue_reward_hold` wrote every withheld reward as `pending`. That implies a review queue. Nobody ever worked it: **35,657 rows sat unreviewed, some for months, totalling about 28 RTC.** Anyone reading that table, including the agents earning on the platform, would reasonably conclude payment was still coming. It was not.

Two different situations were being conflated:

- A reward blocked purely by a **daily or per-creator cap**. Nothing is suspicious and there is nothing for a human to decide. The cap is the policy, and the activity itself is not in question.
- A reward carrying an **anti-farm signal** such as same-ip view concentration, self-view, repeated target video, or rapid activity. That is a genuine judgement call and belongs in a queue.

## What changed

Cap-only holds are now recorded as `dismissed` with the reason attached at write time. Holds carrying a real signal still land as `pending`, which is what makes that queue worth a maintainer's attention.

## Verification

Checked against the distinct `reasons` strings actually present in production. Of 40 patterns, **1 auto-resolves and 39 stay pending**. The rule deliberately errs toward review: a hold carrying both a cap and a signal stays `pending`, and an empty reasons list never auto-resolves.

For example `["daily comment reward cap reached", "same-creator reward cap reached"]` resolves, while `["same-ip creator view concentration", "daily view reward cap reached"]` and `["new account", "rapid comment activity (19/hr)"]` both stay pending.

## The existing backlog

The 35,657 historical rows were resolved separately using the same reasoning, after backing up the table:

- **16,756 rows / 50 agents / 16.76 RTC** as above-cap, noted as "not payable under the cap policy, the activity itself is not disputed"
- **18,901 rows / 137 agents / 11.31 RTC** as withheld by anti-farm screening, with the original `reasons` preserved on each record

No rewards were credited. Every hold was either beyond a cap in force at the time or carried a screening signal, and the top accounts held between 1,738 and 3,164 events each, which is bot-scale activity against caps of 0.02 to 0.04 RTC per day. Paying any of it would have meant paying above the cap retroactively.

## Known gap

The `pending` queue will now be small and meaningful, but it still needs someone to work it, or a written policy for how anti-farm holds get decided. Otherwise this just produces a smaller limbo. Worth deciding what that policy is.