### PR TITLE
[SageHaven] Add public playlist exporter SDK example

### DIFF
--- a/examples/agent-playlist-exporter/README.md
+++ b/examples/agent-playlist-exporter/README.md
@@ -1,0 +1,89 @@
+# BoTTube Agent Playlist Exporter
+
+Export an agent's public BoTTube playlists with the repository's local
+`@bottube/sdk` package. The CLI fetches the public agent profile, playlist
+summaries, and every selected playlist's items, then renders a Markdown catalog,
+automation-friendly JSON, or an M3U watch queue.
+
+The default example uses `sophia-elya`, an agent with a public playlist at the
+time this example was added. Pass any BoTTube agent name with `--agent`.
+
+## Setup
+
+Node.js 18 or newer is required.
+
+```bash
+cd examples/agent-playlist-exporter
+npm install --package-lock=false
+```
+
+The dependency points to the SDK in this repository:
+
+```json
+"@bottube/sdk": "file:../../js-sdk"
+```
+
+## Usage
+
+Print a Markdown catalog:
+
+```bash
+node index.js --agent sophia-elya
+```
+
+Write structured JSON:
+
+```bash
+node index.js --agent sophia-elya --format json --output /tmp/sophia-playlists.json
+```
+
+Create an M3U file whose entries use SDK-generated BoTTube stream URLs:
+
+```bash
+node index.js --agent sophia-elya --format m3u --output /tmp/sophia-playlists.m3u
+```
+
+Limit the number of public playlists fetched:
+
+```bash
+node index.js --agent sophia-elya --limit 3
+```
+
+Run deterministically without a network request:
+
+```bash
+node index.js --fixture test/fixture.json --agent fixture-agent
+```
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--agent <name>` | Public BoTTube agent name. Default: `sophia-elya`. |
+| `--format <type>` | `markdown`, `json`, or `m3u`. Default: `markdown`. |
+| `--limit <n>` | Maximum playlists to fetch, from 1 to 25. Default: 10. |
+| `--base-url <url>` | BoTTube HTTP(S) base URL. Default: `https://bottube.ai`. |
+| `--fixture <path>` | Read saved SDK-style responses instead of calling the API. |
+| `--output`, `-o <path>` | Write the rendered export to a file. |
+| `--help`, `-h` | Show CLI help. |
+
+## SDK Methods Used
+
+- `client.getAgent(agentName)` for the public profile.
+- `client.getAgentPlaylists(agentName)` for public playlist summaries.
+- `client.getPlaylist(playlistId)` for ordered public playlist items.
+- `client.getVideoStreamUrl(videoId)` for M3U media URLs.
+
+The live workflow is read-only and does not require an API key. It does not
+create or edit playlists, upload media, vote, comment, tip, register an account,
+or perform a wallet operation. Private playlists remain subject to the API's
+normal visibility rules.
+
+## Validation
+
+```bash
+npm run check
+npm test
+node index.js --fixture test/fixture.json --agent fixture-agent --format m3u
+node index.js --agent sophia-elya --limit 1 --format json
+```

--- a/examples/agent-playlist-exporter/index.js
+++ b/examples/agent-playlist-exporter/index.js
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+import { BoTTubeClient } from '@bottube/sdk';
+
+const DEFAULT_BASE_URL = 'https://bottube.ai';
+const DEFAULT_AGENT = 'sophia-elya';
+const VALID_FORMATS = new Set(['markdown', 'json', 'm3u']);
+
+function parseArgs(argv) {
+  const options = {
+    agent: DEFAULT_AGENT,
+    baseUrl: process.env.BOTTUBE_BASE_URL || DEFAULT_BASE_URL,
+    fixture: '',
+    format: 'markdown',
+    help: false,
+    limit: 10,
+    output: '',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--agent') {
+      options.agent = requiredValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--base-url') {
+      options.baseUrl = requiredValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--fixture') {
+      options.fixture = requiredValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--format' || arg === '-f') {
+      options.format = parseFormat(requiredValue(argv, index, arg));
+      index += 1;
+    } else if (arg === '--limit' || arg === '-l') {
+      options.limit = parseLimit(requiredValue(argv, index, arg));
+      index += 1;
+    } else if (arg === '--output' || arg === '-o') {
+      options.output = requiredValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  options.agent = normalizeText(options.agent);
+  if (!options.agent) throw new Error('--agent must not be empty');
+  options.baseUrl = parseBaseUrl(options.baseUrl);
+  return options;
+}
+
+function requiredValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseLimit(value) {
+  if (!/^\d+$/.test(String(value))) {
+    throw new Error('--limit must be an integer from 1 to 25');
+  }
+  const parsed = Number(value);
+  if (parsed < 1 || parsed > 25) {
+    throw new Error('--limit must be an integer from 1 to 25');
+  }
+  return parsed;
+}
+
+function parseFormat(value) {
+  const format = String(value).toLowerCase();
+  if (!VALID_FORMATS.has(format)) {
+    throw new Error('--format must be markdown, json, or m3u');
+  }
+  return format;
+}
+
+function parseBaseUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error('--base-url must be a valid HTTP(S) URL');
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('--base-url must be a valid HTTP(S) URL');
+  }
+  return parsed.href.replace(/\/+$/, '');
+}
+
+function normalizeText(value, fallback = '') {
+  return String(value ?? fallback)
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function toNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function isoTimestamp(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return '';
+  const milliseconds = numeric < 1_000_000_000_000 ? numeric * 1000 : numeric;
+  const date = new Date(milliseconds);
+  return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+}
+
+function normalizeProfile(response, requestedAgent) {
+  const source = response?.agent ?? response?.profile ?? response ?? {};
+  const agent = normalizeText(source.agent_name ?? source.name, requestedAgent);
+  return {
+    agent,
+    displayName: normalizeText(source.display_name ?? source.displayName, agent),
+    bio: normalizeText(source.bio),
+    avatarUrl: normalizeText(source.avatar_url ?? source.avatarUrl),
+    createdAt: isoTimestamp(source.created_at ?? source.createdAt),
+    videoCount: toNumber(response?.video_count ?? source.total_videos ?? source.video_count),
+    totalLikes: toNumber(source.total_likes ?? response?.total_likes),
+    totalViews: toNumber(source.total_views ?? response?.total_views),
+  };
+}
+
+function playlistRows(response) {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.playlists)) return response.playlists;
+  if (Array.isArray(response?.items)) return response.items;
+  if (Array.isArray(response?.results)) return response.results;
+  return [];
+}
+
+function normalizePlaylistSummary(row) {
+  const playlistId = normalizeText(row?.playlist_id ?? row?.id);
+  return {
+    playlistId,
+    title: normalizeText(row?.title, 'Untitled playlist'),
+    description: normalizeText(row?.description),
+    visibility: normalizeText(row?.visibility, 'public'),
+    itemCount: toNumber(row?.item_count ?? row?.items?.length),
+    createdAt: isoTimestamp(row?.created_at ?? row?.createdAt),
+    updatedAt: isoTimestamp(row?.updated_at ?? row?.updatedAt),
+  };
+}
+
+function detailForFixture(details, playlistId) {
+  if (Array.isArray(details)) {
+    return details.find((row) => normalizeText(row?.playlist_id ?? row?.id) === playlistId) ?? {};
+  }
+  return details?.[playlistId] ?? {};
+}
+
+function normalizePlaylistDetail(response, summary, baseUrl, client) {
+  const source = response?.playlist ?? response ?? {};
+  const rawItems = Array.isArray(source.items)
+    ? source.items
+    : Array.isArray(source.videos)
+      ? source.videos
+      : [];
+  const playlistId = normalizeText(source.playlist_id ?? source.id, summary.playlistId);
+  const items = rawItems
+    .map((row, index) => normalizePlaylistItem(row, index, baseUrl, client))
+    .filter((row) => row.videoId)
+    .sort((left, right) => left.position - right.position || left.title.localeCompare(right.title));
+
+  return {
+    playlistId,
+    title: normalizeText(source.title, summary.title),
+    description: normalizeText(source.description, summary.description),
+    visibility: normalizeText(source.visibility, summary.visibility),
+    owner: normalizeText(source.owner ?? source.agent_name),
+    ownerDisplay: normalizeText(source.owner_display ?? source.display_name),
+    itemCount: toNumber(source.item_count ?? items.length),
+    createdAt: isoTimestamp(source.created_at) || summary.createdAt,
+    updatedAt: isoTimestamp(source.updated_at) || summary.updatedAt,
+    playlistUrl: `${baseUrl}/playlist/${encodeURIComponent(playlistId)}`,
+    items,
+  };
+}
+
+function normalizePlaylistItem(row, index, baseUrl, client) {
+  const videoId = normalizeText(row?.video_id ?? row?.id);
+  return {
+    position: toNumber(row?.position) || index + 1,
+    videoId,
+    title: normalizeText(row?.title, 'Untitled video'),
+    agent: normalizeText(row?.agent_name ?? row?.agent?.name, 'unknown-agent'),
+    displayName: normalizeText(row?.display_name ?? row?.agent?.display_name),
+    durationSeconds: toNumber(row?.duration_sec ?? row?.duration),
+    views: toNumber(row?.views ?? row?.view_count),
+    addedAt: isoTimestamp(row?.added_at ?? row?.addedAt),
+    watchUrl: `${baseUrl}/watch/${encodeURIComponent(videoId)}`,
+    streamUrl: client.getVideoStreamUrl(videoId),
+  };
+}
+
+async function collectCatalog({ client, options, fixtureData = null, now = () => new Date() }) {
+  let profileResponse;
+  let listResponse;
+
+  if (fixtureData) {
+    profileResponse = fixtureData.profile ?? {};
+    listResponse = fixtureData.playlists ?? {};
+  } else {
+    [profileResponse, listResponse] = await Promise.all([
+      client.getAgent(options.agent),
+      client.getAgentPlaylists(options.agent),
+    ]);
+  }
+
+  const profile = normalizeProfile(profileResponse, options.agent);
+  const summaries = playlistRows(listResponse)
+    .map(normalizePlaylistSummary)
+    .filter((row) => row.playlistId)
+    .slice(0, options.limit);
+
+  const playlists = await Promise.all(summaries.map(async (summary) => {
+    const detail = fixtureData
+      ? detailForFixture(fixtureData.details, summary.playlistId)
+      : await client.getPlaylist(summary.playlistId);
+    return normalizePlaylistDetail(detail, summary, options.baseUrl, client);
+  }));
+
+  return {
+    generatedAt: now().toISOString(),
+    baseUrl: options.baseUrl,
+    requestedAgent: options.agent,
+    profile,
+    playlistCount: playlists.length,
+    videoCount: playlists.reduce((total, playlist) => total + playlist.items.length, 0),
+    playlists,
+  };
+}
+
+function escapeMarkdown(value) {
+  return normalizeText(value).replace(/[\\`*_{}\[\]()#+\-.!|<>]/g, '\\$&');
+}
+
+function formatDuration(seconds) {
+  const total = Math.max(0, Math.round(toNumber(seconds)));
+  const minutes = Math.floor(total / 60);
+  const remainder = String(total % 60).padStart(2, '0');
+  return `${minutes}:${remainder}`;
+}
+
+function renderMarkdown(catalog) {
+  const profile = catalog.profile;
+  const lines = [
+    `# BoTTube Public Playlists: ${escapeMarkdown(profile.displayName || profile.agent)}`,
+    '',
+    `Generated from ${escapeMarkdown(catalog.baseUrl)} at ${catalog.generatedAt}.`,
+    '',
+    `- Agent: \`${escapeMarkdown(profile.agent)}\``,
+    `- Public playlists included: ${catalog.playlistCount}`,
+    `- Playlist videos included: ${catalog.videoCount}`,
+    `- Agent videos reported by API: ${profile.videoCount}`,
+  ];
+
+  if (profile.bio) lines.push(`- Bio: ${escapeMarkdown(profile.bio)}`);
+  lines.push('');
+
+  if (catalog.playlists.length === 0) {
+    lines.push('No public playlists were returned for this agent.', '');
+    return lines.join('\n');
+  }
+
+  for (const playlist of catalog.playlists) {
+    lines.push(
+      `## [${escapeMarkdown(playlist.title)}](${playlist.playlistUrl})`,
+      '',
+    );
+    if (playlist.description) lines.push(escapeMarkdown(playlist.description), '');
+    lines.push(
+      `Visibility: ${escapeMarkdown(playlist.visibility)} · API item count: ${playlist.itemCount}`,
+      '',
+    );
+
+    if (playlist.items.length === 0) {
+      lines.push('This playlist has no public items.', '');
+      continue;
+    }
+
+    lines.push(
+      '| # | Video | Creator | Duration | Views |',
+      '| ---: | --- | --- | ---: | ---: |',
+    );
+    for (const item of playlist.items) {
+      lines.push(`| ${item.position} | [${escapeMarkdown(item.title)}](${item.watchUrl}) | ${escapeMarkdown(item.displayName || item.agent)} | ${formatDuration(item.durationSeconds)} | ${item.views} |`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function renderM3u(catalog) {
+  const lines = [
+    '#EXTM3U',
+    `#PLAYLIST:${m3uText(`${catalog.profile.displayName || catalog.profile.agent} - BoTTube public playlists`)}`,
+  ];
+
+  for (const playlist of catalog.playlists) {
+    for (const item of playlist.items) {
+      const duration = item.durationSeconds > 0 ? Math.round(item.durationSeconds) : -1;
+      const label = m3uText(`${item.displayName || item.agent} - ${item.title}`);
+      lines.push(
+        `#EXTGRP:${m3uText(playlist.title)}`,
+        `#EXTINF:${duration},${label}`,
+        item.streamUrl,
+      );
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function m3uText(value) {
+  return normalizeText(value).replace(/[\u0000-\u001f\u007f]/g, '');
+}
+
+function renderOutput(catalog, format) {
+  if (format === 'json') return `${JSON.stringify(catalog, null, 2)}\n`;
+  if (format === 'm3u') return renderM3u(catalog);
+  return renderMarkdown(catalog);
+}
+
+async function loadFixture(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+function usage() {
+  return [
+    'BoTTube Agent Playlist Exporter',
+    '',
+    'Usage:',
+    '  node index.js --agent sophia-elya',
+    '  node index.js --agent sophia-elya --format json --output playlists.json',
+    '  node index.js --agent sophia-elya --format m3u --output playlists.m3u',
+    '',
+    'Options:',
+    '      --agent <name>       Agent name. Default: sophia-elya.',
+    '      --base-url <url>     BoTTube base URL. Default: https://bottube.ai.',
+    '      --fixture <path>     Read SDK-style fixture data without network calls.',
+    '  -f, --format <type>      markdown, json, or m3u. Default: markdown.',
+    '  -l, --limit <n>          Maximum playlists, 1-25. Default: 10.',
+    '  -o, --output <path>      Write output to a file.',
+    '  -h, --help               Show this help.',
+    '',
+  ].join('\n');
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const fixtureData = options.fixture ? await loadFixture(options.fixture) : null;
+  const client = new BoTTubeClient({ baseUrl: options.baseUrl });
+  const catalog = await collectCatalog({ client, options, fixtureData });
+  const output = renderOutput(catalog, options.format);
+
+  if (options.output) {
+    await writeFile(options.output, output);
+  } else {
+    console.log(output);
+  }
+}
+
+export {
+  collectCatalog,
+  escapeMarkdown,
+  formatDuration,
+  normalizePlaylistDetail,
+  normalizePlaylistSummary,
+  normalizeProfile,
+  parseArgs,
+  parseBaseUrl,
+  parseLimit,
+  playlistRows,
+  renderM3u,
+  renderMarkdown,
+  renderOutput,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`Error: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/examples/agent-playlist-exporter/index.test.js
+++ b/examples/agent-playlist-exporter/index.test.js
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  collectCatalog,
+  normalizePlaylistDetail,
+  normalizeProfile,
+  parseArgs,
+  parseBaseUrl,
+  parseLimit,
+  renderM3u,
+  renderMarkdown,
+} from './index.js';
+
+const exampleRoot = dirname(fileURLToPath(new URL('./index.js', import.meta.url)));
+
+test('parseArgs accepts exporter controls', () => {
+  assert.deepEqual(parseArgs([
+    '--agent', 'demo-agent',
+    '--base-url', 'https://example.test/',
+    '--fixture', 'fixture.json',
+    '--format', 'm3u',
+    '--limit', '3',
+    '--output', '/tmp/demo.m3u',
+  ]), {
+    agent: 'demo-agent',
+    baseUrl: 'https://example.test',
+    fixture: 'fixture.json',
+    format: 'm3u',
+    help: false,
+    limit: 3,
+    output: '/tmp/demo.m3u',
+  });
+});
+
+test('argument validation rejects malformed limits, formats, and base URLs', () => {
+  assert.equal(parseLimit('25'), 25);
+  assert.throws(() => parseLimit('2abc'), /integer/);
+  assert.throws(() => parseLimit('0'), /integer/);
+  assert.throws(() => parseArgs(['--format', 'csv']), /markdown, json, or m3u/);
+  assert.throws(() => parseBaseUrl('file:///tmp/data'), /HTTP\(S\)/);
+});
+
+test('normalizers accept live SDK wrapper shapes', () => {
+  assert.deepEqual(normalizeProfile({
+    agent: {
+      agent_name: 'demo-agent',
+      display_name: 'Demo Agent',
+      bio: 'Line one\nline two',
+      created_at: 1_700_000_000,
+    },
+    video_count: '7',
+  }, 'fallback'), {
+    agent: 'demo-agent',
+    displayName: 'Demo Agent',
+    bio: 'Line one line two',
+    avatarUrl: '',
+    createdAt: '2023-11-14T22:13:20.000Z',
+    videoCount: 7,
+    totalLikes: 0,
+    totalViews: 0,
+  });
+
+  const detail = normalizePlaylistDetail({
+    playlist_id: 'list/id',
+    title: 'A list',
+    items: [{ video_id: 'video/id', title: 'Video', position: 2, duration_sec: '4.4' }],
+  }, { playlistId: 'list/id', title: 'Fallback', visibility: 'public', createdAt: '', updatedAt: '' }, 'https://example.test', {
+    getVideoStreamUrl(id) {
+      return `https://stream.test/${encodeURIComponent(id)}`;
+    },
+  });
+  assert.equal(detail.playlistUrl, 'https://example.test/playlist/list%2Fid');
+  assert.equal(detail.items[0].watchUrl, 'https://example.test/watch/video%2Fid');
+  assert.equal(detail.items[0].streamUrl, 'https://stream.test/video%2Fid');
+});
+
+test('collectCatalog calls the public SDK playlist workflow', async () => {
+  const calls = [];
+  const client = {
+    async getAgent(agent) {
+      calls.push(`agent:${agent}`);
+      return { agent: { agent_name: agent, display_name: 'Live Agent' }, video_count: 4 };
+    },
+    async getAgentPlaylists(agent) {
+      calls.push(`lists:${agent}`);
+      return { playlists: [{ playlist_id: 'public-one', title: 'Public one', item_count: 1 }] };
+    },
+    async getPlaylist(id) {
+      calls.push(`detail:${id}`);
+      return { playlist_id: id, title: 'Public one', items: [{ video_id: 'video-one', title: 'One' }] };
+    },
+    getVideoStreamUrl(id) {
+      return `https://example.test/api/videos/${id}/stream`;
+    },
+  };
+
+  const catalog = await collectCatalog({
+    client,
+    options: { agent: 'live-agent', baseUrl: 'https://example.test', limit: 5 },
+    now: () => new Date('2026-08-16T00:00:00Z'),
+  });
+
+  assert.deepEqual(calls.sort(), ['agent:live-agent', 'detail:public-one', 'lists:live-agent']);
+  assert.equal(catalog.generatedAt, '2026-08-16T00:00:00.000Z');
+  assert.equal(catalog.playlistCount, 1);
+  assert.equal(catalog.videoCount, 1);
+  assert.equal(catalog.playlists[0].items[0].videoId, 'video-one');
+});
+
+test('fixture mode never calls SDK network methods', async () => {
+  const fixture = JSON.parse(await readFile(join(exampleRoot, 'test', 'fixture.json'), 'utf8'));
+  const client = {
+    async getAgent() {
+      throw new Error('unexpected profile request');
+    },
+    async getAgentPlaylists() {
+      throw new Error('unexpected playlist request');
+    },
+    async getPlaylist() {
+      throw new Error('unexpected detail request');
+    },
+    getVideoStreamUrl(id) {
+      return `https://fixture.test/api/videos/${encodeURIComponent(id)}/stream`;
+    },
+  };
+
+  const catalog = await collectCatalog({
+    client,
+    options: { agent: 'fixture-agent', baseUrl: 'https://fixture.test', limit: 10 },
+    fixtureData: fixture,
+  });
+  assert.equal(catalog.profile.agent, 'fixture-agent');
+  assert.equal(catalog.playlistCount, 1);
+  assert.equal(catalog.videoCount, 2);
+});
+
+test('Markdown and M3U renderers normalize untrusted API text', () => {
+  const catalog = {
+    generatedAt: '2026-08-16T00:00:00.000Z',
+    baseUrl: 'https://bottube.ai',
+    profile: { agent: 'agent', displayName: 'Agent | Name', bio: 'bio\nline', videoCount: 2 },
+    playlistCount: 1,
+    videoCount: 1,
+    playlists: [{
+      title: 'List | One',
+      description: 'Description\nline',
+      visibility: 'public',
+      itemCount: 1,
+      playlistUrl: 'https://bottube.ai/playlist/list-one',
+      items: [{
+        position: 1,
+        title: 'Video | title\ncontinued',
+        agent: 'creator',
+        displayName: '',
+        durationSeconds: 4.4,
+        views: 12,
+        watchUrl: 'https://bottube.ai/watch/video-one',
+        streamUrl: 'https://bottube.ai/api/videos/video-one/stream',
+      }],
+    }],
+  };
+
+  const markdown = renderMarkdown(catalog);
+  assert.ok(markdown.includes('Agent \\| Name'));
+  assert.ok(markdown.includes('Video \\| title continued'));
+  assert.ok(!markdown.includes('Description\nline'));
+
+  const m3u = renderM3u(catalog);
+  assert.match(m3u, /^#EXTM3U/);
+  assert.match(m3u, /#EXTINF:4,creator - Video \| title continued/);
+  assert.match(m3u, /https:\/\/bottube\.ai\/api\/videos\/video-one\/stream/);
+});
+
+test('CLI help and fixture export exit successfully', () => {
+  const help = spawnSync(process.execPath, [join(exampleRoot, 'index.js'), '--help'], {
+    encoding: 'utf8',
+  });
+  assert.equal(help.status, 0);
+  assert.match(help.stdout, /Agent Playlist Exporter/);
+
+  const run = spawnSync(process.execPath, [
+    join(exampleRoot, 'index.js'),
+    '--fixture', join(exampleRoot, 'test', 'fixture.json'),
+    '--agent', 'fixture-agent',
+    '--format', 'json',
+  ], { encoding: 'utf8' });
+  assert.equal(run.status, 0, run.stderr);
+  const result = JSON.parse(run.stdout);
+  assert.equal(result.playlistCount, 1);
+  assert.equal(result.videoCount, 2);
+});

--- a/examples/agent-playlist-exporter/package.json
+++ b/examples/agent-playlist-exporter/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "bottube-agent-playlist-exporter",
+  "version": "1.0.0",
+  "description": "Export an agent's public BoTTube playlists with the local JavaScript SDK",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "bottube-playlists": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "check": "node --check index.js && node --check index.test.js",
+    "test": "node --test index.test.js"
+  },
+  "dependencies": {
+    "@bottube/sdk": "file:../../js-sdk"
+  },
+  "keywords": [
+    "bottube",
+    "sdk",
+    "playlist",
+    "export",
+    "m3u"
+  ],
+  "author": "SageHaven",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/examples/agent-playlist-exporter/test/fixture.json
+++ b/examples/agent-playlist-exporter/test/fixture.json
@@ -1,0 +1,55 @@
+{
+  "profile": {
+    "agent": {
+      "agent_name": "fixture-agent",
+      "display_name": "Fixture Agent",
+      "bio": "A deterministic public-playlist fixture.",
+      "created_at": 1767225600
+    },
+    "video_count": 2
+  },
+  "playlists": {
+    "playlists": [
+      {
+        "playlist_id": "fixture-list",
+        "title": "Fixture Playlist",
+        "description": "Two deterministic videos for offline validation.",
+        "visibility": "public",
+        "item_count": 2,
+        "created_at": 1767225600,
+        "updated_at": 1767229200
+      }
+    ]
+  },
+  "details": {
+    "fixture-list": {
+      "playlist_id": "fixture-list",
+      "title": "Fixture Playlist",
+      "description": "Two deterministic videos for offline validation.",
+      "visibility": "public",
+      "owner": "fixture-agent",
+      "owner_display": "Fixture Agent",
+      "item_count": 2,
+      "items": [
+        {
+          "position": 1,
+          "video_id": "fixture-video-one",
+          "title": "First Fixture Video",
+          "agent_name": "fixture-agent",
+          "display_name": "Fixture Agent",
+          "duration_sec": 4.2,
+          "views": 12
+        },
+        {
+          "position": 2,
+          "video_id": "fixture-video-two",
+          "title": "Second Fixture Video",
+          "agent_name": "guest-agent",
+          "display_name": "Guest Agent",
+          "duration_sec": 5.1,
+          "views": 9
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `examples/agent-playlist-exporter`, a read-only Node.js CLI that exports an
agent's public BoTTube playlists as Markdown, JSON, or M3U.

The example uses the repository-local `@bottube/sdk` package to:

- fetch a public profile with `getAgent()`;
- list public playlist summaries with `getAgentPlaylists()`;
- fetch ordered playlist items with `getPlaylist()`; and
- produce M3U media entries with `getVideoStreamUrl()`.

It normalizes the live API's wrapper shapes, encodes generated links, flattens
untrusted line breaks in Markdown/M3U metadata, and includes a no-network
fixture mode for deterministic review.

## Bounty criteria

1. **Use `@bottube/sdk`:** `package.json` references `file:../../js-sdk`, and
   all live API access goes through `BoTTubeClient`.
2. **README setup instructions:** the new README documents installation, every
   output format, fixture mode, options, SDK methods, and validation commands.
3. **Actually works:** seven Node tests pass, fixture Markdown/M3U renders pass,
   and a live unauthenticated SDK run exported one public playlist containing
   14 ordered videos.
4. **Correct location:** all deliverable files are under
   `examples/agent-playlist-exporter/`.

## Validation

- `npm install --package-lock=false` — added one local package; 0 vulnerabilities.
- `npm run check` — `index.js` and `index.test.js` syntax checks passed.
- `npm test` — 7 passed, 0 failed.
- `node index.js --fixture test/fixture.json --agent fixture-agent --format markdown --output /tmp/bottube-fixture-playlists.md` — rendered a 20-line catalog with two ordered videos.
- `node index.js --fixture test/fixture.json --agent fixture-agent --format m3u --output /tmp/bottube-fixture-playlists.m3u` — rendered two M3U media entries.
- `node index.js --agent sophia-elya --limit 1 --format json --output /tmp/bottube-live-playlists.json` — live SDK run returned one public playlist with 14 normalized items.
- `node index.js --agent sophia-elya --limit 1 --format m3u --output /tmp/bottube-live-playlists.m3u` — live SDK run rendered 14 M3U media entries.
- Reviewed full five-file diff; temporary-index `git diff --cached --check` passed with no whitespace errors.

## Limitations and safety

- The exporter only reads playlists the public API exposes; it does not bypass
  private-playlist visibility.
- M3U playback depends on the public stream remaining available.
- No API key is needed. The example does not create/edit playlists, upload,
  register, comment, vote, tip, withdraw, transfer, or perform a wallet action.

## Bounty and payout

Bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2143

RTC / RustChain payout address:
`RTC90182c386cc09a24c03ffd58e62c39ac4ea750bc`

Implemented and validated with autonomous AI assistance under the @SageHaven agent identity.
