### PR TITLE
docs: add docstrings to social graph, generation reliability, and gemini validation tests (39 functions)

### DIFF
--- a/tests/test_gemini_request_validation.py
+++ b/tests/test_gemini_request_validation.py
@@ -16,6 +16,13 @@ if not hasattr(werkzeug, "__version__"):
 
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
+    """Build an isolated Flask app around just the Gemini blueprint.
+
+    Registers only `gemini_bp` on a throwaway `Flask(__name__)` (rather than
+    importing the full `bottube_server` app) and stubs the actual
+    generation calls to always fail the test if reached, so these tests can
+    prove validation runs *before* any expensive/paid Gemini API call.
+    """
     db_path = tmp_path / "gemini.db"
     conn = sqlite3.connect(str(db_path))
     conn.executescript(
@@ -39,6 +46,13 @@ def client(tmp_path, monkeypatch):
     app.register_blueprint(gemini_blueprint.gemini_bp)
 
     def _test_get_db():
+        """Replace `gemini_blueprint.get_db` with a per-request connection to the test DB.
+
+        The blueprint's real `get_db` opens the production database path;
+        swapping it (via `monkeypatch.setattr` below) is what keeps every
+        request in these tests confined to `db_path` instead of touching
+        whatever database the blueprint module was configured for.
+        """
         if "test_db" in g:
             return g.test_db
         db = sqlite3.connect(str(db_path))
@@ -48,6 +62,7 @@ def client(tmp_path, monkeypatch):
 
     @app.teardown_appcontext
     def _close_db(_exc):
+        """Close the per-request test connection so SQLite file handles don't leak across requests."""
         db = g.pop("test_db", None)
         if db is not None:
             db.close()
@@ -74,15 +89,18 @@ def client(tmp_path, monkeypatch):
 
 
 def _auth_headers():
+    """Return the API key header for the single agent seeded by the `client` fixture."""
     return {"X-API-Key": "bottube_sk_gemini_agent"}
 
 
 def _job_count(db_path):
+    """Return how many rows exist in `gemini_jobs`, used to prove rejected requests created none."""
     with sqlite3.connect(str(db_path)) as db:
         return db.execute("SELECT COUNT(*) FROM gemini_jobs").fetchone()[0]
 
 
 def _insert_jobs(db_path, count):
+    """Seed `count` already-completed jobs, oldest first, to test limit/pagination behavior."""
     with sqlite3.connect(str(db_path)) as db:
         for idx in range(count):
             db.execute(
@@ -97,6 +115,12 @@ def _insert_jobs(db_path, count):
 
 
 def test_authenticated_video_rejects_non_object_json_without_job(client):
+    """A JSON array body must 400 before any job row is created.
+
+    `_job_count == 0` afterward is the load-bearing assertion: it proves
+    the rejection happens before the (stubbed-to-fail) generation call, not
+    just that the HTTP status looks right.
+    """
     resp = client.post(
         "/api/gemini/generate-video",
         json=["not", "an", "object"],
@@ -109,6 +133,7 @@ def test_authenticated_video_rejects_non_object_json_without_job(client):
 
 
 def test_authenticated_video_rejects_non_string_prompt_without_job(client):
+    """A list-typed `prompt` must be rejected, not silently stringified into a job."""
     resp = client.post(
         "/api/gemini/generate-video",
         json={"prompt": ["draw this"]},
@@ -121,6 +146,12 @@ def test_authenticated_video_rejects_non_string_prompt_without_job(client):
 
 
 def test_authenticated_video_rejects_non_string_negative_prompt_without_job(client):
+    """`negative_prompt` needs its own type check even though `prompt` is valid here.
+
+    A validator that only checked `prompt` and forwarded the rest of the
+    body unchecked would let a malformed `negative_prompt` reach the
+    (stubbed) generation call instead of failing fast with a clear error.
+    """
     resp = client.post(
         "/api/gemini/generate-video",
         json={"prompt": "draw this", "negative_prompt": ["bad"]},
@@ -133,6 +164,12 @@ def test_authenticated_video_rejects_non_string_negative_prompt_without_job(clie
 
 
 def test_authenticated_image_rejects_non_string_prompt_before_generation(client):
+    """The image endpoint enforces the same `prompt` type check as video, independently.
+
+    Video and image are separate routes/handlers; this guards against the
+    image path having its own, weaker (or missing) copy of the validation
+    the video tests above already cover.
+    """
     resp = client.post(
         "/api/gemini/generate-image",
         json={"prompt": {"text": "draw this"}},
@@ -145,6 +182,7 @@ def test_authenticated_image_rejects_non_string_prompt_before_generation(client)
 
 
 def test_jobs_rejects_malformed_limit(client):
+    """A non-numeric `limit` query param must 400 rather than fall back to a default silently."""
     resp = client.get("/api/gemini/jobs?limit=not-an-int", headers=_auth_headers())
 
     assert resp.status_code == 400
@@ -152,6 +190,13 @@ def test_jobs_rejects_malformed_limit(client):
 
 
 def test_jobs_clamps_limit(client):
+    """`limit` must be clamped into [1, 50], not passed through raw to the SQL query.
+
+    `limit=0` clamping up to 1 and `limit=999` clamping down to 50 (against
+    60 seeded jobs) both matter: an un-clamped 0 would return an empty
+    result silently, and an un-clamped huge limit would let a caller pull
+    the entire job history in one request.
+    """
     _insert_jobs(client.db_path, 60)
 
     resp = client.get("/api/gemini/jobs?limit=0", headers=_auth_headers())
@@ -184,6 +229,13 @@ def test_jobs_clamps_limit(client):
 def test_free_gemini_routes_reject_malformed_json_without_quota_or_job(
     client, path, payload, expected_error
 ):
+    """Unauthenticated /free/* endpoints must reject bad input before spending IP quota.
+
+    Unlike the authenticated tests above, no `_auth_headers()` is sent here
+    -- these routes are rate-limited per IP instead of per API key, so the
+    `_ip_rate_buckets == {}` assertion confirms a malformed request doesn't
+    consume a free-tier quota slot it never earned by reaching real work.
+    """
     resp = client.post(path, json=payload)
 
     assert resp.status_code == 400

--- a/tests/test_generation_reliability.py
+++ b/tests/test_generation_reliability.py
@@ -4,6 +4,12 @@ from generation.reliability import RetryPolicy, classify_error, provider_metrics
 
 
 def test_classify_error_categories():
+    """`classify_error` must sort errors into their retry-policy bucket.
+
+    The category drives `run_with_retries`' retry decision downstream, so
+    getting e.g. auth misclassified as transient would make the retry loop
+    burn attempts hammering a key that will never work.
+    """
     assert classify_error("401 unauthorized api key") == "auth"
     assert classify_error("429 rate limit exceeded") == "throttled"
     assert classify_error(TimeoutError("request timed out")) == "transient"
@@ -11,9 +17,17 @@ def test_classify_error_categories():
 
 
 def test_run_with_retries_retries_transient_then_succeeds():
+    """A transient error on attempt 1 should be retried and then succeed.
+
+    Confirms both the outward result (ok, value, attempts) and that a
+    successful retry still lands in `provider_metrics_snapshot()`, since a
+    retry path that recovers the call but forgets to record it would hide
+    real flakiness from provider health dashboards.
+    """
     calls = {"count": 0}
 
     def flaky():
+        """Fail with a transient timeout once, then return a fake job id."""
         calls["count"] += 1
         if calls["count"] < 2:
             raise TimeoutError("temporary provider timeout")
@@ -37,9 +51,16 @@ def test_run_with_retries_retries_transient_then_succeeds():
 
 
 def test_run_with_retries_does_not_retry_auth_errors():
+    """Auth failures must fail fast instead of burning the retry budget.
+
+    Asserts `calls["count"] == 1` specifically because a bad API key will
+    never succeed on a second try -- retrying it just multiplies wasted
+    provider requests (and, on some providers, lockout risk) for zero gain.
+    """
     calls = {"count": 0}
 
     def auth_failure():
+        """Always raise a 403, simulating a permanently invalid API key."""
         calls["count"] += 1
         raise RuntimeError("403 forbidden: invalid API key")
 
@@ -62,6 +83,13 @@ def test_run_with_retries_does_not_retry_auth_errors():
 
 
 def test_run_with_retries_records_semantic_false_result_as_failure():
+    """A call that returns cleanly but fails its `success_predicate` is a failure.
+
+    Providers can return `(False, "quota exhausted")` without raising, so
+    the retry harness needs a semantic check on top of exception handling
+    -- otherwise a call that "succeeds" at the transport level while
+    failing at the business level would be misreported as a success.
+    """
     ok, value, category, latency_s, attempts = run_with_retries(
         "unit_provider_semantic_false",
         "submit",
@@ -82,11 +110,27 @@ def test_run_with_retries_records_semantic_false_result_as_failure():
 
 
 def test_run_with_retries_classifies_semantic_failure_reason_not_tuple_repr():
+    """Classification must read the failure *reason*, not the truthy check's repr.
+
+    `NoisyFalse` is falsy but reprs as unrelated auth-sounding noise; if
+    `classify_error` were accidentally fed `repr(result[0])` instead of the
+    actual reason string ("validation failed"), this test would catch the
+    category coming back "auth" instead of the correct "permanent".
+    """
     class NoisyFalse:
+        """A falsy sentinel whose repr looks like an unrelated auth error.
+
+        Exists to prove the retry harness classifies failures using the
+        semantic reason string, not whatever `repr()` happens to say about
+        the object that failed the success predicate.
+        """
+
         def __bool__(self):
+            """Report falsy, so `success_predicate=lambda r: r[0]` treats this as a failure."""
             return False
 
         def __repr__(self):
+            """Return misleading auth-flavored text to catch reason/repr confusion."""
             return "api key noise"
 
     ok, value, category, latency_s, attempts = run_with_retries(
@@ -105,9 +149,17 @@ def test_run_with_retries_classifies_semantic_failure_reason_not_tuple_repr():
 
 
 def test_run_with_retries_latency_includes_semantic_retry_sleep():
+    """Reported latency must include the sleep between semantic-failure retries.
+
+    Asserts `latency_s >= 0.01` (the configured `base_delay_s`) so a
+    latency figure that only timed the call attempts and silently dropped
+    the backoff sleep can't understate real end-to-end request time in
+    provider metrics.
+    """
     calls = {"count": 0}
 
     def semantic_then_permanent():
+        """Fail semantically (quota) once, then fail semantically (validation) again."""
         calls["count"] += 1
         if calls["count"] == 1:
             return (False, "quota exhausted")
@@ -129,9 +181,17 @@ def test_run_with_retries_latency_includes_semantic_retry_sleep():
 
 
 def test_run_with_retries_does_not_reuse_stale_semantic_failure_after_exception():
+    """An exception on the retry must overwrite the prior semantic failure, not merge with it.
+
+    Attempt 1 fails semantically ("throttled"); attempt 2 raises a timeout
+    ("transient"). The final `category` must be "transient" -- a harness
+    that kept the first attempt's category around would misreport a
+    provider outage as a quota issue and page the wrong on-call runbook.
+    """
     calls = {"count": 0}
 
     def semantic_then_exception():
+        """Fail semantically (quota) once, then raise a transient timeout."""
         calls["count"] += 1
         if calls["count"] == 1:
             return (False, "quota exhausted")

--- a/tests/test_social_graph.py
+++ b/tests/test_social_graph.py
@@ -18,6 +18,13 @@ _orig_sqlite_connect = sqlite3.connect
 
 
 def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    """Redirect the hardcoded production DB path to the test bootstrap path.
+
+    `paypal_packages`/`bottube_server` import-time code opens
+    `/root/bottube/bottube.db` unconditionally before the `client` fixture
+    gets a chance to monkeypatch `DB_PATH`, so without this shim collecting
+    this test module would create or touch the real production database.
+    """
     if str(path) == "/root/bottube/bottube.db":
         path = os.environ["BOTTUBE_DB_PATH"]
     return _orig_sqlite_connect(path, *args, **kwargs)
@@ -32,6 +39,13 @@ _orig_init_store_db = paypal_packages.init_store_db
 
 
 def _test_init_store_db(db_path=None):
+    """Force paypal_packages' schema init onto the test bootstrap DB.
+
+    `bottube_server` calls `paypal_packages.init_store_db()` with no
+    arguments at import time, which would otherwise default to the real
+    on-disk store; pinning it here keeps the module import side effect
+    isolated from production data.
+    """
     bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
     Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
     return _orig_init_store_db(bootstrap_path)
@@ -46,6 +60,14 @@ sqlite3.connect = _orig_sqlite_connect
 
 @pytest.fixture()
 def client(monkeypatch, tmp_path):
+    """Yield a Flask test client wired to a throwaway per-test SQLite file.
+
+    Also clears the module-level rate-limit buckets: social-graph and
+    agent-interactions endpoints are rate limited, and a leftover bucket
+    from a previous test in the same process would make an otherwise
+    correct request fail with 429 instead of the assertion actually being
+    tested.
+    """
     db_path = tmp_path / "bottube_social_graph_test.db"
     monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
     bottube_server._rate_buckets.clear()
@@ -56,6 +78,12 @@ def client(monkeypatch, tmp_path):
 
 
 def _insert_agent(agent_name: str, created_at: float) -> int:
+    """Insert a minimal agent row and return its id.
+
+    `created_at` is a caller-controlled float rather than `time.time()` so
+    seed helpers below can build a deterministic, orderable timeline of
+    interactions instead of racing real wall-clock time.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         cur = db.execute(
@@ -71,6 +99,13 @@ def _insert_agent(agent_name: str, created_at: float) -> int:
 
 
 def _insert_video(video_id: str, agent_id: int, created_at: float) -> None:
+    """Seed a video row owned by `agent_id` so comments/votes have a target.
+
+    The social-graph and interactions endpoints join through videos to
+    attribute a comment or vote to its owner; without a video row those
+    joins would silently drop the seeded interaction instead of exercising
+    the code path under test.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
@@ -84,6 +119,13 @@ def _insert_video(video_id: str, agent_id: int, created_at: float) -> None:
 
 
 def _insert_comment(video_id: str, agent_id: int, content: str, created_at: float) -> None:
+    """Record `agent_id` commenting on `video_id`, feeding the commenter tally.
+
+    Both the social graph's pairwise `strength` score and the per-agent
+    `commenters`/`comments_given` breakdowns count rows in this table, so
+    tests build expected results by counting how many times this helper
+    was called rather than inspecting the endpoint's SQL.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
@@ -97,6 +139,13 @@ def _insert_comment(video_id: str, agent_id: int, content: str, created_at: floa
 
 
 def _insert_vote(video_id: str, agent_id: int, vote: int, created_at: float) -> None:
+    """Record `agent_id` voting on `video_id`, feeding the liker tally.
+
+    Mirrors `_insert_comment` for the votes table: only upvotes (`vote=1`)
+    are used by the seed data below because the endpoints under test count
+    likes, not net score, so a downvote would silently change what the
+    assertions are actually checking.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
@@ -110,6 +159,13 @@ def _insert_vote(video_id: str, agent_id: int, vote: int, created_at: float) -> 
 
 
 def _insert_subscription(follower_id: int, following_id: int, created_at: float) -> None:
+    """Record `follower_id` following `following_id`, feeding follower counts.
+
+    Direction matters here: the interactions endpoint reports followers
+    under "incoming" for `following_id` and the subscription itself under
+    "outgoing" for `follower_id`, so swapping the two arguments would seed
+    a valid row that asserts against the wrong side of the graph.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
@@ -123,6 +179,13 @@ def _insert_subscription(follower_id: int, following_id: int, created_at: float)
 
 
 def _seed_interaction_data():
+    """Build a fixed three-agent interaction graph shared by every test below.
+
+    Alice is deliberately the hub: she has more incoming than outgoing
+    interactions from Bob and Carol, so `top_pairs`/`most_connected` have an
+    unambiguous top result and the exact-count assertions in the tests
+    below don't depend on ordering ties.
+    """
     t = 1000.0
     alice_id = _insert_agent("alice", t)
     bob_id = _insert_agent("bob", t + 1)
@@ -153,6 +216,13 @@ def _seed_interaction_data():
 
 
 def test_social_graph_has_expected_keys_and_limit(client):
+    """`/api/social/graph` should shape its response, not just return 200.
+
+    Checks response shape with subset assertions (`<=`) rather than
+    equality so the endpoint stays free to add new fields later without
+    breaking this test; only `limit`'s effect on `top_pairs` length is
+    pinned exactly, since that's the behavior actually under test.
+    """
     _seed_interaction_data()
 
     resp = client.get("/api/social/graph?limit=1")
@@ -179,6 +249,12 @@ def test_social_graph_has_expected_keys_and_limit(client):
     ("limit=51", "limit must be <= 50"),
 ])
 def test_social_graph_rejects_invalid_limit(client, query, expected_error):
+    """Non-integer and out-of-range `limit` values must 400 with a specific message.
+
+    No seed data is needed: validation is expected to run before the query
+    touches the (empty) database, so a bug that validates after querying
+    would still pass a test that seeded data first.
+    """
     resp = client.get(f"/api/social/graph?{query}")
 
     assert resp.status_code == 400
@@ -186,6 +262,12 @@ def test_social_graph_rejects_invalid_limit(client, query, expected_error):
 
 
 def test_agent_interactions_shape_not_found_and_limit(client):
+    """Cover both the 404 branch and the full success shape in one test.
+
+    Checking the unknown-agent 404 message right before the happy path
+    guards against a common regression where a broadened query stops
+    filtering by agent and starts returning results for anyone.
+    """
     _seed_interaction_data()
 
     not_found = client.get("/api/agents/no_such_agent/interactions")
@@ -232,6 +314,12 @@ def test_agent_interactions_shape_not_found_and_limit(client):
     ("limit=51", "limit must be <= 50"),
 ])
 def test_agent_interactions_rejects_invalid_limit(client, query, expected_error):
+    """Same invalid-`limit` matrix as the graph endpoint, but on a real agent.
+
+    Data is seeded first (unlike the sibling graph test) so a validation
+    bug that only triggers once there's something to paginate can't hide
+    behind an otherwise-empty result set.
+    """
     _seed_interaction_data()
 
     resp = client.get(f"/api/agents/alice/interactions?{query}")


### PR DESCRIPTION
## Summary
Added docstrings to every previously-undocumented function across three test files:

- `tests/test_social_graph.py` — 13 functions documented
- `tests/test_generation_reliability.py` — 13 functions documented
- `tests/test_gemini_request_validation.py` — 13 functions documented

39 functions documented total, docstrings-only, no logic changed. Each docstring focuses on *why* the test/fixture/helper exists and what regression it catches (e.g. why a fixture clears rate-limit buckets, why a seed helper's argument order matters, why an assertion checks a job count of zero) rather than restating the code.

## Testing
```
pytest -q tests/test_social_graph.py tests/test_generation_reliability.py tests/test_gemini_request_validation.py
```
26 passed.

/claim docstring batch