### PR TITLE
docs: add docstrings to avap_blueprint.py (11 functions, 5.5 RTC)

### DIFF
--- a/avap_blueprint.py
+++ b/avap_blueprint.py
@@ -41,19 +41,23 @@ ANCHOR_PREFIX = "rc2"  # RustChain Node 2 (.153) anchor record
 # crypto (identical scheme to the avap reference package)
 # --------------------------------------------------------------------------- #
 def _canonical(obj) -> bytes:
+    """Serialize an object to canonical (sorted-key, compact) JSON bytes for hashing/signing."""
     return json.dumps(obj, sort_keys=True, separators=(",", ":"),
                       ensure_ascii=False).encode("utf-8")
 
 
 def _signed_core(env: dict) -> dict:
+    """Return the AVAP envelope with the sig and anchor fields stripped, as signed by the sender."""
     return {k: v for k, v in env.items() if k not in ("sig", "anchor")}
 
 
 def _sha256_hex(b: bytes) -> str:
+    """Return the hex-encoded SHA-256 digest of the given bytes."""
     return hashlib.sha256(b).hexdigest()
 
 
 def _address_from_pub(pub_hex: str) -> str:
+    """Derive the RTC address string from a hex-encoded Ed25519 public key."""
     return "RTC" + hashlib.sha256(bytes.fromhex(pub_hex)).hexdigest()[:40]
 
 
@@ -89,6 +93,7 @@ def verify_envelope(env: dict) -> dict:
 # schema
 # --------------------------------------------------------------------------- #
 def init_avap_tables(db_path: str = None):
+    """Create the avap_envelopes and avap_anchors tables (and their index) if they don't exist."""
     conn = sqlite3.connect(str(db_path or DB_PATH))
     try:
         conn.execute("""
@@ -119,6 +124,7 @@ def init_avap_tables(db_path: str = None):
 
 
 def _conn():
+    """Open a new SQLite connection to the AVAP database file."""
     return sqlite3.connect(str(DB_PATH))
 
 
@@ -127,6 +133,7 @@ def _conn():
 # --------------------------------------------------------------------------- #
 @avap_bp.route("/avap/anchor", methods=["POST"])
 def avap_anchor():
+    """Anchor a commitment hash on-chain (idempotent), or return the existing anchor if already recorded."""
     data = request.get_json(silent=True) or {}
     commitment = (data.get("commitment") or "").strip().lower()
     if len(commitment) != 64 or any(c not in "0123456789abcdef" for c in commitment):
@@ -155,6 +162,7 @@ def avap_anchor():
 
 @avap_bp.route("/avap/anchor/<commitment>", methods=["GET"])
 def avap_anchor_get(commitment):
+    """Look up whether a commitment hash has been anchored, returning its tx info or 404."""
     commitment = (commitment or "").strip().lower()
     conn = _conn()
     try:
@@ -174,6 +182,7 @@ def avap_anchor_get(commitment):
 # --------------------------------------------------------------------------- #
 @avap_bp.route("/api/video/<video_id>/avap", methods=["POST"])
 def avap_attach(video_id):
+    """Verify and store an AVAP envelope for a video, rejecting it if crypto verification fails."""
     env = request.get_json(silent=True)
     if not isinstance(env, dict):
         return jsonify({"error": "body must be an AVAP envelope (JSON object)"}), 400
@@ -201,6 +210,7 @@ def avap_attach(video_id):
 
 @avap_bp.route("/api/video/<video_id>/avap", methods=["GET"])
 def avap_get(video_id):
+    """Return the most recently stored AVAP envelope for a video, or 404 if none exists."""
     conn = _conn()
     try:
         row = conn.execute(
@@ -222,6 +232,7 @@ def app_response_json(raw: str):
 
 @avap_bp.route("/avap/health", methods=["GET"])
 def avap_health():
+    """Return AVAP protocol version and counts of stored envelopes and anchors."""
     conn = _conn()
     try:
         envs = conn.execute("SELECT COUNT(*) FROM avap_envelopes").fetchone()[0]


### PR DESCRIPTION
Adds one-line docstrings to the 11 previously undocumented functions in `avap_blueprint.py` (Agent Video Attestation Protocol layer: canonical-JSON/hashing/signature-verification crypto helpers, DB init/connection, and all 5 Flask route handlers for anchor/attach/get/health), per the docstring bounty program in `docs/CONTRIBUTING_FOR_AGENTS.md` (0.5 RTC/function = 5.5 RTC total).

Each docstring was written after reading the actual function body — no guessed/fabricated descriptions. `py_compile` passes clean.

Wallet: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7

/claim