### PR TITLE
fix(analytics): validate metric param on /api/top-videos (#1790)

### DIFF
--- a/analytics_blueprint.py
+++ b/analytics_blueprint.py
@@ -274,6 +274,9 @@ def api_top_videos():
         return jsonify({"error": "agent_id required"}), 400
     
     metric = request.args.get('metric', 'views')
+    if metric not in ('views', 'engagement', 'tips'):
+        return jsonify({"error": "Invalid metric, must be one of: views, engagement, tips"}), 400
+
     try:
         limit = int(request.args.get('limit', '10'))
     except (TypeError, ValueError):
@@ -288,10 +291,8 @@ def api_top_videos():
         order_clause = "ORDER BY view_count DESC"
     elif metric == 'engagement':
         order_clause = "ORDER BY (comments_count * 5 + votes_count * 2) DESC"
-    elif metric == 'tips':
+    else:  # tips
         order_clause = "ORDER BY tips_total DESC"
-    else:
-        order_clause = "ORDER BY view_count DESC"
     
     query = f"""SELECT 
             v.video_id,

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -424,6 +424,15 @@ class TestAnalyticsApiTopVideos:
         assert response.status_code == 400
         assert "limit" in response.get_json()["error"]
 
+    def test_analytics_api_top_videos_rejects_invalid_metric(self, client):
+        """Top videos API should reject unsupported metric values with 400."""
+        aid = _insert_agent("topmetricbad", "test-key-top-metric-bad")
+
+        response = client.get(f"/analytics/api/top-videos?agent_id={aid}&metric=garbage")
+
+        assert response.status_code == 400
+        assert "metric" in response.get_json()["error"]
+
     @pytest.mark.parametrize("limit", ["1", "50"])
     def test_analytics_api_top_videos_accepts_boundary_limits(self, client, limit):
         """Top videos API should accept the documented 1..50 boundary values."""


### PR DESCRIPTION
### Description
Validates the `metric` query parameter on `/analytics/api/top-videos` to ensure it only accepts `{'views', 'engagement', 'tips'}`. Returns a 400 Bad Request with an informative error message if an invalid/unsupported metric is supplied, preventing misleading `"metric": "<invalid>"` responses.

Fixes #1790

### Changes:
1. **`analytics_blueprint.py`**:
   - Added validation check: `if metric not in ('views', 'engagement', 'tips'): return jsonify({"error": "Invalid metric, must be one of: views, engagement, tips"}), 400`
   - Cleaned up redundant fallback branch in the order clause construction.
2. **`tests/test_analytics_dashboard.py`**:
   - Added `test_analytics_api_top_videos_rejects_invalid_metric` regression test asserting 400 status code and informative error message for unsupported metric parameters.