### PR TITLE
Make the CI test step capable of failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,17 @@ jobs:
     
     - name: Run tests
       run: |
-        pytest tests/ -v --cov=. --cov-report=xml || true
+        # Record this branch's failures, then the merge base's, and fail only
+        # if this change ADDED one. `|| true` used to make this step incapable
+        # of failing, so a green tick proved nothing.
+        git fetch --no-tags --depth=1 origin "${{ github.base_ref || 'main' }}"
+        git stash push --include-untracked --quiet || true
+        git checkout --quiet FETCH_HEAD
+        python scripts/ci_baseline_failures.py tests/ > /tmp/base_failures.txt
+        git checkout --quiet -
+        git stash pop --quiet || true
+        python scripts/ci_regression_check.py /tmp/base_failures.txt tests/
+        pytest tests/ -q --cov=. --cov-report=xml || true
     
     - name: Upload coverage
       uses: codecov/codecov-action@v4

--- a/scripts/ci_baseline_failures.py
+++ b/scripts/ci_baseline_failures.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Print the set of failing/erroring test ids, one per line.
+
+Used to capture the merge base's failures so CI can compare against them.
+Shares its parser with ci_regression_check so the two cannot drift apart.
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from ci_regression_check import run_suite
+
+if __name__ == "__main__":
+    target = sys.argv[1] if len(sys.argv) > 1 else "tests/"
+    for t in sorted(run_suite(target)):
+        print(t)

--- a/scripts/ci_regression_check.py
+++ b/scripts/ci_regression_check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Fail CI only when a change ADDS test failures.
+
+Why this exists
+---------------
+The test step used to run `pytest tests/ ... || true`, so it could never fail.
+Every green tick on every pull request meant nothing, and contributors were
+reporting "all tests pass" in good faith on the strength of it.
+
+Deleting the `|| true` is not usable on its own: main currently carries a large
+number of pre-existing failures, so every pull request would go red on work its
+author never touched. That is a different kind of useless.
+
+So this compares failure *sets* rather than counts. It runs the suite twice,
+once on the merge base and once on the pull request head, and fails only if a
+test that passed on the base now fails. Pre-existing failures stay visible in
+the log without blocking anyone, and a pull request that fixes one is reported
+as an improvement.
+
+Counts are deliberately not the signal: the same suite can report 148 or 149
+depending on ordering, so a count comparison is flaky where a set comparison is
+stable.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+# "FAILED tests/test_x.py::test_y - AssertionError: ..." / "ERROR tests/test_z.py"
+_OUTCOME = re.compile(r"^(FAILED|ERROR)\s+(\S+?)(?:\s+-.*)?$", re.M)
+
+
+def run_suite(target: str) -> set[str]:
+    """Run pytest and return the set of failing/erroring test ids.
+
+    A crash of pytest itself is not the same as a test failure, and must not be
+    silently reported as an empty failure set, which would look like success.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", target, "-q", "--no-header",
+         "-p", "no:cacheprovider", "--continue-on-collection-errors"],
+        capture_output=True, text=True,
+    )
+    out = proc.stdout + proc.stderr
+    ids = {m.group(2) for m in _OUTCOME.finditer(out)}
+    # pytest: 0 = all passed, 1 = tests failed, 2 = interrupted, 5 = none collected.
+    if proc.returncode not in (0, 1) and not ids:
+        print(f"::error::pytest exited {proc.returncode} without reporting failures; "
+              f"treating as broken rather than clean")
+        print(out[-4000:])
+        sys.exit(2)
+    return ids
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("usage: ci_regression_check.py <base-failures-file> <target-dir>")
+        return 2
+    base_file, target = sys.argv[1], sys.argv[2]
+    with open(base_file) as fh:
+        base = {ln.strip() for ln in fh if ln.strip()}
+
+    head = run_suite(target)
+    new = sorted(head - base)
+    fixed = sorted(base - head)
+
+    print(f"baseline failing: {len(base)}")
+    print(f"head failing:     {len(head)}")
+
+    if fixed:
+        print(f"\nfixed by this change ({len(fixed)}):")
+        for t in fixed:
+            print(f"  + {t}")
+
+    if new:
+        print(f"\n::error::this change adds {len(new)} new test failure(s):")
+        for t in new:
+            print(f"  - {t}")
+        return 1
+
+    print("\nno new failures")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The test step in this workflow is:

```yaml
pytest tests/ -v --cov=. --cov-report=xml || true
```

It cannot fail. Neither can pylint, bandit or safety, which each carry both `continue-on-error: true` and `|| true`. So every green tick on every pull request in this repo means only that the runner started.

That is not a theoretical problem. Three separate contributors this week reported "all tests pass" in good faith because the badge was green, and one of them shipped a bug that a real test run would have caught immediately. They were not being careless. The pipeline told them they were fine.

Deleting the `|| true` on its own does not work either. Main carries a large pre-existing failure list, so every pull request would go red for work its author never touched, and people would learn to ignore the red exactly the way they currently ignore the green.

So this compares failure **sets** instead. CI runs the suite on the merge base, runs it on the branch, and fails only when a test that passed on the base now fails. Pre-existing failures stay visible in the log without blocking anyone, and a pull request that fixes one gets told so.

Counts are deliberately not the signal. The same suite reported 148 failures on one machine and 149 on another during review, because ordering varies. A set comparison is stable where a count comparison is flaky.

One detail worth calling out in review. `run_suite` distinguishes "pytest ran and some tests failed" from "pytest itself fell over". If pytest exits with an unexpected status and reports no failures at all, the script exits 2 rather than returning an empty set. An empty set would otherwise look exactly like success, which is the same fail-open shape this PR exists to remove.

What I verified and what I did not, plainly:

- The failure parser is unit-checked against the real output shapes: `FAILED path::test - reason`, `FAILED path::Class::test`, bare `ERROR path`, and `ERROR path::test - reason`. It correctly ignores PASSED lines.
- I have **not** run this against the live suite in CI. I do not have a working environment for the full dependency set here, and I would rather say so than claim a green run I did not see. The first CI run on this PR is the real test, and it is safe to let it be, because the worst case is that this one job reports a problem with itself.
- I left the `|| true` on the coverage upload invocation, since coverage reporting failing should not block a merge.
- pylint, bandit and safety are untouched. They have the same defect, but each needs its own judgement about what should block, and bundling four policy decisions into one PR is how nothing gets merged.
