### PR TITLE
fix(security): authorize mood writes (IDOR) and guard every RTC debit against overdraw

### DIFF
--- a/base_wrtc_bridge_blueprint.py
+++ b/base_wrtc_bridge_blueprint.py
@@ -519,10 +519,30 @@ def base_bridge_withdraw():
             now,
         ),
     )
-    db.execute(
-        "UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?",
-        (total_debit, agent["id"]),
+    # Guarded debit. `balance` above came from the row read at authentication
+    # time and is already stale; the per-agent cooldown narrows the race window
+    # but does not close it (the cooldown lookup is itself unsynchronized). The
+    # comparison lives in the UPDATE so read and write are one atomic statement;
+    # a rowcount of 0 rolls back the pending withdrawal row inserted above.
+    cur = db.execute(
+        "UPDATE agents SET rtc_balance = rtc_balance - ? "
+        "WHERE id = ? AND rtc_balance >= ?",
+        (total_debit, agent["id"], total_debit),
     )
+    if cur.rowcount == 0:
+        db.rollback()
+        fresh = db.execute(
+            "SELECT rtc_balance FROM agents WHERE id = ?", (agent["id"],)
+        ).fetchone()
+        return jsonify(
+            {
+                "error": "Insufficient RTC balance",
+                "balance": float(fresh["rtc_balance"] or 0.0) if fresh else 0.0,
+                "required": total_debit,
+                "amount": amount,
+                "fee": BASE_WITHDRAW_FEE,
+            }
+        ), 400
     db.commit()
 
     new_balance = db.execute(

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -3302,6 +3302,44 @@ def award_rtc(db, agent_id: int, amount: float, reason: str, video_id: str = "",
     )
 
 
+def debit_rtc(db: sqlite3.Connection, agent_id: int, amount: float) -> bool:
+    """Atomically debit RTC from an agent. Returns True only if it went through.
+
+    The counterpart to :func:`award_rtc`. Every spend path must go through
+    this rather than issuing a bare ``rtc_balance = rtc_balance - ?``.
+
+    A bare subtract preceded by a ``SELECT rtc_balance`` check is a TOCTOU race:
+    the check and the write are two statements, so two concurrent tips can both
+    read the same balance, both decide it is sufficient, and both subtract --
+    leaving the sender negative and crediting recipients with RTC that was
+    never funded. Because the tip handlers credit the *recipient* right after
+    debiting the sender, an unguarded debit does not merely overdraw one
+    account, it mints supply.
+
+    Putting the comparison in the UPDATE's WHERE clause makes the read and the
+    write a single atomic statement. ``rowcount == 0`` means the funds were not
+    there at the instant of the write, and the caller must abort before issuing
+    any matching credit.
+    """
+    cur = db.execute(
+        "UPDATE agents SET rtc_balance = rtc_balance - ? "
+        "WHERE id = ? AND rtc_balance >= ?",
+        (amount, agent_id, amount),
+    )
+    return cur.rowcount > 0
+
+
+def _insufficient_balance_response(db: sqlite3.Connection, agent_id: int):
+    """Standard 400 for a debit that lost its race (or was never funded)."""
+    row = db.execute(
+        "SELECT rtc_balance FROM agents WHERE id = ?", (agent_id,)
+    ).fetchone()
+    return jsonify({
+        "error": "Insufficient RTC balance",
+        "balance": row["rtc_balance"] if row else 0,
+    }), 400
+
+
 def _queue_reward_hold(
     db: sqlite3.Connection,
     *,
@@ -7305,6 +7343,47 @@ def get_video(video_id):
 # Agent Mood API (Bounty #2283)
 # ---------------------------------------------------------------------------
 
+
+def _authorize_mood_write(agent_name):
+    """Resolve the mood target named in the URL and authorize the caller.
+
+    ``require_api_key`` only *authenticates*: it proves the caller holds some
+    valid key and stashes that row on ``g.agent``. It never inspects the
+    ``agent_name`` path parameter, and the mood handlers used to re-resolve the
+    target straight from the URL while ignoring ``g.agent`` entirely. The result
+    was horizontal privilege escalation -- any valid API key could write any
+    other agent's mood. PR #1639 closed the *anonymous* hole (no key at all);
+    this closes the *cross-agent* one.
+
+    Authorization is deliberately positive: the caller must either own the
+    target agent, or present an explicit operator admin key. "Holds a valid
+    key" is not sufficient.
+
+    Returns ``(agent_row, None)`` when the write may proceed, otherwise
+    ``(None, (response, status))`` for the handler to return.
+    """
+    db = get_db()
+    agent = db.execute(
+        "SELECT id, agent_name FROM agents WHERE agent_name = ?",
+        (agent_name,),
+    ).fetchone()
+    if not agent:
+        return None, (jsonify({"error": "Agent not found"}), 404)
+
+    caller = getattr(g, "agent", None)
+    if caller is not None and caller["id"] == agent["id"]:
+        return agent, None
+
+    # Explicit operator permission is the only cross-agent escape hatch.
+    if _require_admin() is None:
+        return agent, None
+
+    return None, (jsonify({
+        "error": "Forbidden - your API key does not own this agent",
+        "hint": "Write mood only for your own agent, or supply an admin key.",
+    }), 403)
+
+
 @app.route("/api/v1/agents/<agent_name>/mood", methods=["GET"])
 def get_agent_mood(agent_name):
     """
@@ -7355,18 +7434,11 @@ def update_agent_mood(agent_name):
     """
     if not MOOD_ENGINE_AVAILABLE:
         return jsonify({"error": "Mood engine not available"}), 503
-    
-    db = get_db()
-    
-    # Get agent by name
-    agent = db.execute(
-        "SELECT id, agent_name FROM agents WHERE agent_name = ?",
-        (agent_name,)
-    ).fetchone()
-    
-    if not agent:
-        return jsonify({"error": "Agent not found"}), 404
-    
+
+    agent, err = _authorize_mood_write(agent_name)
+    if err:
+        return err
+
     data = request.get_json() or {}
     force_state = data.get("force_state")
     trigger_reason = data.get("trigger_reason", "")
@@ -7389,18 +7461,11 @@ def record_mood_signal(agent_name):
     """
     if not MOOD_ENGINE_AVAILABLE:
         return jsonify({"error": "Mood engine not available"}), 503
-    
-    db = get_db()
-    
-    # Get agent by name
-    agent = db.execute(
-        "SELECT id, agent_name FROM agents WHERE agent_name = ?",
-        (agent_name,)
-    ).fetchone()
-    
-    if not agent:
-        return jsonify({"error": "Agent not found"}), 404
-    
+
+    agent, err = _authorize_mood_write(agent_name)
+    if err:
+        return err
+
     data = request.get_json() or {}
     signal_type = data.get("signal_type")
     signal_value = data.get("signal_value")
@@ -11713,7 +11778,11 @@ def tip_video(video_id):
     else:
         per_recipient = amount
         diff = 0
-    db.execute("UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?", (amount, g.agent["id"]))
+    # Guarded debit MUST succeed before any recipient is credited -- otherwise
+    # a lost race credits collaborators with RTC the sender never had.
+    if not debit_rtc(db, g.agent["id"], amount):
+        db.rollback()
+        return _insufficient_balance_response(db, g.agent["id"])
     for idx, (rid, role) in enumerate(recipients):
         share = per_recipient + (diff if idx == 0 else 0)
         db.execute("UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?", (share, rid))
@@ -11810,8 +11879,10 @@ def web_tip_video(video_id):
     if sender["rtc_balance"] < amount:
         return jsonify({"error": "Insufficient RTC balance", "balance": sender["rtc_balance"]}), 400
 
-    # Execute transfer
-    db.execute("UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?", (amount, g.user["id"]))
+    # Execute transfer -- debit first, and only credit if the debit was funded.
+    if not debit_rtc(db, g.user["id"], amount):
+        db.rollback()
+        return _insufficient_balance_response(db, g.user["id"])
     db.execute("UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?", (amount, video["agent_id"]))
 
     db.execute(
@@ -11903,7 +11974,9 @@ def web_tip_agent(agent_name):
     if sender["rtc_balance"] < amount:
         return jsonify({"error": "Insufficient RTC balance", "balance": sender["rtc_balance"]}), 400
 
-    db.execute("UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?", (amount, g.user["id"]))
+    if not debit_rtc(db, g.user["id"], amount):
+        db.rollback()
+        return _insufficient_balance_response(db, g.user["id"])
     db.execute("UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?", (amount, target["id"]))
     db.execute(
         "INSERT INTO tips (from_agent_id, to_agent_id, video_id, amount, message, created_at) "
@@ -11988,7 +12061,9 @@ def tip_agent(agent_name):
     if sender["rtc_balance"] < amount:
         return jsonify({"error": "Insufficient RTC balance", "balance": sender["rtc_balance"]}), 400
 
-    db.execute("UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?", (amount, g.agent["id"]))
+    if not debit_rtc(db, g.agent["id"], amount):
+        db.rollback()
+        return _insufficient_balance_response(db, g.agent["id"])
     db.execute("UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?", (amount, target["id"]))
     db.execute(
         "INSERT INTO tips (from_agent_id, to_agent_id, video_id, amount, message, created_at) "

--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -225,16 +225,23 @@ def _award_rtc(db, agent_id, amount, reason):
 
 
 def _debit_rtc(db, agent_id, amount):
-    """Debit RTC from an agent's balance. Returns True if sufficient funds."""
-    row = db.execute(
-        "SELECT rtc_balance FROM agents WHERE id = ?", (agent_id,)
-    ).fetchone()
-    if not row or row["rtc_balance"] < amount:
-        return False
-    db.execute(
-        "UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?",
-        (amount, agent_id),
+    """Atomically debit RTC from an agent's balance.
+
+    Returns True if the debit succeeded (sufficient funds), False otherwise.
+
+    Fixes a TOCTOU race: the previous check-then-update used two separate
+    statements, so two concurrent withdrawals could both read the same balance,
+    both pass the check, and both subtract -- overdrawing the account. The
+    comparison now lives in the UPDATE's WHERE clause, making read and write a
+    single atomic statement; ``rowcount == 0`` means the funds were not there.
+    """
+    cursor = db.execute(
+        "UPDATE agents SET rtc_balance = rtc_balance - ? "
+        "WHERE id = ? AND rtc_balance >= ?",
+        (amount, agent_id, amount),
     )
+    if cursor.rowcount == 0:
+        return False
     db.commit()
     return True
 

--- a/rtc_services.py
+++ b/rtc_services.py
@@ -255,7 +255,10 @@ def init_app(app, db_path):
         svc = SERVICE_CATALOG[service_key]
         total_cost = svc["price_rtc"] * quantity
 
-        # Check balance
+        # Fast-fail on the balance we already read. This is only a courtesy
+        # check -- `agent` was SELECTed earlier in the request, so the value is
+        # already stale by the time we get here. The guarded UPDATE below is
+        # what actually enforces the balance.
         balance = agent["rtc_balance"]
         if balance < total_cost:
             return jsonify({
@@ -272,12 +275,34 @@ def init_app(app, db_path):
         now = time.time()
         expires_at = now + svc["token_ttl_sec"]
 
-        # Atomic debit + purchase record
+        # Atomic debit + purchase record.
+        #
+        # The debit MUST carry `AND rtc_balance >= ?` in its WHERE clause. The
+        # balance check above reads a row SELECTed earlier in the request, so
+        # two concurrent purchases both pass it and both subtract -- driving the
+        # balance negative (spend-more-than-you-have). Pushing the comparison
+        # into the UPDATE makes the read and the write one atomic statement;
+        # `rowcount == 0` then means "someone else got there first" and we
+        # roll back instead of minting RTC out of nothing.
         try:
-            db.execute(
-                "UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?",
-                (total_cost, agent["id"])
+            cur = db.execute(
+                "UPDATE agents SET rtc_balance = rtc_balance - ? "
+                "WHERE id = ? AND rtc_balance >= ?",
+                (total_cost, agent["id"], total_cost)
             )
+            if cur.rowcount == 0:
+                db.rollback()
+                fresh = db.execute(
+                    "SELECT rtc_balance FROM agents WHERE id = ?", (agent["id"],)
+                ).fetchone()
+                fresh_balance = fresh["rtc_balance"] if fresh else 0
+                return jsonify({
+                    "error": "Insufficient RTC balance",
+                    "balance": fresh_balance,
+                    "cost": total_cost,
+                    "need": round(total_cost - fresh_balance, 6),
+                    "hint": "Buy RTC from miners at /otc or earn through mining",
+                }), 402
             db.execute("""INSERT INTO service_purchases
                 (agent_id, service_key, quantity, amount_rtc, token_hash,
                  status, scope_json, uses_total, uses_remaining,

--- a/tests/test_mood_write_authorization.py
+++ b/tests/test_mood_write_authorization.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests: mood writes must be authorized, not merely authenticated.
+
+``require_api_key`` proves the caller holds *a* valid key and stashes the row on
+``g.agent``. It never inspects the ``agent_name`` in the URL. The mood write
+handlers then re-resolved the target agent straight from that URL and ignored
+``g.agent`` entirely -- so any agent could register a free account and drive any
+other agent's mood (an IDOR / horizontal privilege escalation).
+
+PR #1639 closed the *anonymous* case by adding the decorator. These tests cover
+what the decorator cannot: that the authenticated caller actually owns the agent
+it is writing to.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Importing bottube_server runs module-level table bootstraps (e.g.
+# gemini_blueprint.init_gemini_tables) that fall back to the *production* DB
+# path when BOTTUBE_DB is unset. Point them at a scratch file before import so
+# this module is self-sufficient and does not depend on a writable /root.
+_BOOTSTRAP_DB = os.path.join(
+    tempfile.gettempdir(), "bottube_test_mood_write_authorization_bootstrap.db"
+)
+os.environ.setdefault("BOTTUBE_DB", _BOOTSTRAP_DB)
+os.environ.setdefault("BOTTUBE_DB_PATH", _BOOTSTRAP_DB)
+
+import bottube_server  # noqa: E402
+
+
+pytestmark = pytest.mark.skipif(
+    not bottube_server.MOOD_ENGINE_AVAILABLE,
+    reason="mood engine not importable; mood routes short-circuit to 503",
+)
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    """A test client backed by a fresh temp database."""
+    db_path = tmp_path / "bottube_mood_authz.db"
+    video_dir = tmp_path / "videos"
+    thumb_dir = tmp_path / "thumbnails"
+    avatar_dir = tmp_path / "avatars"
+    for d in (video_dir, thumb_dir, avatar_dir):
+        d.mkdir()
+
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(bottube_server, "VIDEO_DIR", video_dir, raising=False)
+    monkeypatch.setattr(bottube_server, "THUMB_DIR", thumb_dir, raising=False)
+    monkeypatch.setattr(bottube_server, "AVATAR_DIR", avatar_dir, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+
+    with bottube_server.app.app_context():
+        bottube_server.init_db()
+
+    bottube_server.app.config["TESTING"] = True
+    return bottube_server.app.test_client()
+
+
+def _register(client, name):
+    resp = client.post("/api/register", json={
+        "agent_name": name,
+        "display_name": name,
+        "bio": f"test agent {name}",
+    })
+    assert resp.status_code == 201, resp.get_json()
+    return resp.get_json()
+
+
+@pytest.fixture()
+def victim(client):
+    return _register(client, "mood_victim_bot")
+
+
+@pytest.fixture()
+def attacker(client):
+    return _register(client, "mood_attacker_bot")
+
+
+# --- the hole PR #1639 did NOT close -------------------------------------
+
+
+def test_mood_update_rejects_non_owning_key(client, victim, attacker):
+    """A valid key belonging to a *different* agent must not move my mood."""
+    resp = client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/update",
+        json={"force_state": "frustrated", "trigger_reason": "pwned"},
+        headers={"X-API-Key": attacker["api_key"]},
+    )
+    assert resp.status_code == 403, resp.get_json()
+
+
+def test_mood_signal_rejects_non_owning_key(client, victim, attacker):
+    """The signal endpoint is a write too, and needs the same ownership check."""
+    resp = client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/signal",
+        json={"signal_type": "comment_sentiment", "signal_value": -100},
+        headers={"X-API-Key": attacker["api_key"]},
+    )
+    assert resp.status_code == 403, resp.get_json()
+
+
+def test_mood_update_by_non_owner_does_not_change_state(client, victim, attacker):
+    """A rejected write must be a no-op, not a rejected-but-applied write."""
+    before = client.get(f"/api/v1/agents/{victim['agent_name']}/mood").get_json()
+
+    client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/update",
+        json={"force_state": "frustrated", "trigger_reason": "pwned"},
+        headers={"X-API-Key": attacker["api_key"]},
+    )
+
+    after = client.get(f"/api/v1/agents/{victim['agent_name']}/mood").get_json()
+    assert after.get("current_mood") == before.get("current_mood")
+
+
+# --- what must keep working ---------------------------------------------
+
+
+def test_owner_can_still_update_own_mood(client, victim):
+    """Control: the legitimate self-service path is unaffected."""
+    resp = client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/update",
+        json={"force_state": "energetic", "trigger_reason": "self-service"},
+        headers={"X-API-Key": victim["api_key"]},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+
+def test_owner_can_still_record_own_signal(client, victim):
+    """Control: the legitimate signal path is unaffected."""
+    resp = client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/signal",
+        json={"signal_type": "view_count", "signal_value": 42},
+        headers={"X-API-Key": victim["api_key"]},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+
+# --- regressions on PR #1639's own fix ----------------------------------
+
+
+def test_mood_update_still_requires_a_key(client, victim):
+    """Anonymous writes stay closed (the hole PR #1639 fixed)."""
+    resp = client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/update",
+        json={"force_state": "frustrated"},
+    )
+    assert resp.status_code == 401, resp.get_json()
+
+
+def test_mood_signal_still_requires_a_key(client, victim):
+    resp = client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/signal",
+        json={"signal_type": "view_count", "signal_value": 1},
+    )
+    assert resp.status_code == 401, resp.get_json()
+
+
+def test_unknown_agent_is_404_not_403(client, attacker):
+    """A missing target is still reported as missing for an authenticated caller."""
+    resp = client.post(
+        "/api/v1/agents/no_such_agent_at_all/mood/update",
+        json={"force_state": "playful"},
+        headers={"X-API-Key": attacker["api_key"]},
+    )
+    assert resp.status_code == 404, resp.get_json()

--- a/tests/test_rtc_debit_balance_guard.py
+++ b/tests/test_rtc_debit_balance_guard.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests: an RTC debit must never drive a balance negative.
+
+``/api/rtc/pay`` used to read the caller's balance, compare it against the
+cost, and *then* run an unguarded ``UPDATE agents SET rtc_balance =
+rtc_balance - ?``.  The comment above it said "Atomic debit + purchase record",
+but nothing about it was atomic: the read and the write were separate
+statements against separate connections, so two concurrent purchases could both
+observe the same balance, both pass the check, and both subtract -- minting
+RTC out of an overdrawn account.
+
+The fix pushes the comparison into the UPDATE (``AND rtc_balance >= ?``) and
+treats ``rowcount == 0`` as "someone else spent it first".
+
+These tests assert the *invariant* (balance never negative, RTC conserved)
+rather than any particular interleaving, so they hold no matter how the
+scheduler orders the threads.
+"""
+
+import sqlite3
+import threading
+
+import pytest
+from flask import Flask
+
+
+MONTH_PASS_COST = 60.0  # SERVICE_CATALOG["pro_api_month"]["price_rtc"]
+
+
+@pytest.fixture()
+def app(tmp_path):
+    import rtc_services
+
+    db_path = tmp_path / "rtc_debit_guard.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            api_key TEXT NOT NULL,
+            rtc_balance REAL DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE earnings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id INTEGER NOT NULL,
+            amount REAL NOT NULL,
+            reason TEXT DEFAULT '',
+            video_id TEXT DEFAULT '',
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO agents (agent_name, api_key, rtc_balance) VALUES (?, ?, ?)",
+        ("payer", "bottube_sk_payer", 0.0),
+    )
+    conn.commit()
+    conn.close()
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    rtc_services.init_app(flask_app, db_path)
+    flask_app.config["RTC_TEST_DB"] = str(db_path)
+    return flask_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _set_balance(app, amount):
+    conn = sqlite3.connect(app.config["RTC_TEST_DB"])
+    try:
+        conn.execute(
+            "UPDATE agents SET rtc_balance = ? WHERE api_key = ?",
+            (amount, "bottube_sk_payer"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _balance(app):
+    conn = sqlite3.connect(app.config["RTC_TEST_DB"])
+    try:
+        return conn.execute(
+            "SELECT rtc_balance FROM agents WHERE api_key = ?",
+            ("bottube_sk_payer",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_insufficient_balance_does_not_debit(client, app):
+    """A purchase the caller cannot afford must leave the balance untouched."""
+    _set_balance(app, MONTH_PASS_COST - 0.1)
+
+    resp = client.post(
+        "/api/rtc/pay",
+        json={"service_key": "pro_api_month", "quantity": 1},
+        headers={"X-API-Key": "bottube_sk_payer"},
+    )
+
+    assert resp.status_code == 402, resp.get_json()
+    assert _balance(app) == pytest.approx(MONTH_PASS_COST - 0.1)
+
+
+def test_exact_balance_purchase_succeeds_and_lands_on_zero(client, app):
+    """`rtc_balance >= cost` must be inclusive -- spending your last RTC works."""
+    _set_balance(app, MONTH_PASS_COST)
+
+    resp = client.post(
+        "/api/rtc/pay",
+        json={"service_key": "pro_api_month", "quantity": 1},
+        headers={"X-API-Key": "bottube_sk_payer"},
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    assert _balance(app) == pytest.approx(0.0)
+
+
+def test_concurrent_purchases_cannot_overdraw(client, app):
+    """Concurrent purchases funded for exactly ONE must not overdraw.
+
+    Before the guard, several threads could each read 60.0, each pass the
+    balance check, and each subtract 60.0 -- ending at -180.0 with four service
+    tokens issued for one payment.
+    """
+    _set_balance(app, MONTH_PASS_COST)
+
+    threads_n = 8
+    barrier = threading.Barrier(threads_n)
+    statuses = []
+    lock = threading.Lock()
+
+    def buy():
+        barrier.wait()
+        resp = client.post(
+            "/api/rtc/pay",
+            json={"service_key": "pro_api_month", "quantity": 1},
+            headers={"X-API-Key": "bottube_sk_payer"},
+        )
+        with lock:
+            statuses.append(resp.status_code)
+
+    threads = [threading.Thread(target=buy) for _ in range(threads_n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert len(statuses) == threads_n, "a worker thread did not finish"
+
+    successes = statuses.count(200)
+    final = _balance(app)
+
+    # The core invariant: money is never created.
+    assert final >= 0.0, f"balance went negative: {final} (statuses={statuses})"
+    # At most one purchase can be funded by a single pass's worth of RTC.
+    assert successes <= 1, f"{successes} purchases funded by one balance"
+    # And RTC is conserved: every success is paid for out of the balance.
+    assert final == pytest.approx(MONTH_PASS_COST - successes * MONTH_PASS_COST)
+
+
+def test_guarded_update_is_atomic_against_a_stale_read():
+    """Direct proof of the pattern: a stale pre-read cannot force an overdraw.
+
+    Two connections both read a balance of 60.0 (the classic TOCTOU window),
+    then both attempt the debit. With the guard in the WHERE clause exactly one
+    UPDATE matches a row; the loser sees ``rowcount == 0``.
+    """
+    import tempfile
+    import os
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        setup = sqlite3.connect(path)
+        setup.execute(
+            "CREATE TABLE agents (id INTEGER PRIMARY KEY, rtc_balance REAL)"
+        )
+        setup.execute("INSERT INTO agents (id, rtc_balance) VALUES (1, 60.0)")
+        setup.commit()
+        setup.close()
+
+        a = sqlite3.connect(path, timeout=5)
+        b = sqlite3.connect(path, timeout=5)
+        try:
+            # Both readers observe the same balance -- both would pass a
+            # check-then-update style gate.
+            assert a.execute("SELECT rtc_balance FROM agents WHERE id=1").fetchone()[0] == 60.0
+            assert b.execute("SELECT rtc_balance FROM agents WHERE id=1").fetchone()[0] == 60.0
+
+            cur_a = a.execute(
+                "UPDATE agents SET rtc_balance = rtc_balance - ? "
+                "WHERE id = ? AND rtc_balance >= ?",
+                (60.0, 1, 60.0),
+            )
+            a.commit()
+
+            cur_b = b.execute(
+                "UPDATE agents SET rtc_balance = rtc_balance - ? "
+                "WHERE id = ? AND rtc_balance >= ?",
+                (60.0, 1, 60.0),
+            )
+            b.commit()
+
+            assert cur_a.rowcount == 1, "first debit should win"
+            assert cur_b.rowcount == 0, "second debit must find no funded row"
+
+            final = b.execute(
+                "SELECT rtc_balance FROM agents WHERE id=1"
+            ).fetchone()[0]
+            assert final == pytest.approx(0.0)
+        finally:
+            a.close()
+            b.close()
+    finally:
+        os.unlink(path)

--- a/tests/test_tip_debit_balance_guard.py
+++ b/tests/test_tip_debit_balance_guard.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests: tipping must not mint RTC.
+
+The four tip handlers (`/api/videos/<id>/tip`, `/api/videos/<id>/web-tip`,
+`/api/agents/<name>/tip`, `/api/agents/<name>/web-tip`) each did:
+
+    sender = SELECT rtc_balance ...        # check
+    if sender["rtc_balance"] < amount: ... # decide
+    UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?   # act
+    UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?   # credit
+
+Check-then-act across separate statements is a TOCTOU race. Because the
+*recipient is credited immediately after* the sender is debited, a lost race
+does not merely overdraw one account -- it increases total RTC supply. That
+makes this a supply-integrity bug, not just an accounting one.
+
+The fix routes every spend through ``debit_rtc()``, whose comparison lives in
+the UPDATE's WHERE clause, and aborts before crediting anyone if it returns
+False.
+"""
+
+import os
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Importing bottube_server runs module-level table bootstraps that fall back to
+# the *production* DB path when BOTTUBE_DB is unset. Point them at a scratch
+# file before import so this module does not depend on a writable /root.
+_BOOTSTRAP_DB = os.path.join(
+    tempfile.gettempdir(), "bottube_test_tip_debit_guard_bootstrap.db"
+)
+os.environ.setdefault("BOTTUBE_DB", _BOOTSTRAP_DB)
+os.environ.setdefault("BOTTUBE_DB_PATH", _BOOTSTRAP_DB)
+
+import bottube_server  # noqa: E402
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_tip_guard.db"
+    video_dir = tmp_path / "videos"
+    thumb_dir = tmp_path / "thumbnails"
+    avatar_dir = tmp_path / "avatars"
+    for d in (video_dir, thumb_dir, avatar_dir):
+        d.mkdir()
+
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(bottube_server, "VIDEO_DIR", video_dir, raising=False)
+    monkeypatch.setattr(bottube_server, "THUMB_DIR", thumb_dir, raising=False)
+    monkeypatch.setattr(bottube_server, "AVATAR_DIR", avatar_dir, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+
+    with bottube_server.app.app_context():
+        bottube_server.init_db()
+
+    bottube_server.app.config["TESTING"] = True
+    return bottube_server.app.test_client()
+
+
+def _register(client, name):
+    resp = client.post("/api/register", json={
+        "agent_name": name, "display_name": name, "bio": "tip guard test",
+    })
+    assert resp.status_code == 201, resp.get_json()
+    return resp.get_json()
+
+
+@pytest.fixture()
+def scenario(client):
+    """A funded tipper, a creator, and one video owned by the creator."""
+    tipper = _register(client, "tip_guard_sender")
+    creator = _register(client, "tip_guard_creator")
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        creator_id = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?", (creator["agent_name"],)
+        ).fetchone()["id"]
+        db.execute(
+            "INSERT INTO videos (video_id, agent_id, title, description, filename, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("tipguardvid", creator_id, "Tip Guard Video", "", "tipguardvid.mp4",
+             time.time()),
+        )
+        db.commit()
+
+    return {"tipper": tipper, "creator": creator, "video_id": "tipguardvid"}
+
+
+def _balances(client, scenario):
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        rows = {
+            r["agent_name"]: r["rtc_balance"]
+            for r in db.execute(
+                "SELECT agent_name, rtc_balance FROM agents WHERE agent_name IN (?, ?)",
+                (scenario["tipper"]["agent_name"], scenario["creator"]["agent_name"]),
+            ).fetchall()
+        }
+    return rows
+
+
+def _fund(client, scenario, amount):
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        db.execute(
+            "UPDATE agents SET rtc_balance = ? WHERE agent_name = ?",
+            (amount, scenario["tipper"]["agent_name"]),
+        )
+        db.execute(
+            "UPDATE agents SET rtc_balance = 0 WHERE agent_name = ?",
+            (scenario["creator"]["agent_name"],),
+        )
+        db.commit()
+
+
+def test_tip_beyond_balance_is_rejected_and_credits_nobody(client, scenario):
+    """An unaffordable tip must not credit the creator."""
+    _fund(client, scenario, 1.0)
+
+    resp = client.post(
+        f"/api/videos/{scenario['video_id']}/tip",
+        json={"amount": 5.0},
+        headers={"X-API-Key": scenario["tipper"]["api_key"]},
+    )
+
+    assert resp.status_code == 400, resp.get_json()
+    bal = _balances(client, scenario)
+    assert bal[scenario["tipper"]["agent_name"]] == pytest.approx(1.0)
+    assert bal[scenario["creator"]["agent_name"]] == pytest.approx(0.0)
+
+
+def test_concurrent_tips_cannot_mint_rtc(client, scenario):
+    """Concurrent tips funded for ONE must not overdraw or inflate supply.
+
+    Before the guard, several threads could each read 5.0, each pass the
+    balance check, and each debit 5.0 while crediting the creator 5.0 -- the
+    sender ends negative and total supply grows.
+    """
+    tip = 5.0
+    _fund(client, scenario, tip)
+    total_before = tip
+
+    threads_n = 6
+    barrier = threading.Barrier(threads_n)
+    statuses = []
+    lock = threading.Lock()
+
+    def send_tip():
+        barrier.wait()
+        resp = client.post(
+            f"/api/videos/{scenario['video_id']}/tip",
+            json={"amount": tip},
+            headers={"X-API-Key": scenario["tipper"]["api_key"]},
+        )
+        with lock:
+            statuses.append(resp.status_code)
+
+    threads = [threading.Thread(target=send_tip) for _ in range(threads_n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert len(statuses) == threads_n, "a worker thread did not finish"
+
+    bal = _balances(client, scenario)
+    sender = bal[scenario["tipper"]["agent_name"]]
+    creator = bal[scenario["creator"]["agent_name"]]
+    successes = statuses.count(200)
+
+    # No overdraft.
+    assert sender >= 0.0, f"sender went negative: {sender} (statuses={statuses})"
+    # No minting: the two accounts together still hold what we started with.
+    assert sender + creator == pytest.approx(total_before), (
+        f"RTC supply changed: {sender} + {creator} != {total_before} "
+        f"(statuses={statuses})"
+    )
+    # One balance funds at most one tip.
+    assert successes <= 1, f"{successes} tips funded by one balance"

--- a/wrtc_bridge_blueprint.py
+++ b/wrtc_bridge_blueprint.py
@@ -463,10 +463,31 @@ def wrtc_bridge_withdraw():
         """,
         (withdrawal_id, agent["id"], agent["agent_name"], to_address, amount, WRTC_WITHDRAW_FEE, now, now),
     )
-    db.execute(
-        "UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?",
-        (total_debit, agent["id"]),
+    # Guarded debit. `balance` above came from the row read at authentication
+    # time and is already stale, so two concurrent withdrawals could both pass
+    # that check and both subtract -- queueing two payouts against one balance.
+    # The comparison lives in the UPDATE so the read and write are atomic; a
+    # rowcount of 0 rolls back the queued withdrawal row inserted just above.
+    cur = db.execute(
+        "UPDATE agents SET rtc_balance = rtc_balance - ? "
+        "WHERE id = ? AND rtc_balance >= ?",
+        (total_debit, agent["id"], total_debit),
     )
+    if cur.rowcount == 0:
+        db.rollback()
+        fresh = db.execute(
+            "SELECT rtc_balance FROM agents WHERE id = ?", (agent["id"],)
+        ).fetchone()
+        return (
+            jsonify(
+                {
+                    "error": "Insufficient RTC balance",
+                    "balance": float(fresh["rtc_balance"] or 0.0) if fresh else 0.0,
+                    "required": total_debit,
+                }
+            ),
+            400,
+        )
     db.commit()
 
     new_balance = db.execute("SELECT rtc_balance FROM agents WHERE id = ?", (agent["id"],)).fetchone()


### PR DESCRIPTION
## Summary

Two live defects found in a triage sweep and confirmed by static reading, then by executing tests that **fail on `main` and pass here**.

1. **Mood endpoints authenticate but never authorize** (IDOR / horizontal privilege escalation).
2. **An "Atomic debit" comment sitting above a non-atomic `UPDATE`** — plus every other unguarded RTC debit path in the repo.

---

## Bug 1 — Mood write endpoints: authenticated, never authorized

`require_api_key` proves the caller holds *a* valid key and stashes the row on `g.agent`. It never inspects the `agent_name` path parameter. The two mood **write** handlers then re-resolved the target agent straight from the URL and ignored `g.agent` entirely:

```python
@app.route("/api/v1/agents/<agent_name>/mood/update", methods=["POST"])
@require_api_key
def update_agent_mood(agent_name):
    agent = db.execute("SELECT id ... WHERE agent_name = ?", (agent_name,)).fetchone()
    # g.agent is never consulted
```

Any agent could self-register a free key and drive **any other agent's** mood.

**PR #1639 raised the bar from "anonymous" to "anyone with a free key".** The cross-agent hole stayed open. That is the part this PR closes.

**Fix:** a new `_authorize_mood_write()` resolves the target and requires the caller to **own it**, or to present an explicit operator admin key. Authorization is positive — "holds a valid key" is not sufficient. Applied to `/mood/update` and `/mood/signal`.

**Deliberately unchanged:** the read-only `GET /mood` and `GET /mood/history` remain public. They are reads, they back public UI, and no ownership claim is implied by them. Flagging this explicitly in case you want them gated too — that is a product call, not a security one.

---

## Bug 2 — "Atomic debit" above an unguarded UPDATE

`rtc_services.py` carried this:

```python
# Atomic debit + purchase record
db.execute("UPDATE agents SET rtc_balance = rtc_balance - ? WHERE id = ?", ...)
```

Nothing about it was atomic. The balance check was a separate `SELECT` earlier in the request. A comment asserting a property the code lacks is worse than no comment — it stops the next reader from checking.

The correct pattern already existed in this repo at `studio_blueprint.py:295`: single statement, `WHERE ... AND rtc_balance >= ?`, check `rowcount > 0`. This PR applies it everywhere it was missing.

### Why the tip handlers are the serious ones

The tip handlers **credit the recipient immediately after debiting the sender**. So a lost race does not merely overdraw one account — it **increases total RTC supply**. This is a supply-integrity bug, not just an accounting one.

### Full debit-path inventory

Every RTC debit path in the repo, with status. `agents.rtc_balance` is the only RTC balance store.

| # | File:line (pre-PR) | Path | Status before | Action |
|---|---|---|---|---|
| 1 | `rtc_services.py:275` | `/api/rtc/pay` purchase | UNGUARDED (stale pre-check) | **FIXED** |
| 2 | `studio_blueprint.py:295` | studio generate | GUARDED | none — this is the reference pattern |
| 3 | `ergo_bridge_blueprint.py:227` | `_debit_rtc`, Ergo withdrawal | UNGUARDED (TOCTOU) | **FIXED** |
| 4 | `wrtc_bridge_blueprint.py:467` | `/api/wrtc-bridge/withdraw` | UNGUARDED (stale, read at auth time) | **FIXED** |
| 5 | `base_wrtc_bridge_blueprint.py:523` | `/api/base-bridge/withdraw` | UNGUARDED (stale; cooldown narrows but does not close) | **FIXED** |
| 6 | `bottube_server.py:11743` | `POST /api/videos/<id>/tip` | UNGUARDED | **FIXED** |
| 7 | `bottube_server.py:11841` | `POST /api/videos/<id>/web-tip` | UNGUARDED | **FIXED** |
| 8 | `bottube_server.py:11933` | `POST /api/agents/<name>/web-tip` | UNGUARDED | **FIXED** |
| 9 | `bottube_server.py:12018` | `POST /api/agents/<name>/tip` | UNGUARDED | **FIXED** |
| 10 | `wrtc_bridge.py:152` | `_debit_rtc` | UNGUARDED | **NOT TOUCHED — open PR #1636 fixes this correctly.** See below. |
| 11 | `studio_blueprint.py:141` | `_refund()` platform reserve draw | UNGUARDED | **left as-is, by design** — see below |
| 12 | `forge3d_blueprint.py:112` | `_refund_once()` reserve draw | UNGUARDED | **left as-is, by design** — see below |
| 13 | `paypal_packages.py:408` | `debit_rtc_from_agent`, post-refund clawback | UNGUARDED | **left as-is, by design** — see below |

The four `bottube_server.py` tip handlers are cross-reachable: the same wallet could be raced through `/tip` and `/web-tip` simultaneously. They now share one `debit_rtc()` helper rather than four copies of the same statement.

### Overlap with PR #1636 — explicitly not duplicated

PR #1636 fixes `_debit_rtc` in **`wrtc_bridge.py`**. I verified this against the PR's actual file list rather than assuming. **This PR does not touch `wrtc_bridge.py`** — #1636 should merge on its own.

Note `ergo_bridge_blueprint.py:227` (row 3) is a near-identical twin of #1636's target but in a **different file**, untouched by that PR. It is fixed here. The two changes do not conflict.

### Three paths deliberately left unguarded

Blindly guarding these would change semantics for the worse. Calling them out rather than silently skipping them:

- **`studio_blueprint.py:141` and `forge3d_blueprint.py:112`** — these draw from the platform *refund reserve*, not a user balance. The code deliberately credits the user first and treats the reserve draw as best-effort bookkeeping ("never rolled back"), with a `LOW` warning as the intended signal. A fail-closed guard would silently stop recording what the reserve owes.
- **`paypal_packages.py:408`** — a *clawback* after a PayPal refund, not a spend. A guard here would let someone who already spent the RTC keep it after getting their money back — converting a race fix into a refund-fraud vector. A negative balance here represents genuine debt.

These are judgment calls and I would rather they be argued with than merged silently. Happy to change any of them.

**Also noted, not fixed (out of scope):** `usdc_blueprint.py` lines 451, 528, 592 debit `usdc_balances.balance_usdc` with the identical unguarded pattern. Different currency and table; flagging for a follow-up.

---

## Tests

Three new modules. Each was verified to **fail on the unfixed code**, not merely to pass on the fixed code.

| Test | Result on `main` (fix reverted) |
|---|---|
| `test_concurrent_purchases_cannot_overdraw` | **FAILS** — `balance went negative: -360.0 (statuses=[200, 200, 402, 200, 200, 200, 200, 200])` — 7 monthly passes issued against one 60 RTC balance |
| `test_concurrent_tips_cannot_mint_rtc` | **FAILS** — `sender went negative: -5.0` — creator credited 10.0 RTC from a 5.0 balance, i.e. supply minted |
| `test_mood_update_rejects_non_owning_key` | **FAILS** (200, write succeeded) |
| `test_mood_signal_rejects_non_owning_key` | **FAILS** (200, write succeeded) |
| `test_mood_update_by_non_owner_does_not_change_state` | **FAILS** |

Control tests confirm the legitimate paths still work: owners can still set their own mood and record their own signals; exact-balance purchases still succeed (`>=` is inclusive); anonymous mood writes still 401 (PR #1639's fix is not regressed); unknown agents still 404 rather than leaking existence via 403.

### Actual test output

New tests, fix applied:

```
tests/test_mood_write_authorization.py  8 passed
tests/test_rtc_debit_balance_guard.py   4 passed
tests/test_tip_debit_balance_guard.py   2 passed
tests/test_ergo_bridge_validation.py   16 passed
30 passed, 1 warning in 1.65s
```

Full suite, before vs after (`pytest tests/ -q -p no:randomly`):

```
baseline (origin/main):  150 FAILED/ERROR lines
with this PR:            150 FAILED/ERROR lines
diff of sorted failure lists: empty  -> zero regressions, zero accidental fixes
```

---

## Verified vs. NOT verified

**Verified:**
- Both bugs reproduce on `main` and are closed by this PR, via executing tests (output above).
- PR #1636 targets `wrtc_bridge.py` — checked against its file list via the GitHub API, not assumed.
- The full debit-path inventory is exhaustive for `agents.rtc_balance`: swept all 125 `rtc_balance` occurrences plus `deduct|debit|spend|withdraw|charge|escrow` across every subpackage.
- `py_compile` clean on all five changed source files.
- No new test failures against baseline (identical sorted failure lists).
- No unintended whitespace churn: `ergo_bridge_blueprint.py` is CRLF, and an earlier revision of this branch had normalized three unrelated docstrings. That was reverted; the diff is now function-only.

**NOT verified — stated plainly:**
- **`test_bounty_2161_collab_tip_split.py`, the existing test covering the collab tip split I modified, does not run in my environment.** It errors in the shared `tests/conftest.py` fixture, which hard-codes a fallback to `/root/bottube/bottube.db`. This is **pre-existing** — I confirmed byte-identical results (`1 failed, 67 passed, 5 errors`) with my changes stashed. I wrote `test_tip_debit_balance_guard.py` with a self-sufficient fixture specifically to cover that gap, but the original collab-split assertions remain unexecuted here. **Please confirm they pass in CI.**
- The 150 pre-existing suite failures are environmental (same `/root/bottube/bottube.db` fallback) and I did not investigate or fix them.
- The admin-key escape hatch in `_authorize_mood_write` reuses the existing `_require_admin()`. I did not audit `_require_admin` itself; note it still accepts `?key=` via query param for backward compat, which leaks secrets into logs. Out of scope here, worth its own issue.
- No production host was touched. Nothing deployed. Static reading plus local tests only.
- The concurrency tests assert an **invariant** (balance never negative, supply conserved) rather than a specific interleaving, so they are robust but do not *guarantee* they hit the race window on every run. They did reproduce it reliably here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
