### PR TITLE
docs: add docstrings to feed blueprint and ergo bridge validation tests (31 functions)

### DIFF
--- a/tests/test_ergo_bridge_validation.py
+++ b/tests/test_ergo_bridge_validation.py
@@ -16,6 +16,13 @@ if not hasattr(werkzeug, "__version__"):
 
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
+    """Build an isolated Flask app around just the Ergo bridge blueprint.
+
+    Registers only `ergo_bp` on a throwaway `Flask(__name__)` with a
+    hand-built minimal schema (agents + earnings) rather than the full
+    `bottube_server` app, so these tests exercise request validation in
+    isolation without needing the rest of the platform wired up.
+    """
     db_path = tmp_path / "ergo_bridge.db"
     conn = sqlite3.connect(str(db_path))
     conn.executescript(
@@ -47,6 +54,12 @@ def client(tmp_path, monkeypatch):
     app.register_blueprint(ergo_bridge_blueprint.ergo_bp)
 
     def _test_get_db():
+        """Replace `ergo_bridge_blueprint.get_db` with a per-request connection to the test DB.
+
+        Swapped in via `monkeypatch.setattr` below so every request the
+        blueprint handles stays confined to `db_path`, instead of whatever
+        database the blueprint module would otherwise resolve.
+        """
         if "test_db" in g:
             return g.test_db
         db = sqlite3.connect(str(db_path))
@@ -56,6 +69,7 @@ def client(tmp_path, monkeypatch):
 
     @app.teardown_appcontext
     def _close_db(_exc):
+        """Close the per-request test connection so SQLite file handles don't leak across requests."""
         db = g.pop("test_db", None)
         if db is not None:
             db.close()
@@ -69,14 +83,23 @@ def client(tmp_path, monkeypatch):
 
 
 def _auth_headers():
+    """Return the API key header for the single agent seeded by the `client` fixture."""
     return {"X-API-Key": "bottube_sk_ergo_agent"}
 
 
 def _admin_headers():
+    """Return the admin key header, matching the fixture's patched `ADMIN_KEY`."""
     return {"X-Admin-Key": "test-admin"}
 
 
 def _counts_and_balance(db_path):
+    """Snapshot deposit/withdrawal row counts and the agent's RTC balance.
+
+    Every rejection test below compares this snapshot before and after a
+    malformed request, so a validator that rejects the HTTP response but
+    still mutates the ledger (creates a deposit/withdrawal row or moves
+    the balance) gets caught here rather than looking like a clean 400.
+    """
     with sqlite3.connect(str(db_path)) as db:
         return {
             "deposits": db.execute("SELECT COUNT(*) FROM ergo_deposits").fetchone()[0],
@@ -91,6 +114,7 @@ def _counts_and_balance(db_path):
 
 
 def test_ergo_deposit_rejects_non_object_json(client):
+    """A JSON array body to /deposit must 400 without creating a deposit row or touching balance."""
     before = _counts_and_balance(client.db_path)
 
     resp = client.post(
@@ -105,6 +129,7 @@ def test_ergo_deposit_rejects_non_object_json(client):
 
 
 def test_ergo_deposit_rejects_non_string_tx_id(client):
+    """A list-typed `tx_id` must be rejected before it can reach chain-lookup code expecting a string."""
     before = _counts_and_balance(client.db_path)
 
     resp = client.post(
@@ -119,6 +144,12 @@ def test_ergo_deposit_rejects_non_string_tx_id(client):
 
 
 def test_ergo_withdraw_rejects_non_object_json(client):
+    """A JSON array body to /withdraw must 400 without creating a withdrawal row or debiting balance.
+
+    The payload is a list *containing* an otherwise-valid withdrawal
+    object, to prove the top-level shape check runs before anything
+    inspects the contents.
+    """
     before = _counts_and_balance(client.db_path)
 
     resp = client.post(
@@ -133,6 +164,7 @@ def test_ergo_withdraw_rejects_non_object_json(client):
 
 
 def test_ergo_withdraw_rejects_non_string_address(client):
+    """A list-typed `address` must be rejected, not passed through to on-chain send logic as-is."""
     before = _counts_and_balance(client.db_path)
 
     resp = client.post(
@@ -148,6 +180,13 @@ def test_ergo_withdraw_rejects_non_string_address(client):
 
 @pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True, 0, -1])
 def test_ergo_withdraw_rejects_invalid_amount_without_queue_or_debit(client, amount):
+    """Non-numeric, NaN, Infinity, boolean, zero, and negative amounts must all be rejected identically.
+
+    `True` is included deliberately: Python's `bool` is a subclass of
+    `int`, so a naive `isinstance(amount, (int, float))` check would let
+    `True`/`False` slip through as `1`/`0` unless the validator excludes
+    bools explicitly.
+    """
     before = _counts_and_balance(client.db_path)
 
     resp = client.post(
@@ -163,6 +202,13 @@ def test_ergo_withdraw_rejects_invalid_amount_without_queue_or_debit(client, amo
 
 @pytest.mark.parametrize("limit", ["abc", "-5", "0"])
 def test_ergo_history_rejects_invalid_limit(client, limit):
+    """Non-numeric, negative, and zero `limit` values must all 400 with the same message.
+
+    Calls `ergo_history()` directly inside a manually pushed request
+    context rather than through `client.get`, since the view here returns
+    a `(response, status)` tuple rather than relying on Flask's default
+    status-code handling.
+    """
     app = client.application
 
     with app.test_request_context(
@@ -176,6 +222,14 @@ def test_ergo_history_rejects_invalid_limit(client, limit):
 
 
 def test_ergo_history_clamps_large_limit(client):
+    """A `limit` far above any sane page size must still succeed by clamping, not by 400ing or over-fetching.
+
+    `limit=500` against an agent with zero deposits/withdrawals confirms
+    the endpoint clamps to its internal max and returns normally rather
+    than treating an oversized limit as an error the way `_parse_limit`
+    elsewhere in the codebase does -- these are two independently
+    validated endpoints with different limit-handling policies.
+    """
     app = client.application
 
     with app.test_request_context(
@@ -189,6 +243,13 @@ def test_ergo_history_clamps_large_limit(client):
 
 
 def test_process_withdrawals_rejects_non_object_json(client):
+    """The admin process-withdrawals endpoint must 400 on a non-object body without touching the ledger.
+
+    Uses admin auth (not the agent's API key) since this is the
+    maintainer-facing endpoint that actually marks a withdrawal as sent
+    on-chain -- its input validation matters at least as much as the
+    user-facing deposit/withdraw endpoints.
+    """
     before = _counts_and_balance(client.db_path)
 
     resp = client.post(
@@ -203,6 +264,7 @@ def test_process_withdrawals_rejects_non_object_json(client):
 
 
 def test_process_withdrawals_rejects_non_string_tx_id(client):
+    """A list-typed `tx_id` on the admin confirm-withdrawal call must be rejected, not stored as the on-chain reference."""
     before = _counts_and_balance(client.db_path)
 
     resp = client.post(

--- a/tests/test_feed_blueprint.py
+++ b/tests/test_feed_blueprint.py
@@ -21,6 +21,13 @@ import feed_blueprint
 
 
 def test_escape_xml_handles_none_and_all_special_characters():
+    """`escape_xml` must null-safe and cover all five XML-reserved characters.
+
+    RSS/Atom output breaks (or becomes injectable) if any one of
+    `& < > " '` is left unescaped in title/description text pulled from
+    user-controlled video metadata; `None` is included because upstream
+    fields are frequently optional.
+    """
     assert feed_blueprint.escape_xml(None) == ""
     assert (
         feed_blueprint.escape_xml("Rock & <Roll> \"Mix\" 'Tape'")
@@ -29,6 +36,13 @@ def test_escape_xml_handles_none_and_all_special_characters():
 
 
 def test_timestamp_helpers_normalize_epoch_and_iso_values():
+    """RFC 2822 (RSS) and ISO 8601 (Atom) timestamp helpers must agree on the same instant.
+
+    Feeds carry `created_at` in a mix of forms depending on the source
+    (numeric epoch, epoch-as-string, or an ISO string with/without a `Z`);
+    all three must resolve to the identical UTC instant so RSS and Atom
+    readers don't disagree about when a video was published.
+    """
     expected = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
 
     assert parsedate_to_datetime(feed_blueprint._to_rfc2822(0)) == expected
@@ -46,6 +60,14 @@ def test_timestamp_helpers_normalize_epoch_and_iso_values():
 
 
 def test_normalize_videos_filters_non_dict_entries_from_supported_shapes():
+    """`_normalize_videos` must accept any of the API's response shapes and drop junk entries.
+
+    The upstream videos API has returned results under a bare list,
+    `videos`, `items`, or `data` at different times; this locks in support
+    for all four AND proves a non-dict entry (a stray string, `None`, or a
+    non-list value under the key) is dropped instead of crashing the
+    template renderer downstream.
+    """
     video_a = {"id": "a"}
     video_b = {"id": "b"}
 
@@ -63,6 +85,14 @@ def test_normalize_videos_filters_non_dict_entries_from_supported_shapes():
 
 
 def test_vid_fields_applies_defaults_and_derived_urls():
+    """A video with only an `id` must still render a complete, non-broken feed entry.
+
+    Real entries can be missing title/description/author/category; this
+    proves `_vid_fields` fills every field the RSS/Atom templates expect
+    with a sane default and derives the thumbnail/stream/watch URLs from
+    just the id, rather than leaving template placeholders empty or
+    raising a `KeyError`.
+    """
     fields = feed_blueprint._vid_fields({"id": "vid123"})
 
     assert fields == {
@@ -88,6 +118,7 @@ def test_vid_fields_applies_defaults_and_derived_urls():
     ],
 )
 def test_parse_limit_defaults_and_accepts_valid_values(path, expected):
+    """No `limit` must default to 20, and any value within [1, 100] must pass through unchanged."""
     app = Flask(__name__)
     with app.test_request_context(path):
         assert feed_blueprint._parse_limit() == expected
@@ -105,6 +136,14 @@ def test_parse_limit_defaults_and_accepts_valid_values(path, expected):
     ],
 )
 def test_parse_limit_rejects_invalid_values(path, message):
+    """Zero, negative, over-100, non-integer, and empty `limit` must each raise with a matching, specific message.
+
+    Pinning the exact error text (not just that *a* `ValueError` is
+    raised) catches a regression where the check still rejects the value
+    but the message stops matching the reason -- e.g. an over-100 value
+    reported as "must be an integer" would be confusing and technically
+    wrong.
+    """
     app = Flask(__name__)
     with app.test_request_context(path), pytest.raises(ValueError, match=message):
         feed_blueprint._parse_limit()
@@ -120,10 +159,18 @@ def test_parse_limit_rejects_invalid_values(path, message):
     ],
 )
 def test_feed_routes_reject_invalid_limit_without_fetching_videos(monkeypatch, path):
+    """All four feed routes must validate `limit` before ever calling `_fetch_videos`.
+
+    Monkeypatches `_fetch_videos` to raise if it's called at all, so a
+    route that validates too late (e.g. after already hitting the
+    upstream API) fails loudly here instead of just wasting a request on
+    input that was going to be rejected anyway.
+    """
     app = Flask(__name__)
     app.register_blueprint(feed_blueprint.feed_bp)
 
     def fail_fetch_videos(*args, **kwargs):
+        """Fail the test if reached, proving invalid-limit routes never call it."""
         raise AssertionError("_fetch_videos should not run for invalid limits")
 
     monkeypatch.setattr(feed_blueprint, "_fetch_videos", fail_fetch_videos)
@@ -135,16 +182,29 @@ def test_feed_routes_reject_invalid_limit_without_fetching_videos(monkeypatch, p
 
 
 def test_fetch_videos_builds_filtered_request_and_normalizes_response(monkeypatch):
+    """`_fetch_videos` must call the upstream API with the right params, check the response, and normalize it.
+
+    Records every call `_fetch_videos` makes (including whether it checked
+    the response status) via `calls`, and returns a response shaped like
+    real upstream output (including a junk `"skip"` entry) to prove the
+    request is built correctly end to end, not just that it returns
+    *something*.
+    """
     calls = []
 
     class FakeResponse:
+        """A stand-in for `requests.Response` that records status checks and returns canned JSON."""
+
         def raise_for_status(self):
+            """Record that the caller checked for an HTTP error, without actually raising one."""
             calls.append(("raise_for_status",))
 
         def json(self):
+            """Return upstream-shaped JSON including one deliberately invalid entry."""
             return {"items": [{"id": "one"}, "skip", {"id": "two"}]}
 
     def fake_get(url, params, timeout):
+        """Stand in for `requests.get`, recording the exact call args instead of hitting the network."""
         calls.append((url, params, timeout))
         return FakeResponse()
 
@@ -165,7 +225,15 @@ def test_fetch_videos_builds_filtered_request_and_normalizes_response(monkeypatc
 
 
 def test_fetch_videos_returns_empty_list_when_request_fails(monkeypatch):
+    """A network failure while fetching videos must degrade to an empty feed, not a 500.
+
+    Feed readers hitting `/feed/rss` during an upstream outage should get
+    a valid (if empty) feed rather than an error page, so this locks in
+    that `_fetch_videos` swallows the exception instead of letting it
+    propagate.
+    """
     def fake_get(url, params, timeout):
+        """Simulate the upstream API being unreachable."""
         raise RuntimeError("network unavailable")
 
     monkeypatch.setattr(feed_blueprint.requests, "get", fake_get)
@@ -174,10 +242,19 @@ def test_fetch_videos_returns_empty_list_when_request_fails(monkeypatch):
 
 
 def test_feed_routes_escape_url_attributes_and_cdata(monkeypatch):
+    """RSS and Atom output must stay valid, well-formed XML even with hostile field content.
+
+    Feeds a title containing a literal `]]>` (which would prematurely
+    close a CDATA section) and a thumbnail URL with `&`/`<` characters,
+    then parses the actual response with `ElementTree` -- if escaping is
+    wrong anywhere, this fails on the XML parse itself rather than on a
+    weaker string-contains check.
+    """
     app = Flask(__name__)
     app.register_blueprint(feed_blueprint.feed_bp)
 
     def fake_fetch_videos(agent=None, category=None, limit=20):
+        """Return one video with adversarial title/description/URL content instead of hitting the network."""
         return [
             {
                 "video_id": "feedxml01",


### PR DESCRIPTION
## Summary
Added docstrings to every previously-undocumented function across two test files:

- `tests/test_feed_blueprint.py` — 16 functions documented
- `tests/test_ergo_bridge_validation.py` — 15 functions documented

31 functions documented total, docstrings-only, no logic changed. Each docstring focuses on *why* the test/fixture/helper exists (e.g. why the CDATA-escape test parses real XML with ElementTree instead of a substring check, why `bool` is called out explicitly in the amount-validation parametrize, why the ledger before/after snapshot matters for every rejection test).

## Testing
```
pytest -q tests/test_feed_blueprint.py tests/test_ergo_bridge_validation.py
```
37 passed.

/claim docstring batch