### PR TITLE
fix(docs): homepage upload step no longer conflates the 500MB upload cap with the 2MB transcode target

### DIFF
--- a/bottube_templates/index.html
+++ b/bottube_templates/index.html
@@ -1004,7 +1004,7 @@
         <div class="how-step">
             <div class="step-num">3</div>
             <div class="step-title">Upload</div>
-            <div class="step-desc">720x720 max, 2MB. FFmpeg or raw.</div>
+            <div class="step-desc">Up to 500MB. Auto-transcoded to 720x720, ~2MB.</div>
             <code class="step-code">client.upload("vid.mp4",<br>&nbsp; title="Hello World")</code>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -989,7 +989,7 @@
         <div class="how-step">
             <div class="step-num">3</div>
             <div class="step-title">Upload</div>
-            <div class="step-desc">720x720 max, 2MB. FFmpeg or raw.</div>
+            <div class="step-desc">Up to 500MB. Auto-transcoded to 720x720, ~2MB.</div>
             <code class="step-code">client.upload("vid.mp4",<br>&nbsp; title="Hello World")</code>
         </div>
     </div>

--- a/tests/test_homepage_accessibility.py
+++ b/tests/test_homepage_accessibility.py
@@ -95,3 +95,14 @@ def test_homepage_templates_include_mobile_overflow_guards() -> None:
     assert "width: 100%;" in index_template
     assert "white-space: normal;" in index_template
     assert "overflow-wrap: anywhere;" in index_template
+
+
+def test_homepage_upload_step_does_not_conflate_upload_cap_with_transcode_target() -> None:
+    """Regression for #1741: the "Upload" how-step used to read "720x720 max, 2MB. FFmpeg
+    or raw.", which reads as a 2MB *upload* cap. The real backend limit is 500MB per
+    upload (MAX_VIDEO_SIZE in bottube_server.py); 2MB is only the post-transcode output
+    target. The copy must state the 500MB upload allowance, not just the final size."""
+    index_template = (ROOT / "bottube_templates" / "index.html").read_text(encoding="utf-8")
+
+    assert "720x720 max, 2MB. FFmpeg or raw." not in index_template
+    assert "500MB" in index_template


### PR DESCRIPTION
Fixes #1741

## Summary
The homepage "Upload" how-step read **"720x720 max, 2MB. FFmpeg or raw."** — that phrasing reads as a 2MB *upload* cap. The actual backend limit (`MAX_VIDEO_SIZE` in `bottube_server.py`) is **500MB per upload**; 2MB is only the target final size after server-side transcoding. A new agent reading the homepage would either pre-compress source video unnecessarily, or conclude a perfectly valid upload is too large and never attempt it — a silent drop-off with no error to debug.

I checked every other doc surface the issue flagged as a possible sweep (`README.md`, `AGENT_QUICKSTART.md`, `sdk/README.md`, `skills/bottube/SKILL.md`, `examples/cli-uploader/README.md`, `mobile-app/README.md`) plus `join.html`/`dashboard.html` — they already state the 500MB/2MB split correctly. So this only touches the two remaining stale spots:

- `bottube_templates/index.html` (the served homepage template) — reworded the Upload step to `Up to 500MB. Auto-transcoded to 720x720, ~2MB.`
- `index.html` (an unused legacy duplicate still tracked in-repo) — same fix for consistency, in case it's ever revived

## Testing
- Added `test_homepage_upload_step_does_not_conflate_upload_cap_with_transcode_target` to `tests/test_homepage_accessibility.py`
- `pytest -q tests/test_homepage_accessibility.py` — 3 passed

/claim #1741