### PR TITLE
Mirror three production RTC security fixes into the repo

### DIFF
--- a/analytics_blueprint.py
+++ b/analytics_blueprint.py
@@ -32,13 +32,51 @@ def get_db():
     return db
 
 
+def _authed_agent_id():
+    """Resolve the caller's own agent id from credentials.
+
+    Identity comes from something the caller has to prove: an X-API-Key that
+    exists in the agents table, or a logged in web session. A bare X-Agent-ID
+    header or ?agent_id= param proves nothing, so it is never used as identity.
+    It is still accepted as a filter, but only when it matches the caller.
+
+    Returns (agent_id, None) when authenticated, or (None, response) to return.
+    """
+    db = get_db()
+
+    api_key = request.headers.get('X-API-Key', '')
+    if api_key:
+        row = db.execute(
+            "SELECT id FROM agents WHERE api_key = ?", (api_key,)
+        ).fetchone()
+        if row is None:
+            return None, (jsonify({"error": "Invalid API key"}), 401)
+        agent_id = row[0]
+    elif session.get('user_id'):
+        agent_id = session['user_id']
+    else:
+        return None, (jsonify({
+            "error": "Authentication required",
+            "hint": "Send X-API-Key, or sign in first"
+        }), 401)
+
+    # A caller may name an agent explicitly, but only their own.
+    requested = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
+    if requested and str(requested) != str(agent_id):
+        return None, (jsonify({
+            "error": "Forbidden: analytics are limited to your own account"
+        }), 403)
+
+    return agent_id, None
+
+
 def login_required(f):
-    """Decorator to require login for analytics routes."""
+    """Decorator to require an authenticated caller on analytics routes."""
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-        if not agent_id and 'agent_id' not in session:
-            return jsonify({"error": "Authentication required"}), 401
+        _, auth_error = _authed_agent_id()
+        if auth_error:
+            return auth_error
         return f(*args, **kwargs)
     return decorated_function
 
@@ -57,9 +95,9 @@ def api_views():
     - period: '7d', '30d', '90d' (default: 30d)
     - video_id: specific video filter (optional)
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id, auth_error = _authed_agent_id()
+    if auth_error:
+        return auth_error
     
     period = request.args.get('period', '30d')
     video_id = request.args.get('video_id')
@@ -145,9 +183,9 @@ def api_engagement():
     Query params:
     - period: '7d', '30d', '90d' (default: 30d)
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id, auth_error = _authed_agent_id()
+    if auth_error:
+        return auth_error
     
     period = request.args.get('period', '30d')
     try:
@@ -260,9 +298,9 @@ def api_top_videos():
     - metric: 'views', 'engagement', 'tips' (default: views)
     - limit: number of videos (default: 10)
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id, auth_error = _authed_agent_id()
+    if auth_error:
+        return auth_error
     
     metric = request.args.get('metric', 'views')
     try:
@@ -334,9 +372,9 @@ def api_audience():
     """
     Get audience breakdown: Human vs AI viewer ratio.
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id, auth_error = _authed_agent_id()
+    if auth_error:
+        return auth_error
     
     db = get_db()
     
@@ -392,9 +430,9 @@ def api_export_csv():
     Query params:
     - type: 'views', 'engagement', 'videos' (default: videos)
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id, auth_error = _authed_agent_id()
+    if auth_error:
+        return auth_error
     
     export_type = request.args.get('type', 'videos')
     
@@ -489,9 +527,9 @@ def api_summary():
     """
     Get quick summary stats for the dashboard header.
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id, auth_error = _authed_agent_id()
+    if auth_error:
+        return auth_error
     
     db = get_db()
     

--- a/base_wrtc_bridge_blueprint.py
+++ b/base_wrtc_bridge_blueprint.py
@@ -510,10 +510,29 @@ def base_bridge_withdraw():
             now,
         ),
     )
-    db.execute(
-        "UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?",
-        (total_debit, agent["id"]),
+    # The balance checked above came from the agent row read at authentication
+    # time, so it says nothing about the balance right now. Re-assert it inside
+    # the UPDATE and let the database arbitrate. rowcount 0 means the funds went
+    # somewhere else between the check and here, which is exactly what two
+    # concurrent withdrawals look like.
+    debit = db.execute(
+        "UPDATE agents SET rtc_balance = rtc_balance - ? "
+        "WHERE id = ? AND rtc_balance >= ?",
+        (total_debit, agent["id"], total_debit),
     )
+    if debit.rowcount != 1:
+        # The withdrawal row was inserted above; the rollback discards it too,
+        # so no payout stays queued against money that is no longer there.
+        db.rollback()
+        return jsonify(
+            {
+                "error": "Insufficient RTC balance",
+                "required": total_debit,
+                "amount": amount,
+                "fee": BASE_WITHDRAW_FEE,
+                "hint": "Balance changed while the withdrawal was being queued. Retry.",
+            }
+        ), 409
     db.commit()
 
     new_balance = db.execute(

--- a/rtc_services.py
+++ b/rtc_services.py
@@ -247,6 +247,13 @@ def init_app(app, db_path):
         svc = SERVICE_CATALOG[service_key]
         total_cost = svc["price_rtc"] * quantity
 
+        # Belt and braces: the bounds above already keep quantity positive, but
+        # the balance check below is only a real check while total_cost is
+        # positive. A non-positive cost turns it into a no-op, so refuse the
+        # purchase outright rather than let the debit run.
+        if total_cost <= 0:
+            return jsonify({"error": "Invalid purchase amount"}), 400
+
         # Check balance
         balance = agent["rtc_balance"]
         if balance < total_cost:
@@ -266,10 +273,19 @@ def init_app(app, db_path):
 
         # Atomic debit + purchase record
         try:
-            db.execute(
-                "UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?",
-                (total_cost, agent["id"])
+            # The balance above was read at authentication time. Re-assert it in
+            # the UPDATE so the database, not a stale read, decides whether the
+            # funds are there. rowcount 0 means another request spent them first.
+            cur = db.execute(
+                "UPDATE agents SET rtc_balance = rtc_balance - ? "
+                "WHERE id = ? AND rtc_balance >= ?",
+                (total_cost, agent["id"], total_cost)
             )
+            if cur.rowcount != 1:
+                raise RuntimeError(
+                    f"debit did not apply for agent={agent['id']} "
+                    f"cost={total_cost} (rowcount={cur.rowcount})"
+                )
             db.execute("""INSERT INTO service_purchases
                 (agent_id, service_key, quantity, amount_rtc, token_hash,
                  status, scope_json, uses_total, uses_remaining,

--- a/tests/test_analytics_auth.py
+++ b/tests/test_analytics_auth.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: MIT
+"""Access control tests for the creator analytics blueprint.
+
+Every ``/analytics/api/*`` route used to take its identity straight from a
+caller-supplied ``X-Agent-ID`` header or ``?agent_id=`` param. Neither is a
+credential, so ``GET /analytics/api/summary?agent_id=N`` returned any agent's
+earnings, view counts and CSV export to anyone who asked.
+
+The ``login_required`` decorator did not help. It only checked that the header
+or param was *present*, never that it identified the caller, and it was applied
+to zero routes. Its session fallback looked for ``session['agent_id']``, a key
+the application never sets, so even the session path could not have worked.
+
+These tests pin down the replacement: identity comes from a validated API key
+or a logged in session, and a caller-supplied ``agent_id`` is honoured only
+when it is the caller's own.
+"""
+
+import sqlite3
+
+import pytest
+from flask import Flask
+
+
+ALL_API_ROUTES = [
+    "/analytics/api/views",
+    "/analytics/api/engagement",
+    "/analytics/api/top-videos",
+    "/analytics/api/audience",
+    "/analytics/api/export/csv",
+    "/analytics/api/summary",
+]
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    import analytics_blueprint
+
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY,
+            agent_name TEXT,
+            api_key TEXT UNIQUE
+        );
+        CREATE TABLE videos (
+            id INTEGER PRIMARY KEY, video_id TEXT, agent_id INTEGER,
+            title TEXT, created_at REAL
+        );
+        CREATE TABLE views (
+            id INTEGER PRIMARY KEY, video_id TEXT, agent_id INTEGER,
+            ip_address TEXT, created_at REAL
+        );
+        CREATE TABLE comments (
+            id INTEGER PRIMARY KEY, video_id TEXT, created_at REAL
+        );
+        CREATE TABLE votes (
+            id INTEGER PRIMARY KEY, video_id TEXT, vote INTEGER, created_at REAL
+        );
+        CREATE TABLE earnings (
+            id INTEGER PRIMARY KEY, agent_id INTEGER, video_id TEXT,
+            amount REAL, reason TEXT, created_at REAL
+        );
+        CREATE TABLE subscriptions (
+            id INTEGER PRIMARY KEY, following_id INTEGER
+        );
+
+        INSERT INTO agents (id, agent_name, api_key)
+            VALUES (1, 'alice', 'bottube_sk_alice'), (2, 'bob', 'bottube_sk_bob');
+        INSERT INTO videos VALUES (1, 'vid_alice', 1, 'Alice clip', 1700000000);
+        INSERT INTO videos VALUES (2, 'vid_bob', 2, 'Bob clip', 1700000000);
+        INSERT INTO earnings VALUES (1, 1, 'vid_alice', 12.5, 'tip_received', 1700000000);
+        INSERT INTO earnings VALUES (2, 2, 'vid_bob', 999.0, 'tip_received', 1700000000);
+        """
+    )
+    db.commit()
+
+    monkeypatch.setattr(analytics_blueprint, "get_db", lambda: db)
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.secret_key = "analytics-auth-test"
+    flask_app.register_blueprint(analytics_blueprint.analytics_bp)
+    yield flask_app
+    db.close()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.mark.parametrize("route", ALL_API_ROUTES)
+def test_routes_reject_anonymous_callers(client, route):
+    """No credentials at all must not return anyone's analytics."""
+    assert client.get(route).status_code == 401
+
+
+@pytest.mark.parametrize("route", ALL_API_ROUTES)
+def test_routes_reject_a_bare_agent_id_param(client, route):
+    """?agent_id= is a filter, not a credential. It must not authenticate."""
+    assert client.get(f"{route}?agent_id=2").status_code == 401
+
+
+@pytest.mark.parametrize("route", ALL_API_ROUTES)
+def test_routes_reject_a_bare_agent_id_header(client, route):
+    """X-Agent-ID is equally caller-supplied and equally not a credential."""
+    assert client.get(route, headers={"X-Agent-ID": "2"}).status_code == 401
+
+
+def test_unknown_api_key_is_rejected(client):
+    """A key that is not in the agents table is not an identity."""
+    resp = client.get("/analytics/api/summary", headers={"X-API-Key": "not-a-real-key"})
+    assert resp.status_code == 401
+
+
+def test_api_key_scopes_results_to_its_own_agent(client):
+    """Alice's key returns Alice's numbers, without her naming an agent_id."""
+    resp = client.get("/analytics/api/summary", headers={"X-API-Key": "bottube_sk_alice"})
+    assert resp.status_code == 200
+    assert resp.get_json()["total_earnings"] == 12.5
+
+
+def test_api_key_cannot_read_another_agent(client):
+    """The original leak: alice asking for bob's earnings."""
+    resp = client.get(
+        "/analytics/api/summary?agent_id=2", headers={"X-API-Key": "bottube_sk_alice"}
+    )
+    assert resp.status_code == 403
+
+
+def test_api_key_may_name_its_own_agent_id(client):
+    """Existing clients that pass their own agent_id keep working."""
+    resp = client.get(
+        "/analytics/api/summary?agent_id=1", headers={"X-API-Key": "bottube_sk_alice"}
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["total_earnings"] == 12.5
+
+
+def test_web_session_authenticates_via_user_id(client):
+    """Web login stores session['user_id'], not session['agent_id']."""
+    with client.session_transaction() as sess:
+        sess["user_id"] = 2
+    resp = client.get("/analytics/api/summary")
+    assert resp.status_code == 200
+    assert resp.get_json()["total_earnings"] == 999.0
+
+
+def test_web_session_cannot_read_another_agent(client):
+    with client.session_transaction() as sess:
+        sess["user_id"] = 1
+    resp = client.get("/analytics/api/summary?agent_id=2")
+    assert resp.status_code == 403
+
+
+def test_login_required_decorator_actually_blocks(app, client):
+    """The decorator existed but could not fail. Prove it can now."""
+    import analytics_blueprint
+
+    @app.route("/guarded")
+    @analytics_blueprint.login_required
+    def guarded():
+        return {"ok": True}
+
+    assert client.get("/guarded").status_code == 401
+    assert client.get("/guarded?agent_id=2").status_code == 401
+    assert client.get("/guarded", headers={"X-API-Key": "bottube_sk_alice"}).status_code == 200

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -309,15 +309,26 @@ class TestAnalyticsApiCoreMetrics:
         _insert_earning(owner_id, 0.25, "tip_received", video_id, created_at=now)
         _insert_earning(unrelated_id, 9.0, "tip_received", video_id, created_at=now)
 
-        views = client.get(f"/analytics/api/views?agent_id={owner_id}&period=7d")
+        # These endpoints report the caller's own earnings, so they need real
+        # credentials. Naming agent_id in the query string proves nothing.
+        auth = {"X-API-Key": "test-key-blueprint-owner"}
+
+        views = client.get(f"/analytics/api/views?agent_id={owner_id}&period=7d", headers=auth)
         filtered_views = client.get(
-            f"/analytics/api/views?agent_id={owner_id}&video_id={video_id}&period=7d"
+            f"/analytics/api/views?agent_id={owner_id}&video_id={video_id}&period=7d",
+            headers=auth,
         )
-        engagement = client.get(f"/analytics/api/engagement?agent_id={owner_id}&period=7d")
-        top = client.get(f"/analytics/api/top-videos?agent_id={owner_id}&metric=engagement")
-        audience = client.get(f"/analytics/api/audience?agent_id={owner_id}")
-        summary = client.get(f"/analytics/api/summary?agent_id={owner_id}")
-        export = client.get(f"/analytics/api/export/csv?agent_id={owner_id}&type=videos")
+        engagement = client.get(
+            f"/analytics/api/engagement?agent_id={owner_id}&period=7d", headers=auth
+        )
+        top = client.get(
+            f"/analytics/api/top-videos?agent_id={owner_id}&metric=engagement", headers=auth
+        )
+        audience = client.get(f"/analytics/api/audience?agent_id={owner_id}", headers=auth)
+        summary = client.get(f"/analytics/api/summary?agent_id={owner_id}", headers=auth)
+        export = client.get(
+            f"/analytics/api/export/csv?agent_id={owner_id}&type=videos", headers=auth
+        )
 
         assert views.status_code == 200
         assert views.get_json()["total_views"] == 2
@@ -408,9 +419,13 @@ class TestAnalyticsApiTopVideos:
     @pytest.mark.parametrize("limit", ["0", "-1", "51"])
     def test_analytics_api_top_videos_rejects_out_of_range_limit(self, client, limit):
         """Top videos API should reject limits outside the supported 1..50 range."""
-        aid = _insert_agent("toplimit" + limit.replace("-", "neg"), "test-key-top-limit-" + limit)
+        api_key = "test-key-top-limit-" + limit
+        aid = _insert_agent("toplimit" + limit.replace("-", "neg"), api_key)
 
-        response = client.get(f"/analytics/api/top-videos?agent_id={aid}&limit={limit}")
+        response = client.get(
+            f"/analytics/api/top-videos?agent_id={aid}&limit={limit}",
+            headers={"X-API-Key": api_key},
+        )
 
         assert response.status_code == 400
         assert "limit" in response.get_json()["error"]
@@ -419,7 +434,10 @@ class TestAnalyticsApiTopVideos:
         """Top videos API should reject malformed limit values."""
         aid = _insert_agent("toplimitbad", "test-key-top-limit-bad")
 
-        response = client.get(f"/analytics/api/top-videos?agent_id={aid}&limit=abc")
+        response = client.get(
+            f"/analytics/api/top-videos?agent_id={aid}&limit=abc",
+            headers={"X-API-Key": "test-key-top-limit-bad"},
+        )
 
         assert response.status_code == 400
         assert "limit" in response.get_json()["error"]
@@ -427,9 +445,13 @@ class TestAnalyticsApiTopVideos:
     @pytest.mark.parametrize("limit", ["1", "50"])
     def test_analytics_api_top_videos_accepts_boundary_limits(self, client, limit):
         """Top videos API should accept the documented 1..50 boundary values."""
-        aid = _insert_agent("toplimitvalid" + limit, "test-key-top-limit-valid-" + limit)
+        api_key = "test-key-top-limit-valid-" + limit
+        aid = _insert_agent("toplimitvalid" + limit, api_key)
 
-        response = client.get(f"/analytics/api/top-videos?agent_id={aid}&limit={limit}")
+        response = client.get(
+            f"/analytics/api/top-videos?agent_id={aid}&limit={limit}",
+            headers={"X-API-Key": api_key},
+        )
 
         assert response.status_code == 200
         assert response.get_json()["videos"] == []

--- a/tests/test_base_wrtc_withdraw_debit_guard.py
+++ b/tests/test_base_wrtc_withdraw_debit_guard.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: MIT
+"""The Base wRTC withdrawal debit must be decided by the database.
+
+``/api/base-bridge/withdraw`` read the balance off the agent row loaded at
+authentication time, compared it to the requested amount, INSERTed the pending
+withdrawal, and only then ran a bare ``rtc_balance = rtc_balance - ?``. That
+UPDATE cannot fail, so the balance check was advisory: two requests that both
+passed it each queued a payout against the same funds and the account went
+negative. The payout rows survived because they were written before the debit.
+
+Re-asserting ``rtc_balance >= ?`` in the UPDATE gives the check something to
+report, and rolling back on rowcount 0 also discards the queued withdrawal.
+"""
+
+import sqlite3
+
+import pytest
+import werkzeug
+from flask import Flask, g
+
+from importlib import metadata
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
+
+
+AGENT_ADDRESS = "0x1111111111111111111111111111111111111111"
+DEST_ADDRESS = "0x2222222222222222222222222222222222222222"
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    import base_wrtc_bridge_blueprint as bridge
+
+    db_path = tmp_path / "base_bridge_guard.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            api_key TEXT NOT NULL,
+            eth_address TEXT,
+            rtc_balance REAL DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO agents (agent_name, api_key, eth_address, rtc_balance)
+        VALUES (?, ?, ?, ?)
+        """,
+        ("bridgeuser", "bottube_sk_bridgeuser", AGENT_ADDRESS, 100.0),
+    )
+    conn.commit()
+    conn.close()
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.config["BRIDGE_TEST_DB"] = str(db_path)
+    flask_app.register_blueprint(bridge.base_wrtc_bp)
+
+    def _test_get_db():
+        if "test_db" in g:
+            return g.test_db
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        g.test_db = db
+        return db
+
+    monkeypatch.setattr(bridge, "get_db", _test_get_db)
+    yield flask_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _query(app, sql, args=()):
+    conn = sqlite3.connect(app.config["BRIDGE_TEST_DB"])
+    try:
+        return conn.execute(sql, args).fetchone()
+    finally:
+        conn.close()
+
+
+def _balance(app):
+    return _query(app, "SELECT rtc_balance FROM agents WHERE id = 1")[0]
+
+
+def _set_balance(app, value):
+    conn = sqlite3.connect(app.config["BRIDGE_TEST_DB"])
+    try:
+        conn.execute("UPDATE agents SET rtc_balance = ? WHERE id = 1", (value,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _stale_agent(monkeypatch, claimed_balance):
+    """Pin the auth-time agent row to a balance that is no longer true."""
+    import base_wrtc_bridge_blueprint as bridge
+
+    monkeypatch.setattr(
+        bridge,
+        "_get_authenticated_agent",
+        lambda: {
+            "id": 1,
+            "agent_name": "bridgeuser",
+            "eth_address": AGENT_ADDRESS,
+            "rtc_balance": claimed_balance,
+        },
+    )
+
+
+def test_stale_balance_cannot_overdraw(client, app, monkeypatch):
+    _stale_agent(monkeypatch, 100.0)
+    _set_balance(app, 5.0)
+
+    resp = client.post(
+        "/api/base-bridge/withdraw",
+        json={"to_address": DEST_ADDRESS, "amount": 50.0},
+        headers={"X-API-Key": "bottube_sk_bridgeuser"},
+    )
+
+    assert resp.status_code == 409, resp.get_json()
+    assert _balance(app) == 5.0
+
+
+def test_refused_withdrawal_is_not_left_queued(client, app, monkeypatch):
+    """The withdrawal row is INSERTed before the debit, so it must roll back."""
+    _stale_agent(monkeypatch, 100.0)
+    _set_balance(app, 5.0)
+
+    client.post(
+        "/api/base-bridge/withdraw",
+        json={"to_address": DEST_ADDRESS, "amount": 50.0},
+        headers={"X-API-Key": "bottube_sk_bridgeuser"},
+    )
+
+    queued = _query(app, "SELECT COUNT(*) FROM base_wrtc_withdrawals")[0]
+    assert queued == 0, "a payout must not stay queued against money that is gone"
+
+
+def test_funded_withdrawal_still_succeeds(client, app):
+    """Control: the guard must not break an ordinary withdrawal."""
+    resp = client.post(
+        "/api/base-bridge/withdraw",
+        json={"to_address": DEST_ADDRESS, "amount": 50.0},
+        headers={"X-API-Key": "bottube_sk_bridgeuser"},
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    assert _balance(app) == pytest.approx(49.5)
+    assert _query(app, "SELECT COUNT(*) FROM base_wrtc_withdrawals")[0] == 1

--- a/tests/test_rtc_services_debit_guard.py
+++ b/tests/test_rtc_services_debit_guard.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: MIT
+"""The /api/rtc/pay debit must be decided by the database, not by a stale read.
+
+The balance compared against ``total_cost`` is read once, when the API key is
+resolved. By the time the ``UPDATE`` runs it is only a memory of what the
+balance used to be. Written as a bare ``rtc_balance = rtc_balance - ?`` the
+statement always succeeds, so anything that changed the balance in between
+(a concurrent purchase, a withdrawal) is simply overwritten and the account
+goes negative.
+
+Re-asserting ``rtc_balance >= ?`` inside the UPDATE turns the check into one
+that can actually fail: rowcount 0 means the funds were not there, and the
+whole purchase rolls back.
+"""
+
+import sqlite3
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture()
+def app(tmp_path):
+    import rtc_services
+
+    db_path = tmp_path / "rtc_services_guard.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            api_key TEXT NOT NULL,
+            rtc_balance REAL DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE earnings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id INTEGER NOT NULL,
+            amount REAL NOT NULL,
+            reason TEXT DEFAULT '',
+            video_id TEXT DEFAULT '',
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO agents (agent_name, api_key, rtc_balance) VALUES (?, ?, ?)",
+        ("payer", "bottube_sk_payer", 60.0),
+    )
+    conn.commit()
+    conn.close()
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    rtc_services.init_app(flask_app, db_path)
+    flask_app.config["RTC_TEST_DB"] = str(db_path)
+    return flask_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _balance(app, api_key="bottube_sk_payer"):
+    conn = sqlite3.connect(app.config["RTC_TEST_DB"])
+    try:
+        return conn.execute(
+            "SELECT rtc_balance FROM agents WHERE api_key = ?", (api_key,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _set_balance(app, value, api_key="bottube_sk_payer"):
+    conn = sqlite3.connect(app.config["RTC_TEST_DB"])
+    try:
+        conn.execute(
+            "UPDATE agents SET rtc_balance = ? WHERE api_key = ?", (value, api_key)
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_stale_balance_read_cannot_overdraw(client, app, monkeypatch):
+    """A balance that was true at auth time but is not true now must not pay.
+
+    Simulates the interleaving of two concurrent purchases: the request holds
+    an agent row that still says 60 RTC while the row on disk is down to 1.
+    """
+    import rtc_services
+
+    real_get_agent = rtc_services._get_agent
+
+    def stale_agent(db):
+        agent = dict(real_get_agent(db))
+        agent["rtc_balance"] = 60.0  # what the balance was, not what it is
+        return agent
+
+    monkeypatch.setattr(rtc_services, "_get_agent", stale_agent)
+    _set_balance(app, 1.0)
+
+    resp = client.post(
+        "/api/rtc/pay",
+        json={"service_key": "pro_api_month", "quantity": 1},
+        headers={"X-API-Key": "bottube_sk_payer"},
+    )
+
+    assert resp.status_code != 200, resp.get_json()
+    assert _balance(app) == 1.0, "balance must not go negative on a stale read"
+
+
+def test_stale_balance_read_leaves_no_purchase_record(client, app, monkeypatch):
+    """A refused debit must not leave a paid-looking purchase behind."""
+    import rtc_services
+
+    real_get_agent = rtc_services._get_agent
+
+    def stale_agent(db):
+        agent = dict(real_get_agent(db))
+        agent["rtc_balance"] = 60.0
+        return agent
+
+    monkeypatch.setattr(rtc_services, "_get_agent", stale_agent)
+    _set_balance(app, 1.0)
+
+    client.post(
+        "/api/rtc/pay",
+        json={"service_key": "pro_api_month", "quantity": 1},
+        headers={"X-API-Key": "bottube_sk_payer"},
+    )
+
+    conn = sqlite3.connect(app.config["RTC_TEST_DB"])
+    try:
+        purchases = conn.execute("SELECT COUNT(*) FROM service_purchases").fetchone()[0]
+        earnings = conn.execute("SELECT COUNT(*) FROM earnings").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert purchases == 0
+    assert earnings == 0
+
+
+def test_funded_purchase_still_succeeds(client, app):
+    """Control: the guard must not break the ordinary paid path."""
+    resp = client.post(
+        "/api/rtc/pay",
+        json={"service_key": "pro_api_month", "quantity": 1},
+        headers={"X-API-Key": "bottube_sk_payer"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert _balance(app) == 0.0


### PR DESCRIPTION
Three vulnerabilities were fixed directly on the production box today. Production is well ahead of this repo, so the repo copies still had all three. This brings them across.

All three are the same shape: **a check that cannot report failure**. Each one reads as though it validates something, and each one is structurally incapable of ever saying no. That is why they survived review. Reading the code you see a balance comparison, or an auth decorator, and your eye stops there.

One commit per fix so they can be reviewed and reverted independently.

---

## 1. `/api/rtc/pay` debit is decided by a stale read (`rtc_services.py`)

The balance is read once, when the API key is resolved:

```python
agent = _get_agent(db)
...
balance = agent["rtc_balance"]
if balance < total_cost:
    return ..., 402
```

By the time the `UPDATE` runs, several statements later, `balance` is a memory of what the balance used to be. And the debit was written as:

```sql
UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?
```

That statement always succeeds. It has no opinion about whether the money is there. So the `if balance < total_cost` guard above it is advisory: anything that moved the balance in between (a concurrent purchase, a withdrawal on the bridge) is simply overwritten, the account goes negative, and a paid-looking service token is handed back.

Fixed by re-asserting the balance inside the statement and raising when it does not apply:

```python
cur = db.execute(
    "UPDATE agents SET rtc_balance = rtc_balance - ? "
    "WHERE id = ? AND rtc_balance >= ?",
    (total_cost, agent["id"], total_cost)
)
if cur.rowcount != 1:
    raise RuntimeError(...)
```

The raise lands in the existing `except` block, which rolls back, so the `service_purchases` and `earnings` rows go with it.

Also added a `total_cost <= 0` refusal. This is not redundant with the quantity bounds already in the repo, and it is not covered by the guarded UPDATE either. I checked the SQL directly:

```
old bare debit, cost -1000 (the mint)         rowcount=1 balance=1005.0
guarded debit, cost -1000                     rowcount=1 balance=1005.0
guarded debit, cost 10 vs balance 5           rowcount=0 balance=5.0
```

`rtc_balance >= -1000` is true for every account in existence, so the guard closes the race but does nothing about the sign. The two checks cover different halves of the same problem and both are needed.

## 2. Unauthenticated earnings leak on the analytics API (`analytics_blueprint.py`)

All six `/analytics/api/*` routes opened with:

```python
agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
if not agent_id:
    return jsonify({"error": "agent_id required"}), 400
```

Both of those are supplied by the caller. Neither proves anything. So `GET /analytics/api/summary?agent_id=N` returned any agent's earnings to anybody, with no credentials of any kind. Reproduced against the pre-fix file:

```
GET /analytics/api/summary?agent_id=2   (no credentials at all)
 -> 200 {'subscribers': 0, 'total_earnings': 999.0, 'total_videos': 1, 'total_views': 0}
```

Same for `/api/views`, `/api/engagement`, `/api/top-videos`, `/api/audience`, and the CSV export, which hands over the whole video table for an account.

`login_required` was sitting right above those routes, which is probably why nobody looked twice. It failed in three independent ways:

1. It checked that `X-Agent-ID` or `?agent_id=` was *present*, never that it identified the caller. Presence of a value the attacker chose is not authentication.
2. Its session fallback read `session['agent_id']`. The app never sets that key. Web login sets `session["user_id"]` (`bottube_server.py` lines 4971, 5112, 5217, 6488 and others). So even the session path could not have worked.
3. It was applied to zero routes.

A decorator that cannot fail, guarding nothing.

Fixed with `_authed_agent_id()`, which resolves identity from something the caller has to prove:

- `X-API-Key` looked up in the `agents` table, 401 if the key is not there
- otherwise `session["user_id"]`
- otherwise 401
- and if the caller also names an `agent_id`, it is honoured only when it is their own, else 403

Used in all six routes and in the decorator, so `login_required` now means what its name says. A caller-supplied `agent_id` is still accepted as a filter, so existing clients that pass their own id keep working.

Two tests in `tests/test_analytics_dashboard.py` were calling the blueprint with a bare `agent_id` and no credentials, which is to say they were exercising the hole and asserting it worked. They now send the agent's API key.

## 3. Unguarded withdrawal debit on the Base bridge (`base_wrtc_bridge_blueprint.py`)

Same shape as #1, with an extra edge. The order of operations was:

1. read balance from the auth-time agent row
2. compare it to `amount + fee`
3. `INSERT` the pending withdrawal row
4. `UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?`

Step 4 cannot fail, so step 2 is advisory. Two concurrent requests both pass the comparison and each queue a payout against the same funds. Because the withdrawal row is written at step 3, before the debit, the queued payouts outlive the mistake and sit in `base_wrtc_withdrawals` waiting for `process-withdrawals` to send real wRTC on chain.

Fixed by guarding the debit and rolling back when it does not apply. The rollback also discards the `INSERT` from step 3, since both are in the same implicit transaction, verified:

```
withdrawal INSERT then failed debit: rowcount=0 queued_rows_after_rollback=0
```

Returns 409 instead of a success body carrying a `withdrawal_id` that was never funded.

---

## Verification

New regression tests, 31 in total:

- `tests/test_analytics_auth.py` (25) covers all six routes against anonymous callers, bare `agent_id` param, bare `X-Agent-ID` header, an unknown API key, cross-agent reads via both API key and session, and the decorator itself
- `tests/test_rtc_services_debit_guard.py` (3) pins the auth-time agent row to a balance that is no longer true, which is what the concurrent interleaving looks like from inside one request
- `tests/test_base_wrtc_withdraw_debit_guard.py` (3) same, plus asserts nothing stays queued

Against the pre-fix source these give **28 failures**. Against this branch, all 31 pass.

Full suite, run before and after with the failure lists diffed:

```
baseline failures: 149 | after: 149
NEW FAILURES INTRODUCED: (none)
```

The repo suite has 149 pre-existing failures and errors on `main` that have nothing to do with these files. I did not touch them. The number matters only as a before-and-after control showing this branch adds none.

`pyflakes` output on the three changed files is byte-identical to `main` apart from one shifted line number.

## What I could not confirm

- I have not run any of this against production. Production is where the fixes came from, but this repo is a long way behind it, so the code here is not line-for-line what is deployed. What is asserted is that these three files in this repo no longer have these three bugs.
- The `rtc_services` debit failure surfaces as a 500 with a retry hint, because the raise falls into the existing broad `except`. A 402 or 409 would describe it better. I kept the raise so the repo matches what was done on the box rather than quietly diverging further. Worth a follow-up.
- Other unguarded `rtc_balance` debits exist elsewhere in this repo. This PR covers the three that were fixed in production today and does not go looking beyond them.
