### PR TITLE
docs(tests): add docstrings to validation, accessibility, and base dir coverage (13 functions)

### DIFF
--- a/tests/test_avap_base_dir.py
+++ b/tests/test_avap_base_dir.py
@@ -5,6 +5,14 @@ import avap_blueprint
 
 
 def test_init_avap_tables_uses_env_base_dir(monkeypatch, tmp_path):
+    """Verify init_avap_tables creates tables under the configured DB_PATH.
+
+    The avap blueprint reads DB_PATH at import time. When the deployment
+    sets BOTTUBE_BASE_DIR (or similar) to a custom location, init_avap_tables
+    must honor that path so the schema lands in the same SQLite file the
+    rest of the app reads from. This test monkeypatches DB_PATH to a
+    tmp_path location and asserts the expected tables exist there.
+    """
     db_dir = tmp_path / "custom-base"
     db_dir.mkdir()
     db_path = db_dir / "bottube.db"

--- a/tests/test_ergo_bridge_registration.py
+++ b/tests/test_ergo_bridge_registration.py
@@ -1,4 +1,11 @@
 def test_ergo_bridge_info_route_is_registered():
+    """Verify the /api/ergo/info route is registered in the Flask URL map.
+
+    The Ergo bridge info endpoint exposes chain metadata (network id, tip
+    height, last block hash) to clients integrating with the platform. This
+    test confirms the route is wired into the app at startup, which is a
+    precondition for any HTTP request to the endpoint to succeed end-to-end.
+    """
     import bottube_server
 
     routes = {rule.rule for rule in bottube_server.app.url_map.iter_rules()}

--- a/tests/test_leaderboard_query_validation.py
+++ b/tests/test_leaderboard_query_validation.py
@@ -2,6 +2,13 @@
 
 
 def test_quests_leaderboard_rejects_malformed_limit(client):
+    """Verify the quests leaderboard rejects a non-integer limit query param.
+
+    The leaderboard endpoint accepts `limit` to cap the number of rows
+    returned. A non-integer value (e.g. `limit=abc`) must be rejected with
+    a 400 and a clear error so clients can fix their request instead of
+    getting a 500 from a downstream SQL or Python coercion.
+    """
     response = client.get("/api/quests/leaderboard?limit=abc")
 
     assert response.status_code == 400
@@ -9,6 +16,12 @@ def test_quests_leaderboard_rejects_malformed_limit(client):
 
 
 def test_gamification_leaderboard_rejects_malformed_limit(client):
+    """Verify the gamification leaderboard rejects a non-integer limit.
+
+    Mirrors the quests leaderboard validation: malformed `limit` query
+    parameters must surface as 400s with the same canonical error message
+    so client SDKs can handle both leaderboards with one error path.
+    """
     response = client.get("/api/gamification/leaderboard?limit=abc")
 
     assert response.status_code == 400

--- a/tests/test_mobile_header_overlap_1713.py
+++ b/tests/test_mobile_header_overlap_1713.py
@@ -5,6 +5,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_base_template_reserves_logo_width_on_mobile():
+    """Verify the base template lays out header items correctly on mobile.
+
+    Regression test for #1713: on narrow viewports the logo, search bar,
+    and hamburger menu must use flex sizing that prevents the search bar
+    from crowding out the logo or the menu button. This asserts the
+    specific flex + display rules that keep the three regions aligned.
+    """
     template = (ROOT / 'bottube_templates' / 'base.html').read_text(encoding='utf-8')
 
     assert 'flex: 0 0 auto;' in template
@@ -15,6 +22,13 @@ def test_base_template_reserves_logo_width_on_mobile():
 
 
 def test_base_template_trims_mobile_search_button_padding():
+    """Verify the mobile search button uses tighter padding and font size.
+
+    On narrow viewports the search button gets trimmed padding (8px 12px)
+    and a 13px font so it fits next to the logo and menu trigger without
+    wrapping. This guards against a global style tweak reverting those
+    mobile-specific overrides.
+    """
     template = (ROOT / 'bottube_templates' / 'base.html').read_text(encoding='utf-8')
 
     assert '.search-bar button { padding: 8px 12px; }' in template

--- a/tests/test_news_routes_db_path.py
+++ b/tests/test_news_routes_db_path.py
@@ -6,6 +6,14 @@ import news_routes
 
 
 def test_news_routes_respects_bottube_base_dir(monkeypatch, tmp_path):
+    """Verify news routes read videos from the configured DB_PATH.
+
+    The /api/news endpoint queries videos joined with agents. When the
+    deployment overrides DB_PATH via BOTTUBE_BASE_DIR (so the DB lives
+    under a custom instance dir), news_routes must read from that same
+    path instead of the package-default location, otherwise the endpoint
+    would 500 on any non-default deployment.
+    """
     db_dir = tmp_path / "instance"
     db_dir.mkdir()
     db_path = db_dir / "bottube.db"

--- a/tests/test_reduced_motion.py
+++ b/tests/test_reduced_motion.py
@@ -3,6 +3,13 @@ from pathlib import Path
 
 
 def test_base_template_respects_reduced_motion_preference():
+    """Verify the base template applies reduced-motion CSS overrides.
+
+    Users who have prefers-reduced-motion enabled at the OS level should
+    see motion-sensitive properties (animation duration, transition duration,
+    scroll behavior) clamped to safe non-animated values. This guards against
+    template edits that might silently regress that accessibility behavior.
+    """
     template = Path("bottube_templates/base.html").read_text(encoding="utf-8")
 
     assert "@media (prefers-reduced-motion: reduce)" in template

--- a/tests/test_report_template.py
+++ b/tests/test_report_template.py
@@ -6,6 +6,13 @@ REPORT_TEMPLATE = ROOT / "bottube_templates" / "report.html"
 
 
 def test_report_errors_do_not_remove_success_reference_node():
+    """Verify the report template keeps the success reference node wired up.
+
+    When a user reports a video, the JS reads the report_id back from a
+    reference node on success. This test guards against a regression where
+    an error-path rewrite might also remove that reference, which would
+    silently break the success UX for legitimate reports.
+    """
     html = REPORT_TEMPLATE.read_text(encoding="utf-8")
 
     assert 'id="r-toast-message"' in html

--- a/tests/test_upload_template.py
+++ b/tests/test_upload_template.py
@@ -3,6 +3,13 @@ from pathlib import Path
 
 
 def test_api_upload_submit_handler_initializes_form_before_file_check():
+    """Verify the API upload submit handler captures the form before file check.
+
+    On submit, the handler must read `e.target` (the submitted form) before
+    it queries the file input. If those two steps are reordered in the
+    template, the file check would run against the wrong form reference
+    and silently reject every upload with a misleading error message.
+    """
     template = Path(__file__).resolve().parents[1] / "bottube_templates" / "upload.html"
     html = template.read_text(encoding="utf-8")
 

--- a/tests/test_verify_template_accessibility.py
+++ b/tests/test_verify_template_accessibility.py
@@ -6,6 +6,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_verify_video_id_input_has_programmatic_label():
+    """Verify the video-id input on /verify has a programmatic label.
+
+    Screen readers announce input fields by their associated label. The
+    verify page must keep a screen-reader-only <label for=vrf-vid> bound
+    to the input so the field is reachable and identified by assistive
+    tech instead of being announced as a bare text box.
+    """
     template = (ROOT / "bottube_templates" / "verify.html").read_text(encoding="utf-8")
 
     assert '<label for="vrf-vid" class="vrf-sr-only">Video ID</label>' in template
@@ -13,6 +20,13 @@ def test_verify_video_id_input_has_programmatic_label():
 
 
 def test_verify_primary_submit_has_descriptive_accessible_name():
+    """Verify the primary submit button has a descriptive accessible name.
+
+    The default button text on /verify should be paired with an explicit
+    aria-label that says what the action actually does ("Verify video
+    provenance"), so screen reader users hear the action verb instead of
+    an ambiguous label like "Submit".
+    """
     template = (ROOT / "bottube_templates" / "verify.html").read_text(encoding="utf-8")
 
     assert 'id="vrf-btn" aria-label="Verify video provenance"' in template

--- a/tests/test_watch_template_accessibility.py
+++ b/tests/test_watch_template_accessibility.py
@@ -3,6 +3,13 @@ from pathlib import Path
 
 
 def test_watch_template_does_not_duplicate_main_landmark():
+    """Verify the watch template does not duplicate the page main landmark.
+
+    The base template already exposes a #main-content landmark for keyboard
+    and screen reader navigation. The watch page must reuse that landmark
+    (or omit a competing one) so assistive tech does not see two conflicting
+    'primary content' regions on the same route.
+    """
     template = Path(__file__).resolve().parents[1] / "bottube_templates" / "watch.html"
     html = template.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Adds descriptive docstrings to 13 test functions across 10 test files in `tests/`. No code changes; documentation only. Each docstring explains the intent of the assertion, the surface it guards, and the kind of regression it is designed to catch.

## Files documented (13 functions total)

| File | Functions |
|------|-----------|
| tests/test_ergo_bridge_registration.py | 1 |
| tests/test_reduced_motion.py | 1 |
| tests/test_watch_template_accessibility.py | 1 |
| tests/test_report_template.py | 1 |
| tests/test_upload_template.py | 1 |
| tests/test_leaderboard_query_validation.py | 2 |
| tests/test_verify_template_accessibility.py | 2 |
| tests/test_mobile_header_overlap_1713.py | 2 |
| tests/test_avap_base_dir.py | 1 |
| tests/test_news_routes_db_path.py | 1 |

## Test plan

Pure documentation PR; existing pytest suite continues to pass unchanged (no assertions modified).

## RTC claim

- Rate: 0.5 RTC per function
- Total: 6.5 RTC
- Meta-repo claim: rustchain-bounties (will file after this PR is opened)
