### PR TITLE
fix(usdc): all five authenticated /api/usdc/* endpoints 500 — column is `agents.agent_name`, not `name`

### DIFF
--- a/tests/test_usdc_amount_validation.py
+++ b/tests/test_usdc_amount_validation.py
@@ -32,13 +32,18 @@ def usdc_client(tmp_path):
             db.close()
 
     with sqlite3.connect(db_path) as db:
+        # Mirror the production agents schema (bottube_server.py): the
+        # identity column is agent_name, not name.
         db.execute(
-            "CREATE TABLE agents (name TEXT PRIMARY KEY, api_key TEXT UNIQUE NOT NULL)"
+            "CREATE TABLE agents ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "agent_name TEXT UNIQUE NOT NULL, "
+            "api_key TEXT UNIQUE NOT NULL)"
         )
         usdc_blueprint.init_usdc_tables(db)
         now = time.time()
         db.executemany(
-            "INSERT INTO agents (name, api_key) VALUES (?, ?)",
+            "INSERT INTO agents (agent_name, api_key) VALUES (?, ?)",
             [("alice", "key-alice"), ("bob", "key-bob")],
         )
         db.execute(

--- a/tests/test_usdc_schema_columns.py
+++ b/tests/test_usdc_schema_columns.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests: the USDC blueprint must query the real column names.
+
+Two queries referenced columns that do not exist in production
+(see the schema in ``bottube_server.py``):
+
+* ``SELECT name FROM agents`` — the identity column is ``agent_name``.
+  ``get_authenticated_agent()`` is the front door for /deposit, /balance,
+  /tip, /premium and /payout, so every authenticated USDC call raised
+  ``sqlite3.OperationalError: no such column: name`` -> HTTP 500.
+* ``SELECT agent FROM videos WHERE id = ?`` — ``videos`` has ``agent_id``
+  (int FK) and ``video_id`` (the public string); ``id`` is the integer PK,
+  so tipping by ``video_id`` could never resolve a creator.
+
+The fixture below uses the production schema on purpose: the pre-existing
+USDC fixture declared ``agents(name TEXT PRIMARY KEY)``, which is why the
+suite agreed with the broken queries.
+"""
+
+import sqlite3
+import time
+from importlib import metadata
+
+import pytest
+import werkzeug
+from flask import Flask, g
+
+import usdc_blueprint
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = metadata.version("werkzeug")
+
+
+@pytest.fixture
+def usdc_client(tmp_path):
+    db_path = tmp_path / "bottube.db"
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(usdc_blueprint.usdc_bp)
+
+    @app.before_request
+    def _open_db():
+        g.db = sqlite3.connect(db_path)
+        g.db.row_factory = sqlite3.Row
+
+    @app.teardown_request
+    def _close_db(_exc):
+        db = getattr(g, "db", None)
+        if db is not None:
+            db.close()
+
+    now = time.time()
+    with sqlite3.connect(db_path) as db:
+        db.executescript(
+            """
+            CREATE TABLE agents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_name TEXT UNIQUE NOT NULL,
+                api_key TEXT UNIQUE NOT NULL,
+                eth_address TEXT DEFAULT ''
+            );
+            CREATE TABLE videos (
+                id INTEGER PRIMARY KEY,
+                video_id TEXT UNIQUE NOT NULL,
+                agent_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                created_at REAL NOT NULL
+            );
+            """
+        )
+        usdc_blueprint.init_usdc_tables(db)
+        db.executemany(
+            "INSERT INTO agents (agent_name, api_key) VALUES (?, ?)",
+            [("alice", "key-alice"), ("bob", "key-bob")],
+        )
+        db.execute(
+            "INSERT INTO videos (video_id, agent_id, title, created_at) "
+            "VALUES (?, (SELECT id FROM agents WHERE agent_name = 'bob'), ?, ?)",
+            ("vid_bob_1", "Bob's clip", now),
+        )
+        db.execute(
+            """
+            INSERT INTO usdc_balances
+            (agent_name, balance_usdc, total_deposited, total_spent, total_earned, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("alice", 10.0, 10.0, 0.0, 0.0, now),
+        )
+        db.commit()
+
+    client = app.test_client()
+    client.db_path = db_path
+    return client
+
+
+def _balance(db_path, agent_name):
+    with sqlite3.connect(db_path) as db:
+        db.row_factory = sqlite3.Row
+        return db.execute(
+            "SELECT balance_usdc, total_spent, total_earned FROM usdc_balances "
+            "WHERE agent_name = ?",
+            (agent_name,),
+        ).fetchone()
+
+
+def test_balance_endpoint_authenticates_against_agent_name(usdc_client):
+    """Smoke test for get_authenticated_agent(): used to be a hard 500."""
+    response = usdc_client.get(
+        "/api/usdc/balance", headers={"X-API-Key": "key-alice"}
+    )
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    body = response.get_json()
+    assert body["agent"] == "alice"
+    assert body["balance_usdc"] == pytest.approx(10.0)
+
+
+def test_unknown_api_key_is_401_not_500(usdc_client):
+    response = usdc_client.get(
+        "/api/usdc/balance", headers={"X-API-Key": "key-nobody"}
+    )
+
+    assert response.status_code == 401
+
+
+def test_tip_resolves_creator_from_public_video_id(usdc_client):
+    response = usdc_client.post(
+        "/api/usdc/tip",
+        json={"video_id": "vid_bob_1", "amount_usdc": 1.0},
+        headers={"X-API-Key": "key-alice"},
+    )
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    body = response.get_json()
+    assert body["tip"]["to"] == "bob"
+    assert body["tip"]["video_id"] == "vid_bob_1"
+
+    alice = _balance(usdc_client.db_path, "alice")
+    bob = _balance(usdc_client.db_path, "bob")
+    assert alice["balance_usdc"] == pytest.approx(9.0)
+    assert alice["total_spent"] == pytest.approx(1.0)
+    assert bob["total_earned"] > 0
+
+
+def test_tip_for_unknown_video_id_is_404_not_500(usdc_client):
+    response = usdc_client.post(
+        "/api/usdc/tip",
+        json={"video_id": "vid_missing", "amount_usdc": 1.0},
+        headers={"X-API-Key": "key-alice"},
+    )
+
+    assert response.status_code == 404
+    assert _balance(usdc_client.db_path, "alice")["balance_usdc"] == pytest.approx(10.0)

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -239,8 +239,13 @@ def get_authenticated_agent():
     if not api_key:
         return None
     db = get_db()
-    agent = db.execute("SELECT name FROM agents WHERE api_key = ?", (api_key,)).fetchone()
-    return agent["name"] if agent else None
+    # The column is agents.agent_name; there is no agents.name (see the
+    # schema in bottube_server.py). "SELECT name" raised
+    # OperationalError: no such column: name on every authenticated call.
+    agent = db.execute(
+        "SELECT agent_name FROM agents WHERE api_key = ?", (api_key,)
+    ).fetchone()
+    return agent["agent_name"] if agent else None
 
 
 # ─── Endpoints ────────────────────────────────────────────────
@@ -425,7 +430,13 @@ def usdc_tip():
 
     # Resolve creator from video if needed
     if video_id and not to_agent:
-        video = db.execute("SELECT agent FROM videos WHERE id = ?", (video_id,)).fetchone()
+        # videos has no "agent" column, and "id" is the integer primary key
+        # while the public identifier callers pass is videos.video_id.
+        video = db.execute(
+            "SELECT a.agent_name AS agent FROM videos v "
+            "JOIN agents a ON a.id = v.agent_id WHERE v.video_id = ?",
+            (video_id,),
+        ).fetchone()
         if not video:
             return jsonify({"error": "Video not found"}), 404
         to_agent = video["agent"]


### PR DESCRIPTION
Fixes #1719

## The bug

**1. Auth helper selects a non-existent column.** `get_authenticated_agent()` ran `SELECT name FROM agents WHERE api_key = ?`. Production `agents` (`bottube_server.py:1814`) is `(id, agent_name, display_name, api_key, ...)` — no `name`, and no migration adds one. Result: `sqlite3.OperationalError: no such column: name` on every call.

That helper is the front door for **five** endpoints — `/api/usdc/deposit`, `/balance`, `/tip`, `/premium`, `/payout` — so all of them returned HTTP 500 to any caller holding a valid API key. Notably `/api/usdc/deposit` is what credits a settled on-chain treasury transfer, so a user who has already sent USDC had no path to their balance.

**2. Tip-by-video_id could never resolve a creator.** `usdc_tip()` ran `SELECT agent FROM videos WHERE id = ?`. `videos` has `agent_id` (int FK) and `video_id` (the public string callers pass); `id` is the integer PK. Two errors in one line — wrong column, wrong key — and it sits on the happy path, after amount validation.

## The fix

```diff
-    agent = db.execute("SELECT name FROM agents WHERE api_key = ?", (api_key,)).fetchone()
-    return agent["name"] if agent else None
+    agent = db.execute(
+        "SELECT agent_name FROM agents WHERE api_key = ?", (api_key,)
+    ).fetchone()
+    return agent["agent_name"] if agent else None
```

```diff
-        video = db.execute("SELECT agent FROM videos WHERE id = ?", (video_id,)).fetchone()
+        video = db.execute(
+            "SELECT a.agent_name AS agent FROM videos v "
+            "JOIN agents a ON a.id = v.agent_id WHERE v.video_id = ?",
+            (video_id,),
+        ).fetchone()
```

Scoped to `usdc_blueprint.py`; no shared code paths touched.

## Tests

New `tests/test_usdc_schema_columns.py`, fixture built on the **production** schema:

- `test_balance_endpoint_authenticates_against_agent_name` — `/api/usdc/balance` returns 200 with the right agent.
- `test_unknown_api_key_is_401_not_500` — bad key is a clean 401.
- `test_tip_resolves_creator_from_public_video_id` — alice tips bob's `video_id`, balances move 10.0 -> 9.0 and bob's `total_earned` rises.
- `test_tip_for_unknown_video_id_is_404_not_500` — unknown video is 404 with no debit.

All four **fail on `main`** (`usdc_blueprint.py:242: OperationalError`), all pass here.

`tests/test_usdc_amount_validation.py` declared `agents(name TEXT PRIMARY KEY)` in its own fixture — a schema that exists nowhere in production, and the reason the suite endorsed the broken query. Realigned with `bottube_server.py`; the whole USDC suite still passes:

```
$ python3 -m pytest tests/test_usdc_schema_columns.py tests/test_usdc_amount_validation.py tests/test_usdc_deposit_sender_binding.py -q
28 passed
```

---

/claim #1102 — functional bug (5 RTC).
RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
