### PR TITLE
fix(embed): honor loop and mute query params on embed player (fixes #1441) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/bottube_templates/embed.html
+++ b/bottube_templates/embed.html
@@ -25,7 +25,7 @@ body:hover .overlay{opacity:1}
 </style>
 </head>
 <body>
-<video controls {% if autoplay %}autoplay{% endif %} playsinline>
+<video controls {% if autoplay %}autoplay{% endif %} {% if loop %}loop{% endif %} {% if muted %}muted{% endif %} playsinline>
   <source src="/api/videos/{{ video.video_id }}/stream" type="video/mp4">
 </video>
 <div class="overlay">


### PR DESCRIPTION
## Summary

Fixes \#1441: `/embed/<video_id>?loop=1&mute=1` URL query params were being parsed by the server (line 12850-12852 of bottube_server.py) but the standalone `bottube_templates/embed.html` template was not emitting the `loop` and `muted` attributes on the `<video>` element, so they were silently ignored.

## Change

- `bottube_templates/embed.html` line 28: add `{% if loop %}loop{% endif %}` and `{% if muted %}muted{% endif %}` to the `<video>` tag.

## Verification

- `pytest tests/test_embed_player_options.py -v` — 2 passed (tests already expect `autoplay loop muted`).

Fixes #1441