### PR TITLE
fix: mobile header search form overlaps logo at narrow viewports (Fixes #1713) [RTCbc5271ef42713f1eb8dc27baa620faf6572a5f38]

### DIFF
--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -633,19 +633,26 @@
 
         @media (max-width: 640px) {
             .video-grid { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }
-            .header { gap: 8px; }
-            .header-left { gap: 10px; }
+            .header {
+                gap: 8px;
+                flex-wrap: wrap;
+                height: auto;
+                padding: 8px 12px;
+                row-gap: 8px;
+            }
+            .header-left { gap: 10px; order: 1; }
             .search-bar {
-                flex: 1 1 auto;
-                max-width: none;
+                order: 3;
+                flex: 0 0 100%;
+                max-width: 100%;
                 min-width: 0;
             }
             .search-bar button { padding: 8px 14px; }
-            .mobile-menu-btn { display: block; }
+            .mobile-menu-btn { display: block; order: 2; }
             .header-right {
                 display: none;
                 position: absolute;
-                top: 56px;
+                top: 100%;
                 right: 0;
                 left: 0;
                 background: var(--bg-secondary);
@@ -664,11 +671,11 @@
 
         @media (max-width: 480px) {
             .video-grid { grid-template-columns: 1fr; }
-            .header { padding: 0 8px; }
+            .header { padding: 8px; }
             .header-left { gap: 8px; }
             .logo { font-size: 18px; }
             .logo .bot-icon { font-size: 20px; }
-            .search-bar { max-width: none; }
+            .search-bar { max-width: 100%; }
 
             /* Touch-friendly buttons */
             button, .btn-primary, .btn-secondary, a.btn-api {


### PR DESCRIPTION
## Problem

Fixes #1713

At 390px viewport, the header search form is painted over the "Tube" portion of the BoTTube logo across all routes. The issue is caused by all three header items (logo, search-bar, mobile-menu-btn) being squeezed into a single flex row at narrow widths, with the logo's white-space: nowrap preventing it from shrinking.

## Fix

Convert the header to a two-row layout at ≤640px (similar to YouTube's mobile header):

1. **First row**: logo + mobile-menu-btn (flex-wrap wraps naturally)
2. **Second row**: search-bar full-width (flex: 0 0 100%, order: 3)
3. **Header dropdown**: top: 100% instead of the old top: 56px to sit below the now-variable-height header

## Testing
- Tested at 390px, 360px, 320px, 480px, 640px, and 768px breakpoints
- Mobile menu dropdown still works correctly (absolute positioned at top: 100%)
- Desktop layout unchanged (min-width: 641px)