### PR TITLE
docs(tests): add docstrings for feed and generation validation coverage

### DIFF
--- a/tests/test_feed_blueprint.py
+++ b/tests/test_feed_blueprint.py
@@ -21,6 +21,7 @@ import feed_blueprint
 
 
 def test_escape_xml_handles_none_and_all_special_characters():
+    """Ensure feed XML escaping is safe for missing text and every reserved XML character."""
     assert feed_blueprint.escape_xml(None) == ""
     assert (
         feed_blueprint.escape_xml("Rock & <Roll> \"Mix\" 'Tape'")
@@ -29,6 +30,7 @@ def test_escape_xml_handles_none_and_all_special_characters():
 
 
 def test_timestamp_helpers_normalize_epoch_and_iso_values():
+    """Normalize mixed timestamp shapes into stable RSS and Atom date formats."""
     expected = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
 
     assert parsedate_to_datetime(feed_blueprint._to_rfc2822(0)) == expected
@@ -46,6 +48,7 @@ def test_timestamp_helpers_normalize_epoch_and_iso_values():
 
 
 def test_normalize_videos_filters_non_dict_entries_from_supported_shapes():
+    """Discard malformed video entries while supporting the response envelope shapes the API emits."""
     video_a = {"id": "a"}
     video_b = {"id": "b"}
 
@@ -63,6 +66,7 @@ def test_normalize_videos_filters_non_dict_entries_from_supported_shapes():
 
 
 def test_vid_fields_applies_defaults_and_derived_urls():
+    """Backfill missing metadata so feed entries still expose complete thumbnail, stream, and watch links."""
     fields = feed_blueprint._vid_fields({"id": "vid123"})
 
     assert fields == {
@@ -88,6 +92,7 @@ def test_vid_fields_applies_defaults_and_derived_urls():
     ],
 )
 def test_parse_limit_defaults_and_accepts_valid_values(path, expected):
+    """Accept the documented feed limit range and preserve the caller's requested cap."""
     app = Flask(__name__)
     with app.test_request_context(path):
         assert feed_blueprint._parse_limit() == expected
@@ -105,6 +110,7 @@ def test_parse_limit_defaults_and_accepts_valid_values(path, expected):
     ],
 )
 def test_parse_limit_rejects_invalid_values(path, message):
+    """Fail fast on invalid feed limits instead of letting oversized or malformed requests through."""
     app = Flask(__name__)
     with app.test_request_context(path), pytest.raises(ValueError, match=message):
         feed_blueprint._parse_limit()
@@ -120,6 +126,7 @@ def test_parse_limit_rejects_invalid_values(path, message):
     ],
 )
 def test_feed_routes_reject_invalid_limit_without_fetching_videos(monkeypatch, path):
+    """Return a client error before any upstream fetch when the feed limit itself is invalid."""
     app = Flask(__name__)
     app.register_blueprint(feed_blueprint.feed_bp)
 
@@ -135,6 +142,7 @@ def test_feed_routes_reject_invalid_limit_without_fetching_videos(monkeypatch, p
 
 
 def test_fetch_videos_builds_filtered_request_and_normalizes_response(monkeypatch):
+    """Forward agent, category, and limit filters to the API and strip non-dictionary payload items."""
     calls = []
 
     class FakeResponse:
@@ -165,6 +173,7 @@ def test_fetch_videos_builds_filtered_request_and_normalizes_response(monkeypatc
 
 
 def test_fetch_videos_returns_empty_list_when_request_fails(monkeypatch):
+    """Treat upstream fetch failures as an empty feed instead of crashing the route."""
     def fake_get(url, params, timeout):
         raise RuntimeError("network unavailable")
 
@@ -174,6 +183,7 @@ def test_fetch_videos_returns_empty_list_when_request_fails(monkeypatch):
 
 
 def test_feed_routes_escape_url_attributes_and_cdata(monkeypatch):
+    """Escape XML attributes and CDATA edge cases so generated feeds stay parseable."""
     app = Flask(__name__)
     app.register_blueprint(feed_blueprint.feed_bp)
 

--- a/tests/test_feed_impression_event_validation.py
+++ b/tests/test_feed_impression_event_validation.py
@@ -52,6 +52,7 @@ sqlite3.connect = _orig_sqlite_connect
 
 @pytest.fixture()
 def client(monkeypatch):
+    """Provide a lightweight test client while bypassing schema bootstrapping unrelated to payload validation."""
     bottube_server.app.config["TESTING"] = True
     monkeypatch.setattr(bottube_server, "_feed_imp_ensure_schema", lambda: None)
     yield bottube_server.app.test_client()
@@ -59,6 +60,7 @@ def client(monkeypatch):
 
 @pytest.mark.parametrize("path", ["/api/feed/click", "/api/feed/watch"])
 def test_feed_impression_events_reject_non_object_json(client, path):
+    """Guard click and watch endpoints from array payloads before impression processing begins."""
     resp = client.post(path, json=["bad"])
 
     assert resp.status_code == 400
@@ -70,6 +72,7 @@ def test_feed_impression_events_reject_non_object_json(client, path):
 
 @pytest.mark.parametrize("path", ["/api/feed/click", "/api/feed/watch"])
 def test_feed_impression_events_reject_non_string_impression_id(client, path):
+    """Reject impression identifiers that are not plain strings so analytics rows stay well-formed."""
     resp = client.post(path, json={"imp": ["imp_bad"], "seconds": 1})
 
     assert resp.status_code == 400

--- a/tests/test_feed_query_validation.py
+++ b/tests/test_feed_query_validation.py
@@ -10,6 +10,7 @@ import pytest
     ],
 )
 def test_feed_rejects_unknown_filter_options(client, query):
+    """Reject unsupported mode, bucket, and category values before feed selection starts."""
     response = client.get(f"/api/feed?{query}")
 
     assert response.status_code == 400
@@ -17,6 +18,7 @@ def test_feed_rejects_unknown_filter_options(client, query):
 
 
 def test_feed_accepts_known_filter_options(client):
+    """Accept canonical filter values and echo the resolved feed mode in the payload."""
     response = client.get("/api/feed?mode=latest&bucket=latest&category=music")
 
     assert response.status_code == 200

--- a/tests/test_generation_routes.py
+++ b/tests/test_generation_routes.py
@@ -14,6 +14,7 @@ if not hasattr(werkzeug, "__version__"):
 
 @pytest.fixture
 def fake_bottube_server(monkeypatch):
+    """Stub the server module so generation routes can validate request handling without the real app stack."""
     class FakeDB:
         def execute(self, *_args, **_kwargs):
             return self
@@ -36,6 +37,7 @@ def fake_bottube_server(monkeypatch):
 
 @pytest.fixture
 def generation_client(fake_bottube_server):
+    """Expose the modern generation blueprint through a Flask client for request validation tests."""
     from generation.routes import generation_bp
 
     app = Flask(__name__)
@@ -46,6 +48,7 @@ def generation_client(fake_bottube_server):
 
 @pytest.fixture
 def legacy_generation_client(fake_bottube_server):
+    """Expose the legacy generation blueprint so compatibility checks cover the older route surface too."""
     from video_gen_blueprint import video_gen_bp
 
     app = Flask(__name__)
@@ -55,6 +58,7 @@ def legacy_generation_client(fake_bottube_server):
 
 
 def test_generation_job_rejects_non_object_json_before_auth(generation_client):
+    """Reject array JSON bodies before auth or generation logic touches the request."""
     resp = generation_client.post("/api/generation/jobs", json="not-object")
 
     assert resp.status_code == 400
@@ -62,6 +66,7 @@ def test_generation_job_rejects_non_object_json_before_auth(generation_client):
 
 
 def test_generation_job_rejects_non_string_prompt(generation_client):
+    """Require a string prompt so queued generation jobs always receive text instructions."""
     resp = generation_client.post(
         "/api/generation/jobs",
         json={"prompt": ["make a video"]},
@@ -73,6 +78,7 @@ def test_generation_job_rejects_non_string_prompt(generation_client):
 
 
 def test_generation_job_rejects_non_string_body_api_key(generation_client):
+    """Reject malformed body API keys instead of attempting lookup with non-string values."""
     resp = generation_client.post(
         "/api/generation/jobs",
         json={"agent_api_key": ["test-key"], "prompt": "make a video"},
@@ -85,6 +91,7 @@ def test_generation_job_rejects_non_string_body_api_key(generation_client):
 def test_legacy_generate_video_rejects_non_object_json_before_auth(
     legacy_generation_client,
 ):
+    """Apply the same object-only JSON contract to the legacy generate-video endpoint."""
     resp = legacy_generation_client.post(
         "/api/generate-video",
         json=["not", "an", "object"],
@@ -95,6 +102,7 @@ def test_legacy_generate_video_rejects_non_object_json_before_auth(
 
 
 def test_legacy_generate_video_rejects_malformed_fields(legacy_generation_client):
+    """Validate prompt, duration, category, and title types before the legacy route starts work."""
     headers = {"X-API-Key": "test-key"}
 
     prompt_resp = legacy_generation_client.post(
@@ -134,6 +142,7 @@ def test_legacy_generate_video_rejects_boolean_duration_before_start(
     legacy_generation_client,
     monkeypatch,
 ):
+    """Block boolean duration values so the worker thread never starts from ambiguous input."""
     import video_gen_blueprint
 
     monkeypatch.setattr(
@@ -155,6 +164,7 @@ def test_legacy_generate_video_rejects_boolean_duration_before_start(
 def test_legacy_generate_video_rejects_non_string_body_api_key(
     legacy_generation_client,
 ):
+    """Mirror API-key type validation on the legacy route to keep auth parsing predictable."""
     resp = legacy_generation_client.post(
         "/api/generate-video",
         json={"agent_api_key": ["test-key"], "prompt": "make a video"},


### PR DESCRIPTION
## Summary
- add docstrings to uncovered feed validation tests
- document feed blueprint normalization and XML safety checks
- add docstrings to generation route validation tests

## Testing
- pytest -q tests/test_feed_query_validation.py tests/test_feed_impression_event_validation.py tests/test_feed_blueprint.py tests/test_generation_routes.py

/claim #1764