### PR TITLE
Validate vote JSON payloads

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8150,10 +8150,10 @@ def recent_comments():
 def _parse_vote_payload(req):
     data = req.get_json(silent=True)
     if data is not None and not isinstance(data, dict):
-        return None, (jsonify({"error": "Request body must be a JSON object"}), 400)
+        return None, (jsonify({"ok": False, "error": "JSON body must be an object"}), 400)
     data = data or {}
     vote_val = data.get("vote", 0)
-    if isinstance(vote_val, bool) or not isinstance(vote_val, int) or vote_val not in (1, -1, 0):
+    if type(vote_val) is not int or vote_val not in (1, -1, 0):
         return None, (jsonify({"error": "vote must be 1 (like), -1 (dislike), or 0 (remove)"}), 400)
     return vote_val, None
 

--- a/tests/test_vote_json_validation.py
+++ b/tests/test_vote_json_validation.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for malformed vote request bodies."""
+
+import time
+import gc
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+VIDEO_ID = "vote-json-vid"
+
+
+@pytest.fixture(autouse=True)
+def close_temp_sqlite_handles(app):
+    """Release temp SQLite handles before Windows removes the per-test DB dir."""
+    yield
+
+    import bottube_server
+
+    temp_root = Path(bottube_server.DB_PATH).resolve().parent
+    with app.app_context():
+        bottube_server.close_db(None)
+
+    for obj in gc.get_objects():
+        if not isinstance(obj, sqlite3.Connection):
+            continue
+        try:
+            database_rows = obj.execute("PRAGMA database_list").fetchall()
+        except sqlite3.Error:
+            continue
+        for row in database_rows:
+            db_path = row[2]
+            if db_path and Path(db_path).resolve().is_relative_to(temp_root):
+                obj.close()
+                break
+
+
+def _register(client, name):
+    resp = client.post(
+        "/api/register",
+        json={"agent_name": name, "display_name": name.replace("_", " ").title()},
+    )
+    assert resp.status_code == 201, resp.get_data(as_text=True)
+    return resp.get_json()
+
+
+@pytest.fixture()
+def vote_scenario(app, client):
+    owner = _register(client, "vote_json_owner")
+    voter = _register(client, "vote_json_voter")
+
+    with app.app_context():
+        import bottube_server
+
+        db = bottube_server.get_db()
+        owner_row = db.execute(
+            "SELECT id FROM agents WHERE api_key = ?", (owner["api_key"],)
+        ).fetchone()
+        voter_row = db.execute(
+            "SELECT id FROM agents WHERE api_key = ?", (voter["api_key"],)
+        ).fetchone()
+        db.execute(
+            """INSERT INTO videos
+               (video_id, agent_id, title, filename, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (VIDEO_ID, owner_row["id"], "Vote JSON validation", "vote.mp4", time.time()),
+        )
+        cur = db.execute(
+            """INSERT INTO comments (video_id, agent_id, content, created_at)
+               VALUES (?, ?, ?, ?)""",
+            (VIDEO_ID, owner_row["id"], "hello vote", time.time()),
+        )
+        db.commit()
+
+    return {
+        "api_key": voter["api_key"],
+        "voter_id": voter_row["id"],
+        "comment_id": cur.lastrowid,
+    }
+
+
+def _auth_headers(api_key):
+    return {"X-API-Key": api_key}
+
+
+def _login_web_user(client, user_id):
+    with client.session_transaction() as session:
+        session["user_id"] = user_id
+        session["csrf_token"] = "csrf-token"
+    return {"X-CSRF-Token": "csrf-token"}
+
+
+def _assert_json_object_required(resp):
+    assert resp.status_code == 400, resp.get_data(as_text=True)
+    assert resp.get_json() == {"ok": False, "error": "JSON body must be an object"}
+
+
+def _assert_bad_vote(resp):
+    assert resp.status_code == 400, resp.get_data(as_text=True)
+    assert resp.get_json() == {
+        "error": "vote must be 1 (like), -1 (dislike), or 0 (remove)"
+    }
+
+
+def test_api_video_vote_rejects_non_object_json(client, vote_scenario):
+    resp = client.post(
+        f"/api/videos/{VIDEO_ID}/vote",
+        headers=_auth_headers(vote_scenario["api_key"]),
+        json=["bad"],
+    )
+
+    _assert_json_object_required(resp)
+
+
+def test_api_comment_vote_rejects_bool_and_float_vote_values(client, vote_scenario):
+    for payload in ({"vote": True}, {"vote": 1.0}):
+        resp = client.post(
+            f"/api/comments/{vote_scenario['comment_id']}/vote",
+            headers=_auth_headers(vote_scenario["api_key"]),
+            json=payload,
+        )
+
+        _assert_bad_vote(resp)
+
+
+def test_web_video_vote_rejects_non_object_json(client, vote_scenario):
+    resp = client.post(
+        f"/api/videos/{VIDEO_ID}/web-vote",
+        headers=_login_web_user(client, vote_scenario["voter_id"]),
+        json="bad",
+    )
+
+    _assert_json_object_required(resp)
+
+
+def test_web_comment_vote_rejects_bool_vote_value(client, vote_scenario):
+    resp = client.post(
+        f"/api/comments/{vote_scenario['comment_id']}/web-vote",
+        headers=_login_web_user(client, vote_scenario["voter_id"]),
+        json={"vote": True},
+    )
+
+    _assert_bad_vote(resp)
+
+
+def test_integer_video_vote_still_works(client, vote_scenario):
+    resp = client.post(
+        f"/api/videos/{VIDEO_ID}/vote",
+        headers=_auth_headers(vote_scenario["api_key"]),
+        json={"vote": 1},
+    )
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["likes"] == 1
+    assert body["dislikes"] == 0
+    assert body["your_vote"] == 1


### PR DESCRIPTION
## Summary
- validate vote request bodies as JSON objects before calling `.get()`
- reject JSON bool/float/string values for `vote` instead of letting `True`/`1.0` compare equal to integer `1`
- cover API-key and web-session video/comment vote routes with regression tests

Fixes #1784.

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest -q tests\test_vote_json_validation.py` -> 5 passed
- `python -m py_compile bottube_server.py tests\test_vote_json_validation.py`
- `git diff --check`
- `uv run --no-project --with flake8 python -m flake8 bottube_server.py tests\test_vote_json_validation.py --count --select=E9,F63,F7,F82 --show-source --statistics` -> 0

## Payout metadata

Wallet/miner id / payout alias: `L1nkinPark`
Native RTC payout address: `RTC973498f72747cd1637e395521319c0ad61c0f68c`
Native RTC public key: `ee2b512bf5a18951c328282c07848e76aa9945c35cd56b229e90793dfe069e4c`
Wallet registration/update: https://github.com/Scottcjn/rustchain-bounties/issues/16647#issuecomment-5446887073