### PR TITLE
fix(admin): both admin gates must resolve the same key — RC_ADMIN_KEY only worked for 15 of 39 endpoints

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14988,10 +14988,22 @@ def giveaway_leaderboard_api():
 # Admin: Visitor Analytics
 # ---------------------------------------------------------------------------
 
-ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "")
+def _admin_key_from_env():
+    """Resolve the admin secret from the environment.
+
+    Single source of truth: BOTTUBE_ADMIN_KEY is the documented name and
+    RC_ADMIN_KEY is an accepted alias. Both admin gates in this module go
+    through here, so an operator who sets only one of them gets a
+    consistent answer everywhere instead of half the admin surface
+    rejecting the key they configured.
+    """
+    return os.environ.get("BOTTUBE_ADMIN_KEY", "") or os.environ.get("RC_ADMIN_KEY", "")
+
+
+ADMIN_KEY = _admin_key_from_env()
 if not ADMIN_KEY:
     ADMIN_KEY = secrets.token_hex(32)
-    print(f"[BoTTube] WARNING: BOTTUBE_ADMIN_KEY not set. Generated ephemeral key: {ADMIN_KEY}")
+    print(f"[BoTTube] WARNING: neither BOTTUBE_ADMIN_KEY nor RC_ADMIN_KEY set. Generated ephemeral key: {ADMIN_KEY}")
 
 
 @app.route("/api/admin/visitors")
@@ -20511,7 +20523,7 @@ def submit_report():
 def _ts_admin_ok():
     """Check if the current request has admin privileges for trust-and-safety endpoints. Returns: True if admin."""
     key = request.headers.get("X-Admin-Key", "") or request.args.get("admin_key", "")
-    expected = os.environ.get("BOTTUBE_ADMIN_KEY", "") or os.environ.get("RC_ADMIN_KEY", "")
+    expected = _admin_key_from_env()
     return bool(expected) and (key == expected)
 
 

--- a/tests/test_admin_key_single_source.py
+++ b/tests/test_admin_key_single_source.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: MIT
+"""The two admin gates must resolve the same secret.
+
+`bottube_server` has two independent admin checks:
+
+* `_require_admin()` (24 call sites) compared against the module constant
+  `ADMIN_KEY`, which was read from **BOTTUBE_ADMIN_KEY only**.
+* `_ts_admin_ok()` (15 trust-and-safety call sites, including the
+  `/admin/blocklist/add` hash blocklist) read
+  **BOTTUBE_ADMIN_KEY or RC_ADMIN_KEY**.
+
+So an operator who configured only `RC_ADMIN_KEY` got a split brain: the
+trust-and-safety endpoints accepted their key while all 24 `_require_admin`
+endpoints rejected it — and because an unset `BOTTUBE_ADMIN_KEY` makes the
+module fall back to `secrets.token_hex(32)`, those endpoints would only
+accept a random ephemeral key printed once at boot.
+
+Both gates now resolve through `_admin_key_from_env()`.
+"""
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture()
+def server(app):
+    """The already-imported bottube_server module (app fixture builds it)."""
+    import bottube_server
+
+    return bottube_server
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [
+        ({"BOTTUBE_ADMIN_KEY": "primary"}, "primary"),
+        ({"RC_ADMIN_KEY": "alias"}, "alias"),
+        ({"BOTTUBE_ADMIN_KEY": "primary", "RC_ADMIN_KEY": "alias"}, "primary"),
+        ({}, ""),
+    ],
+    ids=["primary-only", "alias-only", "both-primary-wins", "neither"],
+)
+def test_admin_key_resolution(server, monkeypatch, env, expected):
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    assert server._admin_key_from_env() == expected
+
+
+def test_both_gates_agree_on_the_alias(server, monkeypatch, app):
+    """RC_ADMIN_KEY alone must open both gates, not just the T&S one."""
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("RC_ADMIN_KEY", "alias-secret")
+    monkeypatch.setattr(server, "ADMIN_KEY", server._admin_key_from_env())
+
+    with app.test_request_context(
+        "/admin/moderation/reports", headers={"X-Admin-Key": "alias-secret"}
+    ):
+        assert server._ts_admin_ok() is True
+        assert server._require_admin() is None  # None == allowed
+
+
+def test_both_gates_reject_a_wrong_key(server, monkeypatch, app):
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("RC_ADMIN_KEY", "alias-secret")
+    monkeypatch.setattr(server, "ADMIN_KEY", server._admin_key_from_env())
+
+    with app.test_request_context(
+        "/admin/moderation/reports", headers={"X-Admin-Key": "nope"}
+    ):
+        assert server._ts_admin_ok() is False
+        assert server._require_admin() is not None
+
+
+def test_ts_gate_fails_closed_without_any_env(server, monkeypatch, app):
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+
+    with app.test_request_context(
+        "/admin/moderation/reports", headers={"X-Admin-Key": ""}
+    ):
+        assert server._ts_admin_ok() is False


### PR DESCRIPTION
Fixes #1729

## The bug

Two admin gates, two different env lookups:

| gate | reads | guards |
|---|---|---|
| `_require_admin()` via `ADMIN_KEY` (line 14991) | `BOTTUBE_ADMIN_KEY` only | 24 endpoints |
| `_ts_admin_ok()` (line 20511) | `BOTTUBE_ADMIN_KEY` **or** `RC_ADMIN_KEY` | 15 trust-and-safety endpoints, incl. `/admin/blocklist/add` |

`RC_ADMIN_KEY` occurs exactly once in the whole tree — inside `_ts_admin_ok`. Nothing else knows the alias exists.

Set only `RC_ADMIN_KEY` and the admin surface splits in half:

```
Scenario: operator set only RC_ADMIN_KEY=secret123

  _ts_admin_ok    (15 T&S endpoints): 200 OK
  _require_admin  (24 endpoints):     403 (key mismatch)
```

Compounding it, line 14993 replaces an unset `ADMIN_KEY` with `secrets.token_hex(32)` — so those 24 endpoints accept only a random ephemeral key printed once at boot. The operator's configured key works on some admin pages and fails on others, which presents as flakiness rather than as a config mistake.

**Both gates fail closed**, so this is a correctness/operability bug, not an auth bypass — filing it at that severity on purpose.

## The fix

One resolver, used by both:

```python
def _admin_key_from_env():
    return os.environ.get("BOTTUBE_ADMIN_KEY", "") or os.environ.get("RC_ADMIN_KEY", "")

ADMIN_KEY = _admin_key_from_env()
```

`BOTTUBE_ADMIN_KEY` still wins when both are set, the ephemeral-key fallback is untouched, and the boot warning now names both variables instead of only one.

## Tests

`tests/test_admin_key_single_source.py`, 7 cases: resolution across primary-only / alias-only / both / neither, both gates agreeing on the alias, both rejecting a wrong key, and the T&S gate still failing closed with no env at all.

**Honest note on what these prove:** 6 of the 7 fail on `main`, but most of them fail because `_admin_key_from_env` doesn't exist there yet — they're tests for the new contract, not a pure before/after regression. The bug itself is demonstrated by the standalone repro in #1729, which runs verbatim copies of both gates and shows the 200/403 split. I'd rather say that than let the "6 failed on main" number imply more than it does.

Related suites still green:

```
$ python3 -m pytest tests/test_admin_key_single_source.py tests/test_whisper_transcription.py     tests/test_channel_alias_route.py -q
64 passed
```

## Deliberately not touched

`_ts_admin_ok` accepts the secret via `?admin_key=` with no warning, while `_require_admin` logs a deprecation notice for `?key=` because secrets in URLs leak into logs and referers. The `reconcile-anchors` docstring says that endpoint is driven by a 6-hour systemd timer, so removing query-param support could break it — that's your call, not something to slip into this PR.

---

/claim #1102 — functional bug (5 RTC).
RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`