### PR TITLE
fix(i18n): add missing credits and pricing translation keys to es.json and en.json (#1796)

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -44,6 +44,15 @@
     "hero.need_credits": "Need tipping credits?",
     "hero.deposit": "Deposit wRTC",
     "hero.or": "or",
-    "hero.buy_raydium": "buy on Raydium"
+    "hero.buy_raydium": "buy on Raydium",
+    "credits.title": "Credits & Pricing",
+    "credits.video_gen": "Video generation",
+    "credits.image_gen": "Image generation",
+    "credits.buy_rtc": "Buy RTC credits",
+    "credits.card_topups": "Card top-ups",
+    "credits.desc": "BoTTube uses RTC credits for video generation, tipping creators, and unlocking premium features.",
+    "credits.tipping": "Tipping & Engagement",
+    "credits.withdraw": "Withdraw to wRTC",
+    "credits.deposit": "Deposit wRTC"
   }
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -44,6 +44,15 @@
     "hero.need_credits": "¿Necesitas créditos de propina?",
     "hero.deposit": "Depositar wRTC",
     "hero.or": "o",
-    "hero.buy_raydium": "compra en Raydium"
+    "hero.buy_raydium": "compra en Raydium",
+    "credits.title": "Créditos y Precios",
+    "credits.video_gen": "Generación de video",
+    "credits.image_gen": "Generación de imágenes",
+    "credits.buy_rtc": "Comprar créditos RTC",
+    "credits.card_topups": "Recargas con tarjeta",
+    "credits.desc": "BoTTube utiliza créditos RTC para la generación de videos, propinas a creadores y desbloqueo de funciones premium.",
+    "credits.tipping": "Propinas y Participación",
+    "credits.withdraw": "Retirar a wRTC",
+    "credits.deposit": "Depositar wRTC"
   }
 }


### PR DESCRIPTION
### Description
Adds the missing credits, pricing, tipping, and deposit translation strings to `translations/es.json` and `translations/en.json`, preventing mixed-language rendering on `/credits?lang=es`.

Fixes #1796

### Changes:
- **`translations/es.json`**: Added localized Spanish translations for credits page header, video/image generation, RTC topups, card payments, and tipping.
- **`translations/en.json`**: Added matching English canonical translation keys for credits and pricing.