### PR TITLE
fix: add auth on mood endpoints and use _get_client_ip() for view dedup (fixes #1621)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7309,6 +7309,7 @@ def get_agent_mood(agent_name):
 
 
 @app.route("/api/v1/agents/<agent_name>/mood/update", methods=["POST"])
+@require_api_key
 def update_agent_mood(agent_name):
     """
     Update mood for an agent based on signals.
@@ -7341,6 +7342,7 @@ def update_agent_mood(agent_name):
 
 
 @app.route("/api/v1/agents/<agent_name>/mood/signal", methods=["POST"])
+@require_api_key
 def record_mood_signal(agent_name):
     """
     Record a signal that influences agent mood.
@@ -7531,7 +7533,7 @@ def record_view(video_id):
         if agent:
             agent_id = agent["id"]
 
-    ip = request.headers.get("X-Real-IP", request.remote_addr)
+    ip = _get_client_ip()
     VIEW_COOLDOWN = 1800  # 30 minutes
     recent = db.execute(
         "SELECT 1 FROM views WHERE video_id = ? AND ip_address = ? AND created_at > ?",
@@ -12550,7 +12552,7 @@ def watch(video_id):
         abort(404)
 
     # Record view (deduplicated: 1 view per IP per video per 30 min)
-    ip = request.headers.get("X-Real-IP", request.remote_addr)
+    ip = _get_client_ip()
     VIEW_COOLDOWN = 1800  # 30 minutes
     recent = db.execute(
         "SELECT 1 FROM views WHERE video_id = ? AND ip_address = ? AND created_at > ?",
@@ -14613,7 +14615,7 @@ def api_track_miner_install():
     page, field_error = _public_string_field(data, "page", "unknown", 128)
     if field_error:
         return jsonify({"ok": False, "error": field_error}), 400
-    ip = request.headers.get("X-Forwarded-For", request.remote_addr)
+    ip = _get_client_ip()
     app.logger.info(f"[MINER-TRACK] source={source} page={page} ip={ip}")
 
     db = get_db()


### PR DESCRIPTION
## Fixes #1621

### Vulnerabilities Fixed

**1. Unauthenticated Mood Force** (L7311-7340)
Added `@require_api_key` to `/api/v1/agents/<agent_name>/mood/update`. Only authenticated agents can now force a mood state.

**2. Unauthenticated Mood Signal Injection** (L7343-7380)
Added `@require_api_key` to `/api/v1/agents/<agent_name>/mood/signal`. Only authenticated agents can inject mood signals.

**3. X-Real-IP View Farming** (L7534, L12553, L14616)
Replaced `request.headers.get('X-Real-IP', request.remote_addr)` with the existing `_get_client_ip()` helper, which:
- Trusts `X-Forwarded-For` **only** from localhost proxies (127.0.0.1/::1)
- Otherwise uses `request.remote_addr` (the actual TCP connection IP, not spoofable by HTTP headers)

### Testing
- Mood endpoints now require a valid `X-API-Key` header
- View deduplication uses the server-determined IP instead of the client-supplied header
- All existing tests remain compatible

### Wallet
FaaFyfxR9WAQrL7F98QMMqJmWQmQqTqFkTqKkqKkqKkqKkqKkqK