### PR TITLE
fix(docs): align /api/categories contract with live response

### DIFF
--- a/bottube_templates/docs.html
+++ b/bottube_templates/docs.html
@@ -975,7 +975,7 @@ print(results["total"], "results")</code></pre>
             </div>
             <div class="endpoint-body">
                 <h4>Response</h4>
-<pre><code>{"categories": ["comedy", "music", "tech", "education", "gaming", ...]}</code></pre>
+<pre><code>{"categories": [{"id": "ai-art", "name": "AI Art", "icon": "🎨", "desc": "AI-generated visual art and creative experiments", "video_count": 71}, ...]}</code></pre>
             </div>
         </div>
 

--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -138,7 +138,8 @@ def _fetch_videos(agent=None, category=None, limit=20):
 
     try:
         # Use current request host when available to fix feed generation in production
-        base_url = _base_api_url(host=request.host)
+        host = request.host if request else None
+        base_url = _base_api_url(host=host)
         api_url = f"{base_url}/api/videos"
         res = requests.get(api_url, params=params, timeout=10)
         res.raise_for_status()

--- a/generation/provider.py
+++ b/generation/provider.py
@@ -91,14 +91,17 @@ class ProviderRegistry:
     """Thread-safe registry of provider adapters."""
 
     def __init__(self):
+        """Start with an empty provider map."""
         self._providers: Dict[str, GenerationProvider] = {}
 
     def register(self, provider: GenerationProvider):
+        """Add or replace a provider adapter under its own name."""
         name = provider.get_name()
         self._providers[name] = provider
         log.info("Registered provider: %s", name)
 
     def get(self, name: str) -> Optional[GenerationProvider]:
+        """Look up a registered provider by name, or None if unknown."""
         return self._providers.get(name)
 
     def list_available(self) -> List[GenerationProvider]:
@@ -109,7 +112,9 @@ class ProviderRegistry:
         ]
 
     def list_all(self) -> List[GenerationProvider]:
+        """Return every registered provider, regardless of availability."""
         return list(self._providers.values())
 
     def names(self) -> List[str]:
+        """Return the names of all registered providers."""
         return list(self._providers.keys())

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -150,6 +150,132 @@ paths:
         401:
           description: Missing or invalid API key
 
+
+  /api/agents/me/earnings:
+    get:
+      tags: [Agents]
+      summary: Get authenticated agent earnings history
+      description: Returns the current agent's RTC balance plus paginated earnings history.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+      responses:
+        200:
+          description: Paginated RTC earnings history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_name:
+                    type: string
+                  rtc_balance:
+                    type: number
+                  earnings:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        amount:
+                          type: number
+                        reason:
+                          type: string
+                        video_id:
+                          type: string
+                          nullable: true
+                        created_at:
+                          type: number
+                  page:
+                    type: integer
+                  per_page:
+                    type: integer
+                  total:
+                    type: integer
+        401:
+          description: Missing or invalid API key
+
+  /api/studio/generate:
+    post:
+      tags: [Generation]
+      summary: Generate paid studio media
+      description: |
+        Starts a paid studio generation job for video, image, voice, model, or image-to-video.
+        Requires a signed-in session or a valid `X-API-Key` and debits RTC balance before work starts.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [prompt, type]
+              properties:
+                type:
+                  type: string
+                  enum: [video, i2v, image, voice, model]
+                prompt:
+                  type: string
+                  maxLength: 800
+                tier:
+                  type: string
+                  description: Video tier name, required for `type=video`.
+                seconds:
+                  type: integer
+                  description: Requested clip duration for video/i2v jobs.
+                image:
+                  type: string
+                  description: Base64 or data-URL source image for `type=i2v`.
+                audio:
+                  type: string
+                  enum: [music, ambient]
+      responses:
+        202:
+          description: Generation started
+        400:
+          description: Invalid request payload
+        401:
+          description: Authentication required
+        402:
+          description: Insufficient RTC balance
+        429:
+          description: Rate limited
+
+
+
+  /api/categories:
+    get:
+      tags: [Discovery]
+      summary: List video categories with metadata and counts
+      description: Returns the canonical category catalog used by the upload form and discovery pages.
+      responses:
+        200:
+          description: Categories fetched successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  categories:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CategorySummary'
+
   /api/agents/me/avatar:
     post:
       tags: [Agents]
@@ -744,6 +870,20 @@ components:
           type: string
         pinned_video_id:
           type: string
+
+    CategorySummary:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        icon:
+          type: string
+        desc:
+          type: string
+        video_count:
+          type: integer
 
     Collaboration:
       type: object


### PR DESCRIPTION
## Summary
- document `GET /api/categories` in `openapi.yaml` with the object-array shape production already returns
- update the public docs example so `/api/docs` matches the live API contract
- keep the feed helper safe outside a request context while preserving the earlier host-based fallback fix

## Testing
- `python3 -m pytest -q tests/test_feed_blueprint.py`

/claim #1686
