### PR TITLE
Mirror the production pagination fixes into the repo

### DIFF
--- a/agent_discovery.py
+++ b/agent_discovery.py
@@ -573,7 +573,9 @@ def api_agents_directory():
     db = get_db()
     q = request.args.get("q", "").strip()
     try:
-        page = _parse_agent_directory_int("page", 1, min_value=1)
+        # limit was capped but page was not, and offset = (page-1)*limit
+        # overflowed SQLite's int64 with no handler, so a large page 500d.
+        page = _parse_agent_directory_int("page", 1, min_value=1, max_value=100000)
         limit = _parse_agent_directory_int("limit", 20, min_value=1, max_value=100)
         sort = _parse_agent_directory_choice("sort", "popular", ("newest", "popular", "active"))
         agent_type = _parse_agent_directory_choice("type", "all", ("agent", "human", "all"))

--- a/interactions_blueprint.py
+++ b/interactions_blueprint.py
@@ -21,7 +21,12 @@ def _parse_int_query_arg(name, default, max_value):
         parsed = int(raw_value)
     except (TypeError, ValueError):
         return None, f"{name} must be an integer"
-    return min(parsed, max_value), None
+    # A floor matters as much as the ceiling. SQLite treats a negative LIMIT
+    # as "no limit", so ?limit=-1 turned this into an unauthenticated dump of
+    # the whole table. Measured on the live site before the fix: 1,493,942
+    # bytes against 15,690 for limit=50. The trailing activities[:limit] slice
+    # does not save it either, since [:-1] still returns almost everything.
+    return max(1, min(parsed, max_value)), None
 
 
 def _parse_optional_float_query_arg(name):
@@ -77,10 +82,14 @@ def api_activity_feed():
     db = get_db()
     
     # Build time filter
-    time_filter = ""
+    # created_at exists on videos, agents, comments, votes and tips alike, so
+    # an unqualified reference is ambiguous across these joins and SQLite
+    # rejects the whole statement. Every ?since= request returned 500 before
+    # this, which means the documented polling path had never worked.
+    def _time_filter(alias):
+        return f"AND {alias}.created_at > ?" if since is not None else ""
     params = []
     if since is not None:
-        time_filter = "AND created_at > ?"
         params.append(since)
     
     # Get recent uploads
@@ -96,7 +105,7 @@ def api_activity_feed():
             v.thumbnail
         FROM videos v
         JOIN agents a ON v.agent_id = a.id
-        WHERE 1=1 {time_filter}
+        WHERE 1=1 {_time_filter('v')}
         ORDER BY v.created_at DESC
         LIMIT ?""", params + [limit]).fetchall()
     
@@ -116,7 +125,7 @@ def api_activity_feed():
         FROM comments c
         JOIN agents a ON c.agent_id = a.id
         JOIN videos v ON c.video_id = v.id
-        WHERE 1=1 {time_filter}
+        WHERE 1=1 {_time_filter('c')}
         ORDER BY c.created_at DESC
         LIMIT ?""", params + [limit]).fetchall()
     
@@ -134,7 +143,7 @@ def api_activity_feed():
         FROM votes vo
         JOIN agents a ON vo.agent_id = a.id
         JOIN videos vid ON vo.video_id = vid.id
-        WHERE 1=1 {time_filter}
+        WHERE 1=1 {_time_filter('vo')}
         ORDER BY vo.created_at DESC
         LIMIT ?""", params + [limit]).fetchall()
     
@@ -155,7 +164,7 @@ def api_activity_feed():
         FROM tips t
         JOIN agents fa ON t.from_agent_id = fa.id
         JOIN agents ta ON t.to_agent_id = ta.id
-        WHERE COALESCE(t.status, 'confirmed') = 'confirmed' {time_filter}
+        WHERE COALESCE(t.status, 'confirmed') = 'confirmed' {_time_filter('t')}
         ORDER BY t.created_at DESC
         LIMIT ?""", params + [limit]).fetchall()
     


### PR DESCRIPTION
These three bugs were found and fixed on the live site earlier today. The repo copy still has all three, so this brings it into line.

**A negative limit was an unauthenticated full-table dump.** `_parse_int_query_arg` capped the value but never floored it:

```python
return min(parsed, max_value), None
```

SQLite treats a negative LIMIT as no limit at all, so `?limit=-1` returned everything. Measured against the live site before the fix: **1,493,942 bytes, against 15,690 for `limit=50`**. No auth, no rate limit, repeatable. The trailing `activities[:limit]` slice does not save it either, because `[:-1]` still returns almost everything.

**Every `?since=` request returned 500.** The filter was built unqualified:

```python
time_filter = "AND created_at > ?"
```

and spliced into four queries that join videos, agents, comments, votes and tips. All of those tables have a `created_at`, so the reference is ambiguous and SQLite rejects the whole statement. The filter is now bound to each query's own driving table, `v`, `c`, `vo` and `t`, checked one at a time against the FROM clause. This means the documented polling path had never worked, so nobody was relying on the old behaviour.

**An unbounded page overflowed the offset.** `agent_discovery` capped `limit` but not `page`, and `offset = (page - 1) * limit` overflowed SQLite's int64 with no handler, returning 500. Capped at 100000.

After the equivalent change on the live site: `limit=-1` returns 371 bytes instead of 1.49 MB, `since=` returns 200 instead of 500, a large `page` returns 200, and ordinary requests are unchanged.

One thing worth knowing while reviewing this. The CI test job here runs `pytest tests/ ... || true`, and pylint, bandit and safety each carry both `continue-on-error: true` and `|| true`. None of those checks can fail, so a green tick on this PR is not evidence of anything. Main currently has a stable 148-line failure list, so the honest comparison is failure *lists* against main rather than counts. That is worth fixing separately, and a baseline-diff check would do it without demanding the 148 be cleared first.
