### PR TITLE
fix: validate tip JSON bodies and finite amounts

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -3268,6 +3268,70 @@ def award_rtc(db, agent_id: int, amount: float, reason: str, video_id: str = "",
     )
 
 
+def debit_rtc(db: sqlite3.Connection, agent_id: int, amount: float) -> bool:
+    """Atomically debit RTC from an agent. Returns True only if it went through.
+
+    The counterpart to :func:`award_rtc`. Every spend path must go through
+    this rather than issuing a bare ``rtc_balance = rtc_balance - ?``.
+
+    A bare subtract preceded by a ``SELECT rtc_balance`` check is a TOCTOU race:
+    the check and the write are two statements, so two concurrent tips can both
+    read the same balance, both decide it is sufficient, and both subtract --
+    leaving the sender negative and crediting recipients with RTC that was
+    never funded. Because the tip handlers credit the *recipient* right after
+    debiting the sender, an unguarded debit does not merely overdraw one
+    account, it mints supply.
+
+    Putting the comparison in the UPDATE's WHERE clause makes the read and the
+    write a single atomic statement. ``rowcount == 0`` means the funds were not
+    there at the instant of the write, and the caller must abort before issuing
+    any matching credit.
+    """
+    cur = db.execute(
+        "UPDATE agents SET rtc_balance = rtc_balance - ? "
+        "WHERE id = ? AND rtc_balance >= ?",
+        (amount, agent_id, amount),
+    )
+    return cur.rowcount > 0
+
+
+def _insufficient_balance_response(db: sqlite3.Connection, agent_id: int):
+    """Standard 400 for a debit that lost its race (or was never funded)."""
+    row = db.execute(
+        "SELECT rtc_balance FROM agents WHERE id = ?", (agent_id,)
+    ).fetchone()
+    return jsonify({
+        "error": "Insufficient RTC balance",
+        "balance": row["rtc_balance"] if row else 0,
+    }), 400
+
+
+def _parse_tip_payload():
+    """Parse a tip JSON body while rejecting malformed/non-finite amounts."""
+    data = request.get_json(force=True, silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return None, jsonify({"error": "JSON body must be an object"}), 400
+
+    raw_amount = data.get("amount", 0)
+    if isinstance(raw_amount, bool):
+        return None, jsonify({"error": "Invalid amount"}), 400
+    if raw_amount is None:
+        return None, jsonify({"error": "Invalid amount"}), 400
+    try:
+        amount = round(float(raw_amount), 6)
+    except (ValueError, TypeError):
+        return None, jsonify({"error": "Invalid amount"}), 400
+    if not math.isfinite(amount):
+        return None, jsonify({"error": "Invalid amount"}), 400
+
+    return {
+        "data": data,
+        "amount": amount,
+        "message": str(data.get("message", ""))[:200].strip(),
+    }, None, None
+
 def _queue_reward_hold(
     db: sqlite3.Connection,
     *,
@@ -11580,18 +11644,18 @@ def tip_video(video_id):
     if video["agent_id"] == g.agent["id"]:
         return jsonify({"error": "You cannot tip yourself"}), 400
 
-    data = request.get_json(force=True, silent=True) or {}
-    try:
-        amount = round(float(data.get("amount", 0)), 6)
-    except (ValueError, TypeError):
-        return jsonify({"error": "Invalid amount"}), 400
+    parsed, err_resp, err_code = _parse_tip_payload()
+    if err_resp is not None:
+        return err_resp, err_code
+    data = parsed["data"]
+    amount = parsed["amount"]
 
     if amount < RTC_TIP_MIN:
         return jsonify({"error": f"Minimum tip is {RTC_TIP_MIN} RTC"}), 400
     if amount > RTC_TIP_MAX:
         return jsonify({"error": f"Maximum tip is {RTC_TIP_MAX} RTC"}), 400
 
-    message = str(data.get("message", ""))[:200].strip()
+    message = parsed["message"]
 
     # On-chain tip via RustChain signed transfer (Ed25519)
     if data.get("onchain"):
@@ -11699,18 +11763,18 @@ def web_tip_video(video_id):
     if video["agent_id"] == g.user["id"]:
         return jsonify({"error": "You cannot tip yourself"}), 400
 
-    data = request.get_json(force=True, silent=True) or {}
-    try:
-        amount = round(float(data.get("amount", 0)), 6)
-    except (ValueError, TypeError):
-        return jsonify({"error": "Invalid amount"}), 400
+    parsed, err_resp, err_code = _parse_tip_payload()
+    if err_resp is not None:
+        return err_resp, err_code
+    data = parsed["data"]
+    amount = parsed["amount"]
 
     if amount < RTC_TIP_MIN:
         return jsonify({"error": f"Minimum tip is {RTC_TIP_MIN} RTC"}), 400
     if amount > RTC_TIP_MAX:
         return jsonify({"error": f"Maximum tip is {RTC_TIP_MAX} RTC"}), 400
 
-    message = str(data.get("message", ""))[:200].strip()
+    message = parsed["message"]
 
     # On-chain tip via RustChain signed transfer (Ed25519)
     if data.get("onchain"):
@@ -11793,18 +11857,18 @@ def web_tip_agent(agent_name):
     if target["id"] == g.user["id"]:
         return jsonify({"error": "You cannot tip yourself"}), 400
 
-    data = request.get_json(force=True, silent=True) or {}
-    try:
-        amount = round(float(data.get("amount", 0)), 6)
-    except (ValueError, TypeError):
-        return jsonify({"error": "Invalid amount"}), 400
+    parsed, err_resp, err_code = _parse_tip_payload()
+    if err_resp is not None:
+        return err_resp, err_code
+    data = parsed["data"]
+    amount = parsed["amount"]
 
     if amount < RTC_TIP_MIN:
         return jsonify({"error": f"Minimum tip is {RTC_TIP_MIN} RTC"}), 400
     if amount > RTC_TIP_MAX:
         return jsonify({"error": f"Maximum tip is {RTC_TIP_MAX} RTC"}), 400
 
-    message = str(data.get("message", ""))[:200].strip()
+    message = parsed["message"]
 
     if data.get("onchain"):
         to_wallet = str(target["rtc_wallet"] or "").strip()
@@ -11878,18 +11942,18 @@ def tip_agent(agent_name):
     if target["id"] == g.agent["id"]:
         return jsonify({"error": "You cannot tip yourself"}), 400
 
-    data = request.get_json(force=True, silent=True) or {}
-    try:
-        amount = round(float(data.get("amount", 0)), 6)
-    except (ValueError, TypeError):
-        return jsonify({"error": "Invalid amount"}), 400
+    parsed, err_resp, err_code = _parse_tip_payload()
+    if err_resp is not None:
+        return err_resp, err_code
+    data = parsed["data"]
+    amount = parsed["amount"]
 
     if amount < RTC_TIP_MIN:
         return jsonify({"error": f"Minimum tip is {RTC_TIP_MIN} RTC"}), 400
     if amount > RTC_TIP_MAX:
         return jsonify({"error": f"Maximum tip is {RTC_TIP_MAX} RTC"}), 400
 
-    message = str(data.get("message", ""))[:200].strip()
+    message = parsed["message"]
 
     if data.get("onchain"):
         to_wallet = str(target["rtc_wallet"] or "").strip()

--- a/tests/test_tip_json_amount_validation.py
+++ b/tests/test_tip_json_amount_validation.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_BOOTSTRAP_DB = os.path.join(
+    tempfile.gettempdir(), "bottube_test_tip_json_validation_bootstrap.db"
+)
+os.environ.setdefault("BOTTUBE_DB", _BOOTSTRAP_DB)
+os.environ.setdefault("BOTTUBE_DB_PATH", _BOOTSTRAP_DB)
+
+import bottube_server  # noqa: E402
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "bottube_tip_json_validation.db"
+    video_dir = tmp_path / "videos"
+    thumb_dir = tmp_path / "thumbnails"
+    avatar_dir = tmp_path / "avatars"
+    for d in (video_dir, thumb_dir, avatar_dir):
+        d.mkdir()
+
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(bottube_server, "VIDEO_DIR", video_dir, raising=False)
+    monkeypatch.setattr(bottube_server, "THUMB_DIR", thumb_dir, raising=False)
+    monkeypatch.setattr(bottube_server, "AVATAR_DIR", avatar_dir, raising=False)
+    bottube_server._rate_buckets.clear()
+    bottube_server._rate_last_prune = 0.0
+
+    with bottube_server.app.app_context():
+        bottube_server.init_db()
+
+    bottube_server.app.config["TESTING"] = True
+    return bottube_server.app.test_client()
+
+
+def _register(client, name):
+    resp = client.post("/api/register", json={
+        "agent_name": name, "display_name": name, "bio": "tip validation",
+    })
+    assert resp.status_code == 201, resp.get_json()
+    return resp.get_json()
+
+
+@pytest.fixture()
+def scenario(client):
+    tipper = _register(client, "tip_json_sender")
+    creator = _register(client, "tip_json_creator")
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        creator_row = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?", (creator["agent_name"],)
+        ).fetchone()
+        tipper_row = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?", (tipper["agent_name"],)
+        ).fetchone()
+        db.execute(
+            "UPDATE agents SET rtc_balance = 10 WHERE id = ?", (tipper_row["id"],)
+        )
+        db.execute(
+            "INSERT INTO videos (video_id, agent_id, title, description, filename, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("tipjsonvid", creator_row["id"], "Tip JSON Video", "", "tipjsonvid.mp4", time.time()),
+        )
+        db.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = tipper_row["id"]
+        sess["csrf_token"] = "test-csrf"
+
+    return {
+        "tipper": tipper,
+        "creator": creator,
+        "video_id": "tipjsonvid",
+        "csrf": {"X-CSRF-Token": "test-csrf"},
+    }
+
+
+@pytest.mark.parametrize("path", [
+    "/api/videos/tipjsonvid/tip",
+    "/api/videos/tipjsonvid/web-tip",
+    "/api/agents/tip_json_creator/tip",
+    "/api/agents/tip_json_creator/web-tip",
+])
+def test_tip_routes_reject_non_object_json(client, scenario, path):
+    headers = {}
+    if "/api/" in path and path.endswith("/tip") and "/web-tip" not in path:
+        headers["X-API-Key"] = scenario["tipper"]["api_key"]
+    else:
+        headers.update(scenario["csrf"])
+
+    resp = client.post(path, json=["bad"], headers=headers)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON body must be an object"
+
+
+@pytest.mark.parametrize("bad_amount", [True, False, "oops", float("nan"), float("inf"), -float("inf")])
+def test_api_video_tip_rejects_invalid_amount_types(client, scenario, bad_amount):
+    resp = client.post(
+        f"/api/videos/{scenario['video_id']}/tip",
+        json={"amount": bad_amount},
+        headers={"X-API-Key": scenario["tipper"]["api_key"]},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid amount"
+
+
+def test_web_agent_tip_accepts_valid_numeric_amount(client, scenario):
+    resp = client.post(
+        f"/api/agents/{scenario['creator']['agent_name']}/web-tip",
+        json={"amount": 1, "message": "дякую"},
+        headers=scenario["csrf"],
+    )
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["amount"] == 1.0


### PR DESCRIPTION
## Summary
- add one shared tip payload parser for all four RTC tip handlers
- reject non-object JSON bodies before any `.get(...)` access
- reject boolean, null, NaN, and infinite `amount` values before ledger debit or on-chain forwarding
- keep valid numeric tips working for API-key and web-session routes

## Testing
- `pytest -q tests/test_tip_json_amount_validation.py tests/test_bounty_2161_collab_tip_split.py`
- `python3 -m py_compile bottube_server.py tests/test_tip_json_amount_validation.py`
- `git diff --check`

/claim #1786