### PR TITLE
fix(admin): use one admin key across trust-safety routes

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -20511,8 +20511,8 @@ def submit_report():
 def _ts_admin_ok():
     """Check if the current request has admin privileges for trust-and-safety endpoints. Returns: True if admin."""
     key = request.headers.get("X-Admin-Key", "") or request.args.get("admin_key", "")
-    expected = os.environ.get("BOTTUBE_ADMIN_KEY", "") or os.environ.get("RC_ADMIN_KEY", "")
-    return bool(expected) and (key == expected)
+    expected = ADMIN_KEY
+    return bool(expected) and hmac.compare_digest(key, expected)
 
 
 @app.route("/admin/blocklist/add", methods=["POST"])

--- a/tests/test_admin_key_env.py
+++ b/tests/test_admin_key_env.py
@@ -1,0 +1,50 @@
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture()
+def server_module(monkeypatch, tmp_path):
+    monkeypatch.setenv("BOTTUBE_AUTH_DB_PATH", str(tmp_path / "auth.db"))
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(tmp_path / "bottube.db"))
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    sys.modules.pop("bottube_server", None)
+    module = importlib.import_module("bottube_server")
+    yield module
+    sys.modules.pop("bottube_server", None)
+
+
+def test_trust_safety_gate_uses_ephemeral_admin_key(server_module):
+    client = server_module.app.test_client()
+    response = client.post('/admin/blocklist/add', headers={'X-Admin-Key': server_module.ADMIN_KEY}, json={})
+    assert response.status_code != 401
+
+
+def test_trust_safety_gate_accepts_bottube_admin_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("BOTTUBE_AUTH_DB_PATH", str(tmp_path / "auth.db"))
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(tmp_path / "bottube.db"))
+    monkeypatch.setenv("BOTTUBE_ADMIN_KEY", "bot-key")
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    sys.modules.pop("bottube_server", None)
+    module = importlib.import_module("bottube_server")
+    client = module.app.test_client()
+    ok = client.post('/admin/blocklist/add', headers={'X-Admin-Key': 'bot-key'}, json={})
+    bad = client.post('/admin/blocklist/add', headers={'X-Admin-Key': 'wrong'}, json={})
+    assert ok.status_code != 401
+    assert bad.status_code == 401
+    sys.modules.pop("bottube_server", None)
+
+
+def test_trust_safety_gate_rejects_rc_only_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("BOTTUBE_AUTH_DB_PATH", str(tmp_path / "auth.db"))
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(tmp_path / "bottube.db"))
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("RC_ADMIN_KEY", "legacy-rc-key")
+    sys.modules.pop("bottube_server", None)
+    module = importlib.import_module("bottube_server")
+    client = module.app.test_client()
+    response = client.post('/admin/blocklist/add', headers={'X-Admin-Key': 'legacy-rc-key'}, json={})
+    assert response.status_code == 401
+    sys.modules.pop("bottube_server", None)


### PR DESCRIPTION
## Summary
- make trust-and-safety admin routes reuse the same `ADMIN_KEY` value as the rest of the server
- stop accepting `RC_ADMIN_KEY` as a separate override for those endpoints
- add regression tests covering the ephemeral key path, configured `BOTTUBE_ADMIN_KEY`, and the legacy RC-only mismatch

## Testing
- `pytest -q tests/test_admin_key_env.py`

/claim #1729