### PR TITLE
fix(syndication): backfill crashes on `agents.username` and queues the integer PK instead of `video_id`

### DIFF
--- a/syndication_backfill.py
+++ b/syndication_backfill.py
@@ -18,12 +18,16 @@ print(f"Already queued: {len(already)}")
 
 queued = 0
 for v in videos:
-    vid = str(v["id"])
+    # syndication_queue.video_id holds the PUBLIC video_id string (that is what
+    # syndication_poller enqueues and what the adapters resolve). Using the
+    # integer primary key here made the dedup check above never match, so every
+    # run re-queued the whole catalogue under an id downstream cannot resolve.
+    vid = v["video_id"]
     if vid in already:
         continue
-    # Get agent name from agents table
-    agent = conn.execute("SELECT username FROM agents WHERE id=?", (v["agent_id"],)).fetchone()
-    agent_name = agent["username"] if agent else "unknown"
+    # Get agent name from agents table (the column is agent_name, not username)
+    agent = conn.execute("SELECT agent_name FROM agents WHERE id=?", (v["agent_id"],)).fetchone()
+    agent_name = agent["agent_name"] if agent else "unknown"
     
     conn.execute("""
         INSERT INTO syndication_queue 

--- a/tests/test_syndication_backfill_identifiers.py
+++ b/tests/test_syndication_backfill_identifiers.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for syndication_backfill.py.
+
+The backfill script had two identifier bugs, both fatal to its only job:
+
+1. ``SELECT username FROM agents`` — the column is ``agent_name``. The very
+   first video raised ``sqlite3.OperationalError: no such column: username``,
+   so the script died before queueing anything.
+
+2. ``vid = str(v["id"])`` — it queued the integer primary key, while
+   ``syndication_queue.video_id`` holds the public ``video_id`` string
+   (that is what ``syndication_poller`` enqueues and what the adapters
+   resolve). Two consequences: the "already queued" check never matched, so
+   every run re-queued the entire catalogue, and the rows it wrote carried an
+   id downstream could not resolve.
+
+The script is top-level code driven by ``BOTTUBE_DB_PATH``, so it is exercised
+here as a subprocess against a temp DB built from the production schema.
+"""
+
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "syndication_backfill.py"
+
+
+def _schema(name, source):
+    m = re.search(
+        r"CREATE TABLE IF NOT EXISTS %s \(.*?\n\s*\);" % name, source, re.S
+    )
+    assert m, f"schema for {name} not found"
+    return m.group(0)
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    server = (ROOT / "bottube_server.py").read_text(encoding="utf-8", errors="replace")
+    queue = (ROOT / "syndication_queue.py").read_text(encoding="utf-8", errors="replace")
+
+    path = tmp_path / "bottube.db"
+    conn = sqlite3.connect(str(path))
+    conn.executescript(_schema("agents", server))
+    conn.executescript(_schema("videos", server))
+    # is_removed arrives via ALTER TABLE in the server's migration block
+    conn.execute("ALTER TABLE videos ADD COLUMN is_removed INTEGER DEFAULT 0")
+    conn.executescript(_schema("syndication_queue", queue))
+
+    now = time.time()
+    conn.execute(
+        "INSERT INTO agents (id, agent_name, api_key, created_at) VALUES (1, 'alice', 'K', ?)",
+        (now,),
+    )
+    conn.execute(
+        "INSERT INTO videos (id, video_id, agent_id, title, filename, created_at) "
+        "VALUES (7, 'vid_abc', 1, 'Clip', 'f.mp4', ?)",
+        (now,),
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _run(db_path):
+    env = dict(os.environ, BOTTUBE_DB_PATH=str(db_path))
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)], env=env, capture_output=True, text=True
+    )
+
+
+def _queue_rows(db_path):
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT video_id, agent_name, video_title FROM syndication_queue"
+    ).fetchall()
+    conn.close()
+    return rows
+
+
+def test_backfill_queues_public_video_id_and_agent_name(db_path):
+    result = _run(db_path)
+
+    assert result.returncode == 0, result.stderr
+    rows = _queue_rows(db_path)
+    assert len(rows) == 1
+    # the public string id, not the integer primary key
+    assert rows[0]["video_id"] == "vid_abc"
+    assert rows[0]["agent_name"] == "alice"
+
+
+def test_backfill_is_idempotent(db_path):
+    """A second run must queue nothing — the dedup check has to actually match."""
+    assert _run(db_path).returncode == 0
+    assert len(_queue_rows(db_path)) == 1
+
+    second = _run(db_path)
+    assert second.returncode == 0, second.stderr
+    assert len(_queue_rows(db_path)) == 1, "re-queued a video that was already queued"
+    assert "Queued 0 new videos" in second.stdout
+
+
+def test_backfill_survives_missing_agent(db_path):
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("DELETE FROM agents WHERE id = 1")
+    conn.commit()
+    conn.close()
+
+    result = _run(db_path)
+
+    assert result.returncode == 0, result.stderr
+    rows = _queue_rows(db_path)
+    assert len(rows) == 1
+    assert rows[0]["agent_name"] == "unknown"


### PR DESCRIPTION
Fixes #1722

## The bug

`syndication_backfill.py` is 39 lines whose only job is to queue existing videos for Moltbook syndication. It has two identifier bugs and either one alone is fatal.

**1. `SELECT username FROM agents`** — the column is `agent_name` (`bottube_server.py:1814`); there is no `username` column and no migration adds one. The first video raises `sqlite3.OperationalError: no such column: username` and the script dies having queued nothing.

**2. `vid = str(v["id"])`** — that's the integer primary key, but `syndication_queue.video_id` holds the public `video_id` string: `syndication_poller.py:293` enqueues `v.get("video_id")` from `/api/feed`, and the adapters resolve that value (`syndication_adapter.py:187/323/418`). So even with bug 1 fixed, the dedup check on lines 16-22 compares `"7"` against `"vid_abc"` and never matches — **every run re-queues the whole catalogue** — and the rows written carry an id downstream cannot resolve.

## The fix

```diff
-    vid = str(v["id"])
+    vid = v["video_id"]
     if vid in already:
         continue
-    agent = conn.execute("SELECT username FROM agents WHERE id=?", (v["agent_id"],)).fetchone()
-    agent_name = agent["username"] if agent else "unknown"
+    agent = conn.execute("SELECT agent_name FROM agents WHERE id=?", (v["agent_id"],)).fetchone()
+    agent_name = agent["agent_name"] if agent else "unknown"
```

Scoped to this script; nothing else imports it.

## Tests

New `tests/test_syndication_backfill_identifiers.py`. The script is top-level code driven by `BOTTUBE_DB_PATH`, so the tests run it as a subprocess against a temp DB built from the **production** schema (pulled out of `bottube_server.py` / `syndication_queue.py` at test time, so it can't drift from the real thing):

- `test_backfill_queues_public_video_id_and_agent_name` — one row, `video_id == "vid_abc"`, `agent_name == "alice"`.
- `test_backfill_is_idempotent` — a second run queues nothing and prints `Queued 0 new videos`. This is the one that pins bug 2.
- `test_backfill_survives_missing_agent` — the `"unknown"` fallback still works.

All three **fail on `main`**:

```
FAILED tests/test_syndication_backfill_identifiers.py::test_backfill_queues_public_video_id_and_agent_name
FAILED tests/test_syndication_backfill_identifiers.py::test_backfill_is_idempotent
FAILED tests/test_syndication_backfill_identifiers.py::test_backfill_survives_missing_agent
3 failed
```

and pass with this patch (`3 passed`).

---

Not claiming this one against #1102 — I've already submitted two items there today (#1717, #1719) and the spec says `cap: 2`. Filing it because the script is dead as written, not to pad the count.