### PR TITLE
docs: add docstrings to telegram_bot.py (15 functions/methods, 7.5 RTC)

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -54,14 +54,17 @@ class Video:
 
     @property
     def url(self) -> str:
+        """The public BoTTube watch page URL for this video."""
         return f"https://bottube.ai/watch/{self.id}"
 
     @property
     def short_desc(self) -> str:
+        """The description truncated to 120 chars, with an ellipsis if cut off."""
         d = self.description[:120]
         return d + "..." if len(self.description) > 120 else d
 
     def to_text(self, index: int = 0) -> str:
+        """Render this video as an HTML-formatted Telegram message line, optionally numbered."""
         prefix = f"{index}. " if index else ""
         return (
             f"{prefix}🎬 <b>{_escape(self.title)}</b>\n"
@@ -80,6 +83,7 @@ class Agent:
     video_count: int
 
     def to_text(self) -> str:
+        """Render this agent as an HTML-formatted Telegram profile message."""
         return (
             f"👤 <b>{_escape(self.display_name or self.name)}</b>\n"
             f"📝 {_escape(self.bio[:200])}\n"
@@ -101,12 +105,14 @@ class BoTTubeAPI:
     """REST client for BoTTube."""
 
     def __init__(self, base_url: str = BOTTUBE_BASE, timeout: int = 10):
+        """Create a session-backed client for the given BoTTube API base URL."""
         self.base = base_url.rstrip("/")
         self.session = requests.Session()
         self.session.verify = False  # Self-signed cert
         self.timeout = timeout
 
     def _get(self, path: str, **params) -> Any:
+        """GET a BoTTube API path with query params and return the parsed JSON body."""
         resp = self.session.get(
             f"{self.base}{path}", params=params, timeout=self.timeout,
         )
@@ -114,18 +120,22 @@ class BoTTubeAPI:
         return resp.json()
 
     def latest(self, limit: int = 5) -> List[Video]:
+        """Fetch the most recently published videos."""
         data = self._get("/api/v1/videos", sort="newest", limit=limit)
         return [self._parse_video(v) for v in self._items(data)]
 
     def trending(self, limit: int = 5) -> List[Video]:
+        """Fetch videos sorted by view count."""
         data = self._get("/api/v1/videos", sort="views", limit=limit)
         return [self._parse_video(v) for v in self._items(data)]
 
     def search(self, query: str, limit: int = 5) -> List[Video]:
+        """Search videos by title/description query."""
         data = self._get("/api/v1/videos", q=query, limit=limit)
         return [self._parse_video(v) for v in self._items(data)]
 
     def get_video(self, video_id: str) -> Optional[Video]:
+        """Fetch a single video by id, or None if not found/on error."""
         try:
             data = self._get(f"/api/v1/videos/{video_id}")
             return self._parse_video(data)
@@ -133,6 +143,7 @@ class BoTTubeAPI:
             return None
 
     def get_agent(self, name: str) -> Optional[Agent]:
+        """Fetch an agent's profile by name, or None if not found/on error."""
         try:
             data = self._get(f"/api/v1/agents/{quote(name)}")
             return Agent(
@@ -146,6 +157,7 @@ class BoTTubeAPI:
             return None
 
     def agent_videos(self, name: str, limit: int = 5) -> List[Video]:
+        """Fetch an agent's recent videos, or an empty list if not found/on error."""
         try:
             data = self._get(f"/api/v1/agents/{quote(name)}/videos", limit=limit)
             return [self._parse_video(v) for v in self._items(data)]
@@ -154,12 +166,14 @@ class BoTTubeAPI:
 
     @staticmethod
     def _items(data) -> list:
+        """Normalize a videos API response (bare list or wrapped dict) into a list of video dicts."""
         if isinstance(data, list):
             return data
         return data.get("videos", data.get("data", data.get("results", [])))
 
     @staticmethod
     def _parse_video(v: dict) -> Video:
+        """Convert a raw API video dict into a Video dataclass, filling missing fields with defaults."""
         return Video(
             id=str(v.get("video_id", v.get("id", ""))),
             title=v.get("title", "Untitled"),
@@ -217,6 +231,7 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /help command (alias for /start)."""
     await cmd_start(update, context)
 
 


### PR DESCRIPTION
Adds one-line docstrings to the 15 previously undocumented functions/methods in `telegram_bot.py` (Telegram bot for browsing/searching BoTTube videos: `Video`/`Agent` dataclass properties and text renderers, `BoTTubeAPI` client methods, and the `/help` command handler), per the docstring bounty program in `docs/CONTRIBUTING_FOR_AGENTS.md` (0.5 RTC/function = 7.5 RTC total).

Each docstring was written after reading the actual function body — no guessed/fabricated descriptions. `py_compile` passes clean.

Wallet: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7

/claim