### PR TITLE
fix(ergo): ERG deposits credit 0 RTC and burn the tx_id — earnings column is `reason`, not `source`

### DIFF
--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -212,13 +212,20 @@ def get_platform_erg_balance():
 # ---------------------------------------------------------------------------
 
 def _award_rtc(db, agent_id, amount, reason):
-    """Credit RTC to an agent's balance."""
+    """Credit RTC to an agent's balance.
+
+    The ledger column is ``earnings.reason`` (see the schema in
+    bottube_server.py and every other writer: wrtc_bridge.py,
+    paypal_packages.py, rtc_services.py). Writing ``source`` here raised
+    ``OperationalError: table earnings has no column named source`` on
+    every call, which aborted the credit.
+    """
     db.execute(
         "UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?",
         (amount, agent_id),
     )
     db.execute(
-        "INSERT INTO earnings (agent_id, amount, source, created_at) VALUES (?, ?, ?, ?)",
+        "INSERT INTO earnings (agent_id, amount, reason, created_at) VALUES (?, ?, ?, ?)",
         (agent_id, amount, reason, time.time()),
     )
     db.commit()
@@ -407,9 +414,11 @@ def ergo_deposit():
         (tx_id, result["from_address"], amount_erg, fee_erg, net_erg,
          rtc_amount, agent_id, confirmations, time.time(), time.time()),
     )
-    db.commit()
 
-    # Credit RTC
+    # Credit RTC. No commit above on purpose: the deposit row and the RTC
+    # credit have to land in the SAME transaction. Committing the
+    # 'credited' row first meant that any failure in _award_rtc left the
+    # tx_id permanently claimed (409 on every retry) with 0 RTC issued.
     _award_rtc(db, agent_id, rtc_amount, f"ergo_deposit:{tx_id[:16]}")
 
     return jsonify({

--- a/tests/test_ergo_bridge_validation.py
+++ b/tests/test_ergo_bridge_validation.py
@@ -30,7 +30,7 @@ def client(tmp_path, monkeypatch):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             agent_id INTEGER,
             amount REAL,
-            source TEXT,
+            reason TEXT,
             created_at REAL
         );
         INSERT INTO agents (agent_name, api_key, rtc_balance)

--- a/tests/test_ergo_deposit_credits_rtc.py
+++ b/tests/test_ergo_deposit_credits_rtc.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for the Ergo deposit credit path.
+
+Two bugs are covered here:
+
+1. ``_award_rtc`` inserted into ``earnings (agent_id, amount, source,
+   created_at)``. The production schema (``bottube_server.py``) declares
+   ``earnings(id, agent_id, amount, reason, video_id, created_at)`` and every
+   other writer uses ``reason``. The bad column name raised
+   ``sqlite3.OperationalError: table earnings has no column named source`` on
+   every deposit, so the RTC credit never landed.
+
+2. The ``ergo_deposits`` row was committed *before* the credit was attempted,
+   so the failure above left the tx_id permanently claimed: retrying returned
+   HTTP 409 "Transaction already claimed" while the agent had 0 RTC.
+
+These tests build the fixture with the REAL ``earnings`` schema on purpose —
+the older fixture invented a ``source`` column, which is exactly why the bug
+survived the suite.
+"""
+
+import sqlite3
+
+import pytest
+import werkzeug
+from flask import Flask, g
+
+import ergo_bridge_blueprint
+
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "test"
+
+
+API_KEY = "bottube_sk_ergo_credit"
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "ergo_credit.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            api_key TEXT NOT NULL,
+            rtc_balance REAL DEFAULT 0
+        );
+        -- Production schema, verbatim from bottube_server.py.
+        CREATE TABLE earnings (
+            id INTEGER PRIMARY KEY,
+            agent_id INTEGER NOT NULL,
+            amount REAL NOT NULL,
+            reason TEXT NOT NULL,
+            video_id TEXT DEFAULT '',
+            created_at REAL NOT NULL
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO agents (agent_name, api_key, rtc_balance) VALUES (?, ?, ?)",
+        ("ergo_agent", API_KEY, 0.0),
+    )
+    ergo_bridge_blueprint.init_ergo_tables(conn)
+    conn.commit()
+    conn.close()
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+    app.register_blueprint(ergo_bridge_blueprint.ergo_bp)
+
+    def _test_get_db():
+        if "test_db" in g:
+            return g.test_db
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        g.test_db = db
+        return db
+
+    @app.teardown_appcontext
+    def _close_db(_exc):
+        db = g.pop("test_db", None)
+        if db is not None:
+            db.close()
+
+    monkeypatch.setattr(ergo_bridge_blueprint, "get_db", _test_get_db)
+    monkeypatch.setattr(
+        ergo_bridge_blueprint,
+        "verify_ergo_tx",
+        lambda tx_id: {
+            "ok": True,
+            "amount_erg": 1.0,
+            "confirmations": 3,
+            "from_address": "9fSenderAddress",
+        },
+    )
+
+    test_client = app.test_client()
+    test_client.db_path = db_path
+    return test_client
+
+
+def _state(db_path):
+    with sqlite3.connect(str(db_path)) as db:
+        return {
+            "balance": db.execute(
+                "SELECT rtc_balance FROM agents WHERE api_key = ?", (API_KEY,)
+            ).fetchone()[0],
+            "deposits": db.execute(
+                "SELECT COUNT(*) FROM ergo_deposits"
+            ).fetchone()[0],
+            "earnings": db.execute("SELECT COUNT(*) FROM earnings").fetchone()[0],
+        }
+
+
+def test_deposit_credits_rtc_and_writes_earnings_row(client):
+    resp = client.post(
+        "/api/ergo/deposit",
+        json={"tx_id": "a" * 64},
+        headers={"X-API-Key": API_KEY},
+    )
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    body = resp.get_json()
+    assert body["ok"] is True
+
+    # 1.0 ERG - 1% fee = 0.99 ERG net, x8.0 = 7.92 RTC
+    expected_rtc = 7.92
+    assert body["rtc_credited"] == pytest.approx(expected_rtc)
+
+    state = _state(client.db_path)
+    assert state["balance"] == pytest.approx(expected_rtc)
+    assert state["deposits"] == 1
+    assert state["earnings"] == 1
+
+    with sqlite3.connect(str(client.db_path)) as db:
+        db.row_factory = sqlite3.Row
+        row = db.execute("SELECT * FROM earnings").fetchone()
+    assert row["amount"] == pytest.approx(expected_rtc)
+    assert row["reason"].startswith("ergo_deposit:")
+
+
+def test_failed_credit_does_not_burn_the_tx_id(client, monkeypatch):
+    """If the credit blows up, the deposit row must not survive.
+
+    Otherwise the tx_id is claimed forever (409) with no RTC issued.
+    """
+
+    def _boom(db, agent_id, amount, reason):
+        raise sqlite3.OperationalError("simulated credit failure")
+
+    monkeypatch.setattr(ergo_bridge_blueprint, "_award_rtc", _boom)
+
+    with pytest.raises(sqlite3.OperationalError):
+        client.post(
+            "/api/ergo/deposit",
+            json={"tx_id": "b" * 64},
+            headers={"X-API-Key": API_KEY},
+        )
+
+    state = _state(client.db_path)
+    assert state["deposits"] == 0, "deposit row committed without a credit"
+    assert state["balance"] == pytest.approx(0.0)


### PR DESCRIPTION
Fixes #1717

## The bug

`POST /api/ergo/deposit` has never been able to credit anyone. Two defects compound:

**1. Wrong column name.** `_award_rtc()` wrote `INSERT INTO earnings (agent_id, amount, source, created_at)`, but the schema in `bottube_server.py:1918` declares `earnings(id, agent_id, amount, reason, video_id, created_at)`. There is no `source` column and no migration adds one. Every other writer in the repo uses `reason` (`wrtc_bridge.py:147,520`, `paypal_packages.py:398,413`, `rtc_services.py:293`, `bottube_server.py:3300,11727,11824,11914,11999`) — `ergo_bridge_blueprint.py:221` was the only outlier. Result: `sqlite3.OperationalError: table earnings has no column named source` on every deposit, the `UPDATE agents SET rtc_balance = ...` never commits, caller gets a 500 with 0 RTC.

**2. The tx_id is burned by the failure.** The `ergo_deposits` row was committed with `status='credited'` *before* the credit was attempted. `close_db` only closes the connection, so the balance update rolls back while the `'credited'` row survives — and the dedup check at line 369 then answers every retry with `409 Transaction already claimed`. The ERG sits in the platform wallet and the deposit is unrecoverable without a manual DB edit.

## The fix

- `earnings.source` -> `earnings.reason` in `_award_rtc`.
- Dropped the intermediate `db.commit()` so the deposit row and the RTC credit land in one transaction. A failed credit now rolls the deposit row back too, leaving the tx_id retryable.

Both changes are inside the Ergo bridge only; no shared code paths touched.

## Tests

New `tests/test_ergo_deposit_credits_rtc.py`:

- `test_deposit_credits_rtc_and_writes_earnings_row` — 1.0 ERG - 1% fee, x8.0 rate -> 7.92 RTC credited, `earnings.reason` row written.
- `test_failed_credit_does_not_burn_the_tx_id` — when the credit raises, no `ergo_deposits` row is left behind.

Both **fail on `main`**:

```
FAILED tests/test_ergo_deposit_credits_rtc.py::test_deposit_credits_rtc_and_writes_earnings_row
FAILED tests/test_ergo_deposit_credits_rtc.py::test_failed_credit_does_not_burn_the_tx_id
E       AssertionError: deposit row committed without a credit
2 failed
```

and pass with this patch, along with the existing Ergo suite:

```
$ python3 -m pytest tests/test_ergo_deposit_credits_rtc.py tests/test_ergo_bridge_validation.py tests/test_ergo_bridge_registration.py -q
19 passed
```

The fixture in these new tests uses the **production** `earnings` schema on purpose. `tests/test_ergo_bridge_validation.py` had invented a `source` column in its own fixture, which is precisely why the suite agreed with the buggy code; that fixture is now aligned with `bottube_server.py`.

---

/claim #1102 — functional bug (5 RTC).
RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
