### PR TITLE
docs: add docstrings batch 44 (generation/providers/gemini.py, 6 functions, 3.0 RTC)

### DIFF
--- a/generation/providers/gemini.py
+++ b/generation/providers/gemini.py
@@ -33,9 +33,11 @@ VIDEO_HEIGHT = 720
 class GeminiProvider(GenerationProvider):
 
     def get_name(self) -> str:
+        """Return this provider's registry key."""
         return "gemini"
 
     def get_capabilities(self) -> ProviderCapabilities:
+        """Describe what this provider supports (modes, limits, styles, cost/quality tier, availability)."""
         return ProviderCapabilities(
             name="gemini",
             modes=[
@@ -55,6 +57,7 @@ class GeminiProvider(GenerationProvider):
         )
 
     def validate_input(self, req: GenerationRequest) -> Tuple[bool, str]:
+        """Check the request has a prompt and the API key is configured before submitting."""
         if not req.prompt:
             return False, "prompt is required"
         if not GEMINI_API_KEY:
@@ -62,6 +65,7 @@ class GeminiProvider(GenerationProvider):
         return True, ""
 
     def submit(self, req: GenerationRequest, output_dir: Path) -> Tuple[bool, str]:
+        """Generate a still image via Gemini, then animate it with a Ken Burns zoom into a video."""
         import urllib.request
 
         payload = json.dumps({
@@ -139,10 +143,12 @@ class GeminiProvider(GenerationProvider):
         return False, "ffmpeg ken-burns animation failed"
 
     def get_status(self, external_id: str) -> Tuple[str, float]:
+        """Report job status; submit() runs synchronously, so this just checks the output file exists."""
         if external_id and Path(external_id).exists():
             return "completed", 1.0
         return "failed", 0.0
 
     def get_result(self, external_id: str, output_dir: Path) -> Optional[Path]:
+        """Return the generated video path if it exists on disk."""
         p = Path(external_id)
         return p if p.exists() else None


### PR DESCRIPTION
Adds docstrings to the 6 undocumented methods in generation/providers/gemini.py: get_name, get_capabilities, validate_input, submit, get_status, get_result.

Same provider-adapter pattern as the rest of this series (Gemini image gen + Ken Burns zoom). Verified with py_compile and a full ast re-scan (missing: []) before pushing.

/claim