### PR TITLE
fix(bridges): unify crypto bridge db path resolution

### DIFF
--- a/base_wrtc_bridge_blueprint.py
+++ b/base_wrtc_bridge_blueprint.py
@@ -25,6 +25,8 @@ from math import isfinite
 import requests as http_requests
 from flask import Blueprint, g, jsonify, render_template, request
 
+from bottube_db import resolve_db_path
+
 base_wrtc_bp = Blueprint("base_wrtc_bridge", __name__)
 
 # ─── Base Chain Configuration ─────────────────────────────────
@@ -87,8 +89,7 @@ def get_db():
     """Get database connection from Flask g."""
     if "db" in g:
         return g.db
-    db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
-    g.db = sqlite3.connect(db_path)
+    g.db = sqlite3.connect(resolve_db_path())
     g.db.row_factory = sqlite3.Row
     return g.db
 

--- a/bottube_db.py
+++ b/bottube_db.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+import os
+
+
+def resolve_db_path() -> str:
+    """Resolve the BoTTube SQLite path consistently across server and blueprints.
+
+    Precedence:
+    1. BOTTUBE_DB_PATH (canonical name used by the main server)
+    2. BOTTUBE_DB (legacy alias kept for backward compatibility)
+    3. BOTTUBE_BASE_DIR/bottube.db
+    4. repo-local bottube.db next to this file
+    """
+    explicit = os.environ.get("BOTTUBE_DB_PATH") or os.environ.get("BOTTUBE_DB")
+    if explicit:
+        return explicit
+    base_dir = Path(os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent)))
+    return str(base_dir / "bottube.db")

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15458,10 +15458,10 @@ init_store_db()  # Create store tables if needed
 app.register_blueprint(store_bp)
 
 # USDC Payment Integration (Base Chain)
+from bottube_db import resolve_db_path
 from usdc_blueprint import usdc_bp, init_usdc_tables
 import sqlite3 as _usdc_sqlite3
-_usdc_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
-_usdc_db = _usdc_sqlite3.connect(_usdc_db_path)
+_usdc_db = _usdc_sqlite3.connect(resolve_db_path())
 init_usdc_tables(_usdc_db)
 _usdc_db.close()
 app.register_blueprint(usdc_bp)
@@ -15469,8 +15469,7 @@ app.register_blueprint(usdc_bp)
 # wRTC Bridge Integration (Solana)
 from wrtc_bridge_blueprint import wrtc_bp, init_wrtc_tables
 import sqlite3 as _wrtc_sqlite3
-_wrtc_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
-_wrtc_db = _wrtc_sqlite3.connect(_wrtc_db_path)
+_wrtc_db = _wrtc_sqlite3.connect(resolve_db_path())
 init_wrtc_tables(_wrtc_db)
 _wrtc_db.close()
 app.register_blueprint(wrtc_bp)
@@ -15478,8 +15477,7 @@ app.register_blueprint(wrtc_bp)
 # wRTC Bridge Integration (Base L2 / Ethereum)
 from base_wrtc_bridge_blueprint import base_wrtc_bp, init_base_wrtc_tables
 import sqlite3 as _base_wrtc_sqlite3
-_base_wrtc_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
-_base_wrtc_db = _base_wrtc_sqlite3.connect(_base_wrtc_db_path)
+_base_wrtc_db = _base_wrtc_sqlite3.connect(resolve_db_path())
 init_base_wrtc_tables(_base_wrtc_db)
 _base_wrtc_db.close()
 app.register_blueprint(base_wrtc_bp)
@@ -15487,8 +15485,7 @@ app.register_blueprint(base_wrtc_bp)
 # ERG Bridge Integration (Ergo)
 from ergo_bridge_blueprint import ergo_bp, init_ergo_tables
 import sqlite3 as _ergo_sqlite3
-_ergo_db_path = os.environ.get("BOTTUBE_DB_PATH", str(DB_PATH))
-_ergo_db = _ergo_sqlite3.connect(_ergo_db_path)
+_ergo_db = _ergo_sqlite3.connect(resolve_db_path())
 init_ergo_tables(_ergo_db)
 _ergo_db.close()
 app.register_blueprint(ergo_bp)

--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -24,6 +24,8 @@ import sqlite3
 import time
 import urllib.request
 
+from bottube_db import resolve_db_path
+
 ergo_bp = Blueprint("ergo_bridge", __name__)
 log = logging.getLogger("ergo_bridge")
 
@@ -67,8 +69,7 @@ REQUIRED_CONFIRMATIONS = 3
 def get_db():
     """Get database connection from Flask g."""
     if "db" not in g:
-        db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
-        g.db = sqlite3.connect(db_path)
+        g.db = sqlite3.connect(resolve_db_path())
         g.db.row_factory = sqlite3.Row
     return g.db
 
@@ -76,8 +77,7 @@ def get_db():
 def init_ergo_tables(db=None):
     """Create Ergo bridge tables if they don't exist."""
     if db is None:
-        db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
-        db = sqlite3.connect(db_path)
+        db = sqlite3.connect(resolve_db_path())
         should_close = True
     else:
         should_close = False

--- a/tests/test_crypto_bridge_db_path.py
+++ b/tests/test_crypto_bridge_db_path.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+
+from flask import Flask
+
+import base_wrtc_bridge_blueprint
+import bottube_db
+import ergo_bridge_blueprint
+import usdc_blueprint
+import wrtc_bridge_blueprint
+
+
+def test_resolve_db_path_prefers_bottube_db_path(monkeypatch, tmp_path):
+    canonical = tmp_path / "canonical.db"
+    legacy = tmp_path / "legacy.db"
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(canonical))
+    monkeypatch.setenv("BOTTUBE_DB", str(legacy))
+
+    assert bottube_db.resolve_db_path() == str(canonical)
+
+
+def test_resolve_db_path_falls_back_to_legacy_alias(monkeypatch, tmp_path):
+    legacy = tmp_path / "legacy.db"
+    monkeypatch.delenv("BOTTUBE_DB_PATH", raising=False)
+    monkeypatch.setenv("BOTTUBE_DB", str(legacy))
+
+    assert bottube_db.resolve_db_path() == str(legacy)
+
+
+def test_resolve_db_path_defaults_to_bottube_base_dir(monkeypatch, tmp_path):
+    monkeypatch.delenv("BOTTUBE_DB_PATH", raising=False)
+    monkeypatch.delenv("BOTTUBE_DB", raising=False)
+    monkeypatch.setenv("BOTTUBE_BASE_DIR", str(tmp_path / "instance"))
+
+    assert bottube_db.resolve_db_path() == str((tmp_path / "instance" / "bottube.db"))
+
+
+def test_crypto_bridge_blueprints_share_resolver(monkeypatch, tmp_path):
+    db_path = tmp_path / "shared.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute("CREATE TABLE usdc_deposits (id INTEGER PRIMARY KEY)")
+        db.execute("CREATE TABLE wrtc_deposits (id INTEGER PRIMARY KEY)")
+        db.execute("CREATE TABLE base_wrtc_deposits (id INTEGER PRIMARY KEY)")
+        db.execute("CREATE TABLE ergo_deposits (id INTEGER PRIMARY KEY)")
+
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(db_path))
+    monkeypatch.delenv("BOTTUBE_DB", raising=False)
+
+    app = Flask(__name__)
+    for module in (
+        usdc_blueprint,
+        wrtc_bridge_blueprint,
+        base_wrtc_bridge_blueprint,
+        ergo_bridge_blueprint,
+    ):
+        with app.app_context():
+            db = module.get_db()
+            table = db.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name LIMIT 1").fetchone()
+            assert table is not None

--- a/usdc_blueprint.py
+++ b/usdc_blueprint.py
@@ -13,6 +13,8 @@ import json
 import os
 import requests as http_requests
 
+from bottube_db import resolve_db_path
+
 usdc_bp = Blueprint('usdc', __name__)
 
 # ─── Base Chain Configuration ─────────────────────────────────
@@ -45,8 +47,7 @@ PLATFORM_SHARE = 0.15
 def get_db():
     """Get database connection from Flask g."""
     if 'db' not in g:
-        db_path = os.environ.get('BOTTUBE_DB', '/root/bottube/bottube.db')
-        g.db = sqlite3.connect(db_path)
+        g.db = sqlite3.connect(resolve_db_path())
         g.db.row_factory = sqlite3.Row
     return g.db
 

--- a/wrtc_bridge_blueprint.py
+++ b/wrtc_bridge_blueprint.py
@@ -20,6 +20,8 @@ import urllib.request
 
 from flask import Blueprint, g, jsonify, redirect, render_template, request, url_for
 
+from bottube_db import resolve_db_path
+
 wrtc_bp = Blueprint("wrtc_bridge", __name__)
 
 # Canonical wRTC settings from bounty spec.
@@ -89,8 +91,7 @@ def get_db():
     """Get database connection from Flask g."""
     if "db" in g:
         return g.db
-    db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
-    g.db = sqlite3.connect(db_path)
+    g.db = sqlite3.connect(resolve_db_path())
     g.db.row_factory = sqlite3.Row
     return g.db
 


### PR DESCRIPTION
## Summary
- add a shared `resolve_db_path()` helper for the BoTTube SQLite path
- make the four crypto-bridge blueprints use the same resolver as server-side table init
- keep `BOTTUBE_DB` working as a legacy alias, but prefer `BOTTUBE_DB_PATH` and `BOTTUBE_BASE_DIR`

## Testing
- `pytest -q tests/test_crypto_bridge_db_path.py`
