### PR TITLE
docs: add docstrings to translations tests (16 functions)

### DIFF
--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -24,17 +24,20 @@ class TestGetAllTranslations:
     """Tests for get_all_translations()."""
 
     def test_returns_dict_with_videos_key(self):
+        """get_all_translations returns a dict containing a 'videos' key."""
         result = get_all_translations()
         assert isinstance(result, dict)
         assert "videos" in result
         assert "metadata" in result
 
     def test_videos_is_non_empty_list(self):
+        """The videos collection is a non-empty list."""
         result = get_all_translations()
         assert isinstance(result["videos"], list)
         assert len(result["videos"]) > 0
 
     def test_each_video_has_required_keys(self):
+        """Every video entry carries the required identification keys."""
         result = get_all_translations()
         for video in result["videos"]:
             assert "video_url" in video, f"Missing video_url in {video}"
@@ -44,6 +47,7 @@ class TestGetAllTranslations:
             assert isinstance(video["translations"], dict)
 
     def test_metadata_has_languages(self):
+        """Metadata includes the supported languages list."""
         result = get_all_translations()
         meta = result["metadata"]
         assert "languages" in meta
@@ -55,6 +59,7 @@ class TestGetVideoTranslations:
     """Tests for get_video_translations(url)."""
 
     def test_existing_url_returns_video(self):
+        """A known watch URL resolves to its translation record."""
         url = "https://bottube.ai/watch/tech-revolution-2024"
         result = get_video_translations(url)
         assert result is not None
@@ -62,10 +67,12 @@ class TestGetVideoTranslations:
         assert "translations" in result
 
     def test_nonexistent_url_returns_none(self):
+        """An unknown watch URL returns None."""
         result = get_video_translations("https://bottube.ai/watch/nonexistent-video")
         assert result is None
 
     def test_empty_string_url_returns_none(self):
+        """An empty URL returns None instead of raising."""
         result = get_video_translations("")
         assert result is None
 
@@ -78,6 +85,7 @@ class TestGetVideoTranslations:
         assert result_upper is None
 
     def test_returned_video_has_translations_for_all_languages(self):
+        """A translated video carries entries for every supported language."""
         url = "https://bottube.ai/watch/crypto-trading-guide"
         result = get_video_translations(url)
         assert result is not None
@@ -92,11 +100,13 @@ class TestGetTranslationsByLanguage:
     """Tests for get_translations_by_language(language)."""
 
     def test_chinese_returns_all_videos(self):
+        """Filtering by chinese returns all translated videos as a list."""
         result = get_translations_by_language("chinese")
         assert isinstance(result, list)
         assert len(result) == len(TRANSLATION_DATA["videos"])
 
     def test_spanish_returns_correct_structure(self):
+        """Spanish-filtered entries carry the expected structure."""
         result = get_translations_by_language("spanish")
         for entry in result:
             assert "video_url" in entry
@@ -107,10 +117,12 @@ class TestGetTranslationsByLanguage:
             assert "description" in entry["translation"]
 
     def test_unsupported_language_returns_empty_list(self):
+        """An unsupported language filter returns an empty list."""
         result = get_translations_by_language("klingon")
         assert result == []
 
     def test_empty_string_language_returns_empty_list(self):
+        """An empty language filter returns an empty list."""
         result = get_translations_by_language("")
         assert result == []
 
@@ -126,21 +138,25 @@ class TestGetSupportedLanguages:
     """Tests for get_supported_languages()."""
 
     def test_returns_list(self):
+        """get_supported_languages returns a list."""
         result = get_supported_languages()
         assert isinstance(result, list)
 
     def test_contains_expected_languages(self):
+        """The supported languages include the documented set."""
         result = get_supported_languages()
         expected = ["chinese", "spanish", "french", "portuguese", "german"]
         for lang in expected:
             assert lang in result, f"Missing language: {lang}"
 
     def test_no_empty_strings_in_languages(self):
+        """No language entry is blank."""
         result = get_supported_languages()
         for lang in result:
             assert lang.strip() != "", "Empty string found in supported languages"
 
     def test_languages_are_lowercase(self):
+        """All language names are lowercase."""
         result = get_supported_languages()
         for lang in result:
             assert lang == lang.lower(), f"Language not lowercase: {lang}"


### PR DESCRIPTION
## docs: add docstrings to translations tests (16 functions)

Continues the docstring program (bulk proposal on #16548). Adds docstrings to all 16 previously undocumented test functions in `tests/test_translations.py`:

- get_all_translations (4): structure, non-empty, required keys, language metadata
- get_video_translations (4): existing URL, unknown URL, empty string, full language coverage
- get_translations_by_language (4): chinese, spanish structure, unsupported, empty
- get_supported_languages (4): list type, expected set, no blanks, lowercase

**Verification:** `pytest tests/test_translations.py -q` → **18 passed**; file parses clean. Docstrings-only change.

Wallet: ezequiellich44-cmd (#16548)