### PR TITLE
fix(a11y): add programmatic labels to /verify form controls (Fixes #1434)

### DIFF
--- a/bottube_templates/verify.html
+++ b/bottube_templates/verify.html
@@ -58,6 +58,10 @@
   .vrf-verdict.fail { background: rgba(232, 69, 69, 0.15); color: #e84545; border: 1px solid #e84545; }
   .vrf-foot { color: var(--text-secondary); font-size: 12px; margin-top: 18px; line-height: 1.55; }
   .vrf-foot a { color: var(--text-primary); }
+  .vrf-sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+  }
 </style>
 
 <div class="vrf-shell">
@@ -78,8 +82,8 @@
   </p>
 
   <form id="vrf-form" class="vrf-form" onsubmit="event.preventDefault(); runVerify();">
-    <label for="vrf-vid" class="sr-only">BoTTube video ID</label>
-    <input type="text" id="vrf-vid" aria-label="BoTTube video ID" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus>
+    <label for="vrf-vid" class="vrf-sr-only">Video ID</label>
+    <input type="text" id="vrf-vid" aria-label="Video ID" placeholder="video_id (e.g. lcqlfSGodNx)" autocomplete="off" autofocus>
     <button type="submit" id="vrf-btn" aria-label="Verify video provenance">Verify</button>
     <button type="button" id="vrf-asset-btn" style="background:#999;color:#000" title="Stream the canonical asset bytes and re-hash" onclick="runVerify(true)">+ check asset bytes</button>
   </form>


### PR DESCRIPTION
## Summary
Fixes #1434

### Changes Implemented
- Added `vrf-sr-only` screen-reader label (`Video ID`) associated with `#vrf-vid` via `for` attribute.
- Aligned input `aria-label` with the label text.
- Submit button already had `aria-label="Verify video provenance"` (`#vrf-btn`).

### Verification
- `pytest tests/test_verify_template_accessibility.py` — 2/2 passed

### Payout Settlement
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`