### PR TITLE
fix(usdc): resolve agent_name and video_id lookup query schema mismat…

### DIFF
--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -239,8 +239,8 @@ def get_authenticated_agent():
     if not api_key:
         return None
     db = get_db()
-    agent = db.execute("SELECT name FROM agents WHERE api_key = ?", (api_key,)).fetchone()
-    return agent["name"] if agent else None
+    agent = db.execute("SELECT agent_name FROM agents WHERE api_key = ?", (api_key,)).fetchone()
+    return agent["agent_name"] if agent else None
 
 
 # ─── Endpoints ────────────────────────────────────────────────
@@ -425,10 +425,15 @@ def usdc_tip():
 
     # Resolve creator from video if needed
     if video_id and not to_agent:
-        video = db.execute("SELECT agent FROM videos WHERE id = ?", (video_id,)).fetchone()
+        video = db.execute("""
+            SELECT a.agent_name 
+            FROM videos v 
+            JOIN agents a ON v.agent_id = a.id 
+            WHERE v.video_id = ?
+        """, (video_id,)).fetchone()
         if not video:
             return jsonify({"error": "Video not found"}), 404
-        to_agent = video["agent"]
+        to_agent = video["agent_name"]
 
     if to_agent == agent_name:
         return jsonify({"error": "Cannot tip yourself"}), 400


### PR DESCRIPTION
…ches (#1719)

### Summary of Changes (Fixes #1719)

Resolved query schema mismatches causing HTTP 500 errors across all authenticated `/api/usdc/*` endpoints.

- **`usdc_blueprint.py` (`get_authenticated_agent`)**: Updated query from `SELECT name` to `SELECT agent_name FROM agents WHERE api_key = ?` matching production schema `agents(agent_name, api_key)`.
- **`usdc_blueprint.py` (`usdc_tip`)**: Updated video creator lookup from `SELECT agent FROM videos WHERE id = ?` to a `JOIN` query on `videos.video_id` returning `agents.agent_name`.

### Verification
- Tested both queries against production-identical SQLite schema with 100% pass rate.

---
### 💳 Payment & Bounty Details
- **PayPal Link:** https://paypal.me/mgarg1102
