### PR TITLE
docs: add docstrings to captions_blueprint.py

### DIFF
--- a/captions_blueprint.py
+++ b/captions_blueprint.py
@@ -41,6 +41,7 @@ WHISPER_MODEL = os.environ.get("BOTTUBE_WHISPER_MODEL", "whisper-1")
 
 
 def _db_path() -> str:
+    """Resolve the sqlite database path from globals/env, falling back to bottube.db next to this file."""
     from pathlib import Path
     if "DB_PATH" in globals():
         return str(globals()["DB_PATH"])
@@ -53,12 +54,14 @@ def _db_path() -> str:
 
 
 def _connect_db() -> sqlite3.Connection:
+    """Open a sqlite connection to the captions DB with row access by column name."""
     db = sqlite3.connect(_db_path())
     db.row_factory = sqlite3.Row
     return db
 
 
 def _table_exists(db: sqlite3.Connection, name: str) -> bool:
+    """Return True if a table with this name exists in the sqlite schema."""
     row = db.execute(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
         (name,),
@@ -67,10 +70,12 @@ def _table_exists(db: sqlite3.Connection, name: str) -> bool:
 
 
 def _normalized_sql(sql: str) -> str:
+    """Strip whitespace and lowercase a CREATE TABLE statement for structural comparison."""
     return re.sub(r"\s+", "", (sql or "").lower())
 
 
 def _migrate_captions_table(db: sqlite3.Connection) -> None:
+    """Create video_captions if missing, or rebuild it onto the target schema (with the (video_id, language, format) unique constraint) preserving existing rows."""
     target_sql = """
         CREATE TABLE IF NOT EXISTS video_captions (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -114,6 +119,7 @@ def _migrate_captions_table(db: sqlite3.Connection) -> None:
 
 
 def _rebuild_caption_search_index(db: sqlite3.Connection) -> None:
+    """Recreate the FTS5 caption search table and repopulate it from all stored captions."""
     try:
         db.execute(
             """
@@ -248,6 +254,7 @@ def _google_words_to_cues(words: list[dict]) -> list[dict]:
 
 
 def _whisper_segments_to_cues(segments: list[dict]) -> list[dict]:
+    """Convert Whisper API segments into subtitle cues, dropping empty-text segments."""
     cues = []
     for segment in segments:
         text = str(segment.get("text", "")).strip()
@@ -264,6 +271,7 @@ def _whisper_segments_to_cues(segments: list[dict]) -> list[dict]:
 
 
 def _format_vtt_time(seconds: float) -> str:
+    """Format seconds as a WebVTT timestamp (HH:MM:SS.mmm)."""
     hours = int(seconds // 3600)
     minutes = int((seconds % 3600) // 60)
     secs = seconds % 60
@@ -271,6 +279,7 @@ def _format_vtt_time(seconds: float) -> str:
 
 
 def _format_srt_time(seconds: float) -> str:
+    """Format seconds as an SRT timestamp (HH:MM:SS,mmm)."""
     hours = int(seconds // 3600)
     minutes = int((seconds % 3600) // 60)
     secs = int(seconds % 60)
@@ -279,6 +288,7 @@ def _format_srt_time(seconds: float) -> str:
 
 
 def _cues_to_vtt(cues: list[dict]) -> str:
+    """Render a list of subtitle cues as a WebVTT document."""
     lines = ["WEBVTT", ""]
     for idx, cue in enumerate(cues, start=1):
         lines.append(str(idx))
@@ -289,6 +299,7 @@ def _cues_to_vtt(cues: list[dict]) -> str:
 
 
 def _cues_to_srt(cues: list[dict]) -> str:
+    """Render a list of subtitle cues as an SRT document."""
     lines = []
     for idx, cue in enumerate(cues, start=1):
         lines.append(str(idx))
@@ -299,6 +310,7 @@ def _cues_to_srt(cues: list[dict]) -> str:
 
 
 def _speech_to_text_google(audio_path: str) -> list[dict]:
+    """Transcribe audio via Google Cloud Speech-to-Text, polling for long-running results, and return word timestamps."""
     token = _get_access_token()
     if not token:
         return []
@@ -365,6 +377,7 @@ def _speech_to_text_google(audio_path: str) -> list[dict]:
 
 
 def _speech_to_text_whisper(audio_path: str) -> dict:
+    """Transcribe audio via the OpenAI Whisper API and return the verbose JSON response."""
     if not OPENAI_API_KEY:
         return {}
 
@@ -389,6 +402,7 @@ def _speech_to_text_whisper(audio_path: str) -> dict:
 
 
 def _refresh_caption_search_index(db: sqlite3.Connection, video_id: str, text: str) -> None:
+    """Replace a single video's entry in the caption FTS index with the given text."""
     try:
         db.execute("DELETE FROM video_captions_fts WHERE video_id = ?", (video_id,))
         db.execute(
@@ -400,6 +414,7 @@ def _refresh_caption_search_index(db: sqlite3.Connection, video_id: str, text: s
 
 
 def _caption_provider():
+    """Return the configured captions provider name ('whisper' or 'google'), or None if unconfigured."""
     if OPENAI_API_KEY:
         return "whisper"
     if GOOGLE_CREDS:
@@ -477,6 +492,7 @@ def generate_captions_async(video_id: str, video_path: str) -> None:
 
 
 def _fts_query(raw_query: str) -> str:
+    """Turn free-text input into a quoted FTS5 MATCH expression, capped at 8 tokens."""
     tokens = re.findall(r"[A-Za-z0-9_]+", raw_query.lower())
     if not tokens:
         return ""
@@ -484,6 +500,7 @@ def _fts_query(raw_query: str) -> str:
 
 
 def find_caption_video_ids(query: str, limit: int = 200) -> list[str]:
+    """Search indexed caption text and return distinct matching video ids."""
     fts_query = _fts_query(query)
     try:
         with _connect_db() as db:
@@ -505,6 +522,7 @@ def find_caption_video_ids(query: str, limit: int = 200) -> list[str]:
 
 
 def _parse_caption_limit(default: int = 50, max_value: int = 500) -> int:
+    """Parse the ?limit= query param into a bounded positive int, raising ValueError on bad input."""
     raw_value = request.args.get("limit")
     if raw_value is None or raw_value == "":
         return default


### PR DESCRIPTION
Adds docstrings to all 18 undocumented functions in `captions_blueprint.py` (auto-captions with Whisper/Google STT provider fallback): DB helpers (`_db_path`, `_connect_db`, `_table_exists`, `_normalized_sql`), schema migration (`_migrate_captions_table`, `_rebuild_caption_search_index`), cue formatting (`_whisper_segments_to_cues`, `_format_vtt_time`, `_format_srt_time`, `_cues_to_vtt`, `_cues_to_srt`), STT provider calls (`_speech_to_text_google`, `_speech_to_text_whisper`), search index maintenance (`_refresh_caption_search_index`, `_fts_query`, `find_caption_video_ids`), provider selection (`_caption_provider`), and query parsing (`_parse_caption_limit`). Verified with `py_compile` and an `ast`-based scan — zero missing docstrings remain in the file.

/claim

Payout wallet: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7