### PR TITLE
fix(bridge): /bridge renders an empty contract address — stub route shadows wrtc_bridge_landing()

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13319,16 +13319,6 @@ def api_redirect():
     return redirect(url_for("docs_page"))
 
 
-@app.route("/bridge")
-def bridge_page():
-    """wRTC bridge landing page with safe defaults for unauthenticated users."""
-    return render_template("bridge.html",
-        user_balance=0.0,
-        swap_url="https://jup.ag/",
-        reserve_wallet="Not connected — log in to view",
-        user_sol_address="")
-
-
 @app.route("/docs")
 def docs_page():
     """API documentation page."""

--- a/tests/test_bridge_route_not_shadowed.py
+++ b/tests/test_bridge_route_not_shadowed.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+"""Regression test: /bridge must be served by the wRTC blueprint, not a stub.
+
+`bottube_server.py` used to declare its own `@app.route("/bridge")` returning
+`bridge.html` with hardcoded placeholders (balance 0.0, reserve wallet
+"Not connected — log in to view", no `wrtc_mint` at all). Because that
+module-level decorator runs on import — thousands of lines before
+`app.register_blueprint(wrtc_bp)` — it won the URL match, and
+`wrtc_bridge_blueprint.wrtc_bridge_landing()`, the handler that actually
+passes the mint, the reserve wallet and the logged-in user's balance, was
+unreachable.
+
+The visible damage: `bridge.html` interpolates `wrtc_mint` five times, so the
+contract address rendered blank, the Copy button copied an empty string, and
+the Solscan / Birdeye / GeckoTerminal links degraded to bare
+`https://solscan.io/token/` URLs.
+"""
+
+import pytest
+
+import wrtc_bridge_blueprint
+
+
+def _bridge_endpoints(app):
+    return sorted(
+        r.endpoint for r in app.url_map.iter_rules() if str(r) == "/bridge"
+    )
+
+
+def test_bridge_is_served_only_by_the_wrtc_blueprint(app):
+    assert _bridge_endpoints(app) == ["wrtc_bridge.wrtc_bridge_landing"]
+
+
+def test_bridge_page_renders_the_contract_address_block(client):
+    """The copy-to-clipboard contract address must not be empty.
+
+    Note the mint also appears once as a hardcoded Raydium swap link, so a
+    bare `WRTC_MINT in html` check passes even with the stub -- assert on the
+    interpolated block instead.
+    """
+    response = client.get("/bridge")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+
+    assert f'class="addr">{wrtc_bridge_blueprint.WRTC_MINT}</span>' in html
+    assert 'class="addr"></span>' not in html
+    assert "copyText('', this)" not in html
+
+
+def test_bridge_explorer_links_are_not_truncated(client):
+    """A blank wrtc_mint silently produced links pointing at nothing."""
+    html = client.get("/bridge").get_data(as_text=True)
+
+    for broken in (
+        'href="https://solscan.io/token/"',
+        'href="https://birdeye.so/token/?chain=solana"',
+        'href="https://www.geckoterminal.com/solana/tokens/"',
+    ):
+        assert broken not in html, f"explorer link rendered without a mint: {broken}"


### PR DESCRIPTION
Fixes #1724

## The bug

Two handlers register `/bridge`:

| | |
|---|---|
| `bottube_server.py:13322` `bridge_page()` | hardcoded placeholders — `user_balance=0.0`, `reserve_wallet="Not connected — log in to view"`, `swap_url="https://jup.ag/"`, **no `wrtc_mint`** |
| `wrtc_bridge_blueprint.py:570` `wrtc_bridge_landing()` | the real one — mint, reserve wallet, buy URL, the logged-in user's balance and SOL address |

The `@app.route` decorator runs on import, ~2,100 lines before `app.register_blueprint(wrtc_bp)` at line 15486, so the stub is added to the URL map first and wins. `wrtc_bridge_landing()` has been dead code.

`bottube_templates/bridge.html` interpolates `wrtc_mint` five times (351, 352, 434, 435, 436) and Jinja isn't in strict-undefined mode, so the missing variable renders as `""` — no error, just a page with no contract address:

- `<span class="addr"></span>` — nothing to read
- `copyText('', this)` — Copy button puts an empty string on the clipboard
- `https://solscan.io/token/`, `https://birdeye.so/token/?chain=solana`, `https://www.geckoterminal.com/solana/tokens/` — three explorer links pointing at no token

## The fix

Remove the stub. Nothing references the `bridge_page` endpoint — no `url_for("bridge_page")` anywhere in the tree, no template links to it — so deleting it hands `/bridge` to the blueprint handler with no other change. Ten lines out, nothing else touched.

## Tests

New `tests/test_bridge_route_not_shadowed.py`, on the full app fixture:

- `test_bridge_is_served_only_by_the_wrtc_blueprint` — exactly one endpoint owns `/bridge`, and it's `wrtc_bridge.wrtc_bridge_landing`.
- `test_bridge_page_renders_the_contract_address_block` — `class="addr">{mint}</span>` is present, and neither `class="addr"></span>` nor `copyText('', this)` is.
- `test_bridge_explorer_links_are_not_truncated` — no bare `solscan.io/token/` / `birdeye.so/token/?chain=solana` / `geckoterminal.com/solana/tokens/`.

All three **fail on `main`**, all three pass here. Related suites still green:

```
$ python3 -m pytest tests/test_bridge_template_accessibility.py tests/test_wrtc_bridge_validation.py     tests/test_accessibility.py tests/test_channel_alias_route.py tests/test_bridge_route_not_shadowed.py -q
56 passed, 10 subtests passed
```

⚠️ One trap worth flagging for review: the mint string is *also* hardcoded once in a Raydium swap link (`bridge.html:681`), so a plain `WRTC_MINT in html` assertion passes even with the stub in place. My first draft of the test did exactly that and gave a false green — it now asserts on the interpolated block instead.

---

/claim #1102 — functional bug (5 RTC).
RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`