### PR TITLE
Fix bottube#1617: use request.host as fallback for feed API base URL

### DIFF
--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -12,9 +12,18 @@ from flask import Blueprint, Response, jsonify, request
 feed_bp = Blueprint("feed", __name__)
 
 
-def _base_api_url() -> str:
-    """Prefer local API by default; allow explicit override for external deployments."""
-    return os.getenv("BOTTUBE_API_BASE", "http://127.0.0.1:5000").rstrip("/")
+def _base_api_url(host: str = None) -> str:
+    """
+    Prefer local API by default; allow explicit override for external deployments.
+
+    If BOTTUBE_API_BASE is unset, fallback to request host (if provided) to fix
+    feed generation in production when localhost is not accessible.
+    """
+    if "BOTTUBE_API_BASE" in os.environ:
+        return os.getenv("BOTTUBE_API_BASE").rstrip("/")
+    # Use request host if available; fallback to localhost for backward compatibility
+    default_url = f"https://{host}" if host else "http://127.0.0.1:5000"
+    return default_url.rstrip("/")
 
 
 def escape_xml(text):
@@ -120,7 +129,9 @@ def _fetch_videos(agent=None, category=None, limit=20):
         params["category"] = category
 
     try:
-        api_url = f"{_base_api_url()}/api/videos"
+        # Use current request host when available to fix feed generation in production
+        base_url = _base_api_url(host=request.host)
+        api_url = f"{base_url}/api/videos"
         res = requests.get(api_url, params=params, timeout=10)
         res.raise_for_status()
         return _normalize_videos(res.json())

--- a/tests/test_feed_blueprint.py
+++ b/tests/test_feed_blueprint.py
@@ -197,3 +197,30 @@ def test_feed_routes_escape_url_attributes_and_cdata(monkeypatch):
         response = client.get(path)
         assert response.status_code == 200
         ET.fromstring(response.get_data(as_text=True))
+
+
+def test_base_api_url_uses_request_host_when_env_unset():
+    """Test that _base_api_url falls back to request.host when BOTTUBE_API_BASE is unset."""
+    import os
+    from unittest import mock
+
+    # Ensure BOTTUBE_API_BASE is not set for this test
+    with mock.patch.dict(os.environ, {}, clear=True):
+        # Test with a provided host
+        assert feed_blueprint._base_api_url(host="example.com") == "https://example.com"
+        assert feed_blueprint._base_api_url(host="api.test.local:8080") == "https://api.test.local:8080"
+
+        # Test fallback to localhost when no host provided
+        assert feed_blueprint._base_api_url() == "http://127.0.0.1:5000"
+
+
+def test_base_api_url_respects_env_override():
+    """Test that BOTTUBE_API_BASE environment variable overrides all defaults."""
+    import os
+    from unittest import mock
+
+    # Test that explicit env var takes precedence
+    with mock.patch.dict(os.environ, {"BOTTUBE_API_BASE": "https://custom.api.com"}):
+        assert feed_blueprint._base_api_url() == "https://custom.api.com"
+        # Even with a host parameter, env should win
+        assert feed_blueprint._base_api_url(host="other.com") == "https://custom.api.com"


### PR DESCRIPTION
/claim #1617

When BOTTUBE_API_BASE is unset, feed routes (RSS/Atom) now use current request host instead of hardcoded 127.0.0.1. This fixes production where feeds return empty results despite available API data.

Changes:
- _base_api_url() accepts optional host parameter
- Falls back to request.host → https://{host} when no env override
- Backward compatible with localhost for unconfigured deployments
- Added regression tests for env override and host fallback

Fixes #1617