### PR TITLE
fix(gemini): honor canonical db path env vars

### DIFF
--- a/bottube_db.py
+++ b/bottube_db.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+import os
+
+
+def resolve_db_path() -> str:
+    """Resolve the BoTTube SQLite path consistently across server and blueprints.
+
+    Precedence:
+    1. BOTTUBE_DB_PATH (canonical name used by the main server)
+    2. BOTTUBE_DB (legacy alias kept for backward compatibility)
+    3. BOTTUBE_BASE_DIR/bottube.db
+    4. repo-local bottube.db next to this file
+    """
+    explicit = os.environ.get("BOTTUBE_DB_PATH") or os.environ.get("BOTTUBE_DB")
+    if explicit:
+        return explicit
+    base_dir = Path(os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent)))
+    return str(base_dir / "bottube.db")

--- a/gemini_blueprint.py
+++ b/gemini_blueprint.py
@@ -23,6 +23,8 @@ import time
 import hashlib
 import shutil
 
+from bottube_db import resolve_db_path
+
 gemini_bp = Blueprint("gemini", __name__)
 log = logging.getLogger("gemini")
 
@@ -68,8 +70,7 @@ def _get_client():
 def get_db():
     """Get database connection from Flask g."""
     if "db" not in g:
-        db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
-        g.db = sqlite3.connect(db_path)
+        g.db = sqlite3.connect(resolve_db_path())
         g.db.row_factory = sqlite3.Row
     return g.db
 
@@ -77,8 +78,7 @@ def get_db():
 def init_gemini_tables(db=None):
     """Create Gemini-related tables if they don't exist."""
     if db is None:
-        db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
-        db = sqlite3.connect(db_path)
+        db = sqlite3.connect(resolve_db_path())
         should_close = True
     else:
         should_close = False
@@ -159,7 +159,7 @@ def _check_rate(agent_id, job_type, max_per_hour):
 def _generate_video_async(job_id, agent_id, prompt, negative_prompt="",
                           aspect_ratio="16:9", resolution="720p", fast=False):
     """Background thread for video generation via Veo 3."""
-    db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
+    db_path = resolve_db_path()
 
     try:
         client = _get_client()
@@ -620,7 +620,7 @@ def image_to_video():
 
 def _generate_i2v_async(job_id, agent_id, prompt, image_path, aspect_ratio="16:9"):
     """Background thread for image-to-video generation."""
-    db_path = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
+    db_path = resolve_db_path()
 
     try:
         client = _get_client()

--- a/tests/test_gemini_db_path.py
+++ b/tests/test_gemini_db_path.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+import importlib
+import os
+import sqlite3
+from pathlib import Path
+
+
+def test_gemini_uses_bottube_db_path_for_app_and_worker(tmp_path, monkeypatch):
+    db_dir = tmp_path / "custom-db-dir"
+    db_dir.mkdir()
+    db_path = db_dir / "bottube.db"
+
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(db_path))
+    monkeypatch.delenv("BOTTUBE_DB", raising=False)
+
+    import gemini_blueprint
+    importlib.reload(gemini_blueprint)
+
+    gemini_blueprint.init_gemini_tables()
+    assert db_path.exists(), "init_gemini_tables() should create the configured DB file"
+
+    from flask import Flask
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    with app.app_context():
+        db = gemini_blueprint.get_db()
+        row = db.execute("PRAGMA database_list").fetchone()
+        assert Path(row[2]) == db_path
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO gemini_jobs (job_id, agent_id, job_type, model, prompt, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ("job-1", 1, "video", "veo", "prompt", 0),
+    )
+    conn.commit()
+    conn.close()
+
+    gemini_blueprint._update_job(str(db_path), "job-1", "completed", result_path="/tmp/out.mp4")
+
+    conn = sqlite3.connect(db_path)
+    status, result_path = conn.execute(
+        "SELECT status, result_path FROM gemini_jobs WHERE job_id = ?",
+        ("job-1",),
+    ).fetchone()
+    conn.close()
+
+    assert status == "completed"
+    assert result_path == "/tmp/out.mp4"


### PR DESCRIPTION
## Summary
- route Gemini blueprint DB access through the same resolver already used by the bridge fixes
- honor `BOTTUBE_DB_PATH` before legacy `BOTTUBE_DB` in request handlers and background workers
- add a regression test that proves the configured DB file is used for both app and worker updates

## Testing
- pytest -q tests/test_gemini_db_path.py tests/test_gemini_blueprint_registration.py

/claim #1735