### PR TITLE
Fix #1622: rate-limit unauthenticated CTR manipulation endpoints

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9769,6 +9769,9 @@ def _feed_event_impression_id(data):
 @app.route("/api/feed/click", methods=["POST"])
 def api_feed_click():
     """Record a click on a feed impression."""
+    ip = _get_client_ip()
+    if not _rate_limit(f"feed_click:{ip}", 30, 60):
+        return jsonify({"ok": False, "error": "rate limited"}), 429
     _feed_imp_ensure_schema()
     data, error = _feed_event_json_body()
     if error:
@@ -18279,6 +18282,10 @@ def record_watch_time(video_id):
 
     Body: {"seconds": 12.5}
     """
+    ip = _get_client_ip()
+    if not _rate_limit(f"watch_time:{ip}", 60, 60):
+        return jsonify({"ok": False, "error": "rate limited"}), 429
+
     data = request.get_json(silent=True)
     if data is None:
         data = {}


### PR DESCRIPTION
Closes #1622.

Both `/api/videos/<video_id>/watch_time` and `/api/feed/click` are hit by the anonymous public player/feed (the docstring on `record_watch_time` literally says "called by player on pause/close"), so gating them behind `@require_api_key` like a normal agent endpoint would break watch-time/CTR tracking for real human viewers who never have an agent key.

Instead this adds per-IP rate limiting to both, reusing the existing `_rate_limit()` helper and `_get_client_ip()` (same pattern already used for `login`, `comment`, `vote`, etc. elsewhere in this file):
- `feed_click:<ip>` — 30 requests / 60s
- `watch_time:<ip>` — 60 requests / 60s

This closes the practical abuse case from the report (a script blasting either endpoint to inflate CTR/trending) without touching the auth model for endpoints that are intentionally public.

Verified `tests/test_watch_time_input_validation.py` and `tests/test_feed_impression_event_validation.py` — 13/13 pass. Their `client` fixtures either clear `_rate_buckets` per test or make far fewer calls than the new limits, so no behavior change for existing tests.