### PR TITLE
fix(admin): unify BOTTUBE_ADMIN_KEY and RC_ADMIN_KEY across both gates (#1729)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14995,10 +14995,19 @@ def giveaway_leaderboard_api():
 # Admin: Visitor Analytics
 # ---------------------------------------------------------------------------
 
-ADMIN_KEY = os.environ.get("BOTTUBE_ADMIN_KEY", "")
+def _admin_key_from_env():
+    """Resolve the admin secret from the environment.
+
+    BOTTUBE_ADMIN_KEY is the documented name; RC_ADMIN_KEY is an accepted alias.
+    Both admin gates in this module read ADMIN_KEY, which is initialized from here.
+    """
+    return os.environ.get("BOTTUBE_ADMIN_KEY", "") or os.environ.get("RC_ADMIN_KEY", "")
+
+
+ADMIN_KEY = _admin_key_from_env()
 if not ADMIN_KEY:
     ADMIN_KEY = secrets.token_hex(32)
-    print(f"[BoTTube] WARNING: BOTTUBE_ADMIN_KEY not set. Generated ephemeral key: {ADMIN_KEY}")
+    print(f"[BoTTube] WARNING: neither BOTTUBE_ADMIN_KEY nor RC_ADMIN_KEY set. Generated ephemeral key: {ADMIN_KEY}")
 
 
 @app.route("/api/admin/visitors")

--- a/tests/test_admin_key_env.py
+++ b/tests/test_admin_key_env.py
@@ -37,7 +37,7 @@ def test_trust_safety_gate_accepts_bottube_admin_key(monkeypatch, tmp_path):
     sys.modules.pop("bottube_server", None)
 
 
-def test_trust_safety_gate_rejects_rc_only_key(monkeypatch, tmp_path):
+def test_trust_safety_gate_accepts_rc_admin_key_alias(monkeypatch, tmp_path):
     monkeypatch.setenv("BOTTUBE_AUTH_DB_PATH", str(tmp_path / "auth.db"))
     monkeypatch.setenv("BOTTUBE_DB_PATH", str(tmp_path / "bottube.db"))
     monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
@@ -46,5 +46,5 @@ def test_trust_safety_gate_rejects_rc_only_key(monkeypatch, tmp_path):
     module = importlib.import_module("bottube_server")
     client = module.app.test_client()
     response = client.post('/admin/blocklist/add', headers={'X-Admin-Key': 'legacy-rc-key'}, json={})
-    assert response.status_code == 401
+    assert response.status_code != 401
     sys.modules.pop("bottube_server", None)

--- a/tests/test_admin_key_single_source.py
+++ b/tests/test_admin_key_single_source.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+"""Both admin gates must resolve the same secret (fixes #1729)."""
+
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture()
+def server_module(monkeypatch, tmp_path):
+    monkeypatch.setenv("BOTTUBE_AUTH_DB_PATH", str(tmp_path / "auth.db"))
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(tmp_path / "bottube.db"))
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    sys.modules.pop("bottube_server", None)
+    module = importlib.import_module("bottube_server")
+    yield module
+    sys.modules.pop("bottube_server", None)
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [
+        ({"BOTTUBE_ADMIN_KEY": "primary"}, "primary"),
+        ({"RC_ADMIN_KEY": "alias"}, "alias"),
+        ({"BOTTUBE_ADMIN_KEY": "primary", "RC_ADMIN_KEY": "alias"}, "primary"),
+        ({}, ""),
+    ],
+    ids=["primary-only", "alias-only", "both-primary-wins", "neither"],
+)
+def test_admin_key_resolution(server_module, monkeypatch, env, expected):
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert server_module._admin_key_from_env() == expected
+
+
+def test_rc_admin_key_opens_trust_safety_gate(server_module, monkeypatch, tmp_path):
+    monkeypatch.setenv("BOTTUBE_AUTH_DB_PATH", str(tmp_path / "auth.db"))
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(tmp_path / "bottube.db"))
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("RC_ADMIN_KEY", "alias-secret")
+    sys.modules.pop("bottube_server", None)
+    module = importlib.import_module("bottube_server")
+    client = module.app.test_client()
+    ok = client.post("/admin/blocklist/add", headers={"X-Admin-Key": "alias-secret"}, json={})
+    bad = client.post("/admin/blocklist/add", headers={"X-Admin-Key": "nope"}, json={})
+    assert ok.status_code != 401
+    assert bad.status_code in (401, 403)
+    sys.modules.pop("bottube_server", None)
+
+
+def test_rc_admin_key_opens_require_admin_gate(server_module, monkeypatch, tmp_path):
+    monkeypatch.setenv("BOTTUBE_AUTH_DB_PATH", str(tmp_path / "auth.db"))
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(tmp_path / "bottube.db"))
+    monkeypatch.delenv("BOTTUBE_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("RC_ADMIN_KEY", "alias-secret")
+    sys.modules.pop("bottube_server", None)
+    module = importlib.import_module("bottube_server")
+    client = module.app.test_client()
+    ok = client.get("/api/admin/visitors", headers={"X-Admin-Key": "alias-secret"})
+    bad = client.get("/api/admin/visitors", headers={"X-Admin-Key": "nope"})
+    assert ok.status_code != 401
+    assert bad.status_code in (401, 403)
+    sys.modules.pop("bottube_server", None)


### PR DESCRIPTION
## Summary
- Add `_admin_key_from_env()` as single source of truth for admin secrets
- `BOTTUBE_ADMIN_KEY` is canonical; `RC_ADMIN_KEY` is accepted legacy alias
- Both `_require_admin()` (24 endpoints) and `_ts_admin_ok()` (15 T&S endpoints) now agree

## Bug
Fixes #1729 — operators who configured only `RC_ADMIN_KEY` could access trust-and-safety routes but were locked out of the other 24 admin endpoints.

## Test plan
- [x] `pytest tests/test_admin_key_single_source.py tests/test_admin_key_env.py` — 9/9 passing