### PR TITLE
docs: add docstrings to syndication queue tests (14 functions)

### DIFF
--- a/outreach/test_queue.py
+++ b/outreach/test_queue.py
@@ -15,22 +15,27 @@ from poll_upload_queue import Video, QueueEntry, SyndicationQueue
 
 class TestVideo(unittest.TestCase):
     def test_opt_out_tag_nosyndicate(self):
+        """The 'nosyndicate' tag triggers the syndication opt-out."""
         v = Video("v1", "Test", "agent1", "2026-01-01", tags=["nosyndicate"])
         self.assertTrue(v.has_opt_out_tag())
 
     def test_opt_out_tag_mixed_case(self):
+        """The opt-out tag match is case-insensitive."""
         v = Video("v2", "Test", "agent1", "2026-01-01", tags=["NoSyndicate", "game"])
         self.assertTrue(v.has_opt_out_tag())
 
     def test_no_opt_out(self):
+        """Videos without the opt-out tag are not opted out."""
         v = Video("v3", "Test", "agent1", "2026-01-01", tags=["ai", "demo"])
         self.assertFalse(v.has_opt_out_tag())
 
     def test_empty_tags(self):
+        """Videos with no tags are not opted out."""
         v = Video("v4", "Test", "agent1", "2026-01-01", tags=[])
         self.assertFalse(v.has_opt_out_tag())
 
     def test_from_api(self):
+        """Video.from_api builds a Video from the API payload shape."""
         data = {
             "video_id": "vid123",
             "title": "My Video",
@@ -47,17 +52,20 @@ class TestVideo(unittest.TestCase):
 
 class TestSyndicationQueue(unittest.TestCase):
     def setUp(self):
+        """Create a temp directory for queue and state files."""
         self.tmpdir = tempfile.mkdtemp()
         self.queue_file = os.path.join(self.tmpdir, "queue.json")
         self.state_file = os.path.join(self.tmpdir, "state.json")
 
     def tearDown(self):
+        """Remove temp queue/state files after each test."""
         for f in [self.queue_file, self.state_file]:
             if os.path.exists(f):
                 os.remove(f)
         os.rmdir(self.tmpdir)
 
     def test_enqueue_new_video(self):
+        """A new video is enqueued for syndication."""
         q = SyndicationQueue(self.queue_file, self.state_file)
         v = Video("v1", "Test Video", "agent1", "2026-01-01")
         result = q.enqueue(v)
@@ -65,6 +73,7 @@ class TestSyndicationQueue(unittest.TestCase):
         self.assertEqual(q.size(), 1)
 
     def test_dedupe_already_processed(self):
+        """Already-processed videos are not re-enqueued."""
         q = SyndicationQueue(self.queue_file, self.state_file)
         v = Video("v1", "Test Video", "agent1", "2026-01-01")
         q.mark_processed("v1")
@@ -73,6 +82,7 @@ class TestSyndicationQueue(unittest.TestCase):
         self.assertEqual(q.size(), 0)
 
     def test_dedupe_already_queued(self):
+        """Videos already in the queue are not duplicated."""
         q = SyndicationQueue(self.queue_file, self.state_file)
         v = Video("v1", "Test Video", "agent1", "2026-01-01")
         q.enqueue(v)
@@ -81,6 +91,7 @@ class TestSyndicationQueue(unittest.TestCase):
         self.assertEqual(q.size(), 1)
 
     def test_opt_out_skipped(self):
+        """Opted-out videos are skipped during enqueue."""
         q = SyndicationQueue(self.queue_file, self.state_file)
         v = Video("v1", "Test", "agent1", "2026-01-01", tags=["nosyndicate"])
         result = q.enqueue(v)
@@ -89,6 +100,7 @@ class TestSyndicationQueue(unittest.TestCase):
         self.assertIn("v1", q._processed_ids)
 
     def test_persistence_across_restarts(self):
+        """Queue state survives a full object reload from disk."""
         q1 = SyndicationQueue(self.queue_file, self.state_file)
         v = Video("v1", "Test", "agent1", "2026-01-01")
         q1.enqueue(v)
@@ -101,6 +113,7 @@ class TestSyndicationQueue(unittest.TestCase):
         self.assertIn("v1", q2._processed_ids)
 
     def test_get_pending(self):
+        """get_pending returns queued videos not yet processed."""
         q = SyndicationQueue(self.queue_file, self.state_file)
         q.enqueue(Video("v1", "T1", "a", "2026-01-01"))
         q.enqueue(Video("v2", "T2", "a", "2026-01-01"))
@@ -110,6 +123,7 @@ class TestSyndicationQueue(unittest.TestCase):
         self.assertEqual(pending[1].video_id, "v2")
 
     def test_mark_processed_removes_from_queue(self):
+        """mark_processed removes the video from the pending queue."""
         q = SyndicationQueue(self.queue_file, self.state_file)
         v = Video("v1", "Test", "agent1", "2026-01-01")
         q.enqueue(v)


### PR DESCRIPTION
## docs: add docstrings to syndication queue tests (14 functions)

Completes the docstring program for the outreach module (bulk proposal on #16548). Adds docstrings to all 14 previously undocumented test functions in `outreach/test_queue.py`:

- Opt-out detection (4): nosyndicate tag, case-insensitive match, no-tag pass, empty tags
- Video model (1): from_api payload construction
- Queue lifecycle (7): enqueue, dedupe (processed + queued), opt-out skip, persistence, get_pending, mark_processed
- Fixtures (2): setUp/tearDown

**Verification:** `pytest outreach/test_queue.py -q` → **12 passed**; file parses clean. Docstrings-only change.

This is the LAST file with undocumented functions in the outreach module.

Wallet: ezequiellich44-cmd (#16548)