### PR TITLE
Fix feed API base URL fallback

### DIFF
--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -7,14 +7,19 @@ import os
 from email.utils import format_datetime
 
 import requests
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, has_request_context, jsonify, request
 
 feed_bp = Blueprint("feed", __name__)
 
 
 def _base_api_url() -> str:
     """Prefer local API by default; allow explicit override for external deployments."""
-    return os.getenv("BOTTUBE_API_BASE", "http://127.0.0.1:5000").rstrip("/")
+    configured = os.getenv("BOTTUBE_API_BASE")
+    if configured:
+        return configured.rstrip("/")
+    if has_request_context():
+        return request.host_url.rstrip("/")
+    return "http://127.0.0.1:5000"
 
 
 def escape_xml(text):

--- a/tests/test_feed_blueprint.py
+++ b/tests/test_feed_blueprint.py
@@ -110,6 +110,14 @@ def test_parse_limit_rejects_invalid_values(path, message):
         feed_blueprint._parse_limit()
 
 
+def test_base_api_url_uses_current_request_host_when_unconfigured(monkeypatch):
+    app = Flask(__name__)
+    monkeypatch.delenv("BOTTUBE_API_BASE", raising=False)
+
+    with app.test_request_context("/feed/rss", base_url="https://bottube.ai/"):
+        assert feed_blueprint._base_api_url() == "https://bottube.ai"
+
+
 @pytest.mark.parametrize(
     "path",
     [


### PR DESCRIPTION
## Summary
- use the current request host as the default feed API base when `BOTTUBE_API_BASE` is not configured
- keep the explicit env override and non-request fallback behavior intact
- add a regression test for the unconfigured request-host fallback

## Root cause
The deployed RSS/Atom feed routes call `_fetch_videos()`, which defaults to `http://127.0.0.1:5000/api/videos` when `BOTTUBE_API_BASE` is unset. In production this can fail internally, and the exception path returns an empty list, so `/feed/rss` and `/feed/atom` return valid-but-empty feeds even though `/api/videos` has public videos.

## Production evidence checked 2026-07-29
- `GET https://bottube.ai/api/videos?per_page=3` returned `total: 2882` with 3 video objects
- `GET https://bottube.ai/feed/rss` returned 200 but only the channel shell, with no `<item>` entries
- `GET https://bottube.ai/feed/atom` returned 200 but only the feed shell, with no `<entry>` entries

## Validation
- `git diff --check` passed
- `PYTHONPYCACHEPREFIX=/tmp/bottube_pycache python3 -m py_compile feed_blueprint.py tests/test_feed_blueprint.py` passed
- `python3 -m pytest tests/test_feed_blueprint.py -q` was not run locally because this environment does not have pytest installed

RTC payout identity / miner ID: `qiann0512-gif`