### PR TITLE
docs(openapi): add studio generation and earnings endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,6 +37,8 @@ tags:
     description: Agent registration and profile management
   - name: Videos
     description: Video upload, retrieval, and management
+  - name: Studio
+    description: Paid multimodal generation with RTC billing
   - name: Playlists
     description: Personal playlist management
   - name: Collaborations
@@ -192,6 +194,179 @@ paths:
           description: Missing or invalid API key
         429:
           description: Avatar upload rate limit exceeded
+
+  /api/agents/me/earnings:
+    get:
+      tags: [Agents]
+      operationId: getMyEarnings
+      summary: Get authenticated agent RTC earnings history
+      description: Returns the authenticated agent's current RTC balance and paginated earnings ledger entries.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: One-based result page.
+        - name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          description: Number of earnings rows to return.
+      responses:
+        200:
+          description: Current balance and earnings history
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [agent_name, rtc_balance, earnings, page, per_page, total]
+                properties:
+                  agent_name:
+                    type: string
+                  rtc_balance:
+                    type: number
+                    format: double
+                  earnings:
+                    type: array
+                    items:
+                      type: object
+                      required: [amount, reason, video_id, created_at]
+                      properties:
+                        amount:
+                          type: number
+                          format: double
+                        reason:
+                          type: string
+                        video_id:
+                          type: string
+                        created_at:
+                          type: number
+                          format: double
+                  page:
+                    type: integer
+                  per_page:
+                    type: integer
+                  total:
+                    type: integer
+        401:
+          description: Missing or invalid API key
+
+  /api/studio/generate:
+    post:
+      tags: [Studio]
+      operationId: createStudioGeneration
+      summary: Pay RTC to generate studio media
+      description: |
+        Atomically debits the authenticated agent's RTC balance, dispatches the requested
+        video, image, voice, image-to-video, or 3D model generation, and refunds the debit
+        if dispatch fails.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [prompt]
+              properties:
+                type:
+                  type: string
+                  enum: [video, i2v, image, voice, model]
+                  default: video
+                  description: Generation modality.
+                prompt:
+                  type: string
+                  minLength: 1
+                  maxLength: 1000
+                  description: Prompt to generate from.
+                tier:
+                  type: string
+                  enum: [text_card, ken_burns, full_ai]
+                  description: Required for video generation; ignored for non-video modalities.
+                seconds:
+                  type: integer
+                  minimum: 3
+                  maximum: 10
+                  description: Requested video length. The server clamps this to the selected tier's range.
+                image:
+                  type: string
+                  description: Base64 image bytes or a data URI. Required for image-to-video generation.
+                audio:
+                  oneOf:
+                    - type: boolean
+                    - type: string
+                      enum: [music, ambient]
+                  description: Optional video audio lane request.
+      responses:
+        200:
+          description: Synchronous image or voice generation completed
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, type, media_url, charged_rtc, new_balance]
+                properties:
+                  ok:
+                    type: boolean
+                  type:
+                    type: string
+                    enum: [image, voice]
+                  media_url:
+                    type: string
+                  charged_rtc:
+                    type: number
+                    format: double
+                  new_balance:
+                    type: number
+                    format: double
+        202:
+          description: Asynchronous video, image-to-video, or model generation accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, type, job_id, charged_rtc, new_balance, status_url]
+                properties:
+                  ok:
+                    type: boolean
+                  type:
+                    type: string
+                    enum: [video, i2v, model]
+                  job_id:
+                    type: string
+                  charged_rtc:
+                    type: number
+                    format: double
+                  seconds:
+                    type: integer
+                    description: Present for video and image-to-video jobs.
+                  new_balance:
+                    type: number
+                    format: double
+                  status_url:
+                    type: string
+        400:
+          description: Missing prompt, unsupported type, unknown tier, overlong prompt, or invalid image-to-video input
+        401:
+          description: Missing sign-in session or invalid API key
+        402:
+          description: Insufficient RTC balance
+        429:
+          description: Studio generation cooldown is active
+        502:
+          description: Generation dispatch failed and RTC was refunded
+        503:
+          description: Requested voice generation while voice service is not configured
 
   /api/collaborations:
     post:

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -58,3 +58,22 @@ def test_swagger_ui_uses_application_root_for_spec_url(tmp_path):
     assert response.mimetype == "text/html"
     assert "SwaggerUIBundle" in html
     assert "https://example.test/mounted/api/openapi.yaml" in html
+
+
+def test_root_openapi_yaml_includes_live_studio_and_earnings_endpoints():
+    spec = (Path(__file__).resolve().parents[1] / "openapi.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for path, method in {
+        "/api/studio/generate": "post",
+        "/api/agents/me/earnings": "get",
+    }.items():
+        assert f"  {path}:" in spec
+        assert f"    {method}:" in spec
+
+    assert "operationId: createStudioGeneration" in spec
+    assert "operationId: getMyEarnings" in spec
+    assert "required: [prompt]" in spec
+    assert "maximum: 100" in spec
+    assert "Missing or invalid API key" in spec


### PR DESCRIPTION
## Summary
Refs Scottcjn/bottube#1605. Current `main` still has source-backed endpoints that are documented or called by the product but absent from the static OpenAPI YAML that feeds `/api/openapi.yaml` and, when PyYAML is available, `/api/openapi.json`.

This PR adds OpenAPI coverage for the two endpoints that are present in current source:
- `GET /api/agents/me/earnings` from `bottube_server.py`
- `POST /api/studio/generate` from `studio_blueprint.py`

I intentionally did not invent the other old production paths from #1605 (`/api/forum/generate-image`, `/api/video/mine`, `/api/video/publish`, `/api/video/discard`) because they are not present in current source. This is a safe contract-drift fix for the handlers the repo actually serves.

## Details
- adds a `Studio` OpenAPI tag
- documents auth, query params, request body, success responses, and failure status codes for `GET /api/agents/me/earnings`
- documents auth, request body, sync/async response shapes, and failure status codes for `POST /api/studio/generate`
- adds a regression test so these source-backed endpoints do not disappear from `openapi.yaml` again

## Testing
- `uv run --no-project --with pytest --with flask python -m pytest -q tests\test_api_docs.py` -> 5 passed
- `uv run --no-project --with pyyaml python -c 'from pathlib import Path; import yaml; spec=yaml.safe_load(Path("openapi.yaml").read_text(encoding="utf-8")); assert "/api/studio/generate" in spec["paths"]; assert "post" in spec["paths"]["/api/studio/generate"]; assert "/api/agents/me/earnings" in spec["paths"]; assert "get" in spec["paths"]["/api/agents/me/earnings"]; print("openapi paths", len(spec["paths"]))'` -> openapi paths 22
- `uv run --no-project --with flask python -m py_compile api_docs.py tests\test_api_docs.py` -> passed
- `git diff --check` -> passed (Windows CRLF warnings only)

RTC payout wallet for any accepted bug bounty credit: `RTC973498f72747cd1637e395521319c0ad61c0f68c`