### PR TITLE
docs: add docstrings batch 11 (14 functions, 7.0 RTC)

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -82,6 +82,7 @@ def get_db():
 
 
 def _request_json_object():
+    """Parse the request body as a JSON object, or return a 400 error response."""
     data = request.get_json(silent=True) or {}
     if not isinstance(data, dict):
         return None, (jsonify({"error": "JSON object required"}), 400)
@@ -89,6 +90,7 @@ def _request_json_object():
 
 
 def _parse_positive_ban_amount(data):
+    """Validate and coerce ``data["amount"]`` into a finite positive Banano amount."""
     raw_amount = data.get("amount", 0)
     if isinstance(raw_amount, bool):
         return None, (jsonify({"error": "amount must be a finite positive number"}), 400)
@@ -102,6 +104,7 @@ def _parse_positive_ban_amount(data):
 
 
 def _json_text_field(data, name, default=""):
+    """Extract and strip a string field ``name`` from ``data``, falling back to ``default``."""
     value = data.get(name, default)
     if value is None:
         value = default

--- a/base_wrtc_bridge_blueprint.py
+++ b/base_wrtc_bridge_blueprint.py
@@ -166,6 +166,7 @@ def _finite_amount(value):
 
 
 def _parse_history_limit(default: int = 50, max_value: int = 200):
+    """Read the ``limit`` query param, defaulting and capping it at ``max_value``."""
     raw_value = request.args.get("limit")
     if raw_value is None or raw_value == "":
         return default, None

--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -244,6 +244,7 @@ def _debit_rtc(db, agent_id, amount):
 # ---------------------------------------------------------------------------
 
 def _request_json_object():
+    """Parse the request body as a JSON object, or return a 400 error response."""
     data = request.get_json(silent=True)
     if data is None:
         data = {}
@@ -253,6 +254,7 @@ def _request_json_object():
 
 
 def _string_field(data, field_name):
+    """Extract and strip a required string field ``field_name`` from ``data``."""
     value = data.get(field_name, "")
     if not isinstance(value, str):
         return None, (jsonify({"error": f"{field_name} must be a string"}), 400)
@@ -260,6 +262,7 @@ def _string_field(data, field_name):
 
 
 def _positive_finite_amount(value):
+    """Coerce ``value`` to a finite positive float, or return None if it isn't one."""
     if isinstance(value, bool):
         return None
     try:

--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -37,6 +37,7 @@ def _cdata_safe(text):
 
 
 def _video_description_html(fields):
+    """Build the HTML snippet (thumbnail + description) used inside an RSS item."""
     thumb = escape_xml(fields["thumb"])
     desc = _cdata_safe(escape_xml(fields["desc"]))
     return f'<img src="{thumb}" /><p>{desc}</p>'
@@ -148,6 +149,7 @@ def _parse_limit():
 
 
 def _limit_error_response(exc):
+    """Wrap a validation exception as a 400 JSON error response."""
     return jsonify({"error": str(exc)}), 400
 
 

--- a/forge3d_blueprint.py
+++ b/forge3d_blueprint.py
@@ -32,11 +32,13 @@ STUDIO_MEDIA_DIR = os.environ.get("STUDIO_MEDIA_DIR",
 
 
 def _db_path():
+    """Resolve the SQLite database path from env vars, defaulting under BOTTUBE_BASE_DIR."""
     base = os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent))
     return os.environ.get("BOTTUBE_DB_PATH", str(Path(base) / "bottube.db"))
 
 
 def _conn():
+    """Open a SQLite connection to the bottube DB with row access and a busy timeout."""
     c = sqlite3.connect(_db_path(), timeout=30)
     c.row_factory = sqlite3.Row
     c.execute("PRAGMA busy_timeout=30000")
@@ -44,6 +46,7 @@ def _conn():
 
 
 def init_forge3d_tables(db_path: str = None):
+    """Create the forge3d_jobs table if it doesn't already exist."""
     c = sqlite3.connect(db_path or _db_path(), timeout=30)
     try:
         c.execute("""
@@ -66,6 +69,7 @@ def init_forge3d_tables(db_path: str = None):
 
 
 def _set(job_id, **kw):
+    """Update arbitrary columns of a forge3d_jobs row by id, stamping updated_at."""
     if not kw:
         return
     kw["updated_at"] = time.time()
@@ -98,6 +102,7 @@ def _refund_once(job_id, agent_id, cost):
 
 
 def _save_glb(data: bytes) -> str:
+    """Write a generated GLB model to STUDIO_MEDIA_DIR under a random filename."""
     Path(STUDIO_MEDIA_DIR).mkdir(parents=True, exist_ok=True)
     fname = uuid.uuid4().hex + ".glb"
     with open(os.path.join(STUDIO_MEDIA_DIR, fname), "wb") as f:


### PR DESCRIPTION
Batch 11: 14 docstrings across banano_blueprint.py, ergo_bridge_blueprint.py, base_wrtc_bridge_blueprint.py, feed_blueprint.py, forge3d_blueprint.py (7.0 RTC)

Covers `_request_json_object`, `_parse_positive_ban_amount`, `_json_text_field` (banano), `_request_json_object`, `_string_field`, `_positive_finite_amount` (ergo), `_parse_history_limit` (base wRTC bridge), `_video_description_html`, `_limit_error_response` (feed), and `_db_path`, `_conn`, `init_forge3d_tables`, `_set`, `_save_glb` (forge3d) — none of these had docstrings before. Verified `python3 -m py_compile` on all five files.

Wallet: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7