### PR TITLE
ci: add per-step/job timeouts so hangs fail fast with a clear message

### DIFF
--- a/.github/workflows/bottube-verify.yml
+++ b/.github/workflows/bottube-verify.yml
@@ -39,20 +39,27 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    # Explicit per-job timeout: a hang (network fetch, package index,
+    # external API) now fails fast with a clear "timed out after N
+    # minutes" message instead of hanging until the default 360-minute
+    # job limit and blaming the caller.
+    timeout-minutes: 15
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+        timeout-minutes: 5
 
       - name: Install bottube-verify
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip --timeout 30
           # Install from the repo until the PyPI publish lands. Pinned to
           # the v0.4.0 tag so a malicious branch tip can't change verifier
           # logic mid-build.
-          pip install "git+https://github.com/Scottcjn/bottube@v0.4.0-verifier#egg=bottube-verify" || \
-            pip install "git+https://github.com/Scottcjn/bottube@main#egg=bottube-verify"
+          pip install --timeout 30 "git+https://github.com/Scottcjn/bottube@v0.4.0-verifier#egg=bottube-verify" || \
+            pip install --timeout 30 "git+https://github.com/Scottcjn/bottube@main#egg=bottube-verify"
+        timeout-minutes: 10
 
       - name: Run verifier on each video
         env:
@@ -82,3 +89,4 @@ jobs:
             exit 1
           fi
           echo "All videos verified clean."
+        timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,81 +6,139 @@ on:
   pull_request:
     branches: [ main ]
 
+# If several workflows fire on the same commit (push + PR, or rapid
+# pushes), don't queue a pile of redundant runs: cancel the superseded
+# ones. This reduces runner load and avoids the resource-exhaustion
+# pattern where jobs wait forever for a hosted runner.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    # Explicit job-level timeout: a hung step now fails the job with a
+    # clear "exceeded the maximum execution time" annotation instead of
+    # silently waiting (the default is 360 minutes).
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
-    
+      timeout-minutes: 3
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    
+      timeout-minutes: 5
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pylint
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    
+        python -m pip install --upgrade pip --timeout 30
+        pip install --timeout 30 flake8 pylint
+        if [ -f requirements.txt ]; then pip install --timeout 30 -r requirements.txt; fi
+      timeout-minutes: 8
+
     - name: Lint with flake8
       run: |
         # Stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # Exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    
+      timeout-minutes: 5
+
     - name: Lint with pylint
       continue-on-error: true
       run: |
         pylint bottube_server.py --disable=C,R,W || true
+      timeout-minutes: 5
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
-    
+      timeout-minutes: 3
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    
+      timeout-minutes: 5
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    
+        python -m pip install --upgrade pip --timeout 30
+        pip install --timeout 30 pytest pytest-cov
+        if [ -f requirements.txt ]; then pip install --timeout 30 -r requirements.txt; fi
+      timeout-minutes: 8
+
     - name: Run tests
       run: |
         pytest tests/ -v --cov=. --cov-report=xml || true
-    
+      timeout-minutes: 10
+
     - name: Upload coverage
       uses: codecov/codecov-action@v4
       if: always()
+      timeout-minutes: 5
 
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
-    
+      timeout-minutes: 3
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    
+      timeout-minutes: 5
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install bandit safety
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    
+        python -m pip install --upgrade pip --timeout 30
+        pip install --timeout 30 bandit safety
+        if [ -f requirements.txt ]; then pip install --timeout 30 -r requirements.txt; fi
+      timeout-minutes: 8
+
     - name: Run Bandit security linter
       continue-on-error: true
       run: |
         bandit -r . -x ./tests || true
-    
+      timeout-minutes: 5
+
     - name: Check dependencies for vulnerabilities
       continue-on-error: true
       run: |
         safety check || true
+      timeout-minutes: 5
+
+  # Outcome report: tells the contributor *why* a check is red.
+  # A job cancelled by its timeout-minutes limit reports "cancelled";
+  # a job where a step exited non-zero reports "failure". That
+  # distinction is the difference between "CI infra hung" and
+  # "your code failed", which is exactly what the 15m01s failures
+  # obscured.
+  report:
+    name: CI outcome report
+    runs-on: ubuntu-latest
+    needs: [lint, test, security]
+    if: always()
+    timeout-minutes: 2
+    steps:
+      - name: Distinguish timeout from failure
+        run: |
+          L="${{ needs.lint.result }}"
+          T="${{ needs.test.result }}"
+          S="${{ needs.security.result }}"
+          echo "lint=$L test=$T security=$S"
+          if echo "$L $T $S" | grep -q cancelled; then
+            echo "::error::A CI job was CANCELLED at its timeout-minutes limit (infrastructure hang, not necessarily a code failure). Re-run the workflow to confirm."
+            exit 1
+          elif echo "$L $T $S" | grep -qE 'failure|error'; then
+            echo "::error::A CI job FAILED on a step. Look at the failing job's logs above - that is a real failure."
+            exit 1
+          else
+            echo "All CI jobs completed successfully."
+          fi

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,12 +8,23 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   label:
     runs-on: ubuntu-latest
+    # Job-level timeout so a hung step fails fast with a clear
+    # "exceeded the maximum execution time" annotation instead of a
+    # misleading 15-minute silent wait (see bottube#1639/#1640 where
+    # label/lint/security/test all "failed" at 15m01s on an infra
+    # outage that never ran any step).
+    timeout-minutes: 5
     steps:
       - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler.yml
           sync-labels: false
+        timeout-minutes: 4


### PR DESCRIPTION
## Root cause (evidenced from job logs)

On 2026-08-06, PRs #1639 and #1640 failed all four checks (label/lint/security/test) with a uniform **15m01s** duration — a job timeout, not a test failure. The logs show:

- `Failed to resolve action download info. Error: Service Unavailable` (label job, run 31120673316: `Set up job` step only)
- `The job was not acquired by Runner of type hosted even after multiple attempts` (lint/test/security, run 31117884071)
- Every step shows `UNKNOWN STEP` — **no workflow step ever executed**

This was a GitHub Actions infrastructure outage (action-download resolution 503 + hosted runner acquisition failure), not contributor code. Proof: the same `label` job passes on the 30 other open PRs, and the same jobs passed before/after (e.g. all CI green 2026-08-20→22). The 15m01s is the hosted-runner acquisition wait being reported as a failed check — contributors were blamed for failures that were never theirs.

## Fix

1. **Explicit job-level `timeout-minutes`** (lint/test/security 10m, labeler 5m, verifier 15m) — a hung job now fails fast with GitHub's clear `exceeded the maximum execution time` annotation instead of silently waiting up to the 360m default.
2. **Per-step `timeout-minutes`** on checkout/setup-python/install/lint/pytest/bandit/safety/codecov — a single hanging step fails with a clear `timed out after N minutes` message.
3. **`pip --timeout 30`** on network-bound installs so package fetches fail instead of hanging forever.
4. **`concurrency` groups** — stacked runs on the same ref are cancelled instead of queueing more runner demand (one of the suspected resource-exhaustion vectors).
5. **`CI outcome report` job** — distinguishes a cancelled (timed-out) job from a genuine failure in what the contributor sees, so a recurrence says *"infrastructure hang, re-run"* rather than *"your code failed"*.

Fixes bounty #16472 (20 RTC; also satisfies the +5 RTC distinguisher clause).