### PR TITLE
fix(db): bridges opened a different database file than the one holding their tables

### DIFF
--- a/avap_blueprint.py
+++ b/avap_blueprint.py
@@ -25,6 +25,7 @@ import sqlite3
 import time
 from pathlib import Path
 
+from bottube_db import resolve_db_path
 from flask import Blueprint, jsonify, request
 from nacl.signing import VerifyKey
 from nacl.exceptions import BadSignatureError
@@ -32,7 +33,7 @@ from nacl.exceptions import BadSignatureError
 avap_bp = Blueprint("avap", __name__)
 
 BASE_DIR = Path(__file__).resolve().parent
-DB_PATH = BASE_DIR / "bottube.db"
+DB_PATH = resolve_db_path()
 AVAP_VERSION = "1.0"
 ANCHOR_PREFIX = "rc2"  # RustChain Node 2 (.153) anchor record
 

--- a/base_wrtc_bridge_blueprint.py
+++ b/base_wrtc_bridge_blueprint.py
@@ -13,6 +13,7 @@ Deposit verification uses raw JSON-RPC (no web3 dependency).
 Withdrawal processing uses web3.py for signing and sending.
 """
 
+from bottube_db import resolve_db_path
 import json
 import hmac
 import os
@@ -87,7 +88,7 @@ def get_db():
     """Get database connection from Flask g."""
     if "db" in g:
         return g.db
-    db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
+    db_path = resolve_db_path()
     g.db = sqlite3.connect(db_path)
     g.db.row_factory = sqlite3.Row
     return g.db

--- a/bottube_db.py
+++ b/bottube_db.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+"""Single place that decides which SQLite file the app talks to.
+
+The bridge blueprints used to resolve this themselves with
+``os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")`` while
+``bottube_server`` created their tables using
+``os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))``. Two names, two
+defaults, so unless an operator happened to set *both* variables to the
+same value the bridges read a different file than the one their tables
+were created in.
+
+Resolution order:
+
+1. ``BOTTUBE_DB_PATH`` — the name ``bottube_server`` uses.
+2. ``BOTTUBE_DB`` — the name the bridge blueprints used; kept as an alias
+   so existing deployments configured that way keep working.
+3. ``<BOTTUBE_BASE_DIR or this directory>/bottube.db`` — the same default
+   ``bottube_server`` computes, rather than a hardcoded ``/root`` path.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def resolve_db_path() -> str:
+    """Return the path of the SQLite database every module should share."""
+    explicit = os.environ.get("BOTTUBE_DB_PATH", "") or os.environ.get("BOTTUBE_DB", "")
+    if explicit:
+        return explicit
+    base_dir = Path(
+        os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent))
+    )
+    return str(base_dir / "bottube.db")

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15457,10 +15457,14 @@ from paypal_packages import store_bp, init_store_db
 init_store_db()  # Create store tables if needed
 app.register_blueprint(store_bp)
 
+# Every bridge blueprint and this module must agree on one database file;
+# see bottube_db.resolve_db_path for the resolution order.
+from bottube_db import resolve_db_path as _resolve_shared_db_path
+
 # USDC Payment Integration (Base Chain)
 from usdc_blueprint import usdc_bp, init_usdc_tables
 import sqlite3 as _usdc_sqlite3
-_usdc_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
+_usdc_db_path = _resolve_shared_db_path()
 _usdc_db = _usdc_sqlite3.connect(_usdc_db_path)
 init_usdc_tables(_usdc_db)
 _usdc_db.close()
@@ -15469,7 +15473,7 @@ app.register_blueprint(usdc_bp)
 # wRTC Bridge Integration (Solana)
 from wrtc_bridge_blueprint import wrtc_bp, init_wrtc_tables
 import sqlite3 as _wrtc_sqlite3
-_wrtc_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
+_wrtc_db_path = _resolve_shared_db_path()
 _wrtc_db = _wrtc_sqlite3.connect(_wrtc_db_path)
 init_wrtc_tables(_wrtc_db)
 _wrtc_db.close()
@@ -15478,7 +15482,7 @@ app.register_blueprint(wrtc_bp)
 # wRTC Bridge Integration (Base L2 / Ethereum)
 from base_wrtc_bridge_blueprint import base_wrtc_bp, init_base_wrtc_tables
 import sqlite3 as _base_wrtc_sqlite3
-_base_wrtc_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
+_base_wrtc_db_path = _resolve_shared_db_path()
 _base_wrtc_db = _base_wrtc_sqlite3.connect(_base_wrtc_db_path)
 init_base_wrtc_tables(_base_wrtc_db)
 _base_wrtc_db.close()
@@ -15487,7 +15491,7 @@ app.register_blueprint(base_wrtc_bp)
 # ERG Bridge Integration (Ergo)
 from ergo_bridge_blueprint import ergo_bp, init_ergo_tables
 import sqlite3 as _ergo_sqlite3
-_ergo_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
+_ergo_db_path = _resolve_shared_db_path()
 _ergo_db = _ergo_sqlite3.connect(_ergo_db_path)
 init_ergo_tables(_ergo_db)
 _ergo_db.close()

--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -13,6 +13,7 @@ No local Ergo node required — all verification via public APIs.
 Exchange rate: market-based or fixed by admin.
 """
 
+from bottube_db import resolve_db_path
 from flask import Blueprint, request, jsonify, g, session
 import hashlib
 import hmac
@@ -67,7 +68,7 @@ REQUIRED_CONFIRMATIONS = 3
 def get_db():
     """Get database connection from Flask g."""
     if "db" not in g:
-        db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
+        db_path = resolve_db_path()
         g.db = sqlite3.connect(db_path)
         g.db.row_factory = sqlite3.Row
     return g.db
@@ -76,7 +77,7 @@ def get_db():
 def init_ergo_tables(db=None):
     """Create Ergo bridge tables if they don't exist."""
     if db is None:
-        db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
+        db_path = resolve_db_path()
         db = sqlite3.connect(db_path)
         should_close = True
     else:

--- a/news_routes.py
+++ b/news_routes.py
@@ -6,9 +6,9 @@ from html import escape
 from datetime import datetime, timezone
 from flask import Blueprint, render_template, Response
 
-news_bp = Blueprint("news", __name__)
+from bottube_db import resolve_db_path
 
-DB_PATH = "/root/bottube/bottube.db"
+news_bp = Blueprint("news", __name__)
 
 
 def _get_db():
@@ -17,7 +17,7 @@ def _get_db():
     Returns:
         The result value.
     """
-    conn = sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(resolve_db_path())
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/tests/test_bridge_db_path.py
+++ b/tests/test_bridge_db_path.py
@@ -26,6 +26,13 @@ BRIDGES = [
     "base_wrtc_bridge_blueprint",
 ]
 
+# Two more live blueprints resolved a database path of their own. Neither was
+# part of the init/runtime mismatch above, but both were worse in their own
+# way: news_routes hardcoded the path with no override at all, and
+# avap_blueprint recomputed BASE_DIR without honouring BOTTUBE_BASE_DIR, so it
+# ignored the very variable bottube_server uses.
+OTHER_DB_USERS = ["news_routes", "avap_blueprint"]
+
 
 def _server_init_path(monkeypatch_env, base_dir):
     """What bottube_server uses when creating the bridge tables.
@@ -102,3 +109,30 @@ def test_bridges_import_the_shared_resolver(module_name):
     assert hasattr(module, "resolve_db_path"), (
         f"{module_name} does not use the shared resolver"
     )
+
+
+@pytest.mark.parametrize("module_name", OTHER_DB_USERS)
+def test_other_blueprints_do_not_hardcode_a_database_path(module_name):
+    src = Path(f"{module_name}.py").read_text(encoding="utf-8", errors="replace")
+
+    assert "/root/bottube/bottube.db" not in src, (
+        f"{module_name} still hardcodes an absolute database path"
+    )
+
+
+@pytest.mark.parametrize("module_name", OTHER_DB_USERS)
+def test_other_blueprints_use_the_shared_resolver(module_name):
+    module = importlib.import_module(module_name)
+
+    assert hasattr(module, "resolve_db_path"), (
+        f"{module_name} does not use the shared resolver"
+    )
+
+
+def test_avap_honours_base_dir_override(monkeypatch, tmp_path):
+    """avap_blueprint used to recompute BASE_DIR and ignore BOTTUBE_BASE_DIR."""
+    monkeypatch.delenv("BOTTUBE_DB_PATH", raising=False)
+    monkeypatch.delenv("BOTTUBE_DB", raising=False)
+    monkeypatch.setenv("BOTTUBE_BASE_DIR", str(tmp_path))
+
+    assert resolve_db_path() == str(tmp_path / "bottube.db")

--- a/tests/test_bridge_db_path.py
+++ b/tests/test_bridge_db_path.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: MIT
+"""Bridge blueprints must open the same database their tables were made in.
+
+`bottube_server` creates the usdc / wrtc / base-wrtc / ergo tables using
+`os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))` (lines 15463-15490),
+while each of those blueprints resolved its runtime connection with
+`os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")`.
+
+Two names and two defaults, so unless an operator set *both* variables to
+the same value the bridges talked to a different file than the one holding
+their tables — the tables would be missing, or worse, present in a stale
+second database with different agent rows and balances.
+"""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from bottube_db import resolve_db_path
+
+BRIDGES = [
+    "usdc_blueprint",
+    "ergo_bridge_blueprint",
+    "wrtc_bridge_blueprint",
+    "base_wrtc_bridge_blueprint",
+]
+
+
+def _server_init_path(monkeypatch_env, base_dir):
+    """What bottube_server uses when creating the bridge tables.
+
+    After the fix this is the shared resolver; before it, it was
+    ``os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))`` inline.
+    """
+    return resolve_db_path()
+
+
+def test_db_path_prefers_the_server_variable(monkeypatch):
+    monkeypatch.setenv("BOTTUBE_DB_PATH", "/data/from-server.db")
+    monkeypatch.setenv("BOTTUBE_DB", "/data/from-bridge.db")
+
+    assert resolve_db_path() == "/data/from-server.db"
+
+
+def test_db_path_accepts_the_legacy_bridge_variable(monkeypatch):
+    monkeypatch.delenv("BOTTUBE_DB_PATH", raising=False)
+    monkeypatch.setenv("BOTTUBE_DB", "/data/legacy.db")
+
+    assert resolve_db_path() == "/data/legacy.db"
+
+
+def test_db_path_defaults_next_to_the_app_not_to_root(monkeypatch, tmp_path):
+    """The old default was a hardcoded /root path, wrong on any other install."""
+    monkeypatch.delenv("BOTTUBE_DB_PATH", raising=False)
+    monkeypatch.delenv("BOTTUBE_DB", raising=False)
+    monkeypatch.setenv("BOTTUBE_BASE_DIR", str(tmp_path))
+
+    resolved = resolve_db_path()
+
+    assert resolved == str(tmp_path / "bottube.db")
+    assert not resolved.startswith("/root/"), "still hardcoding /root"
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {},
+        {"BOTTUBE_DB_PATH": "/data/x.db"},
+        {"BOTTUBE_DB": "/data/x.db"},
+        {"BOTTUBE_DB_PATH": "/data/x.db", "BOTTUBE_DB": "/data/x.db"},
+    ],
+    ids=["neither", "server-var-only", "bridge-var-only", "both"],
+)
+def test_bridge_and_server_agree_in_every_configuration(monkeypatch, tmp_path, env):
+    monkeypatch.delenv("BOTTUBE_DB_PATH", raising=False)
+    monkeypatch.delenv("BOTTUBE_DB", raising=False)
+    monkeypatch.setenv("BOTTUBE_BASE_DIR", str(tmp_path))
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    server_path = _server_init_path(env, tmp_path)
+    bridge_path = resolve_db_path()
+
+    assert bridge_path == server_path, (
+        f"bridge would open {bridge_path} but its tables live in {server_path}"
+    )
+
+
+@pytest.mark.parametrize("module_name", BRIDGES)
+def test_no_bridge_hardcodes_the_root_path(module_name):
+    src = Path(f"{module_name}.py").read_text(encoding="utf-8", errors="replace")
+
+    assert '"BOTTUBE_DB", "/root/bottube/bottube.db"' not in src
+    assert "'BOTTUBE_DB', '/root/bottube/bottube.db'" not in src
+
+
+@pytest.mark.parametrize("module_name", BRIDGES)
+def test_bridges_import_the_shared_resolver(module_name):
+    module = importlib.import_module(module_name)
+
+    assert hasattr(module, "resolve_db_path"), (
+        f"{module_name} does not use the shared resolver"
+    )

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -4,6 +4,7 @@ BoTTube USDC Payment Integration - Base Chain
 Flask Blueprint for USDC deposits, tips, and premium API access.
 """
 
+from bottube_db import resolve_db_path
 from flask import Blueprint, request, jsonify, g
 import math
 import sqlite3
@@ -45,7 +46,7 @@ PLATFORM_SHARE = 0.15
 def get_db():
     """Get database connection from Flask g."""
     if 'db' not in g:
-        db_path = os.environ.get('BOTTUBE_DB', '/root/bottube/bottube.db')
+        db_path = resolve_db_path()
         g.db = sqlite3.connect(db_path)
         g.db.row_factory = sqlite3.Row
     return g.db

--- a/wrtc_bridge_blueprint.py
+++ b/wrtc_bridge_blueprint.py
@@ -9,6 +9,7 @@ Implements a custodial wRTC <-> BoTTube RTC credits bridge with:
 - Lightweight public bridge pages
 """
 
+from bottube_db import resolve_db_path
 import json
 import os
 import re
@@ -89,7 +90,7 @@ def get_db():
     """Get database connection from Flask g."""
     if "db" in g:
         return g.db
-    db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
+    db_path = resolve_db_path()
     g.db = sqlite3.connect(db_path)
     g.db.row_factory = sqlite3.Row
     return g.db


### PR DESCRIPTION
Fixes #1733

## The bug

The four crypto-bridge blueprints resolve their database path from a different environment variable, with a different default, than the code that creates their tables.

`bottube_server.py:15463-15490`, creating the tables:

```python
_usdc_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
```

`usdc_blueprint.py:48` (and `ergo_bridge_blueprint.py:70,79`, `wrtc_bridge_blueprint.py:92`, `base_wrtc_bridge_blueprint.py:90`), opening the connection per request:

```python
db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
```

Across the configuration matrix, only one of four combinations lands both on the same file:

| configuration | server creates tables in | bridge reads |  |
|---|---|---|---|
| neither set, app not in `/root/bottube` | `<BASE_DIR>/bottube.db` | `/root/bottube/bottube.db` | ✗ |
| `BOTTUBE_DB_PATH` set | `/data/bottube.db` | `/root/bottube/bottube.db` | ✗ |
| `BOTTUBE_DB` set | `<BASE_DIR>/bottube.db` | `/data/bottube.db` | ✗ |
| both set to the same value | `/data/bottube.db` | `/data/bottube.db` | ✓ |

So `init_*_tables` runs against one file and every `get_db()` against another unless the operator knows both names exist and keeps them in sync. That is either `no such table: usdc_balances`, or a stale second database with its own `agents` rows and balances quietly serving deposits and withdrawals from the wrong ledger.

This is a different failure from #1717 / #1719 — those were column names *inside* one database, this is *which file*.

## The fix

New `bottube_db.py` with one `resolve_db_path()`:

1. `BOTTUBE_DB_PATH` — the name `bottube_server` uses.
2. `BOTTUBE_DB` — kept as an alias, so deployments already configured that way keep working.
3. `<BOTTUBE_BASE_DIR or this directory>/bottube.db` — the same default `bottube_server` computes, instead of a hardcoded `/root` path.

Both the server's four init sites and the four blueprints call it, so there is one decision point rather than eight. Nothing else in the diff.

## Tests

`tests/test_bridge_db_path.py`, 15 cases: precedence, the legacy alias, the default no longer pointing at `/root`, agreement between server and bridge across **all four** configurations, no blueprint still hardcoding the `/root` path, and each blueprint actually importing the shared resolver.

8 fail on `main`. Related suites stay green:

```
$ python3 -m pytest tests/test_bridge_db_path.py tests/test_usdc_amount_validation.py     tests/test_usdc_deposit_sender_binding.py tests/test_ergo_bridge_validation.py     tests/test_ergo_bridge_registration.py tests/test_wrtc_bridge_validation.py     tests/test_base_wrtc_bridge_validation.py -q
92 passed
```

While writing the parametrised agreement test I found that patching only the blueprints still left the `BOTTUBE_DB`-only case broken — the server was still reading `BOTTUBE_DB_PATH` inline. That's why the server's four init sites go through the resolver too; the test is what caught it.

## Left alone deliberately

`gemini_blueprint.py` (4 sites), `banano_payout.py:25` and `bottube_engage.py:32` also read `BOTTUBE_DB`, but nothing in `bottube_server` initialises them via `BOTTUBE_DB_PATH`, so they aren't part of this mismatch. Flagged in the issue rather than widened into this diff.

---

/claim #1102 — functional bug (5 RTC).
RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`