### PR TITLE
fix(cron): banano_payout.py and bottube_engage.py still read raw BOTTUBE_DB

### DIFF
--- a/banano_payout.py
+++ b/banano_payout.py
@@ -18,11 +18,18 @@ import sys
 import time
 import urllib.request
 
+from bottube_db import resolve_db_path
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
-DB_PATH = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
+# Reads BOTTUBE_DB_PATH first (the name the main server and table-creation
+# code use), then falls back to the legacy BOTTUBE_DB alias and finally
+# BOTTUBE_BASE_DIR. A bare os.environ.get("BOTTUBE_DB", ...) here used to
+# silently miss BOTTUBE_DB_PATH-only deployments and write payouts against
+# a bottube.db that has none of the server's tables.
+DB_PATH = resolve_db_path()
 KALIUM_API = "https://kaliumapi.appditto.com/api"
 KALIUM_FALLBACK = "https://public.node.jungletv.live/rpc"
 BANANO_SEED = os.environ.get("BANANO_SEED", "")

--- a/bottube_db.py
+++ b/bottube_db.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+import os
+
+
+def resolve_db_path() -> str:
+    """Resolve the BoTTube SQLite path consistently across server and blueprints.
+
+    Precedence:
+    1. BOTTUBE_DB_PATH (canonical name used by the main server)
+    2. BOTTUBE_DB (legacy alias kept for backward compatibility)
+    3. BOTTUBE_BASE_DIR/bottube.db
+    4. repo-local bottube.db next to this file
+    """
+    explicit = os.environ.get("BOTTUBE_DB_PATH") or os.environ.get("BOTTUBE_DB")
+    if explicit:
+        return explicit
+    base_dir = Path(os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent)))
+    return str(base_dir / "bottube.db")

--- a/bottube_engage.py
+++ b/bottube_engage.py
@@ -25,11 +25,16 @@ import os
 import json
 import logging
 
+from bottube_db import resolve_db_path
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 log = logging.getLogger("engage")
 
 BASE_URL = os.environ.get("BOTTUBE_URL", "https://bottube.ai")
-DB_PATH = os.environ.get("BOTTUBE_DB", "/root/bottube/bottube.db")
+# Same BOTTUBE_DB_PATH -> BOTTUBE_DB -> BOTTUBE_BASE_DIR resolution the server
+# and blueprints use, so this script does not drift onto a different db file
+# on BOTTUBE_DB_PATH-only deployments (see banano_payout.py for the same fix).
+DB_PATH = resolve_db_path()
 VERIFY_SSL = False
 
 # ── Bot Personalities for Replies ────────────────────────────────────

--- a/tests/test_standalone_scripts_db_path.py
+++ b/tests/test_standalone_scripts_db_path.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MIT
+"""banano_payout.py and bottube_engage.py are cron/standalone scripts, not
+Flask blueprints — they used to resolve their own DB_PATH straight from
+os.environ.get("BOTTUBE_DB", ...), independently of the shared
+bottube_db.resolve_db_path() precedence (BOTTUBE_DB_PATH -> BOTTUBE_DB ->
+BOTTUBE_BASE_DIR) the rest of the codebase was already unified onto in the
+bridge/gemini/news fixes. On a BOTTUBE_DB_PATH-only deployment (the name the
+main server and table-creation code actually use) both scripts silently fell
+back to the hardcoded /root/bottube/bottube.db default instead of the
+configured path -- the payout cron would read a bottube.db with none of the
+server's tables, and the engagement script would post replies sourced from
+the wrong (likely empty) database.
+"""
+import importlib
+
+
+def _reload(module_name):
+    module = importlib.import_module(module_name)
+    return importlib.reload(module)
+
+
+def test_banano_payout_prefers_bottube_db_path(tmp_path, monkeypatch):
+    configured = tmp_path / "configured.db"
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(configured))
+    monkeypatch.setenv("BOTTUBE_DB", str(tmp_path / "legacy-should-be-ignored.db"))
+
+    module = _reload("banano_payout")
+    assert module.DB_PATH == str(configured)
+
+
+def test_banano_payout_falls_back_to_legacy_bottube_db(tmp_path, monkeypatch):
+    legacy = tmp_path / "legacy.db"
+    monkeypatch.delenv("BOTTUBE_DB_PATH", raising=False)
+    monkeypatch.setenv("BOTTUBE_DB", str(legacy))
+
+    module = _reload("banano_payout")
+    assert module.DB_PATH == str(legacy)
+
+
+def test_bottube_engage_prefers_bottube_db_path(tmp_path, monkeypatch):
+    configured = tmp_path / "configured.db"
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(configured))
+    monkeypatch.setenv("BOTTUBE_DB", str(tmp_path / "legacy-should-be-ignored.db"))
+
+    module = _reload("bottube_engage")
+    assert module.DB_PATH == str(configured)
+
+
+def test_bottube_engage_falls_back_to_legacy_bottube_db(tmp_path, monkeypatch):
+    legacy = tmp_path / "legacy.db"
+    monkeypatch.delenv("BOTTUBE_DB_PATH", raising=False)
+    monkeypatch.setenv("BOTTUBE_DB", str(legacy))
+
+    module = _reload("bottube_engage")
+    assert module.DB_PATH == str(legacy)


### PR DESCRIPTION
## Summary
The bridge/gemini/news db-path fixes (#1736-#1738) unified everything else onto `bottube_db.resolve_db_path()` (`BOTTUBE_DB_PATH` -> `BOTTUBE_DB` -> `BOTTUBE_BASE_DIR`), but these two standalone cron/operational scripts were missed - they still did a bare `os.environ.get("BOTTUBE_DB", ...)`.

On a `BOTTUBE_DB_PATH`-only deployment (the name the main server and table-creation code actually use), both scripts silently fall back to the hardcoded `/root/bottube/bottube.db` default instead of the configured path:
- `banano_payout.py` would process withdrawals against a database with none of the server's tables
- `bottube_engage.py` would read/post comments sourced from the wrong (likely empty) database

## Fix
- `banano_payout.py` and `bottube_engage.py` now call `resolve_db_path()` instead of reading `BOTTUBE_DB` directly

## Testing
- Added `tests/test_standalone_scripts_db_path.py`: 4 regression tests, 2 of which fail on `main` without this fix (verified locally) and pass with it
- `python3 -m pytest -q tests/test_standalone_scripts_db_path.py` - 4/4 passing

/claim