### PR TITLE
fix(whisper): /api/transcript/backfill is documented admin-only but anyone can call it; cap batch_size

### DIFF
--- a/tests/test_whisper_transcription.py
+++ b/tests/test_whisper_transcription.py
@@ -380,6 +380,20 @@ def flask_client(tmp_db, monkeypatch, tmp_path):
     return app.test_client()
 
 
+@pytest.fixture()
+def admin_client(flask_client, monkeypatch):
+    """flask_client with the admin gate satisfied.
+
+    /api/transcript/backfill is admin-only. These body-validation tests are
+    about parsing, not authorisation, so the gate is stubbed out here; the
+    gate itself is covered by test_backfill_requires_admin* below.
+    """
+    import whisper_transcription_blueprint as wtb
+
+    monkeypatch.setattr(wtb, "_require_admin", lambda: None)
+    return flask_client
+
+
 def test_get_transcript_not_found(flask_client):
     resp = flask_client.get("/api/videos/nonexistent/transcript")
     assert resp.status_code == 404
@@ -542,15 +556,15 @@ def test_search_endpoint_no_query(flask_client):
     assert resp.status_code == 400
 
 
-def test_backfill_rejects_non_object_json(flask_client):
-    resp = flask_client.post("/api/transcript/backfill", json=["not", "an", "object"])
+def test_backfill_rejects_non_object_json(admin_client):
+    resp = admin_client.post("/api/transcript/backfill", json=["not", "an", "object"])
 
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "JSON object required"
 
 
-def test_backfill_rejects_invalid_batch_size(flask_client):
-    resp = flask_client.post("/api/transcript/backfill", json={"batch_size": "not-an-int"})
+def test_backfill_rejects_invalid_batch_size(admin_client):
+    resp = admin_client.post("/api/transcript/backfill", json={"batch_size": "not-an-int"})
 
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "batch_size must be a positive integer"
@@ -558,7 +572,7 @@ def test_backfill_rejects_invalid_batch_size(flask_client):
 
 @pytest.mark.parametrize("batch_size", [0, -1, True, 1.5, float("inf")])
 def test_backfill_rejects_non_positive_or_non_integer_batch_size(
-    flask_client,
+    admin_client,
     monkeypatch,
     batch_size,
 ):
@@ -569,7 +583,7 @@ def test_backfill_rejects_non_positive_or_non_integer_batch_size(
 
     monkeypatch.setattr(wtb.wt, "backfill_existing_videos", fail_backfill)
 
-    resp = flask_client.post("/api/transcript/backfill", json={"batch_size": batch_size})
+    resp = admin_client.post("/api/transcript/backfill", json={"batch_size": batch_size})
 
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "batch_size must be a positive integer"
@@ -578,3 +592,78 @@ def test_backfill_rejects_non_positive_or_non_integer_batch_size(
 def test_trigger_transcription_video_not_found(flask_client):
     resp = flask_client.post("/api/videos/nosuchvid/transcript/trigger", json={})
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /api/transcript/backfill is admin-only
+# ---------------------------------------------------------------------------
+
+def test_backfill_requires_admin(flask_client, monkeypatch):
+    """An anonymous POST must not be able to start the Whisper worker."""
+    import whisper_transcription_blueprint as wtb
+
+    def fail_backfill(**_kwargs):
+        raise AssertionError("anonymous caller reached backfill_existing_videos")
+
+    monkeypatch.setattr(wtb.wt, "backfill_existing_videos", fail_backfill)
+
+    resp = flask_client.post("/api/transcript/backfill", json={})
+
+    assert resp.status_code == 403
+    assert resp.get_json()["error"] == "Forbidden"
+
+
+def test_backfill_fails_closed_without_admin_key(flask_client, monkeypatch):
+    """A bogus admin key is rejected too, not just a missing one."""
+    import whisper_transcription_blueprint as wtb
+
+    def fail_backfill(**_kwargs):
+        raise AssertionError("bogus admin key reached backfill_existing_videos")
+
+    monkeypatch.setattr(wtb.wt, "backfill_existing_videos", fail_backfill)
+
+    resp = flask_client.post(
+        "/api/transcript/backfill",
+        json={},
+        headers={"X-Admin-Key": "definitely-not-the-key"},
+    )
+
+    assert resp.status_code == 403
+
+
+def test_backfill_caps_batch_size(admin_client, monkeypatch):
+    """One request must not be able to queue the entire library."""
+    import whisper_transcription_blueprint as wtb
+
+    def fail_backfill(**_kwargs):
+        raise AssertionError("oversized batch_size should not enqueue work")
+
+    monkeypatch.setattr(wtb.wt, "backfill_existing_videos", fail_backfill)
+
+    resp = admin_client.post(
+        "/api/transcript/backfill", json={"batch_size": 10_000_000}
+    )
+
+    assert resp.status_code == 400
+    assert "batch_size" in resp.get_json()["error"]
+
+
+def test_backfill_allows_batch_size_at_the_cap(admin_client, monkeypatch):
+    import whisper_transcription_blueprint as wtb
+
+    seen = {}
+
+    def record(**kwargs):
+        seen.update(kwargs)
+        return 3
+
+    monkeypatch.setattr(wtb.wt, "backfill_existing_videos", record)
+
+    resp = admin_client.post(
+        "/api/transcript/backfill",
+        json={"batch_size": wtb._BACKFILL_BATCH_MAX},
+    )
+
+    assert resp.status_code == 200
+    assert seen["batch_size"] == wtb._BACKFILL_BATCH_MAX
+    assert resp.get_json()["enqueued"] == 3

--- a/whisper_transcription_blueprint.py
+++ b/whisper_transcription_blueprint.py
@@ -24,6 +24,10 @@ import whisper_transcription as wt
 
 log = logging.getLogger("bottube.whisper_transcription_blueprint")
 
+# Upper bound for a single backfill call, so one request cannot queue the
+# entire library at once.
+_BACKFILL_BATCH_MAX = 500
+
 whisper_bp = Blueprint("whisper_transcription", __name__)
 
 
@@ -41,8 +45,11 @@ def _request_json_object():
     return data, None
 
 
-def _parse_positive_int(data, field_name: str, default: int):
+def _parse_positive_int(data, field_name: str, default: int,
+                        max_value: Optional[int] = None):
     """Parse positive integer fields from JSON request bodies."""
+    if max_value is not None:
+        assert default <= max_value
     value = data.get(field_name, default)
     if isinstance(value, bool):
         return None, (
@@ -73,6 +80,11 @@ def _parse_positive_int(data, field_name: str, default: int):
     if parsed < 1:
         return None, (
             jsonify({"error": f"{field_name} must be a positive integer"}),
+            400,
+        )
+    if max_value is not None and parsed > max_value:
+        return None, (
+            jsonify({"error": f"{field_name} must be <= {max_value}"}),
             400,
         )
     return parsed, None
@@ -109,6 +121,24 @@ def _parse_positive_int_arg(field_name: str, default: int, max_value: Optional[i
             400,
         )
     return parsed, None
+
+
+def _require_admin():
+    """Gate an admin-only endpoint using the main server's admin check.
+
+    Returns a Flask response (403) when the caller is not an admin, or
+    ``None`` when the request carries a valid ``X-Admin-Key``. Delegating to
+    ``bottube_server._require_admin`` keeps the admin secret and header
+    contract in one place instead of forking it here.
+    """
+    try:
+        import bottube_server  # type: ignore
+
+        return bottube_server._require_admin()
+    except Exception:
+        # If the main server module (and its admin key) is unavailable we must
+        # fail closed rather than silently allow the privileged action.
+        return jsonify({"error": "Forbidden"}), 403
 
 
 def _video_dir() -> str:
@@ -270,13 +300,23 @@ def trigger_backfill():
 
     Body (JSON, optional):
         { "force": false, "batch_size": 50 }
+
+    Requires ``X-Admin-Key``: this starts the Whisper worker and enqueues
+    transcription jobs, which is expensive enough that it must not be
+    reachable anonymously.
     """
+    error = _require_admin()
+    if error:
+        return error
+
     body, error = _request_json_object()
     if error:
         return error
 
     force = bool(body.get("force", False))
-    batch_size, error = _parse_positive_int(body, "batch_size", 50)
+    batch_size, error = _parse_positive_int(
+        body, "batch_size", 50, max_value=_BACKFILL_BATCH_MAX
+    )
     if error:
         return error
 


### PR DESCRIPTION
Fixes #1726

## The bug

`whisper_transcription_blueprint.py`'s own module header says:

```
- POST /api/transcript/backfill                   → backfill existing videos (admin)
```

but `trigger_backfill()` had no authorisation check of any kind. Grepping the whole 292-line module for `session`, `X-API-Key`, `X-Admin-Key`, `api_key`, `admin`, `require`, `before_request`, `g.` turns up nothing but the word "admin" inside two docstrings, there's no `before_request` on `whisper_bp`, and the blueprint is registered unconditionally (`bottube_server.py:15607`).

So this works from anywhere, with no credentials:

```
curl -X POST /api/transcript/backfill -d '{"force": true, "batch_size": 1000000}'
```

`wt.backfill_existing_videos()` calls `start_worker()` and enqueues Whisper transcription jobs — CPU-heavy ML work — and `force: true` re-does videos that already have transcripts.

**And `batch_size` had no ceiling.** `_parse_positive_int` took no `max_value`, even though its query-string sibling *in the same file* does: `/api/transcript/search` two functions away already caps with `_parse_positive_int_arg("limit", 50, max_value=500)`. The cheap endpoint was capped; the expensive one wasn't.

## The fix

- Added the `_require_admin()` delegate that `agent_relationships.py:95` already uses — defers to `bottube_server._require_admin` so the admin secret and header contract stay in one place, and **fails closed** (403) if that import is unavailable rather than silently allowing the privileged action.
- Gated `trigger_backfill` with it.
- Gave `_parse_positive_int` the same optional `max_value` its sibling has, and capped `batch_size` at `_BACKFILL_BATCH_MAX = 500`.

## Tests

`54 passed` (was 50).

Four new:

- `test_backfill_requires_admin` — anonymous POST gets 403 and `backfill_existing_videos` is never reached (the stub raises if it is).
- `test_backfill_fails_closed_without_admin_key` — a *wrong* key is rejected too, not just a missing one.
- `test_backfill_caps_batch_size` — `batch_size: 10_000_000` is a 400 and enqueues nothing.
- `test_backfill_allows_batch_size_at_the_cap` — exactly 500 still works and is passed through, so the cap isn't off-by-one.

On `main` the two gate tests **fail** with `AssertionError: anonymous caller reached backfill_existing_videos` — i.e. they demonstrate the hole directly. The two cap tests error there rather than fail, since they reference the new `_BACKFILL_BATCH_MAX` constant.

⚠️ **Heads-up on the three pre-existing tests I touched.** `test_backfill_rejects_non_object_json`, `test_backfill_rejects_invalid_batch_size` and `test_backfill_rejects_non_positive_or_non_integer_batch_size` posted to the endpoint anonymously and asserted `400`. Those assertions only held *because* the endpoint was open — the suite had encoded the missing gate as expected behaviour. They now go through an `admin_client` fixture that stubs the gate, since what they actually test is body parsing, not authorisation. No assertion inside them was weakened.

## Not in this PR

`POST /api/videos/<video_id>/transcript/trigger` (line 226) is also unauthenticated and also enqueues transcription work, with `force: true` permitting repeated re-transcription. I deliberately left it alone: unlike backfill it is *not* documented as admin, so who should be allowed to call it is a product decision, not a clear-cut bug. Flagged in the issue.

---

/claim #1102 — functional bug (5 RTC).
RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`