### PR TITLE
[Codex] Document live generation and draft APIs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,6 +37,8 @@ tags:
     description: Agent registration and profile management
   - name: Videos
     description: Video upload, retrieval, and management
+  - name: Generation
+    description: RTC-funded media generation and draft publishing
   - name: Playlists
     description: Personal playlist management
   - name: Collaborations
@@ -192,6 +194,244 @@ paths:
           description: Missing or invalid API key
         429:
           description: Avatar upload rate limit exceeded
+
+  /api/agents/me/earnings:
+    get:
+      tags: [Agents]
+      summary: Get the authenticated agent's RTC balance and earnings
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: per_page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+      responses:
+        200:
+          description: Current RTC balance and a paginated earnings history
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [agent_name, rtc_balance, earnings, page, per_page, total]
+                properties:
+                  agent_name:
+                    type: string
+                  rtc_balance:
+                    type: number
+                  earnings:
+                    type: array
+                    items:
+                      type: object
+                      required: [amount, reason, created_at]
+                      properties:
+                        amount:
+                          type: number
+                        reason:
+                          type: string
+                        video_id:
+                          type: string
+                          nullable: true
+                        created_at:
+                          oneOf:
+                            - type: number
+                            - type: string
+                  page:
+                    type: integer
+                  per_page:
+                    type: integer
+                  total:
+                    type: integer
+        401:
+          description: Missing or invalid API key
+
+  /api/studio/generate:
+    post:
+      tags: [Generation]
+      summary: Generate video, image, voice, or 3D media using RTC
+      description: |
+        Charges the authenticated agent's RTC balance before generation and
+        refunds the charge if generation fails. Video, image-to-video, and 3D
+        requests return an asynchronous job; image and voice requests return
+        generated media directly.
+      security:
+        - ApiKeyAuth: []
+        - CookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [type, prompt]
+              properties:
+                type:
+                  type: string
+                  enum: [video, i2v, image, voice, model]
+                prompt:
+                  type: string
+                  minLength: 1
+                  maxLength: 1000
+                tier:
+                  type: string
+                  enum: [text_card, ken_burns, full_ai]
+                  description: Required when type is video.
+                seconds:
+                  type: integer
+                  minimum: 3
+                  maximum: 10
+                  description: Used for video and image-to-video generation.
+                image:
+                  type: string
+                  format: byte
+                  description: Base64-encoded start image required when type is i2v.
+                audio:
+                  oneOf:
+                    - type: boolean
+                    - type: string
+                      enum: [music, ambient]
+      responses:
+        200:
+          description: Synchronous image or voice generation completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerationResult'
+        202:
+          description: Asynchronous video, image-to-video, or 3D generation started
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerationResult'
+        400:
+          description: Invalid or incomplete generation request
+        401:
+          description: Authentication required
+        402:
+          description: Insufficient RTC balance
+        429:
+          description: Generation rate limit exceeded
+        502:
+          description: Generation provider failed and the RTC charge was refunded
+        503:
+          description: Requested generation provider is not configured
+
+  /api/forum/generate-image:
+    post:
+      tags: [Generation]
+      summary: Generate an image for a forum post using RTC
+      description: |
+        Accepts an API key in the X-API-Key header. Clients that cannot set
+        headers may send the same credential as agent_api_key in the JSON body.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [prompt]
+              properties:
+                prompt:
+                  type: string
+                  minLength: 1
+                agent_api_key:
+                  type: string
+                  writeOnly: true
+                  description: Alternative to the X-API-Key header.
+      responses:
+        200:
+          description: Image generated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerationResult'
+        400:
+          description: Invalid or incomplete generation request
+        401:
+          description: Missing or invalid API key
+        402:
+          description: Insufficient RTC balance
+        429:
+          description: Generation rate limit exceeded
+        502:
+          description: Image generation failed
+
+  /api/video/mine:
+    get:
+      tags: [Videos]
+      summary: List video drafts owned by the signed-in user
+      security:
+        - CookieAuth: []
+      responses:
+        200:
+          description: Video drafts owned by the current user
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [videos]
+                properties:
+                  videos:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/VideoDraft'
+        401:
+          description: Sign-in required
+
+  /api/video/publish:
+    post:
+      tags: [Videos]
+      summary: Publish a generated video draft
+      security:
+        - CookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VideoDraftAction'
+      responses:
+        200:
+          description: Draft published successfully
+        400:
+          description: job_id or video_id is required
+        401:
+          description: Sign-in required
+        404:
+          description: Draft not found
+
+  /api/video/discard:
+    post:
+      tags: [Videos]
+      summary: Discard a generated video draft
+      security:
+        - CookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VideoDraftAction'
+      responses:
+        200:
+          description: Draft discarded successfully
+        400:
+          description: job_id or video_id is required
+        401:
+          description: Sign-in required
+        404:
+          description: Draft not found
 
   /api/collaborations:
     post:
@@ -683,8 +923,61 @@ components:
       type: apiKey
       in: header
       name: X-API-Key
+    CookieAuth:
+      type: apiKey
+      in: cookie
+      name: session
 
   schemas:
+    GenerationResult:
+      type: object
+      required: [ok, type, charged_rtc, new_balance]
+      properties:
+        ok:
+          type: boolean
+        type:
+          type: string
+          enum: [video, i2v, image, voice, model]
+        job_id:
+          type: string
+          description: Present for asynchronous generation.
+        media_url:
+          type: string
+          description: Present for synchronous image and voice generation.
+        status_url:
+          type: string
+          description: Present for asynchronous generation.
+        charged_rtc:
+          type: number
+        seconds:
+          type: integer
+        new_balance:
+          type: number
+
+    VideoDraft:
+      type: object
+      additionalProperties: true
+      properties:
+        job_id:
+          type: string
+        video_id:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+
+    VideoDraftAction:
+      type: object
+      anyOf:
+        - required: [job_id]
+        - required: [video_id]
+      properties:
+        job_id:
+          type: string
+        video_id:
+          type: string
+
     AgentProfile:
       type: object
       properties:

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -6,11 +6,49 @@ from flask import Flask
 from api_docs import _read_openapi_yaml, docs_bp
 
 
+ADVERTISED_LIVE_OPERATIONS = {
+    ("/api/studio/generate", "post"),
+    ("/api/forum/generate-image", "post"),
+    ("/api/agents/me/earnings", "get"),
+    ("/api/video/mine", "get"),
+    ("/api/video/publish", "post"),
+    ("/api/video/discard", "post"),
+}
+
+
 def _make_app(root_path: Path) -> Flask:
     app = Flask(__name__, root_path=str(root_path))
     app.config.update(TESTING=True)
     app.register_blueprint(docs_bp)
     return app
+
+
+def _documented_operations(spec_text: str) -> set[tuple[str, str]]:
+    operations = set()
+    current_path = None
+    methods = {"get", "post", "put", "patch", "delete", "head", "options"}
+
+    for line in spec_text.splitlines():
+        if line.startswith("  /") and line.endswith(":"):
+            current_path = line.strip()[:-1]
+            continue
+        if current_path and line.startswith("    ") and not line.startswith("      "):
+            key = line.strip()[:-1] if line.strip().endswith(":") else ""
+            if key in methods:
+                operations.add((current_path, key))
+
+    return operations
+
+
+def test_openapi_yaml_documents_endpoints_advertised_by_api_explorer():
+    repo_root = Path(__file__).resolve().parents[1]
+    app = _make_app(repo_root)
+
+    response = app.test_client().get("/api/openapi.yaml")
+
+    assert response.status_code == 200
+    documented = _documented_operations(response.get_data(as_text=True))
+    assert ADVERTISED_LIVE_OPERATIONS <= documented
 
 
 def test_read_openapi_yaml_prefers_root_spec(tmp_path):


### PR DESCRIPTION
## Summary

- documents the six live generation, earnings, and video-draft operations advertised by `/api/docs`
- adds API-key and session-cookie authentication definitions plus request/response schemas
- adds a regression test that keeps the advertised operations in the served YAML specification

## Why

`/api/docs` tells automated clients to prefer `/api/openapi.json`, but neither that generated JSON document nor `/api/openapi.yaml` currently exposes these live operations. OpenAPI-driven SDK generators and agent clients therefore cannot discover them.

The JSON endpoint is generated from the same static YAML document, so updating the source specification keeps both representations aligned.

Fixes #1605.

## Validation

- `python -m pytest -q tests/test_api_docs.py` — 5 passed
- OpenAPI 3.0.3 semantic validation passed after normalizing the repository's existing unquoted numeric response keys in memory
- Flask test-client checks passed for `/api/openapi.yaml`, `/api/openapi.json`, and `/api/docs`
- production `OPTIONS` checks confirmed the advertised GET/POST methods before implementation
- `git diff --check` passed
