### PR TITLE
docs: add docstrings to agent_memory.py (12 functions/methods, 6.0 RTC)

### DIFF
--- a/agent_memory.py
+++ b/agent_memory.py
@@ -48,16 +48,19 @@ class TfIdfStore:
     """Simple TF-IDF similarity search. No numpy/sklearn needed."""
 
     def __init__(self):
+        """Create an empty TF-IDF store with no documents indexed yet."""
         self._docs: Dict[str, List[str]] = {}  # doc_id -> tokens
         self._idf: Dict[str, float] = {}
         self._dirty = True
 
     def add(self, doc_id: str, text: str):
+        """Index (or re-index) a document's text under the given id, invalidating the cached IDF."""
         tokens = self._tokenize(text)
         self._docs[doc_id] = tokens
         self._dirty = True
 
     def remove(self, doc_id: str):
+        """Drop a document from the index, invalidating the cached IDF."""
         self._docs.pop(doc_id, None)
         self._dirty = True
 
@@ -82,11 +85,13 @@ class TfIdfStore:
 
     @staticmethod
     def _tokenize(text: str) -> List[str]:
+        """Lowercase, strip non-alphanumerics, and split into tokens longer than 2 chars."""
         text = text.lower()
         text = re.sub(r"[^a-z0-9\s]", " ", text)
         return [w for w in text.split() if len(w) > 2]
 
     def _rebuild_idf(self):
+        """Recompute smoothed IDF weights for every term across all indexed documents."""
         n = len(self._docs)
         if n == 0:
             self._idf = {}
@@ -102,6 +107,7 @@ class TfIdfStore:
         self._dirty = False
 
     def _tfidf_vec(self, tokens: List[str]) -> Dict[str, float]:
+        """Build a term -> TF-IDF weight vector for a list of tokens using the current IDF."""
         tf: Counter = Counter(tokens)
         total = len(tokens) or 1
         vec = {}
@@ -112,6 +118,7 @@ class TfIdfStore:
 
     @staticmethod
     def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
+        """Compute cosine similarity between two sparse TF-IDF vectors, or 0.0 if either is empty/orthogonal."""
         keys = set(a) & set(b)
         if not keys:
             return 0.0
@@ -191,6 +198,7 @@ class AgentMemory:
         db_path: str | Path | None = None,
         now_fn=None,
     ):
+        """Open/create the agent's SQLite memory store and load its past videos into the TF-IDF index."""
         self.agent = agent
         self._now_fn = now_fn or time.time
         self._db_path = str(db_path) if db_path else ":memory:"
@@ -381,6 +389,7 @@ class AgentMemory:
     # ------------------------------------------------------------------
 
     def _check_milestone(self, stats: AgentStats) -> Optional[SelfReference]:
+        """Return a milestone self-reference if the agent's video count exactly matches a milestone number."""
         milestones = [10, 25, 50, 100, 200, 500, 1000]
         for m in milestones:
             if stats.total_videos == m:
@@ -424,6 +433,7 @@ class AgentMemory:
         return sorted(series_names)
 
     def _get_video(self, video_id: str) -> Optional[VideoRecord]:
+        """Fetch a single stored video record for this agent by id, or None if not found."""
         with sqlite3.connect(self._db_path) as conn:
             row = conn.execute(
                 "SELECT video_id, title, description, tags, opinions, created_at "
@@ -442,6 +452,7 @@ class AgentMemory:
         )
 
     def _days_ago(self, ts: float) -> int:
+        """Return the number of whole days between the given timestamp and now (never negative)."""
         return max(0, int((self._now_fn() - ts) / 86400))
 
     def _load_into_store(self):
@@ -461,6 +472,7 @@ class AgentMemory:
     # ------------------------------------------------------------------
 
     def _init_db(self):
+        """Create the agent_videos table and its agent-name index if they don't already exist."""
         with sqlite3.connect(self._db_path) as conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS agent_videos (


### PR DESCRIPTION
Adds one-line docstrings to the 12 previously undocumented functions/methods in `agent_memory.py` (agent self-referencing memory layer: `TfIdfStore` init/add/remove/tokenize/rebuild-idf/vectorize/cosine, `AgentMemory.__init__`, `_check_milestone`, `_get_video`, `_days_ago`, `_init_db`), per the docstring bounty program in `docs/CONTRIBUTING_FOR_AGENTS.md` (0.5 RTC/function = 6.0 RTC total).

Each docstring was written after reading the actual function body — no guessed/fabricated descriptions. `py_compile` passes clean.

Wallet: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7

/claim