### PR TITLE
docs: add docstrings batch 12 (16 functions, 8.0 RTC)

### DIFF
--- a/interactions_blueprint.py
+++ b/interactions_blueprint.py
@@ -16,6 +16,7 @@ interactions_bp = Blueprint('interactions', __name__, url_prefix='/social')
 
 
 def _parse_int_query_arg(name, default, max_value):
+    """Read an integer query param, defaulting and capping it at ``max_value``."""
     raw_value = request.args.get(name, default)
     try:
         parsed = int(raw_value)
@@ -25,6 +26,7 @@ def _parse_int_query_arg(name, default, max_value):
 
 
 def _parse_optional_float_query_arg(name):
+    """Read an optional float query param; returns (None, None) if absent."""
     raw_value = request.args.get(name)
     if not raw_value:
         return None, None

--- a/translation_routes.py
+++ b/translation_routes.py
@@ -8,6 +8,7 @@ translation_bp = Blueprint('translation', __name__)
 
 
 def _request_json_object():
+    """Parse the request body as a JSON object, or return a 400 error response."""
     data = request.get_json(silent=True)
     if data is None:
         return {}, None
@@ -18,6 +19,7 @@ def _request_json_object():
 
 @translation_bp.route('/translations')
 def translations_page():
+    """Render the translations overview page (available languages + recent entries)."""
     db = get_db()
     
     # Get all available languages
@@ -42,6 +44,7 @@ def translations_page():
 
 @translation_bp.route('/api/translations/<int:video_id>')
 def get_translations(video_id):
+    """Return all translations for a video, newest first."""
     db = get_db()
     
     translations = db.execute('''
@@ -55,6 +58,7 @@ def get_translations(video_id):
 
 @translation_bp.route('/api/translations/<int:video_id>/<language>')
 def get_translation_by_language(video_id, language):
+    """Return the most recent translation of a video in a given language."""
     db = get_db()
     
     translation = db.execute('''
@@ -71,6 +75,7 @@ def get_translation_by_language(video_id, language):
 @translation_bp.route('/api/translations', methods=['POST'])
 @require_auth
 def add_translation():
+    """Create or update the current user's translation of a video into a language."""
     data, error = _request_json_object()
     if error:
         return error
@@ -105,6 +110,7 @@ def add_translation():
 
 @translation_bp.route('/api/videos/translated/<language>')
 def get_videos_by_language(language):
+    """List videos that have a translation available in the given language."""
     db = get_db()
     
     videos = db.execute('''
@@ -119,6 +125,7 @@ def get_videos_by_language(language):
 
 @translation_bp.route('/api/languages')
 def get_supported_languages():
+    """Return the fixed list of languages the platform accepts translations in."""
     languages = [
         'Chinese', 'Spanish', 'Portuguese', 'French', 'Japanese', 
         'Korean', 'German', 'Russian', 'Arabic', 'Hindi'

--- a/translations.py
+++ b/translations.py
@@ -148,15 +148,18 @@ TRANSLATION_DATA = {
 }
 
 def get_all_translations():
+    """Return the full static TRANSLATION_DATA structure."""
     return TRANSLATION_DATA
 
 def get_video_translations(video_url):
+    """Look up the translation entry for a video by its URL, or None if absent."""
     for video in TRANSLATION_DATA["videos"]:
         if video["video_url"] == video_url:
             return video
     return None
 
 def get_translations_by_language(language):
+    """Collect every video's translation into a given language, with source metadata."""
     translations = []
     for video in TRANSLATION_DATA["videos"]:
         if language in video["translations"]:
@@ -169,4 +172,5 @@ def get_translations_by_language(language):
     return translations
 
 def get_supported_languages():
+    """Return the list of languages declared in TRANSLATION_DATA's metadata."""
     return TRANSLATION_DATA["metadata"]["languages"]

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -52,6 +52,7 @@ def get_db():
 
 
 def _request_json_object():
+    """Parse the request body as a JSON object, or return a 400 error response."""
     data = request.get_json(silent=True)
     if data is None:
         return {}, None
@@ -61,6 +62,7 @@ def _request_json_object():
 
 
 def _parse_finite_usdc_amount(data):
+    """Validate and coerce ``data["amount_usdc"]`` into a finite float."""
     raw_amount = data.get("amount_usdc", 0)
     if isinstance(raw_amount, bool):
         return None, (jsonify({"error": "amount_usdc must be a finite number"}), 400)
@@ -74,6 +76,7 @@ def _parse_finite_usdc_amount(data):
 
 
 def _optional_string_field(data, field_name):
+    """Extract and strip an optional string field, defaulting to ''."""
     value = data.get(field_name)
     if value is None:
         return "", None


### PR DESCRIPTION
Batch 12: 16 docstrings across usdc_blueprint.py, translation_routes.py, translations.py, interactions_blueprint.py (8.0 RTC)

Covers `_request_json_object`, `_parse_finite_usdc_amount`, `_optional_string_field` (usdc); `_request_json_object`, `translations_page`, `get_translations`, `get_translation_by_language`, `add_translation`, `get_videos_by_language`, `get_supported_languages` (translation_routes); `get_all_translations`, `get_video_translations`, `get_translations_by_language`, `get_supported_languages` (translations.py, static-data lookups — distinct module from translation_routes.py); `_parse_int_query_arg`, `_parse_optional_float_query_arg` (interactions) — none had docstrings before. Verified `python3 -m py_compile` on all four files.

Wallet: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7