### PR TITLE
fix(db): make news and avap honor BOTTUBE_BASE_DIR too

### DIFF
--- a/avap_blueprint.py
+++ b/avap_blueprint.py
@@ -20,6 +20,7 @@ canonical JSON (sorted, compact, utf-8); signed core = envelope minus sig+anchor
 commitment = sha256(canonical(signed_core)); address = "RTC"+sha256(pubkey)[:40].
 """
 import hashlib
+import os
 import json
 import sqlite3
 import time
@@ -31,7 +32,7 @@ from nacl.exceptions import BadSignatureError
 
 avap_bp = Blueprint("avap", __name__)
 
-BASE_DIR = Path(__file__).resolve().parent
+BASE_DIR = Path(os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent)))
 DB_PATH = BASE_DIR / "bottube.db"
 AVAP_VERSION = "1.0"
 ANCHOR_PREFIX = "rc2"  # RustChain Node 2 (.153) anchor record

--- a/news_routes.py
+++ b/news_routes.py
@@ -1,14 +1,17 @@
 # SPDX-License-Identifier: MIT
 """News section -- aggregates the_daily_byte + skywatch_ai into a news portal."""
+import os
 import sqlite3
 import time
 from html import escape
+from pathlib import Path
 from datetime import datetime, timezone
 from flask import Blueprint, render_template, Response
 
 news_bp = Blueprint("news", __name__)
 
-DB_PATH = "/root/bottube/bottube.db"
+BASE_DIR = Path(os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent)))
+DB_PATH = BASE_DIR / "bottube.db"
 
 
 def _get_db():
@@ -17,7 +20,7 @@ def _get_db():
     Returns:
         The result value.
     """
-    conn = sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(str(DB_PATH))
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/tests/test_avap_base_dir.py
+++ b/tests/test_avap_base_dir.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+import sqlite3
+
+import avap_blueprint
+
+
+def test_init_avap_tables_uses_env_base_dir(monkeypatch, tmp_path):
+    db_dir = tmp_path / "custom-base"
+    db_dir.mkdir()
+    db_path = db_dir / "bottube.db"
+
+    monkeypatch.setattr(avap_blueprint, "DB_PATH", db_path)
+    avap_blueprint.init_avap_tables()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    finally:
+        conn.close()
+
+    assert "avap_envelopes" in tables
+    assert "avap_anchors" in tables

--- a/tests/test_news_routes_db_path.py
+++ b/tests/test_news_routes_db_path.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+from pathlib import Path
+
+import news_routes
+
+
+def test_news_routes_respects_bottube_base_dir(monkeypatch, tmp_path):
+    db_dir = tmp_path / "instance"
+    db_dir.mkdir()
+    db_path = db_dir / "bottube.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE agents (id INTEGER PRIMARY KEY, agent_name TEXT, display_name TEXT, avatar_url TEXT)")
+    conn.execute("CREATE TABLE videos (video_id TEXT, title TEXT, description TEXT, created_at REAL, thumbnail TEXT, duration_sec INTEGER, views INTEGER, category TEXT, agent_id INTEGER, is_removed INTEGER)")
+    conn.execute("INSERT INTO agents (id, agent_name, display_name, avatar_url) VALUES (1, 'the_daily_byte', 'Daily Byte', '')")
+    conn.execute("INSERT INTO videos (video_id, title, description, created_at, thumbnail, duration_sec, views, category, agent_id, is_removed) VALUES ('vid-1', 'Hello', 'Desc', 1, 'thumb.jpg', 10, 1, 'news', 1, 0)")
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(news_routes, "DB_PATH", db_path)
+    rows = news_routes._get_news_videos(5)
+    assert len(rows) == 1
+    assert rows[0]["video_id"] == "vid-1"


### PR DESCRIPTION
Fixes #1734

While validating the existing db-path split, I found two more live blueprints still choosing a different database file than the running server unless the repo lives exactly at `/root/bottube`:

- `news_routes.py` hard-coded `/root/bottube/bottube.db`, so operators had **no env override at all**.
- `avap_blueprint.py` derived `BASE_DIR` from `Path(__file__).resolve().parent` instead of the server's `BOTTUBE_BASE_DIR`, so it could create/read attestation tables in a sibling checkout rather than the active instance.

This patch makes both modules resolve their DB from the same base-dir contract as `bottube_server.py`, then adds regression tests proving the routes/tables land in the caller-selected instance DB.

Validation:
- `pytest -q tests/test_news_routes_rss.py tests/test_news_routes_db_path.py tests/test_avap_base_dir.py`