### PR TITLE
fix(whisper): default-vs-cap invariant should raise ValueError, not a bare assert (-O strips it)

### DIFF
--- a/tests/test_whisper_transcription.py
+++ b/tests/test_whisper_transcription.py
@@ -667,3 +667,65 @@ def test_backfill_allows_batch_size_at_the_cap(admin_client, monkeypatch):
     assert resp.status_code == 200
     assert seen["batch_size"] == wtb._BACKFILL_BATCH_MAX
     assert resp.get_json()["enqueued"] == 3
+
+
+# ---------------------------------------------------------------------------
+# _parse_positive_int / _parse_positive_int_arg: default-vs-cap invariant
+# ---------------------------------------------------------------------------
+
+def test_parse_positive_int_rejects_default_above_cap():
+    """A default above its own cap is a wiring mistake, not a user error."""
+    import whisper_transcription_blueprint as wtb
+
+    with pytest.raises(ValueError) as excinfo:
+        wtb._parse_positive_int({}, "batch_size", 500, max_value=50)
+
+    assert "batch_size" in str(excinfo.value)
+
+
+def test_parse_positive_int_arg_rejects_default_above_cap(flask_client):
+    import whisper_transcription_blueprint as wtb
+
+    with flask_client.application.test_request_context("/api/transcript/search?q=x"):
+        with pytest.raises(ValueError):
+            wtb._parse_positive_int_arg("limit", 500, max_value=50)
+
+
+def test_parse_positive_int_accepts_default_equal_to_cap():
+    import whisper_transcription_blueprint as wtb
+
+    value, error = wtb._parse_positive_int({}, "batch_size", 50, max_value=50)
+
+    assert error is None
+    assert value == 50
+
+
+def test_default_vs_cap_invariant_survives_python_O():
+    """The check must not be a bare assert: -O strips those.
+
+    Runs the invariant in a subprocess under python -O; a bare `assert`
+    would silently vanish there and the call would return normally.
+    """
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    code = (
+        "import whisper_transcription_blueprint as wtb\n"
+        "try:\n"
+        "    wtb._parse_positive_int({}, 'batch_size', 500, max_value=50)\n"
+        "except ValueError:\n"
+        "    print('RAISED')\n"
+        "else:\n"
+        "    print('SILENT')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        cwd=str(root), capture_output=True, text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "RAISED" in result.stdout, (
+        "invariant was optimised away under -O: " + result.stdout
+    )

--- a/whisper_transcription_blueprint.py
+++ b/whisper_transcription_blueprint.py
@@ -47,9 +47,15 @@ def _request_json_object():
 
 def _parse_positive_int(data, field_name: str, default: int,
                         max_value: Optional[int] = None):
-    """Parse positive integer fields from JSON request bodies."""
-    if max_value is not None:
-        assert default <= max_value
+    """Parse positive integer fields from JSON request bodies.
+
+    Raises:
+        ValueError: if the caller wires up a default above its own cap.
+    """
+    if max_value is not None and default > max_value:
+        raise ValueError(
+            f"{field_name}: default {default} exceeds max_value {max_value}"
+        )
     value = data.get(field_name, default)
     if isinstance(value, bool):
         return None, (
@@ -91,9 +97,15 @@ def _parse_positive_int(data, field_name: str, default: int,
 
 
 def _parse_positive_int_arg(field_name: str, default: int, max_value: Optional[int] = None):
-    """Parse positive integer fields from query-string arguments."""
-    if max_value is not None:
-        assert default <= max_value
+    """Parse positive integer fields from query-string arguments.
+
+    Raises:
+        ValueError: if the caller wires up a default above its own cap.
+    """
+    if max_value is not None and default > max_value:
+        raise ValueError(
+            f"{field_name}: default {default} exceeds max_value {max_value}"
+        )
     raw_value = request.args.get(field_name)
     if raw_value is None:
         return default, None


### PR DESCRIPTION
Follow-up to your review note on #1727:

> One non-blocking nit for next time: `assert default <= max_value` in `_parse_positive_int` is a bare `assert`, so it vanishes under `python -O`. It's an internal invariant and both call sites are fine, so I am not holding the merge on it — a `raise ValueError` would just be sturdier.

You're right, and it's worth doing properly rather than leaving as a known-soft spot. Demonstrated concretely:

```
$ python3    -c 'assert 500 <= 50'   ->  AssertionError
$ python3 -O -c 'assert 500 <= 50'   ->  passes, no error
```

## Scope

Both parsers in the module carried the same bare assert, not just the one I added:

- `_parse_positive_int` (line 52) — mine, from #1727
- `_parse_positive_int_arg` (line 96) — pre-existing, guards `/api/transcript/search`

Both are now an explicit `ValueError` that names the field, and both docstrings document the `Raises:` contract. The behaviour for *callers* is unchanged — this only fires when the code itself is wired with a default above its own cap, which is a programming mistake, not user input.

## Tests

`58 passed` (was 54). Four new:

- `test_parse_positive_int_rejects_default_above_cap` — `ValueError` mentioning the field name.
- `test_parse_positive_int_arg_rejects_default_above_cap` — same for the query-string sibling, inside a request context.
- `test_parse_positive_int_accepts_default_equal_to_cap` — `default == max_value` is still legal, so the fix isn't off-by-one.
- `test_default_vs_cap_invariant_survives_python_O` — runs the invariant in a **subprocess under `python -O`** and asserts it still raises. A bare assert prints `SILENT` there; the raise prints `RAISED`. This is the one that would have caught the original nit.

Three of the four fail on `main`.

No claim attached — this is cleanup on your review note, not a new bounty item.