### PR TITLE
fix(feed): harden feed host fallback and studio media rendering

### DIFF
--- a/bottube_templates/studio.html
+++ b/bottube_templates/studio.html
@@ -144,8 +144,95 @@
 
   function allButtons(){ return document.querySelectorAll(".gen"); }
   function setBusy(b){ allButtons().forEach(function(x){ x.disabled = b; }); }
-  function say(m){ statusEl.innerHTML = m; }
-  function clearResult(){ resultEl.innerHTML = ""; }
+  function say(m){ statusEl.textContent = m == null ? "" : String(m); }
+  function clearResult(){ resultEl.replaceChildren(); }
+  function safeAmount(value) {
+    var n = Number(value);
+    return Number.isFinite(n) ? String(n) : "?";
+  }
+  function safeHttpUrl(value) {
+    try {
+      var url = new URL(String(value || ""), window.location.origin);
+      if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+      return url.href;
+    } catch (e) {
+      return "";
+    }
+  }
+  function safeSameOriginUrl(value) {
+    var href = safeHttpUrl(value);
+    if (!href) return "";
+    try {
+      return new URL(href).origin === window.location.origin ? href : "";
+    } catch (e) {
+      return "";
+    }
+  }
+  function setBalance(value) {
+    var strong = document.createElement("strong");
+    strong.textContent = safeAmount(value) + " RTC";
+    balEl.replaceChildren("Your balance: ", strong);
+  }
+  function setLoginPrompt() {
+    var link = document.createElement("a");
+    link.href = "/login";
+    link.textContent = "log in";
+    balEl.replaceChildren("Sign in to generate — ", link, ".");
+  }
+  function renderDownloadLink(url, label) {
+    var wrap = document.createElement("div");
+    wrap.style.marginTop = "8px";
+    var link = document.createElement("a");
+    link.href = url;
+    link.download = "";
+    link.textContent = label;
+    wrap.appendChild(link);
+    return wrap;
+  }
+  function renderImageResult(mediaUrl) {
+    var img = document.createElement("img");
+    img.src = mediaUrl;
+    img.alt = "generated image";
+    img.loading = "lazy";
+    img.decoding = "async";
+    img.width = 720;
+    img.height = 720;
+    resultEl.replaceChildren(img, renderDownloadLink(mediaUrl, "Download image →"));
+  }
+  function renderAudioResult(mediaUrl) {
+    var audio = document.createElement("audio");
+    audio.controls = true;
+    audio.autoplay = true;
+    audio.src = mediaUrl;
+    resultEl.replaceChildren(audio, renderDownloadLink(mediaUrl, "Download audio →"));
+  }
+  function renderModelResult(modelUrl, formats) {
+    var viewer = document.createElement("model-viewer");
+    viewer.src = modelUrl;
+    viewer.setAttribute("camera-controls", "");
+    viewer.setAttribute("auto-rotate", "");
+    viewer.setAttribute("ar", "");
+    viewer.setAttribute("shadow-intensity", "1");
+    viewer.style.cssText = "width:100%;height:360px;background:#111;border-radius:8px;";
+
+    var wrap = renderDownloadLink(modelUrl, "Download GLB →");
+    if (Array.isArray(formats) && formats.length) {
+      var safeFormats = formats.map(function (item) { return String(item); }).join(", ");
+      wrap.appendChild(document.createTextNode(" · formats: " + safeFormats));
+    }
+    resultEl.replaceChildren(viewer, wrap);
+  }
+  function sayWithWatchLink(watchUrl) {
+    var href = safeSameOriginUrl(watchUrl);
+    if (!href) {
+      say("🎬 Done — check your channel.");
+      return;
+    }
+    var link = document.createElement("a");
+    link.href = href;
+    link.textContent = "Watch your video →";
+    statusEl.replaceChildren("🎬 Done! ", link);
+  }
 
   window.stMode = function (mode) {
     curMode = mode;
@@ -173,8 +260,8 @@
         signedIn = !!d.signed_in;
         voiceEnabled = d.voice_enabled !== false;
         try { i2vRate = d.tiers.video.full_ai.rtc_per_sec || 1.0; window.stSecondsI2v && window.stSecondsI2v(); } catch (e) {}
-        if (!signedIn) { balEl.innerHTML = 'Sign in to generate — <a href="/login">log in</a>.'; setBusy(true); }
-        else { balEl.innerHTML = "Your balance: <strong>" + (d.rtc_balance != null ? d.rtc_balance : "?") + " RTC</strong>"; }
+        if (!signedIn) { setLoginPrompt(); setBusy(true); }
+        else { setBalance(d.rtc_balance); }
         if (!voiceEnabled) {
           var vb = document.getElementById("voice-btn");
           if (vb) { vb.disabled = true; vb.textContent = "Voice temporarily unavailable"; }
@@ -209,16 +296,22 @@
           else say(res.d.error || ("error " + res.status));
           return;
         }
-        balEl.innerHTML = "Your balance: <strong>" + res.d.new_balance + " RTC</strong>";
+        setBalance(res.d.new_balance);
         if (res.d.type === "image") {
           setBusy(false); say("✅ Charged " + res.d.charged_rtc + " RTC.");
-          resultEl.innerHTML = '<img src="' + res.d.media_url + '" alt="generated image"><div style="margin-top:8px"><a href="' + res.d.media_url + '" download>Download image →</a></div>';
+          var imageUrl = safeHttpUrl(res.d.media_url);
+          if (imageUrl) renderImageResult(imageUrl);
+          else say("Image generated, but the returned media URL was invalid.");
         } else if (res.d.type === "voice") {
           setBusy(false); say("✅ Charged " + res.d.charged_rtc + " RTC.");
-          resultEl.innerHTML = '<audio controls autoplay src="' + res.d.media_url + '"></audio><div style="margin-top:8px"><a href="' + res.d.media_url + '" download>Download audio →</a></div>';
+          var audioUrl = safeHttpUrl(res.d.media_url);
+          if (audioUrl) renderAudioResult(audioUrl);
+          else say("Voice generated, but the returned media URL was invalid.");
         } else {
           say("✅ Charged " + res.d.charged_rtc + " RTC. Generating… this can take a couple minutes.");
-          poll(res.d.status_url);
+          var statusUrl = safeSameOriginUrl(res.d.status_url);
+          if (statusUrl) poll(statusUrl);
+          else { setBusy(false); say("Generation started, but the returned status URL was invalid."); }
         }
       })
       .catch(function(){ setBusy(false); say("Couldn't reach the studio. Try again."); });
@@ -262,16 +355,13 @@
         if (d.model_url) {
           clearInterval(iv); setBusy(false);
           say("🧊 Done! Charged successfully.");
-          resultEl.innerHTML =
-            '<model-viewer src="' + d.model_url + '" camera-controls auto-rotate ' +
-            'style="width:100%;height:360px;background:#111;border-radius:8px;" ' +
-            'ar shadow-intensity="1"></model-viewer>' +
-            '<div style="margin-top:8px"><a href="' + d.model_url + '" download>Download GLB →</a>' +
-            ((d.formats && d.formats.length) ? ' · formats: ' + d.formats.join(", ") : "") + '</div>';
+          var modelUrl = safeHttpUrl(d.model_url);
+          if (modelUrl) renderModelResult(modelUrl, d.formats);
+          else say("3D model generated, but the returned model URL was invalid.");
         } else if (d.status === "completed" || d.video_id) {
           clearInterval(iv); setBusy(false);
           var watch = d.watch_url || (d.video_id ? ("/watch/" + d.video_id) : null);
-          say(watch ? ("🎬 Done! <a href='" + watch + "'>Watch your video →</a>") : "🎬 Done — check your channel.");
+          watch ? sayWithWatchLink(watch) : say("🎬 Done — check your channel.");
         } else if (d.status === "failed" || d.error) {
           clearInterval(iv); setBusy(false);
           say("Generation failed: " + (d.error || "unknown") + ". (RTC for failed jobs is refunded.)");

--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -5,24 +5,94 @@
 import datetime
 import os
 from email.utils import format_datetime
+from urllib.parse import quote, urlsplit
 
 import requests
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, has_request_context, jsonify, request
 
 feed_bp = Blueprint("feed", __name__)
+
+_LOOPBACK_FEED_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def _normalize_host(host: str = None) -> str:
+    """Return a lowercase hostname without a port, or an empty string if invalid."""
+    raw = str(host or "").strip()
+    if not raw or any(ch.isspace() for ch in raw) or any(ch in raw for ch in "/\\@"):
+        return ""
+
+    if raw.startswith("["):
+        end = raw.find("]")
+        if end == -1:
+            return ""
+        name = raw[1:end]
+        suffix = raw[end + 1 :]
+        if suffix and (not suffix.startswith(":") or not suffix[1:].isdigit()):
+            return ""
+        return name.lower().rstrip(".")
+
+    # Accept host:port for ordinary names and IPv4. Leave unbracketed IPv6 alone.
+    if raw.count(":") == 1:
+        name, port = raw.rsplit(":", 1)
+        if not port.isdigit():
+            return ""
+        raw = name
+    elif raw.count(":") > 1:
+        return raw.lower().rstrip(".")
+
+    return raw.lower().rstrip(".")
+
+
+def _feed_allowed_hosts() -> set[str]:
+    """Allowed request hosts that may be used as the feed API origin."""
+    canonical = _normalize_host(os.getenv("BOTTUBE_CANONICAL_HOST", "bottube.ai"))
+    allowed = set(_LOOPBACK_FEED_HOSTS)
+    if canonical:
+        allowed.add(canonical)
+        if canonical.startswith("www."):
+            allowed.add(canonical[4:])
+        else:
+            allowed.add(f"www.{canonical}")
+
+    for item in os.getenv("BOTTUBE_FEED_ALLOWED_HOSTS", "").split(","):
+        normalized = _normalize_host(item)
+        if normalized:
+            allowed.add(normalized)
+    return allowed
+
+
+def _safe_request_host(host: str = None) -> str:
+    """Return the original host only when its normalized hostname is allowlisted."""
+    raw = str(host or "").strip()
+    normalized = _normalize_host(raw)
+    if normalized and normalized in _feed_allowed_hosts():
+        return raw
+    return ""
 
 
 def _base_api_url(host: str = None) -> str:
     """
     Prefer local API by default; allow explicit override for external deployments.
 
-    If BOTTUBE_API_BASE is unset, fallback to request host (if provided) to fix
-    feed generation in production when localhost is not accessible.
+    If BOTTUBE_API_BASE is unset, only use an allowlisted request host. Host
+    headers are attacker-controlled at the HTTP edge, so unlisted hosts fall
+    back to the canonical BoTTube origin instead of becoming an SSRF target.
     """
     if "BOTTUBE_API_BASE" in os.environ:
         return os.getenv("BOTTUBE_API_BASE").rstrip("/")
-    # Use request host if available; fallback to localhost for backward compatibility
-    default_url = f"https://{host}" if host else "http://127.0.0.1:5000"
+
+    safe_host = _safe_request_host(host)
+    if safe_host:
+        scheme = "http" if _normalize_host(safe_host) in _LOOPBACK_FEED_HOSTS else "https"
+        return f"{scheme}://{safe_host}".rstrip("/")
+
+    # Preserve local fallback when there is no request host, but do not trust a
+    # present unlisted Host header.
+    if not host:
+        return "http://127.0.0.1:5000"
+
+    canonical = _normalize_host(os.getenv("BOTTUBE_CANONICAL_HOST", "bottube.ai"))
+    default_url = f"https://{canonical or 'bottube.ai'}"
     return default_url.rstrip("/")
 
 
@@ -45,6 +115,17 @@ def _cdata_safe(text):
     return str(text or "").replace("]]>", "]]]]><![CDATA[>")
 
 
+def _is_safe_feed_url(value) -> bool:
+    """Allow http(s) and same-origin absolute-path URLs in feed HTML/media attrs."""
+    raw = str(value or "").strip()
+    if not raw or any(ch.isspace() for ch in raw):
+        return False
+    if raw.startswith("/"):
+        return not raw.startswith("//")
+    parsed = urlsplit(raw)
+    return parsed.scheme.lower() in {"http", "https"} and bool(parsed.netloc)
+
+
 def _video_description_html(fields):
     """Video description html.
     
@@ -54,9 +135,17 @@ def _video_description_html(fields):
     Returns:
         The result value.
     """
-    thumb = escape_xml(fields["thumb"])
+    thumb = escape_xml(fields["thumb"]) if _is_safe_feed_url(fields.get("thumb")) else ""
+    title = fields.get("title") or "BoTTube video"
+    alt = escape_xml(f"Video thumbnail: {title}")
     desc = _cdata_safe(escape_xml(fields["desc"]))
-    return f'<img src="{thumb}" /><p>{desc}</p>'
+    image = (
+        f'<img src="{thumb}" alt="{alt}" loading="lazy" decoding="async" '
+        'width="720" height="720" />'
+        if thumb
+        else ""
+    )
+    return f"{image}<p>{desc}</p>"
 
 
 def _to_rfc2822(value):
@@ -137,8 +226,9 @@ def _fetch_videos(agent=None, category=None, limit=20):
         params["category"] = category
 
     try:
-        # Use current request host when available to fix feed generation in production
-        base_url = _base_api_url(host=request.host)
+        # Use current request host only when a Flask request context exists.
+        request_host = request.host if has_request_context() else None
+        base_url = _base_api_url(host=request_host)
         api_url = f"{base_url}/api/videos"
         res = requests.get(api_url, params=params, timeout=10)
         res.raise_for_status()
@@ -181,17 +271,20 @@ def _limit_error_response(exc):
 def _vid_fields(vid):
     """Extract common fields from a video dict."""
     vid_id = vid.get("video_id") or vid.get("id") or ""
+    safe_vid_id = quote(str(vid_id), safe="")
+    default_thumb = f"https://bottube.ai/api/videos/{safe_vid_id}/thumbnail"
+    thumb = vid.get("thumbnail_url", default_thumb)
+    if not _is_safe_feed_url(thumb):
+        thumb = default_thumb
     return {
         "id": vid_id,
         "title": vid.get("title", "Untitled Video"),
         "desc": vid.get("description", ""),
         "author": vid.get("agent_name", "AI Agent"),
         "category": vid.get("category", "General"),
-        "thumb": vid.get(
-            "thumbnail_url", f"https://bottube.ai/api/videos/{vid_id}/thumbnail"
-        ),
-        "stream": f"https://bottube.ai/api/videos/{vid_id}/stream",
-        "watch": f"https://bottube.ai/watch/{vid_id}",
+        "thumb": thumb,
+        "stream": f"https://bottube.ai/api/videos/{safe_vid_id}/stream",
+        "watch": f"https://bottube.ai/watch/{safe_vid_id}",
         "created_at": vid.get("created_at"),
     }
 

--- a/tests/test_feed_blueprint.py
+++ b/tests/test_feed_blueprint.py
@@ -78,6 +78,48 @@ def test_vid_fields_applies_defaults_and_derived_urls():
     }
 
 
+def test_vid_fields_rejects_unsafe_thumbnail_urls_and_quotes_ids():
+    fields = feed_blueprint._vid_fields(
+        {
+            "id": "vid 123/<bad>",
+            "thumbnail_url": "javascript:alert(1)",
+        }
+    )
+
+    assert fields["thumb"] == "https://bottube.ai/api/videos/vid%20123%2F%3Cbad%3E/thumbnail"
+    assert fields["stream"] == "https://bottube.ai/api/videos/vid%20123%2F%3Cbad%3E/stream"
+    assert fields["watch"] == "https://bottube.ai/watch/vid%20123%2F%3Cbad%3E"
+
+
+def test_video_description_html_uses_accessible_lazy_thumbnail_markup():
+    html = feed_blueprint._video_description_html(
+        {
+            "thumb": "https://cdn.example.test/thumb.jpg?x=1&y=2",
+            "title": "A <great> video",
+            "desc": "hello",
+        }
+    )
+
+    assert '<img src="https://cdn.example.test/thumb.jpg?x=1&amp;y=2"' in html
+    assert 'alt="Video thumbnail: A &lt;great&gt; video"' in html
+    assert 'loading="lazy" decoding="async" width="720" height="720"' in html
+    assert "<p>hello</p>" in html
+
+
+def test_video_description_html_omits_unsafe_thumbnail_url():
+    html = feed_blueprint._video_description_html(
+        {
+            "thumb": "javascript:alert(1)",
+            "title": "Unsafe thumb",
+            "desc": "description",
+        }
+    )
+
+    assert "<img" not in html
+    assert "javascript:" not in html
+    assert html == "<p>description</p>"
+
+
 @pytest.mark.parametrize(
     ("path", "expected"),
     [
@@ -164,6 +206,35 @@ def test_fetch_videos_builds_filtered_request_and_normalizes_response(monkeypatc
     ]
 
 
+def test_fetch_videos_does_not_trust_unlisted_host_header(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        def raise_for_status(self):
+            calls.append(("raise_for_status",))
+
+        def json(self):
+            return {"videos": [{"id": "one"}]}
+
+    def fake_get(url, params, timeout):
+        calls.append((url, params, timeout))
+        return FakeResponse()
+
+    app = Flask(__name__)
+    monkeypatch.delenv("BOTTUBE_API_BASE", raising=False)
+    monkeypatch.delenv("BOTTUBE_FEED_ALLOWED_HOSTS", raising=False)
+    monkeypatch.setattr(feed_blueprint.requests, "get", fake_get)
+
+    with app.test_request_context("/feed/rss", headers={"Host": "169.254.169.254"}):
+        videos = feed_blueprint._fetch_videos(limit=2)
+
+    assert videos == [{"id": "one"}]
+    assert calls == [
+        ("https://bottube.ai/api/videos", {"per_page": 2}, 10),
+        ("raise_for_status",),
+    ]
+
+
 def test_fetch_videos_returns_empty_list_when_request_fails(monkeypatch):
     def fake_get(url, params, timeout):
         raise RuntimeError("network unavailable")
@@ -200,18 +271,44 @@ def test_feed_routes_escape_url_attributes_and_cdata(monkeypatch):
 
 
 def test_base_api_url_uses_request_host_when_env_unset():
-    """Test that _base_api_url falls back to request.host when BOTTUBE_API_BASE is unset."""
+    """Trusted request hosts still work when BOTTUBE_API_BASE is unset."""
     import os
     from unittest import mock
 
     # Ensure BOTTUBE_API_BASE is not set for this test
     with mock.patch.dict(os.environ, {}, clear=True):
-        # Test with a provided host
-        assert feed_blueprint._base_api_url(host="example.com") == "https://example.com"
-        assert feed_blueprint._base_api_url(host="api.test.local:8080") == "https://api.test.local:8080"
+        assert feed_blueprint._base_api_url(host="bottube.ai") == "https://bottube.ai"
+        assert feed_blueprint._base_api_url(host="www.bottube.ai") == "https://www.bottube.ai"
+        assert feed_blueprint._base_api_url(host="localhost:8097") == "http://localhost:8097"
 
         # Test fallback to localhost when no host provided
         assert feed_blueprint._base_api_url() == "http://127.0.0.1:5000"
+
+
+def test_base_api_url_rejects_untrusted_request_host_when_env_unset():
+    """Untrusted Host headers must not become outbound feed API origins."""
+    import os
+    from unittest import mock
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert feed_blueprint._base_api_url(host="169.254.169.254") == "https://bottube.ai"
+        assert feed_blueprint._base_api_url(host="evil.example.test") == "https://bottube.ai"
+        assert feed_blueprint._base_api_url(host="bottube.ai@evil.example.test") == "https://bottube.ai"
+
+
+def test_base_api_url_allows_explicit_feed_host_allowlist():
+    import os
+    from unittest import mock
+
+    with mock.patch.dict(
+        os.environ,
+        {"BOTTUBE_FEED_ALLOWED_HOSTS": "feeds.example.test"},
+        clear=True,
+    ):
+        assert (
+            feed_blueprint._base_api_url(host="feeds.example.test:8443")
+            == "https://feeds.example.test:8443"
+        )
 
 
 def test_base_api_url_respects_env_override():

--- a/tests/test_seo_audit_fix_pack.py
+++ b/tests/test_seo_audit_fix_pack.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def read(path: str) -> str:
-    return (ROOT / path).read_text()
+    return (ROOT / path).read_text(encoding="utf-8")
 
 
 def test_static_cdn_scripts_are_version_pinned_with_sri():

--- a/tests/test_studio_frontend_security.py
+++ b/tests/test_studio_frontend_security.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_studio_results_render_api_urls_with_dom_api():
+    source = (ROOT / "bottube_templates" / "studio.html").read_text(encoding="utf-8")
+
+    assert "resultEl.innerHTML" not in source
+    assert 'src="\' + res.d.media_url + \'"' not in source
+    assert 'src="\' + d.model_url + \'"' not in source
+    assert "function safeHttpUrl(value)" in source
+    assert "function safeSameOriginUrl(value)" in source
+    assert "resultEl.replaceChildren(img, renderDownloadLink(mediaUrl, \"Download image →\"));" in source
+    assert "resultEl.replaceChildren(audio, renderDownloadLink(mediaUrl, \"Download audio →\"));" in source
+    assert "resultEl.replaceChildren(viewer, wrap);" in source
+
+
+def test_studio_generated_images_are_lazy_decoded_and_sized():
+    source = (ROOT / "bottube_templates" / "studio.html").read_text(encoding="utf-8")
+
+    assert 'img.alt = "generated image";' in source
+    assert 'img.loading = "lazy";' in source
+    assert 'img.decoding = "async";' in source
+    assert "img.width = 720;" in source
+    assert "img.height = 720;" in source
+
+
+def test_studio_status_messages_default_to_text_content():
+    source = (ROOT / "bottube_templates" / "studio.html").read_text(encoding="utf-8")
+
+    assert "function say(m){ statusEl.textContent = m == null ? \"\" : String(m); }" in source
+    assert "Done! <a href=" not in source
+    assert "statusEl.replaceChildren(\"🎬 Done! \", link);" in source


### PR DESCRIPTION
## Summary

Refs Scottcjn/rustchain-bounties#1102 and Scottcjn/rustchain-bounties#121.

This PR hardens two BoTTube surfaces found during local audit:

- Feed generation no longer trusts arbitrary `Host` headers as the server-side API origin. `BOTTUBE_API_BASE` still overrides explicitly, trusted BoTTube/loopback hosts still work, and deployments can opt in additional hosts through `BOTTUBE_FEED_ALLOWED_HOSTS`.
- Studio media results no longer render API-provided `media_url`, `model_url`, `formats`, errors, or watch links through HTML string concatenation. The result/status UI now uses DOM APIs, textContent, same-origin status/watch validation, and http(s)-only media URLs.
- Feed thumbnail HTML now includes `alt`, `loading="lazy"`, `decoding="async"`, and dimensions, and rejects unsafe thumbnail schemes before RSS/Atom HTML/media output.
- SEO audit tests now read template files as UTF-8 on Windows.

## Reproduction before the patch

From current `main`:

```text
uv run --no-project --with flask --with requests python -c "import feed_blueprint; print(feed_blueprint._base_api_url(host='169.254.169.254')); print(feed_blueprint._video_description_html({'thumb':'https://cdn.example/thumb.jpg','desc':'hello'}))"
```

Before patch this printed:

```text
https://169.254.169.254
<img src="https://cdn.example/thumb.jpg" /><p>hello</p>
```

That shows an attacker-controlled Host value could become the outbound feed API base URL, and feed images lacked the SEO/accessibility attributes from the audit checklist.

The studio page also had HTML string sinks such as:

```text
resultEl.innerHTML = '<img src="' + res.d.media_url + '" ...>'
resultEl.innerHTML = '<model-viewer src="' + d.model_url + '" ...>'
say("🎬 Done! <a href='" + watch + "'>Watch your video →</a>")
```

## Verification

- `uv run --no-project --with pytest --with flask --with requests pytest -q tests\test_feed_blueprint.py tests\test_seo_audit_hygiene.py tests\test_seo_audit_fix_pack.py tests\test_studio_frontend_security.py` -> 41 passed
- `python -m py_compile feed_blueprint.py tests\test_feed_blueprint.py tests\test_seo_audit_fix_pack.py tests\test_studio_frontend_security.py`
- `node -e "const fs=require('fs'); const html=fs.readFileSync('bottube_templates/studio.html','utf8'); const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)].map(m=>m[1]); scripts.forEach((s,i)=>{ try { new Function(s); } catch (e) { console.error('script '+i+' failed:', e.message); process.exit(1); } }); console.log('studio inline scripts parse ok');"`
- `git diff --check`

Payout wallet if accepted: `RTC973498f72747cd1637e395521319c0ad61c0f68c`

AI-assisted; manually reproduced and verified locally on Windows. No production probing or exploitation performed.