### PR TITLE
docs: add docstrings to founding leaderboard, referrals, and badges tests (34 functions)

### DIFF
--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -19,6 +19,12 @@ _orig_sqlite_connect = sqlite3.connect
 
 
 def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    """Redirect the hardcoded production DB path to the test bootstrap path.
+
+    Import-time code opens `/root/bottube/bottube.db` before the `client`
+    fixture can monkeypatch `DB_PATH`, so without this shim collecting this
+    module would touch production badge data.
+    """
     if str(path) == "/root/bottube/bottube.db":
         path = os.environ["BOTTUBE_DB_PATH"]
     return _orig_sqlite_connect(path, *args, **kwargs)
@@ -33,6 +39,12 @@ _orig_init_store_db = paypal_packages.init_store_db
 
 
 def _test_init_store_db(db_path=None):
+    """Force paypal_packages' schema init onto a clean test bootstrap DB.
+
+    Removes any stale bootstrap file first so leftover badge/referral rows
+    from a prior interrupted run can't inflate this run's candidate or
+    cohort-number assertions.
+    """
     bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
     Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
     Path(bootstrap_path).unlink(missing_ok=True)
@@ -48,6 +60,12 @@ sqlite3.connect = _orig_sqlite_connect
 
 @pytest.fixture()
 def client(monkeypatch, tmp_path):
+    """Yield a Flask test client on an isolated DB with a fixed admin key.
+
+    Pins `ADMIN_KEY` so badge assign/remove/candidates calls can
+    authenticate without depending on whatever key the server module
+    loaded from the environment.
+    """
     db_path = tmp_path / "bottube_badges.db"
     monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
     monkeypatch.setattr(bottube_server, "ADMIN_KEY", "test-admin", raising=False)
@@ -59,6 +77,12 @@ def client(monkeypatch, tmp_path):
 
 
 def _insert_agent(agent_name: str, api_key: str, *, is_human: bool = False) -> int:
+    """Insert a minimal agent row directly, bypassing signup/registration.
+
+    Used for the creator/referrer seed in each test; referred accounts are
+    still created through the real signup/register endpoints below, where
+    the badge-candidate logic actually needs to observe them.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         cur = db.execute(
@@ -74,6 +98,12 @@ def _insert_agent(agent_name: str, api_key: str, *, is_human: bool = False) -> i
 
 
 def _lookup_agent(agent_name: str) -> sqlite3.Row:
+    """Fetch an agent's full row, asserting it exists.
+
+    Called right after signup/registration; a missing row means account
+    creation silently failed, so asserting here turns that into an
+    immediate failure instead of a confusing `NoneType` error later.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         row = db.execute("SELECT * FROM agents WHERE agent_name = ?", (agent_name,)).fetchone()
@@ -82,6 +112,14 @@ def _lookup_agent(agent_name: str) -> sqlite3.Row:
 
 
 def _insert_video(agent_id: int, video_id: str, *, created_at: float = 5.0) -> None:
+    """Seed a video and drive it through the referral first-upload hooks.
+
+    Badge-candidate eligibility is derived from referral activation state,
+    which only flips on a real first upload -- calling the production
+    `_referral_mark_first_upload`/`_referral_refresh_invite_state` hooks
+    here (instead of writing activation flags directly) keeps the test
+    honest about what actually earns a candidate their badge.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
@@ -98,6 +136,12 @@ def _insert_video(agent_id: int, video_id: str, *, created_at: float = 5.0) -> N
 
 
 def _create_referral_code(client, referrer_id: int) -> str:
+    """Log in as `referrer_id` via the session and fetch their referral code.
+
+    Writes straight into the Flask session rather than going through the
+    login form -- what's under test is badge-candidate logic, not
+    authentication, so this keeps the fixture setup fast and focused.
+    """
     with client.session_transaction() as sess:
         sess["user_id"] = referrer_id
         sess["csrf_token"] = "test-csrf"
@@ -107,6 +151,13 @@ def _create_referral_code(client, referrer_id: int) -> str:
 
 
 def _activate_referred_human(client, code: str, username: str) -> sqlite3.Row:
+    """Sign up a human agent through `code`, then complete profile/wallet/upload.
+
+    Goes through the real `/signup` form so the referral code is actually
+    consumed and validated, then finishes profile, wallet, and first-upload
+    steps so the account reaches the fully-activated state badge-candidate
+    scanning looks for.
+    """
     with client.session_transaction() as sess:
         sess.pop("user_id", None)
         sess["csrf_token"] = "test-csrf"
@@ -144,6 +195,12 @@ def _activate_referred_human(client, code: str, username: str) -> sqlite3.Row:
 
 
 def _activate_referred_agent(client, code: str, agent_name: str) -> sqlite3.Row:
+    """Register an AI agent through `code`, then complete wallet/upload.
+
+    Mirrors `_activate_referred_human` for the agent track (`/api/register`
+    instead of `/signup`) so agent-cohort badge candidates are driven
+    through the same code path a real referred agent would use.
+    """
     reg_resp = client.post(
         "/api/register",
         json={
@@ -167,6 +224,15 @@ def _activate_referred_agent(client, code: str, agent_name: str) -> sqlite3.Row:
 
 
 def test_badge_assignment_renders_on_public_surfaces_and_can_be_removed(client):
+    """A badge assigned via the admin API must appear everywhere it's shown, and clear everywhere on removal.
+
+    Walks the full surface area a founding badge touches -- the admin
+    listing, the agent's own API record, their public channel page, a
+    watch page for their video, and their own dashboard -- then removes
+    it and re-checks the agent API. A badge that renders on some surfaces
+    but not others (or that lingers after removal) would only be caught
+    by exercising all of them in one pass like this.
+    """
     creator_id = _insert_agent("founderhuman", "bottube_sk_founderhuman", is_human=True)
     _insert_video(creator_id, "founderwatch1")
 
@@ -231,6 +297,15 @@ def test_badge_assignment_renders_on_public_surfaces_and_can_be_removed(client):
 
 
 def test_badge_candidates_follow_referral_activation_and_scout_thresholds(client):
+    """The candidates scan must surface both per-invitee and scout-bonus badges correctly.
+
+    One referrer activates 3 humans and 1 agent: this checks each
+    activated invitee gets the right badge with the right cohort/campaign
+    metadata, AND that the referrer's own "founding scout" candidate
+    reports the correct pair count and which bonus thresholds it crossed
+    -- a miscount either way would misattribute credit for founding-cohort
+    slots.
+    """
     referrer_id = _insert_agent("captainleet", "bottube_sk_captainleet", is_human=True)
     code = _create_referral_code(client, referrer_id)
 

--- a/tests/test_founding_leaderboard.py
+++ b/tests/test_founding_leaderboard.py
@@ -19,6 +19,13 @@ _orig_sqlite_connect = sqlite3.connect
 
 
 def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    """Redirect the hardcoded production DB path to the test bootstrap path.
+
+    Import-time code in `paypal_packages`/`bottube_server` opens the real
+    `/root/bottube/bottube.db` before the `client` fixture can monkeypatch
+    `DB_PATH`, so without this shim just collecting this module would touch
+    production data.
+    """
     if str(path) == "/root/bottube/bottube.db":
         path = os.environ["BOTTUBE_DB_PATH"]
     return _orig_sqlite_connect(path, *args, **kwargs)
@@ -33,6 +40,12 @@ _orig_init_store_db = paypal_packages.init_store_db
 
 
 def _test_init_store_db(db_path=None):
+    """Force paypal_packages' schema init onto a clean test bootstrap DB.
+
+    Deletes any stale bootstrap file first so leftover state from a prior
+    interrupted run can't leak founding-cohort/badge rows into this run's
+    slot-count assertions.
+    """
     bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
     Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
     Path(bootstrap_path).unlink(missing_ok=True)
@@ -48,6 +61,12 @@ sqlite3.connect = _orig_sqlite_connect
 
 @pytest.fixture()
 def client(monkeypatch, tmp_path):
+    """Yield a Flask test client on an isolated DB with a fixed admin key.
+
+    Pins `ADMIN_KEY` to a known value so `_assign_badge` can authenticate
+    without depending on whatever admin key the server module happened to
+    load from the environment.
+    """
     db_path = tmp_path / "bottube_founding.db"
     monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
     monkeypatch.setattr(bottube_server, "ADMIN_KEY", "test-admin", raising=False)
@@ -59,6 +78,13 @@ def client(monkeypatch, tmp_path):
 
 
 def _insert_agent(agent_name: str, api_key: str, *, is_human: bool = False) -> int:
+    """Insert a minimal agent row directly, bypassing signup/registration.
+
+    Used only for the referrer seed: the leaderboard tests need a referrer
+    that already exists before a referral code can be minted, and going
+    through the real signup/register flow here would be redundant with the
+    referred-activation helpers below.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         cur = db.execute(
@@ -74,6 +100,14 @@ def _insert_agent(agent_name: str, api_key: str, *, is_human: bool = False) -> i
 
 
 def _lookup_agent(agent_name: str) -> sqlite3.Row:
+    """Fetch an agent's full row, asserting it exists.
+
+    The assertion here is deliberate: callers use this right after
+    signup/registration, so a missing row means account creation silently
+    failed and every downstream assertion in the test would otherwise
+    fail with a confusing `NoneType` error instead of pointing at the
+    actual cause.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         row = db.execute("SELECT * FROM agents WHERE agent_name = ?", (agent_name,)).fetchone()
@@ -82,6 +116,15 @@ def _lookup_agent(agent_name: str) -> sqlite3.Row:
 
 
 def _insert_video(agent_id: int, video_id: str, *, created_at: float = 5.0) -> None:
+    """Seed a video and drive it through the referral-activation hooks.
+
+    A referred signup alone does not count as "activated" for the
+    leaderboard -- the real server only flips that state once the referred
+    agent uploads their first video, so this helper calls the same
+    `_referral_mark_first_upload`/`_referral_refresh_invite_state` hooks
+    the production upload path calls, instead of writing activation flags
+    directly and risking a test that passes for reasons the app doesn't.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
@@ -98,6 +141,13 @@ def _insert_video(agent_id: int, video_id: str, *, created_at: float = 5.0) -> N
 
 
 def _create_referral_code(client, referrer_id: int) -> str:
+    """Log in as `referrer_id` via the session and fetch their referral code.
+
+    Bypasses the login form entirely by writing straight into the Flask
+    session -- what's under test here is the leaderboard/referral logic,
+    not authentication, so a direct session write keeps the test focused
+    and fast instead of re-proving login works on every referral test.
+    """
     with client.session_transaction() as sess:
         sess["user_id"] = referrer_id
         sess["csrf_token"] = "test-csrf"
@@ -107,6 +157,13 @@ def _create_referral_code(client, referrer_id: int) -> str:
 
 
 def _activate_referred_human(client, code: str, username: str) -> sqlite3.Row:
+    """Sign up a human agent through `code`, then complete profile/wallet/upload.
+
+    Goes through the real `/signup` form (not a direct DB insert) so the
+    referral code is actually consumed and validated the way a live invite
+    link would be, then finishes profile, wallet and first-upload steps so
+    the account reaches the same "activated" state the leaderboard counts.
+    """
     with client.session_transaction() as sess:
         sess.pop("user_id", None)
         sess["csrf_token"] = "test-csrf"
@@ -144,6 +201,13 @@ def _activate_referred_human(client, code: str, username: str) -> sqlite3.Row:
 
 
 def _activate_referred_agent(client, code: str, agent_name: str) -> sqlite3.Row:
+    """Register an AI agent through `code`, then complete wallet/upload.
+
+    Mirrors `_activate_referred_human` for the agent track (`/api/register`
+    instead of `/signup`, no bio/avatar PATCH step since registration
+    already takes those fields) so agent-cohort activation is driven
+    through the same code path a real referred agent would use.
+    """
     reg_resp = client.post(
         "/api/register",
         json={
@@ -167,6 +231,12 @@ def _activate_referred_agent(client, code: str, agent_name: str) -> sqlite3.Row:
 
 
 def _assign_badge(client, agent_name: str, badge_key: str, *, cohort_number: int = 0):
+    """Award a founding badge to `agent_name` via the admin endpoint and return it.
+
+    Uses the real admin API (with the fixture's fixed `X-Admin-Key`) rather
+    than inserting a badge row directly, so these tests also cover that the
+    admin-assign endpoint itself works, not just the leaderboard read side.
+    """
     resp = client.post(
         "/api/admin/badges/assign",
         headers={"X-Admin-Key": "test-admin"},
@@ -181,6 +251,13 @@ def _assign_badge(client, agent_name: str, badge_key: str, *, cohort_number: int
 
 
 def test_founding_leaderboard_api_splits_tracks_and_surfaces_badges(client):
+    """The leaderboard API must keep human and agent referral tracks separate.
+
+    One referrer sponsors both a human and an agent, so this also proves
+    the two cohorts don't cross-contaminate each other's slot counts,
+    badge status, or bonus-progress thresholds -- a shared counter bug
+    would silently under- or over-report remaining founding slots.
+    """
     referrer_id = _insert_agent("captainleet", "bottube_sk_captainleet", is_human=True)
     code = _create_referral_code(client, referrer_id)
 
@@ -223,6 +300,13 @@ def test_founding_leaderboard_api_splits_tracks_and_surfaces_badges(client):
 
 
 def test_public_founding_page_renders_required_sections(client):
+    """The public `/founding` HTML page must render both leaderboards and named entries.
+
+    Checks for both the section headings and the actual activated
+    usernames in the rendered HTML, so a regression that keeps the page
+    structure but silently drops the server-rendered data (e.g. an empty
+    template context) would still fail this test.
+    """
     referrer_id = _insert_agent("humanlead", "bottube_sk_humanlead", is_human=True)
     code = _create_referral_code(client, referrer_id)
 

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -19,6 +19,12 @@ _orig_sqlite_connect = sqlite3.connect
 
 
 def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    """Redirect the hardcoded production DB path to the test bootstrap path.
+
+    Import-time code opens `/root/bottube/bottube.db` before the `client`
+    fixture can monkeypatch `DB_PATH`, so without this shim collecting this
+    module would touch production data.
+    """
     if str(path) == "/root/bottube/bottube.db":
         path = os.environ["BOTTUBE_DB_PATH"]
     return _orig_sqlite_connect(path, *args, **kwargs)
@@ -33,6 +39,12 @@ _orig_init_store_db = paypal_packages.init_store_db
 
 
 def _test_init_store_db(db_path=None):
+    """Force paypal_packages' schema init onto a clean test bootstrap DB.
+
+    Removes any stale bootstrap file first so a prior interrupted run
+    can't leave referral/milestone rows behind that would inflate this
+    run's invited/activated counts.
+    """
     bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
     Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
     Path(bootstrap_path).unlink(missing_ok=True)
@@ -48,6 +60,12 @@ sqlite3.connect = _orig_sqlite_connect
 
 @pytest.fixture()
 def client(monkeypatch, tmp_path):
+    """Yield a Flask test client on an isolated DB with a fixed admin key.
+
+    Pins `ADMIN_KEY` so the admin-review/export tests can authenticate
+    without depending on whatever key the server module loaded from the
+    environment.
+    """
     db_path = tmp_path / "bottube_referrals.db"
     monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
     monkeypatch.setattr(bottube_server, "ADMIN_KEY", "test-admin", raising=False)
@@ -59,6 +77,12 @@ def client(monkeypatch, tmp_path):
 
 
 def _insert_agent(agent_name: str, api_key: str, *, is_human: bool = False) -> int:
+    """Insert a minimal agent row directly, bypassing signup/registration.
+
+    Used to seed the referrer -- referred accounts are created through the
+    real `/signup`/`/api/register` endpoints below, so the referral code
+    itself gets validated the way a live invite would exercise it.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         cur = db.execute(
@@ -74,6 +98,13 @@ def _insert_agent(agent_name: str, api_key: str, *, is_human: bool = False) -> i
 
 
 def _insert_video_and_mark(agent_id: int, video_id: str, *, created_at: float = 5.0) -> None:
+    """Seed a video and run it through the referral first-upload hooks.
+
+    A referred account only counts as activated once it uploads, so this
+    calls the same `_referral_mark_first_upload`/`_referral_refresh_invite_state`
+    hooks the real upload path calls, rather than flipping an activation
+    flag directly and risking milestones that pass for the wrong reason.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
@@ -90,6 +121,13 @@ def _insert_video_and_mark(agent_id: int, video_id: str, *, created_at: float = 
 
 
 def _lookup_agent(agent_name: str) -> sqlite3.Row:
+    """Fetch an agent's full row, asserting it exists.
+
+    Called right after signup/registration in every test below; a missing
+    row means account creation silently failed, and asserting here turns
+    that into an immediate, obvious failure instead of a confusing
+    `NoneType` error several lines further down.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         row = db.execute("SELECT * FROM agents WHERE agent_name = ?", (agent_name,)).fetchone()
@@ -99,6 +137,12 @@ def _lookup_agent(agent_name: str) -> sqlite3.Row:
 
 @pytest.mark.parametrize("limit", ["abc", "1.5", "0", "-1", "201"])
 def test_referral_leaderboard_rejects_invalid_limit(client, limit):
+    """Non-integer, zero, negative, and out-of-range `limit` values must all 400.
+
+    Covers the boundary just past the valid range (`"201"`) alongside
+    clearly malformed input (`"abc"`, `"1.5"`), so an off-by-one in the
+    upper-bound check can't slip through as a passing edge case.
+    """
     resp = client.get(f"/api/referrals/leaderboard?limit={limit}")
 
     assert resp.status_code == 400
@@ -108,6 +152,12 @@ def test_referral_leaderboard_rejects_invalid_limit(client, limit):
 
 @pytest.mark.parametrize("limit", [None, "1", "200"])
 def test_referral_leaderboard_accepts_default_and_boundary_limits(client, limit):
+    """No `limit`, and both ends of the valid range (1 and 200), must succeed.
+
+    Paired with the rejection test above so the boundary is proven from
+    both sides: 200 must pass here while 201 fails there, otherwise the
+    limit check's edge could be off by one in either direction unnoticed.
+    """
     path = "/api/referrals/leaderboard"
     if limit is not None:
         path = f"{path}?limit={limit}"
@@ -121,6 +171,14 @@ def test_referral_leaderboard_accepts_default_and_boundary_limits(client, limit)
 
 
 def test_referral_dashboard_tracks_human_and_agent_funnels(client):
+    """One referrer, one human + one agent invite: milestones must count both tracks.
+
+    Drives a full human signup and a full agent registration through the
+    same referral code, then checks the referrer's summary counts each
+    track separately (`invited`) as well as combined milestone/pair totals
+    -- a bug that only tracked one funnel would halve these numbers
+    silently instead of erroring.
+    """
     referrer_id = _insert_agent("founder1337", "bottube_sk_founder", is_human=True)
 
     with client.session_transaction() as sess:
@@ -210,6 +268,14 @@ def test_referral_dashboard_tracks_human_and_agent_funnels(client):
 
 
 def test_referral_admin_review_and_export(client):
+    """Admin review and CSV-style export must reflect the same referral end to end.
+
+    Checks that the admin listing exposes verifiable evidence refs (the
+    actual video/wallet-settings URLs, not just booleans) and that
+    approving a referral there is what makes it show up as "approved" in
+    the export -- proving review and export share one source of truth
+    instead of drifting independently.
+    """
     referrer_id = _insert_agent("captainref", "bottube_sk_captain", is_human=True)
 
     with client.session_transaction() as sess:
@@ -264,6 +330,13 @@ def test_referral_admin_review_and_export(client):
 
 
 def test_referral_track_setting_blocks_wrong_funnel(client):
+    """A code locked to `allowed_track: "human"` must reject an agent registration.
+
+    Referrers can restrict their invite code to one track; this proves
+    that restriction is enforced server-side at `/api/register`, not just
+    surfaced as a UI hint, so a locked code can't be used to onboard the
+    wrong kind of account.
+    """
     referrer_id = _insert_agent("humancode", "bottube_sk_humancode")
 
     resp = client.post(


### PR DESCRIPTION
## Summary
Added docstrings to every previously-undocumented function across three test files:

- `tests/test_founding_leaderboard.py` — 12 functions documented
- `tests/test_referrals.py` — 11 functions documented
- `tests/test_badges.py` — 11 functions documented

34 functions documented total, docstrings-only, no logic changed. Each docstring focuses on *why* the test/fixture/helper exists and what it guards against (e.g. why activation is driven through the real referral hooks instead of writing flags directly, why the badge-removal test walks every public surface in one pass, why the limit-boundary tests are paired).

## Testing
```
pytest -q tests/test_founding_leaderboard.py tests/test_referrals.py tests/test_badges.py
```
15 passed.

/claim docstring batch