### PR TITLE
fix(discover): resolve templates from install dir when BOTTUBE_BASE_DIR is set (Fixes #1411)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -81,7 +81,8 @@ except ImportError:
 # Allow overriding storage location via env.
 # Default: the directory containing this file (works in production when deployed under /root/bottube,
 # and in local development when running from a repo checkout).
-BASE_DIR = Path(os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().parent)))
+INSTALL_DIR = Path(__file__).resolve().parent
+BASE_DIR = Path(os.environ.get("BOTTUBE_BASE_DIR", str(INSTALL_DIR)))
 
 DB_PATH = BASE_DIR / "bottube.db"
 VIDEO_DIR = BASE_DIR / "videos"
@@ -112,7 +113,8 @@ def _get_ab_manager():
     return _ab_manager
 
 AVATAR_DIR = BASE_DIR / "avatars"
-TEMPLATE_DIR = BASE_DIR / "bottube_templates"
+# Templates/static ship with the install tree; BOTTUBE_BASE_DIR is writable data only.
+TEMPLATE_DIR = INSTALL_DIR / "bottube_templates"
 
 # Largest value SQLite can store in an INTEGER column / accept as a bound
 # parameter. Larger Python ints raise OverflowError in the driver.
@@ -1385,7 +1387,7 @@ _load_translations()
 # App setup
 # ---------------------------------------------------------------------------
 
-STATIC_DIR = BASE_DIR / "bottube_static"
+STATIC_DIR = INSTALL_DIR / "bottube_static"
 app = Flask(__name__, template_folder=str(TEMPLATE_DIR), static_folder=str(STATIC_DIR), static_url_path="/static")
 app.config["MAX_CONTENT_LENGTH"] = MAX_VIDEO_SIZE + 10 * 1024 * 1024  # extra for form data
 app.secret_key = os.environ.get("BOTTUBE_SECRET_KEY", secrets.token_hex(32))

--- a/tests/test_discover_page_render.py
+++ b/tests/test_discover_page_render.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MIT
+"""Regression for #1411: /discover must render when BOTTUBE_BASE_DIR is set."""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def discover_client(monkeypatch):
+    """App with BOTTUBE_BASE_DIR pointing at an empty data dir (no templates)."""
+    server_path = Path(__file__).resolve().parent.parent
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv("BOTTUBE_BASE_DIR", tmpdir)
+        monkeypatch.setenv("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+        monkeypatch.setenv("RUSTCHAIN_DISABLE_P2P_AUTO_START", "1")
+
+        for mod_name in list(sys.modules):
+            if mod_name in {"bottube_server", "search_blueprint"} or mod_name.startswith("bottube_server."):
+                sys.modules.pop(mod_name, None)
+
+        sys.path.insert(0, str(server_path))
+        import bottube_server
+
+        db_path = Path(tmpdir) / "bottube.db"
+        bottube_server.DB_PATH = db_path
+        bottube_server.VIDEO_DIR = Path(tmpdir) / "videos"
+        bottube_server.THUMB_DIR = Path(tmpdir) / "thumbnails"
+        bottube_server.AVATAR_DIR = Path(tmpdir) / "avatars"
+        for d in (bottube_server.VIDEO_DIR, bottube_server.THUMB_DIR, bottube_server.AVATAR_DIR):
+            d.mkdir(parents=True, exist_ok=True)
+
+        app = bottube_server.app
+        app.config["TESTING"] = True
+        with app.app_context():
+            bottube_server.init_db()
+
+        yield app.test_client()
+
+
+def test_discover_page_renders_with_external_base_dir(discover_client):
+    resp = discover_client.get("/discover/")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Discover" in body
+    assert "discover-container" in body


### PR DESCRIPTION
## Summary
Fixes #1411

### Root cause
`TEMPLATE_DIR` and `STATIC_DIR` were derived from `BOTTUBE_BASE_DIR`. Production sets that env var to the writable data directory, which does not contain `bottube_templates/` — so `/discover/` raised `TemplateNotFound` and returned HTTP 500.

### Changes
- Introduce `INSTALL_DIR` (package root) separate from `BASE_DIR` (writable data).
- Resolve `bottube_templates/` and `bottube_static/` from `INSTALL_DIR`; keep DB/video/thumbnail paths on `BASE_DIR`.
- Regression test `tests/test_discover_page_render.py` asserts `/discover/` returns 200 when `BOTTUBE_BASE_DIR` points at an empty data directory.

### Verification
- `pytest tests/test_discover_page_render.py tests/test_discover_thumbnail_urls.py tests/test_search_blueprint_query_validation.py -q` — 20 passed.

### Payout Settlement
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`