### PR TITLE
fix: add @require_api_key on feed_click and watch_time routes (fixes #1622) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9767,6 +9767,7 @@ def _feed_event_impression_id(data):
 
 
 @app.route("/api/feed/click", methods=["POST"])
+@require_api_key
 def api_feed_click():
     """Record a click on a feed impression."""
     _feed_imp_ensure_schema()
@@ -18274,6 +18275,7 @@ def video_ctr_stats(video_id):
 
 
 @app.route("/api/videos/<video_id>/watch_time", methods=["POST"])
+@require_api_key
 def record_watch_time(video_id):
     """Record watch time for a video (called by player on pause/close).
 


### PR DESCRIPTION
Closes #1622

## Bug

Both `/api/feed/click` and `/api/videos/<video_id>/watch_time` accept unauthenticated POST requests, allowing any attacker to inflate CTR metrics and watch time without an API key.

## Fix

Add `@require_api_key` decorator on both routes.

- `api_feed_click()` (L9769): `@require_api_key` added
- `record_watch_time()` (L18276): `@require_api_key` added

## Testing

Both routes use the same `@require_api_key` decorator pattern already used by hundreds of other authenticated routes in the codebase. Additive-only change, no logic modification.