### PR TITLE
Fix #1621: unauthenticated mood manipulation + X-Real-IP view farming

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7309,6 +7309,7 @@ def get_agent_mood(agent_name):
 
 
 @app.route("/api/v1/agents/<agent_name>/mood/update", methods=["POST"])
+@require_api_key
 def update_agent_mood(agent_name):
     """
     Update mood for an agent based on signals.
@@ -7341,6 +7342,7 @@ def update_agent_mood(agent_name):
 
 
 @app.route("/api/v1/agents/<agent_name>/mood/signal", methods=["POST"])
+@require_api_key
 def record_mood_signal(agent_name):
     """
     Record a signal that influences agent mood.
@@ -7531,7 +7533,7 @@ def record_view(video_id):
         if agent:
             agent_id = agent["id"]
 
-    ip = request.headers.get("X-Real-IP", request.remote_addr)
+    ip = _get_client_ip()
     VIEW_COOLDOWN = 1800  # 30 minutes
     recent = db.execute(
         "SELECT 1 FROM views WHERE video_id = ? AND ip_address = ? AND created_at > ?",
@@ -12550,7 +12552,7 @@ def watch(video_id):
         abort(404)
 
     # Record view (deduplicated: 1 view per IP per video per 30 min)
-    ip = request.headers.get("X-Real-IP", request.remote_addr)
+    ip = _get_client_ip()
     VIEW_COOLDOWN = 1800  # 30 minutes
     recent = db.execute(
         "SELECT 1 FROM views WHERE video_id = ? AND ip_address = ? AND created_at > ?",


### PR DESCRIPTION
Closes #1621.

- Added `@require_api_key` to `/api/v1/agents/<agent_name>/mood/update` and `/mood/signal` — both accepted unauthenticated POSTs, letting anyone force any agent into a mood state or inject fake signals (view_count, comment_sentiment, etc).
- Replaced `request.headers.get("X-Real-IP", request.remote_addr)` with the existing `_get_client_ip()` helper in `record_view()` and `watch()`. The raw `X-Real-IP` header is client-spoofable, so an attacker could send a fresh value on every request and get unlimited deduped views (and RTC reward) on the same video from one machine. `_get_client_ip()` only trusts `X-Forwarded-For` when the request actually comes from the local nginx proxy, otherwise it falls back to `request.remote_addr`.

Verified `python3 -m py_compile bottube_server.py` passes.