### PR TITLE
fix(agents): reject non-positive page/limit on /api/agents (Fixes #1439)

### DIFF
--- a/agent_discovery.py
+++ b/agent_discovery.py
@@ -47,8 +47,9 @@ def _parse_agent_directory_int(name: str, default: int, min_value: int, max_valu
         except (TypeError, ValueError) as exc:
             raise ValueError(f"{name} must be an integer") from exc
 
-    value = max(min_value, value)
-    if max_value is not None:
+    if value < min_value:
+        raise ValueError(f"invalid {name}; must be int >= {min_value}")
+    if max_value is not None and value > max_value:
         value = min(max_value, value)
     return value
 

--- a/tests/test_agent_directory_query_validation.py
+++ b/tests/test_agent_directory_query_validation.py
@@ -66,10 +66,25 @@ def test_agent_directory_rejects_malformed_page(agent_directory_client):
     assert fake_db.calls == []
 
 
-def test_agent_directory_clamps_valid_numeric_bounds(agent_directory_client):
+def test_agent_directory_rejects_non_positive_page_and_limit(agent_directory_client):
     client, fake_db = agent_directory_client
 
-    resp = client.get("/api/agents?page=0&limit=250")
+    for query, want in [
+        ("/api/agents?page=0", "invalid page; must be int >= 1"),
+        ("/api/agents?page=-1", "invalid page; must be int >= 1"),
+        ("/api/agents?limit=0", "invalid limit; must be int >= 1"),
+        ("/api/agents?limit=-1", "invalid limit; must be int >= 1"),
+    ]:
+        resp = client.get(query)
+        assert resp.status_code == 400, query
+        assert resp.get_json() == {"error": want}
+        assert fake_db.calls == []
+
+
+def test_agent_directory_clamps_upper_limit_only(agent_directory_client):
+    client, fake_db = agent_directory_client
+
+    resp = client.get("/api/agents?page=1&limit=250")
 
     assert resp.status_code == 200
     body = resp.get_json()


### PR DESCRIPTION
## Summary
Fixes #1439

### Changes Implemented:
- `/api/agents` no longer silently coerces `page=0`, `page=-1`, `limit=0`, or `limit=-1` to defaults — returns HTTP 400 with structured JSON errors.
- Malformed non-numeric values (`limit=abc`, `page=abc`) continue to return 400 (already on main).
- Upper bound still clamps `limit` to the documented max of 100.
- Regression tests updated/added in `tests/test_agent_directory_query_validation.py` — 13/13 passing.

### Verification:
`uv run --no-project --with pytest python -m pytest -q tests/test_agent_directory_query_validation.py`

### Payout Settlement:
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`