### PR TITLE
Validate malformed live chat JSON fields

### DIFF
--- a/chat_handlers.py
+++ b/chat_handlers.py
@@ -59,6 +59,10 @@ def init_chat_tables(db):
     db.commit()
 
 
+def _bad_request(message):
+    return jsonify({"error": message}), 400
+
+
 def _json_object_body():
     """Extract a JSON field from the request body.
     
@@ -69,7 +73,7 @@ def _json_object_body():
     if data is None:
         return {}, None
     if not isinstance(data, dict):
-        return None, (jsonify({"error": "JSON object required"}), 400)
+        return None, _bad_request("JSON object required")
     return data, None
 
 
@@ -131,7 +135,13 @@ def send_message(video_id):
     if error:
         return error
     username = session.get("username", data.get("username", "Anonymous"))
-    msg_text = (data.get("message") or "").strip()
+    msg_value = data.get("message")
+    if msg_value is None:
+        msg_text = ""
+    elif isinstance(msg_value, str):
+        msg_text = msg_value.strip()
+    else:
+        return _bad_request("message must be a string")
     if not msg_text or len(msg_text) > 500:
         return jsonify({"error": "Message must be 1-500 chars"}), 400
 
@@ -148,9 +158,9 @@ def send_message(video_id):
     is_super = _coerce_chat_flag(data.get("is_super", 0), "is_super")
     tip = _coerce_non_negative_number(data.get("tip_amount", 0), "tip_amount")
     if is_super is None:
-        return jsonify({"error": "is_super must be 0/1 or boolean"}), 400
+        return _bad_request("is_super must be 0/1 or boolean")
     if tip is None:
-        return jsonify({"error": "tip_amount must be a finite non-negative number"}), 400
+        return _bad_request("tip_amount must be a finite non-negative number")
 
     db.execute(
         "INSERT INTO chat_messages (id, video_id, user_id, username, message, is_super, tip_amount, created_at)"
@@ -169,18 +179,27 @@ def ban_user(video_id):
     data, error = _json_object_body()
     if error:
         return error
+    user_id_value = data.get("user_id")
+    if user_id_value is None:
+        user_id = ""
+    elif isinstance(user_id_value, str):
+        user_id = user_id_value.strip()
+    else:
+        return _bad_request("user_id must be a string")
+    if not user_id:
+        return _bad_request("user_id is required")
     db = get_db()
     init_chat_tables(db)
-    duration = data.get("duration")  # seconds, None = permanent
-    if duration is not None:
-        duration = _coerce_non_negative_number(duration, "duration")
+    duration = None
+    if data.get("duration") is not None:
+        duration = _coerce_non_negative_number(data.get("duration"), "duration")
         if duration is None:
-            return jsonify({"error": "duration must be a finite non-negative number"}), 400
+            return _bad_request("duration must be a finite non-negative number")
     expires = time.time() + duration if duration else None
     db.execute(
         "INSERT INTO chat_bans (id, video_id, user_id, banned_by, reason, expires_at, created_at)"
         " VALUES (?,?,?,?,?,?,?)",
-        (str(_uuid.uuid4()), video_id, data["user_id"], session.get("username", "mod"),
+        (str(_uuid.uuid4()), video_id, user_id, session.get("username", "mod"),
          data.get("reason", ""), expires, time.time()),
     )
     db.commit()

--- a/tests/test_chat_handlers_validation.py
+++ b/tests/test_chat_handlers_validation.py
@@ -41,8 +41,32 @@ def chat_client(tmp_path):
 
 
 def _chat_message_count(db_path):
+    return _table_count(db_path, "chat_messages")
+
+
+def _chat_ban_count(db_path):
+    return _table_count(db_path, "chat_bans")
+
+
+def _table_count(db_path, table_name):
     with sqlite3.connect(db_path) as db:
-        return db.execute("SELECT COUNT(*) FROM chat_messages").fetchone()[0]
+        return db.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0]
+
+
+def _chat_settings_row(db_path, video_id):
+    with sqlite3.connect(db_path) as db:
+        db.row_factory = sqlite3.Row
+        row = db.execute(
+            "SELECT slow_mode, sub_only, premiere FROM chat_settings WHERE video_id = ?",
+            (video_id,),
+        ).fetchone()
+        return dict(row) if row else None
+
+
+def _make_moderator(client):
+    with client.session_transaction() as sess:
+        sess["is_mod"] = True
+        sess["username"] = "mod"
 
 
 def test_send_message_rejects_non_object_json_without_insert(chat_client):
@@ -50,6 +74,38 @@ def test_send_message_rejects_non_object_json_without_insert(chat_client):
 
     assert resp.status_code == 400
     assert resp.get_json() == {"error": "JSON object required"}
+    assert _chat_message_count(chat_client.db_path) == 0
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        ({"username": "Ada", "message": 42}, "message must be a string"),
+        (
+            {"username": "Ada", "message": "Hello chat", "is_super": "boost"},
+            "is_super must be 0/1 or boolean",
+        ),
+        (
+            {"username": "Ada", "message": "Hello chat", "tip_amount": "oops"},
+            "tip_amount must be a finite non-negative number",
+        ),
+        (
+            {"username": "Ada", "message": "Hello chat", "tip_amount": "nan"},
+            "tip_amount must be a finite non-negative number",
+        ),
+        (
+            {"username": "Ada", "message": "Hello chat", "tip_amount": -1},
+            "tip_amount must be a finite non-negative number",
+        ),
+    ],
+)
+def test_send_message_rejects_malformed_fields_without_insert(
+    chat_client, payload, expected_error
+):
+    resp = chat_client.post("/api/chat/video-1/send", json=payload)
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": expected_error}
     assert _chat_message_count(chat_client.db_path) == 0
 
 
@@ -64,37 +120,97 @@ def test_send_message_still_records_valid_json_object(chat_client):
     assert _chat_message_count(chat_client.db_path) == 1
 
 
-def test_send_message_rejects_non_finite_tip_without_insert(chat_client):
-    resp = chat_client.post(
-        "/api/chat/video-1/send",
-        json={"username": "Ada", "message": "Hello chat", "tip_amount": float("inf")},
-    )
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        (["not", "an", "object"], "JSON object required"),
+        ({"user_id": 123}, "user_id must be a string"),
+        ({"user_id": ""}, "user_id is required"),
+        (
+            {"user_id": "victim", "duration": "later"},
+            "duration must be a finite non-negative number",
+        ),
+        (
+            {"user_id": "victim", "duration": -1},
+            "duration must be a finite non-negative number",
+        ),
+    ],
+)
+def test_ban_user_rejects_malformed_json_without_insert(
+    chat_client, payload, expected_error
+):
+    _make_moderator(chat_client)
+
+    resp = chat_client.post("/api/chat/video-1/ban", json=payload)
 
     assert resp.status_code == 400
-    assert resp.get_json() == {"error": "tip_amount must be a finite non-negative number"}
-    assert _chat_message_count(chat_client.db_path) == 0
+    assert resp.get_json() == {"error": expected_error}
+    assert _chat_ban_count(chat_client.db_path) == 0
 
 
-def test_ban_rejects_non_numeric_duration(chat_client):
-    with chat_client.session_transaction() as sess:
-        sess["is_mod"] = True
-        sess["username"] = "mod"
+def test_ban_user_still_accepts_valid_duration(chat_client):
+    _make_moderator(chat_client)
+
     resp = chat_client.post(
         "/api/chat/video-1/ban",
-        json={"user_id": "user-1", "duration": "forever"},
+        json={"user_id": " victim ", "duration": 60, "reason": "spam"},
     )
 
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "banned"}
+    assert _chat_ban_count(chat_client.db_path) == 1
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        (["not", "an", "object"], "JSON object required"),
+        (
+            {"slow_mode": "fast"},
+            "slow_mode, sub_only, and premiere must be 0/1 or boolean",
+        ),
+        (
+            {"slow_mode": 2, "sub_only": 0, "premiere": 1},
+            "slow_mode, sub_only, and premiere must be 0/1 or boolean",
+        ),
+        (
+            {"sub_only": "maybe"},
+            "slow_mode, sub_only, and premiere must be 0/1 or boolean",
+        ),
+        (
+            {"premiere": "soon"},
+            "slow_mode, sub_only, and premiere must be 0/1 or boolean",
+        ),
+        (
+            {"premiere_at": "soon"},
+            "premiere_at must be a finite non-negative number",
+        ),
+    ],
+)
+def test_chat_settings_rejects_malformed_json_without_update(
+    chat_client, payload, expected_error
+):
+    _make_moderator(chat_client)
+
+    resp = chat_client.post("/api/chat/video-1/settings", json=payload)
+
     assert resp.status_code == 400
-    assert resp.get_json() == {"error": "duration must be a finite non-negative number"}
+    assert resp.get_json() == {"error": expected_error}
+    assert _chat_settings_row(chat_client.db_path, "video-1") is None
 
 
-def test_settings_reject_non_boolean_like_flags(chat_client):
-    with chat_client.session_transaction() as sess:
-        sess["is_mod"] = True
+def test_chat_settings_still_accepts_valid_numeric_strings_and_booleans(chat_client):
+    _make_moderator(chat_client)
+
     resp = chat_client.post(
         "/api/chat/video-1/settings",
-        json={"slow_mode": 2, "sub_only": 0, "premiere": 1},
+        json={"slow_mode": True, "sub_only": 0, "premiere": 1},
     )
 
-    assert resp.status_code == 400
-    assert resp.get_json() == {"error": "slow_mode, sub_only, and premiere must be 0/1 or boolean"}
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "updated"}
+    assert _chat_settings_row(chat_client.db_path, "video-1") == {
+        "slow_mode": 1,
+        "sub_only": 0,
+        "premiere": 1,
+    }

--- a/tests/test_websocket_server_validation.py
+++ b/tests/test_websocket_server_validation.py
@@ -9,6 +9,34 @@ import types
 from flask import Flask
 
 
+def _init_chat_db(db_path):
+    with sqlite3.connect(db_path) as db:
+        db.executescript(
+            """
+            CREATE TABLE chat_bans (
+                video_id TEXT,
+                user_id TEXT,
+                expires_at REAL
+            );
+            CREATE TABLE chat_messages (
+                id TEXT,
+                video_id TEXT,
+                user_id TEXT,
+                username TEXT,
+                message TEXT,
+                is_super INTEGER,
+                tip_amount REAL,
+                created_at REAL
+            );
+            """
+        )
+
+
+def _table_count(db_path, table_name):
+    with sqlite3.connect(db_path) as db:
+        return db.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0]
+
+
 def _load_websocket_server(monkeypatch):
     events = []
 
@@ -55,26 +83,7 @@ def test_chat_message_rejects_non_string_message(monkeypatch):
 def test_chat_message_accepts_valid_string_message(monkeypatch, tmp_path):
     websocket_server, events = _load_websocket_server(monkeypatch)
     db_path = tmp_path / "chat.db"
-    with sqlite3.connect(db_path) as db:
-        db.executescript(
-            """
-            CREATE TABLE chat_bans (
-                video_id TEXT,
-                user_id TEXT,
-                expires_at REAL
-            );
-            CREATE TABLE chat_messages (
-                id TEXT,
-                video_id TEXT,
-                user_id TEXT,
-                username TEXT,
-                message TEXT,
-                is_super INTEGER,
-                tip_amount REAL,
-                created_at REAL
-            );
-            """
-        )
+    _init_chat_db(db_path)
 
     app = Flask(__name__)
     app.config["CHAT_DB_PATH"] = str(db_path)
@@ -100,9 +109,23 @@ def test_chat_message_accepts_valid_string_message(monkeypatch, tmp_path):
     assert row == ("hello",)
 
 
-def test_chat_message_rejects_non_finite_tip(monkeypatch):
+def test_chat_message_rejects_non_object_event(monkeypatch):
     websocket_server, events = _load_websocket_server(monkeypatch)
+
+    websocket_server.on_chat_message(["not", "an", "object"])
+
+    assert events == [(("error", {"message": "Event data must be an object"}), {})]
+
+
+def test_chat_message_rejects_malformed_numeric_fields_without_insert(
+    monkeypatch, tmp_path
+):
+    websocket_server, events = _load_websocket_server(monkeypatch)
+    db_path = tmp_path / "chat.db"
+    _init_chat_db(db_path)
+
     app = Flask(__name__)
+    app.config["CHAT_DB_PATH"] = str(db_path)
     websocket_server._last_message_time.clear()
 
     with app.app_context():
@@ -112,35 +135,73 @@ def test_chat_message_rejects_non_finite_tip(monkeypatch):
                 "username": "alice",
                 "user_id": "user-1",
                 "message": "hello",
-                "tip_amount": float("nan"),
+                "tip_amount": "oops",
             }
         )
 
     assert events == [
         (("error", {"message": "tip_amount must be a finite non-negative number"}), {})
     ]
+    assert _table_count(db_path, "chat_messages") == 0
+    assert websocket_server._last_message_time == {}
 
 
-def test_super_chat_rejects_zero_tip(monkeypatch):
+def test_super_chat_rejects_malformed_tip_without_insert(monkeypatch, tmp_path):
     websocket_server, events = _load_websocket_server(monkeypatch)
+    db_path = tmp_path / "chat.db"
+    _init_chat_db(db_path)
 
-    websocket_server.on_super_chat(
-        {
-            "video_id": "video-1",
-            "username": "alice",
-            "user_id": "user-1",
-            "message": "hello",
-            "tip_amount": 0,
-        }
-    )
+    app = Flask(__name__)
+    app.config["CHAT_DB_PATH"] = str(db_path)
+    websocket_server._last_message_time.clear()
+
+    with app.app_context():
+        websocket_server.on_super_chat(
+            {
+                "video_id": "video-1",
+                "username": "alice",
+                "user_id": "user-1",
+                "message": "boost",
+                "tip_amount": "nan",
+            }
+        )
 
     assert events == [
         (("error", {"message": "tip_amount must be a finite positive number"}), {})
     ]
+    assert _table_count(db_path, "chat_messages") == 0
+    assert websocket_server._last_message_time == {}
 
 
-def test_mod_action_timeout_rejects_non_numeric_duration(monkeypatch):
+def test_mod_action_rejects_malformed_ban_duration_without_insert(
+    monkeypatch, tmp_path
+):
     websocket_server, events = _load_websocket_server(monkeypatch)
+    db_path = tmp_path / "chat.db"
+    _init_chat_db(db_path)
+
+    app = Flask(__name__)
+    app.config["CHAT_DB_PATH"] = str(db_path)
+
+    with app.app_context():
+        websocket_server.on_mod_action(
+            {
+                "action": "ban",
+                "video_id": "video-1",
+                "target_user_id": "user-1",
+                "duration": "later",
+            }
+        )
+
+    assert events == [
+        (("error", {"message": "duration must be a finite non-negative number"}), {})
+    ]
+    assert _table_count(db_path, "chat_bans") == 0
+
+
+def test_mod_action_rejects_malformed_timeout_duration(monkeypatch):
+    websocket_server, events = _load_websocket_server(monkeypatch)
+    websocket_server._last_message_time.clear()
 
     websocket_server.on_mod_action(
         {
@@ -154,3 +215,4 @@ def test_mod_action_timeout_rejects_non_numeric_duration(monkeypatch):
     assert events == [
         (("error", {"message": "duration must be a finite non-negative number"}), {})
     ]
+    assert websocket_server._last_message_time == {}

--- a/websocket_server.py
+++ b/websocket_server.py
@@ -31,6 +31,13 @@ def _get_db(app):
     return db
 
 
+def _event_object(data):
+    if isinstance(data, dict):
+        return data
+    emit("error", {"message": "Event data must be an object"})
+    return None
+
+
 def _coerce_flag(value):
     """Return safe 0/1 int from bool/int values or None when invalid."""
     if isinstance(value, bool):
@@ -56,6 +63,9 @@ def _coerce_non_negative_number(value, default=0.0):
 @socketio.on("join")
 def on_join(data):
     """User joins a video chat room."""
+    data = _event_object(data)
+    if data is None:
+        return
     room = data.get("video_id", "")
     username = data.get("username", "Anonymous")
     join_room(room)
@@ -69,6 +79,9 @@ def on_leave(data):
     Args:
         data: Parameter value.
     """
+    data = _event_object(data)
+    if data is None:
+        return
     room = data.get("video_id", "")
     username = data.get("username", "Anonymous")
     leave_room(room)
@@ -79,6 +92,9 @@ def on_leave(data):
 def on_chat_message(data):
     """Handle incoming chat message via WebSocket."""
     from flask import current_app
+    data = _event_object(data)
+    if data is None:
+        return
     room = data.get("video_id", "")
     username = data.get("username", "Anonymous")
     user_id = data.get("user_id", "")
@@ -94,14 +110,6 @@ def on_chat_message(data):
         emit("error", {"message": "Message must be 1-500 characters"})
         return
 
-    # Rate limit: 1 message per 2 seconds per user per room
-    key = f"{user_id}:{room}"
-    now = time.time()
-    if key in _last_message_time and (now - _last_message_time[key]) < 2:
-        emit("error", {"message": "Slow down! Wait 2 seconds between messages."})
-        return
-    _last_message_time[key] = now
-
     is_super = _coerce_flag(data.get("is_super", 0))
     tip = _coerce_non_negative_number(data.get("tip_amount", 0), default=0.0)
     if is_super is None:
@@ -110,6 +118,14 @@ def on_chat_message(data):
     if tip is None:
         emit("error", {"message": "tip_amount must be a finite non-negative number"})
         return
+
+    # Rate limit: 1 message per 2 seconds per user per room
+    key = f"{user_id}:{room}"
+    now = time.time()
+    if key in _last_message_time and (now - _last_message_time[key]) < 2:
+        emit("error", {"message": "Slow down! Wait 2 seconds between messages."})
+        return
+    _last_message_time[key] = now
 
     # Check ban
     db = _get_db(current_app)
@@ -147,19 +163,26 @@ def on_chat_message(data):
 @socketio.on("super_chat")
 def on_super_chat(data):
     """Handle super chat (highlighted message with RTC tip)."""
+    data = _event_object(data)
+    if data is None:
+        return
     tip = _coerce_non_negative_number(data.get("tip_amount", 1), default=1.0)
     if tip is None or tip <= 0:
         emit("error", {"message": "tip_amount must be a finite positive number"})
         return
-    data["is_super"] = 1
-    data["tip_amount"] = tip
-    on_chat_message(data)
+    payload = dict(data)
+    payload["is_super"] = 1
+    payload["tip_amount"] = tip
+    on_chat_message(payload)
 
 
 @socketio.on("mod_action")
 def on_mod_action(data):
     """Moderator actions: ban, timeout, slow_mode."""
     from flask import current_app
+    data = _event_object(data)
+    if data is None:
+        return
     action = data.get("action")
     room = data.get("video_id", "")
     


### PR DESCRIPTION
## Summary
- adds shared validation helpers for live chat REST JSON object, integer, and number fields
- returns JSON 400 responses for malformed REST `/send`, `/ban`, and `/settings` inputs instead of letting `ValueError`/`TypeError`/`AttributeError` escape
- validates SocketIO live chat event payloads for `chat_message`, `super_chat`, and `mod_action`, emitting client-safe `error` events instead of raising from malformed numeric payloads
- keeps successful valid chat send, ban duration, settings update, and SocketIO message paths covered by regression tests

Fixes #1780

## Testing
- `uv run --no-project --with pytest --with flask python -m pytest -q tests\test_chat_handlers_validation.py`
- `uv run --no-project --with pytest --with flask --with flask-socketio python -m pytest -q tests\test_chat_handlers_validation.py tests\test_websocket_server_validation.py`
- `python -m py_compile chat_handlers.py websocket_server.py`
- `git diff --check`