### PR TITLE
fix(tips): validate JSON amount payloads

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11688,6 +11688,35 @@ def my_earnings():
 # RTC Tipping
 # ---------------------------------------------------------------------------
 
+def _tip_json_body():
+    """Parse tip JSON while preserving legacy content-type leniency."""
+    data = request.get_json(force=True, silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON body must be an object"}), 400)
+    return data, None
+
+
+def _parse_tip_amount(data):
+    """Validate a tip amount before touching internal or on-chain ledgers."""
+    raw_amount = data.get("amount", 0)
+    if isinstance(raw_amount, bool):
+        return None, (jsonify({"error": "Invalid amount"}), 400)
+    try:
+        amount = round(float(raw_amount), 6)
+    except (ValueError, TypeError):
+        return None, (jsonify({"error": "Invalid amount"}), 400)
+
+    if not math.isfinite(amount):
+        return None, (jsonify({"error": "Invalid amount"}), 400)
+    if amount < RTC_TIP_MIN:
+        return None, (jsonify({"error": f"Minimum tip is {RTC_TIP_MIN} RTC"}), 400)
+    if amount > RTC_TIP_MAX:
+        return None, (jsonify({"error": f"Maximum tip is {RTC_TIP_MAX} RTC"}), 400)
+    return amount, None
+
+
 @app.route("/api/videos/<video_id>/tip", methods=["POST"])
 @require_api_key
 def tip_video(video_id):
@@ -11712,16 +11741,12 @@ def tip_video(video_id):
     if video["agent_id"] == g.agent["id"]:
         return jsonify({"error": "You cannot tip yourself"}), 400
 
-    data = request.get_json(force=True, silent=True) or {}
-    try:
-        amount = round(float(data.get("amount", 0)), 6)
-    except (ValueError, TypeError):
-        return jsonify({"error": "Invalid amount"}), 400
-
-    if amount < RTC_TIP_MIN:
-        return jsonify({"error": f"Minimum tip is {RTC_TIP_MIN} RTC"}), 400
-    if amount > RTC_TIP_MAX:
-        return jsonify({"error": f"Maximum tip is {RTC_TIP_MAX} RTC"}), 400
+    data, error = _tip_json_body()
+    if error:
+        return error
+    amount, error = _parse_tip_amount(data)
+    if error:
+        return error
 
     message = str(data.get("message", ""))[:200].strip()
 
@@ -11835,16 +11860,12 @@ def web_tip_video(video_id):
     if video["agent_id"] == g.user["id"]:
         return jsonify({"error": "You cannot tip yourself"}), 400
 
-    data = request.get_json(force=True, silent=True) or {}
-    try:
-        amount = round(float(data.get("amount", 0)), 6)
-    except (ValueError, TypeError):
-        return jsonify({"error": "Invalid amount"}), 400
-
-    if amount < RTC_TIP_MIN:
-        return jsonify({"error": f"Minimum tip is {RTC_TIP_MIN} RTC"}), 400
-    if amount > RTC_TIP_MAX:
-        return jsonify({"error": f"Maximum tip is {RTC_TIP_MAX} RTC"}), 400
+    data, error = _tip_json_body()
+    if error:
+        return error
+    amount, error = _parse_tip_amount(data)
+    if error:
+        return error
 
     message = str(data.get("message", ""))[:200].strip()
 
@@ -11931,16 +11952,12 @@ def web_tip_agent(agent_name):
     if target["id"] == g.user["id"]:
         return jsonify({"error": "You cannot tip yourself"}), 400
 
-    data = request.get_json(force=True, silent=True) or {}
-    try:
-        amount = round(float(data.get("amount", 0)), 6)
-    except (ValueError, TypeError):
-        return jsonify({"error": "Invalid amount"}), 400
-
-    if amount < RTC_TIP_MIN:
-        return jsonify({"error": f"Minimum tip is {RTC_TIP_MIN} RTC"}), 400
-    if amount > RTC_TIP_MAX:
-        return jsonify({"error": f"Maximum tip is {RTC_TIP_MAX} RTC"}), 400
+    data, error = _tip_json_body()
+    if error:
+        return error
+    amount, error = _parse_tip_amount(data)
+    if error:
+        return error
 
     message = str(data.get("message", ""))[:200].strip()
 
@@ -12018,16 +12035,12 @@ def tip_agent(agent_name):
     if target["id"] == g.agent["id"]:
         return jsonify({"error": "You cannot tip yourself"}), 400
 
-    data = request.get_json(force=True, silent=True) or {}
-    try:
-        amount = round(float(data.get("amount", 0)), 6)
-    except (ValueError, TypeError):
-        return jsonify({"error": "Invalid amount"}), 400
-
-    if amount < RTC_TIP_MIN:
-        return jsonify({"error": f"Minimum tip is {RTC_TIP_MIN} RTC"}), 400
-    if amount > RTC_TIP_MAX:
-        return jsonify({"error": f"Maximum tip is {RTC_TIP_MAX} RTC"}), 400
+    data, error = _tip_json_body()
+    if error:
+        return error
+    amount, error = _parse_tip_amount(data)
+    if error:
+        return error
 
     message = str(data.get("message", ""))[:200].strip()
 

--- a/tests/test_tip_json_amount_validation.py
+++ b/tests/test_tip_json_amount_validation.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for RTC tip payload validation."""
+
+import hashlib
+import importlib
+import time
+
+import pytest
+
+
+def _server():
+    return importlib.import_module("bottube_server")
+
+
+def _register(client, name):
+    resp = client.post(
+        "/api/register",
+        json={
+            "agent_name": name,
+            "display_name": name.replace("_", " ").title(),
+            "bio": "tip validation test",
+        },
+    )
+    assert resp.status_code == 201, resp.get_json()
+    return resp.get_json()
+
+
+def _prepare(app, client, *, creator_wallet=""):
+    bottube_server = _server()
+    sender = _register(client, "tip_valid_sender")
+    creator = _register(client, "tip_valid_creator")
+    video_id = "tipvalidvid"
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        sender_id = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?",
+            (sender["agent_name"],),
+        ).fetchone()["id"]
+        creator_id = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?",
+            (creator["agent_name"],),
+        ).fetchone()["id"]
+        db.execute(
+            "UPDATE agents SET rtc_balance = ? WHERE id = ?",
+            (10.0, sender_id),
+        )
+        db.execute(
+            "UPDATE agents SET rtc_balance = ?, rtc_wallet = ? WHERE id = ?",
+            (0.0, creator_wallet, creator_id),
+        )
+        db.execute(
+            "INSERT INTO videos (video_id, agent_id, title, description, filename, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (video_id, creator_id, "Tip validation video", "", "tipvalid.mp4", time.time()),
+        )
+        db.commit()
+
+    return {
+        "sender": sender,
+        "sender_id": sender_id,
+        "creator": creator,
+        "creator_id": creator_id,
+        "video_id": video_id,
+    }
+
+
+def _login(client, sender_id):
+    with client.session_transaction() as sess:
+        sess["user_id"] = sender_id
+        sess["csrf_token"] = "test-csrf"
+
+
+def _request_for(target, scenario):
+    if target == "api_video":
+        return {
+            "path": f"/api/videos/{scenario['video_id']}/tip",
+            "headers": {"X-API-Key": scenario["sender"]["api_key"]},
+        }
+    if target == "api_agent":
+        return {
+            "path": f"/api/agents/{scenario['creator']['agent_name']}/tip",
+            "headers": {"X-API-Key": scenario["sender"]["api_key"]},
+        }
+    if target == "web_video":
+        return {
+            "path": f"/api/videos/{scenario['video_id']}/web-tip",
+            "headers": {"X-CSRF-Token": "test-csrf"},
+        }
+    if target == "web_agent":
+        return {
+            "path": f"/api/agents/{scenario['creator']['agent_name']}/web-tip",
+            "headers": {"X-CSRF-Token": "test-csrf"},
+        }
+    raise AssertionError(f"unknown target {target}")
+
+
+def _balances(app, scenario):
+    bottube_server = _server()
+    with app.app_context():
+        db = bottube_server.get_db()
+        rows = db.execute(
+            "SELECT id, rtc_balance FROM agents WHERE id IN (?, ?)",
+            (scenario["sender_id"], scenario["creator_id"]),
+        ).fetchall()
+    return {r["id"]: r["rtc_balance"] for r in rows}
+
+
+def _tip_count(app):
+    bottube_server = _server()
+    with app.app_context():
+        db = bottube_server.get_db()
+        return db.execute("SELECT COUNT(*) FROM tips").fetchone()[0]
+
+
+@pytest.mark.parametrize("target", ["api_video", "api_agent", "web_video", "web_agent"])
+def test_tip_handlers_reject_non_object_json_without_writes(app, client, target):
+    scenario = _prepare(app, client)
+    if target.startswith("web_"):
+        _login(client, scenario["sender_id"])
+
+    req = _request_for(target, scenario)
+    before = _balances(app, scenario)
+
+    resp = client.post(req["path"], json=["not", "an", "object"], headers=req["headers"])
+
+    assert resp.status_code == 400, resp.get_json()
+    assert resp.get_json()["error"] == "JSON body must be an object"
+    assert _balances(app, scenario) == before
+    assert _tip_count(app) == 0
+
+
+@pytest.mark.parametrize("target", ["api_video", "api_agent", "web_video", "web_agent"])
+def test_tip_handlers_reject_boolean_amount_without_transferring(app, client, target):
+    scenario = _prepare(app, client)
+    if target.startswith("web_"):
+        _login(client, scenario["sender_id"])
+
+    req = _request_for(target, scenario)
+    before = _balances(app, scenario)
+
+    resp = client.post(req["path"], json={"amount": True}, headers=req["headers"])
+
+    assert resp.status_code == 400, resp.get_json()
+    assert resp.get_json()["error"] == "Invalid amount"
+    assert _balances(app, scenario) == before
+    assert _tip_count(app) == 0
+
+
+def test_onchain_tip_rejects_nan_amount_before_forwarding_to_rustchain(
+    app, client, monkeypatch
+):
+    bottube_server = _server()
+    public_key = "11" * 32
+    from_address = f"RTC{hashlib.sha256(bytes.fromhex(public_key)).hexdigest()[:40]}"
+    to_address = "RTC" + "a" * 40
+    scenario = _prepare(app, client, creator_wallet=to_address)
+    calls = []
+
+    def fake_rustchain_post(path, payload, timeout=10.0):
+        calls.append((path, payload, timeout))
+        return 200, {"ok": True, "phase": "pending", "pending_id": 123, "tx_hash": "tx123"}
+
+    monkeypatch.setattr(bottube_server, "_rustchain_post_json", fake_rustchain_post)
+
+    resp = client.post(
+        f"/api/agents/{scenario['creator']['agent_name']}/tip",
+        json={
+            "amount": "NaN",
+            "onchain": True,
+            "from_address": from_address,
+            "to_address": to_address,
+            "nonce": 1,
+            "signature": "sig",
+            "public_key": public_key,
+            "memo": "tip",
+        },
+        headers={"X-API-Key": scenario["sender"]["api_key"]},
+    )
+
+    assert resp.status_code == 400, resp.get_json()
+    assert resp.get_json()["error"] == "Invalid amount"
+    assert calls == []
+    assert _tip_count(app) == 0


### PR DESCRIPTION
## Summary
- add a shared RTC tip JSON parser that rejects non-object bodies before `data.get(...)`
- reject boolean and non-finite tip amounts before internal ledger debits or RustChain on-chain forwarding
- add regression coverage for API-key and web-session tip handlers, including an on-chain `NaN` guard

Fixes #1786

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest -q tests\test_tip_json_amount_validation.py`
- `uv run --no-project --with pytest --with flask python -m pytest -q tests\test_tip_json_amount_validation.py tests\test_tip_debit_balance_guard.py tests\test_bounty_2161_collab_tip_split.py`
- `python -m py_compile bottube_server.py tests\test_tip_json_amount_validation.py`
- `git diff --check` (only the existing CRLF warning)
- `uv run --no-project --with flake8 python -m flake8 bottube_server.py tests\test_tip_json_amount_validation.py --select=E9,F63,F7,F82`

## Payout metadata

Wallet/miner id / payout alias: `L1nkinPark`
Native RTC payout address: `RTC973498f72747cd1637e395521319c0ad61c0f68c`
Native RTC public key: `ee2b512bf5a18951c328282c07848e76aa9945c35cd56b229e90793dfe069e4c`
Wallet registration/update: https://github.com/Scottcjn/rustchain-bounties/issues/16647#issuecomment-5446887073