### PR TITLE
docs: add docstrings to feed pagination and report input validation tests (28 functions)

### DIFF
--- a/tests/test_feed_query_param_validation.py
+++ b/tests/test_feed_query_param_validation.py
@@ -14,6 +14,7 @@ authenticated /api/feed/subscriptions routes.
 
 
 def test_feed_rejects_non_integer_page(client):
+    """A non-numeric `page` must 400 with a message naming the field and the reason."""
     response = client.get("/api/feed?page=abc")
     assert response.status_code == 400
     data = response.get_json()
@@ -22,6 +23,7 @@ def test_feed_rejects_non_integer_page(client):
 
 
 def test_feed_rejects_non_integer_per_page(client):
+    """A non-numeric `per_page` must 400, mirroring the `page` check above for the size parameter."""
     response = client.get("/api/feed?per_page=xyz")
     assert response.status_code == 400
     data = response.get_json()
@@ -29,26 +31,31 @@ def test_feed_rejects_non_integer_per_page(client):
 
 
 def test_feed_rejects_zero_page(client):
+    """`page=0` must 400 -- pagination is 1-indexed, so zero is out of range, not just falsy."""
     response = client.get("/api/feed?page=0")
     assert response.status_code == 400
 
 
 def test_feed_rejects_negative_page(client):
+    """A negative `page` must 400 rather than being coerced into page 1 or crashing an OFFSET query."""
     response = client.get("/api/feed?page=-5")
     assert response.status_code == 400
 
 
 def test_feed_rejects_zero_per_page(client):
+    """`per_page=0` must 400 -- a request for zero results is almost certainly a client bug, not intent."""
     response = client.get("/api/feed?per_page=0")
     assert response.status_code == 400
 
 
 def test_feed_rejects_negative_per_page(client):
+    """A negative `per_page` must 400 rather than being passed through to a SQL LIMIT."""
     response = client.get("/api/feed?per_page=-1")
     assert response.status_code == 400
 
 
 def test_feed_rejects_per_page_above_max(client):
+    """`per_page` above the server's page-size cap must 400, not silently clamp -- callers relying on the requested size need to know it wasn't honored."""
     response = client.get("/api/feed?per_page=51")
     assert response.status_code == 400
     data = response.get_json()
@@ -56,21 +63,25 @@ def test_feed_rejects_per_page_above_max(client):
 
 
 def test_feed_rejects_float_page(client):
+    """A float-looking `page` like `1.5` must 400, not get silently truncated to page 1."""
     response = client.get("/api/feed?page=1.5")
     assert response.status_code == 400
 
 
 def test_feed_rejects_null_page(client):
+    """The literal string `null` (a common client-side bug when a JS value is undefined) must 400, not be parsed as 0/None."""
     response = client.get("/api/feed?page=null")
     assert response.status_code == 400
 
 
 def test_feed_rejects_nan_page(client):
+    """The literal string `NaN` must 400 -- Python's `int("NaN")` raises, but a looser numeric parser might not."""
     response = client.get("/api/feed?page=NaN")
     assert response.status_code == 400
 
 
 def test_feed_accepts_valid_pagination(client):
+    """A well-formed `page`/`per_page` pair must succeed and echo the requested page back."""
     response = client.get("/api/feed?page=1&per_page=10")
     assert response.status_code == 200
     data = response.get_json()
@@ -80,6 +91,7 @@ def test_feed_accepts_valid_pagination(client):
 
 
 def test_feed_omits_defaults_when_unset(client):
+    """A request with no pagination params at all must still succeed, defaulting to page 1."""
     response = client.get("/api/feed")
     assert response.status_code == 200
     data = response.get_json()
@@ -88,6 +100,11 @@ def test_feed_omits_defaults_when_unset(client):
 
 
 def test_feed_per_page_boundary_values(client):
+    """The exact edges of the valid range (1 and 50) must pass; one step past the max must fail.
+
+    Checks 51, 999, and 1000 together to prove the cap rejects anything
+    over the limit uniformly, not just values close to the boundary.
+    """
     for pp in (1, 50):
         r = client.get(f"/api/feed?per_page={pp}")
         assert r.status_code == 200
@@ -100,6 +117,12 @@ def test_feed_per_page_boundary_values(client):
 
 
 def test_feed_helper_direct_call_with_malformed_page(app):
+    """`_parse_positive_int_query` itself (not just the route) must return an error tuple for bad input.
+
+    Calls the shared helper directly rather than through `client.get`, so a
+    regression in the helper is caught here even if some future route
+    forgets to check its return value and drops the 400 response.
+    """
     with app.test_request_context("/api/feed?page=abc"):
         from bottube_server import _parse_positive_int_query
         value, error = _parse_positive_int_query("page", 1)

--- a/tests/test_report_input_validation.py
+++ b/tests/test_report_input_validation.py
@@ -24,6 +24,12 @@ _orig_sqlite_connect = sqlite3.connect
 
 
 def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    """Redirect the hardcoded production DB path to the test bootstrap path.
+
+    Import-time code opens `/root/bottube/bottube.db` before the `client`
+    fixture can monkeypatch `DB_PATH`, so without this shim collecting
+    this module would touch production report/comment data.
+    """
     if str(path) == "/root/bottube/bottube.db":
         path = os.environ["BOTTUBE_DB_PATH"]
     return _orig_sqlite_connect(path, *args, **kwargs)
@@ -38,6 +44,7 @@ _orig_init_store_db = paypal_packages.init_store_db
 
 
 def _test_init_store_db(db_path=None):
+    """Force paypal_packages' schema init onto the test bootstrap DB, not the real one."""
     bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
     Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
     return _orig_init_store_db(bootstrap_path)
@@ -52,6 +59,7 @@ sqlite3.connect = _orig_sqlite_connect
 
 @pytest.fixture()
 def client(monkeypatch, tmp_path):
+    """Yield a Flask test client on an isolated, per-test SQLite database."""
     db_path = tmp_path / "bottube_report_input_test.db"
     monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
     bottube_server._rate_buckets.clear()
@@ -62,6 +70,12 @@ def client(monkeypatch, tmp_path):
 
 
 def _insert_agent(agent_name: str, api_key: str) -> int:
+    """Insert a minimal agent row directly and return its id.
+
+    Used to seed both the video/comment owner and the reporter, since
+    report validation itself doesn't depend on how the accounts were
+    created.
+    """
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         cur = db.execute(
@@ -78,6 +92,7 @@ def _insert_agent(agent_name: str, api_key: str) -> int:
 
 
 def _insert_video(agent_id: int, video_id: str) -> None:
+    """Seed a video owned by `agent_id` so `/api/videos/<id>/report` has a target to reject or accept a report against."""
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
@@ -92,6 +107,7 @@ def _insert_video(agent_id: int, video_id: str) -> None:
 
 
 def _insert_comment(agent_id: int, video_id: str, content: str) -> int:
+    """Seed a comment and return its id, so `/api/comments/<id>/report` has a target."""
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         cur = db.execute(
@@ -106,12 +122,18 @@ def _insert_comment(agent_id: int, video_id: str, content: str) -> int:
 
 
 def _report_count() -> int:
+    """Return how many rows exist in `reports`, used to prove a rejected request inserted nothing."""
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         return int(db.execute("SELECT COUNT(*) FROM reports").fetchone()[0])
 
 
 def test_video_report_null_reason_uses_existing_invalid_reason_error(client):
+    """`reason: null` must fail the same "Invalid reason" check as an unrecognized reason string, not a separate null-check path.
+
+    Proves `null` doesn't get special-cased into passing through or into a
+    different (weaker) error message than a plain bad `reason` value would get.
+    """
     owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
     _insert_agent("reporter", "bottube_sk_reporter")
     _insert_video(owner_id, "ownervideo01A")
@@ -128,6 +150,12 @@ def test_video_report_null_reason_uses_existing_invalid_reason_error(client):
 
 
 def test_video_report_rejects_non_string_details_without_insert(client):
+    """A dict-typed `details` on a video report must 400 with a specific message and write nothing.
+
+    `reason` here is valid ("spam"), isolating the check to `details`
+    alone -- proves the two fields are validated independently rather
+    than one bad field's error masking a check on the other.
+    """
     owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
     _insert_agent("reporter", "bottube_sk_reporter")
     _insert_video(owner_id, "ownervideo01A")
@@ -144,6 +172,7 @@ def test_video_report_rejects_non_string_details_without_insert(client):
 
 
 def test_comment_report_rejects_non_string_reason_without_insert(client):
+    """A list-typed `reason` on a comment report must 400 and insert nothing, mirroring the video-report reason check."""
     owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
     _insert_agent("reporter", "bottube_sk_reporter")
     _insert_video(owner_id, "ownervideo01A")
@@ -161,6 +190,7 @@ def test_comment_report_rejects_non_string_reason_without_insert(client):
 
 
 def test_comment_report_rejects_non_object_json(client):
+    """A JSON array body to /comments/<id>/report must 400 with "JSON body must be an object" and write nothing."""
     owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
     _insert_agent("reporter", "bottube_sk_reporter")
     _insert_video(owner_id, "ownervideo01A")
@@ -178,6 +208,7 @@ def test_comment_report_rejects_non_object_json(client):
 
 
 def test_video_report_rejects_falsy_non_object_json(client):
+    """An empty JSON array (`[]`, which is falsy in Python) must still be rejected as "not an object", not treated as "no body"."""
     owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
     _insert_agent("reporter", "bottube_sk_reporter")
     _insert_video(owner_id, "ownervideo02A")
@@ -194,6 +225,13 @@ def test_video_report_rejects_falsy_non_object_json(client):
 
 
 def test_comment_report_rejects_falsy_non_object_json(client):
+    """The same falsy-empty-array case as the video-report test above, but for the comment-report endpoint.
+
+    A validator using `if not body:` to mean "body missing" would wrongly
+    let `[]` fall through as "no body provided" instead of "wrong type" --
+    covering both endpoints catches this if only one of the two handlers
+    shares that bug.
+    """
     owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
     _insert_agent("reporter", "bottube_sk_reporter")
     _insert_video(owner_id, "ownervideo03A")
@@ -211,6 +249,13 @@ def test_comment_report_rejects_falsy_non_object_json(client):
 
 
 def test_video_report_accepts_null_details_as_empty(client):
+    """`details: null` must succeed (unlike `reason: null`) since details is genuinely optional.
+
+    Paired with `test_video_report_null_reason_...` above: `null` is
+    rejected for the required `reason` field but accepted for the
+    optional `details` field, proving the two aren't validated by one
+    blanket "no nulls" rule.
+    """
     owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
     _insert_agent("reporter", "bottube_sk_reporter")
     _insert_video(owner_id, "ownervideo01A")


### PR DESCRIPTION
## Summary
Added docstrings to every previously-undocumented function across two test files:

- `tests/test_feed_query_param_validation.py` — 14 functions documented
- `tests/test_report_input_validation.py` — 14 functions documented

28 functions documented total, docstrings-only, no logic changed. Each docstring focuses on *why* the test exists (e.g. why zero/negative/float/null/NaN page values are each their own distinct test rather than one parametrized "bad input" case, why `reason: null` and `details: null` get opposite verdicts, why the falsy-empty-array `[]` body is checked separately from the general non-object case on both the video and comment report endpoints).

## Testing
```
pytest -q tests/test_feed_query_param_validation.py tests/test_report_input_validation.py
```
21 passed.

/claim docstring batch