### PR TITLE
docs(tests): add docstrings to 64 test functions (SDK + beef system, batch 59)

### DIFF
--- a/tests/test_beef_system.py
+++ b/tests/test_beef_system.py
@@ -64,6 +64,7 @@ def app(db_path, monkeypatch):
     from flask import g as _g
 
     def _test_get_db():
+        """Per-test SQLite connection swapped in for the beef store's get_db."""
         if "beef_db" in _g:
             return _g.beef_db
         conn = _sqlite3.connect(str(db_path))
@@ -78,6 +79,7 @@ def app(db_path, monkeypatch):
 
 @pytest.fixture()
 def client(app):
+    """Flask test client for the beef API app."""
     return app.test_client()
 
 
@@ -86,6 +88,7 @@ def client(app):
 # ---------------------------------------------------------------------------
 
 def _post_event(client, a_id, b_id, event_type, delta, description=""):
+    """POST one relationship event for an agent pair and return the response."""
     return client.post(
         "/api/beef/relationships",
         json={
@@ -119,6 +122,7 @@ def test_tables_created(db_path):
 # ---------------------------------------------------------------------------
 
 def test_canonical_pair_ordering():
+    """_canonical_pair orders an agent pair by id so (a,b) and (b,a) share one row."""
     import agent_relationships as ar
     assert ar._canonical_pair(5, 3) == (3, 5)
     assert ar._canonical_pair(1, 2) == (1, 2)
@@ -129,27 +133,32 @@ def test_canonical_pair_ordering():
 # ---------------------------------------------------------------------------
 
 def test_transition_neutral_to_friendly():
+    """Tension at the friendly threshold moves a neutral pair to friendly."""
     import agent_relationships as ar
     # tension at threshold → friendly
     assert ar._transition_state(30, "neutral", None) == "friendly"
 
 
 def test_transition_friendly_to_rivals():
+    """Higher tension moves a friendly pair to rivals."""
     import agent_relationships as ar
     assert ar._transition_state(60, "friendly", None) == "rivals"
 
 
 def test_transition_rivals_to_beef():
+    """Tension at the beef threshold moves a rivals pair to beef."""
     import agent_relationships as ar
     assert ar._transition_state(85, "rivals", None) == "beef"
 
 
 def test_transition_below_threshold_stays_neutral():
+    """Tension below the first threshold leaves the pair neutral."""
     import agent_relationships as ar
     assert ar._transition_state(20, "neutral", None) == "neutral"
 
 
 def test_max_beef_duration_forces_frenemies():
+    """A beef older than the max duration is force-downgraded to frenemies."""
     import agent_relationships as ar
     # beef_started_at 15 days ago → should flip to frenemies
     started = time.time() - 15 * 86400
@@ -158,6 +167,7 @@ def test_max_beef_duration_forces_frenemies():
 
 
 def test_beef_within_14_days_stays_beef():
+    """A beef younger than the max duration stays beef."""
     import agent_relationships as ar
     started = time.time() - 5 * 86400
     result = ar._transition_state(90, "beef", started)
@@ -169,12 +179,14 @@ def test_beef_within_14_days_stays_beef():
 # ---------------------------------------------------------------------------
 
 def test_list_relationships_empty(client):
+    """The relationships list starts empty."""
     resp = client.get("/api/beef/relationships")
     assert resp.status_code == 200
     assert resp.get_json() == []
 
 
 def test_list_relationships_rejects_malformed_agent_filter(client):
+    """A non-integer agent_id filter is rejected with 400."""
     _post_event(client, 1, 2, "comment_disagree", 10)
 
     resp = client.get("/api/beef/relationships?agent_id=not-an-int")
@@ -188,6 +200,7 @@ def test_list_relationships_rejects_malformed_agent_filter(client):
 # ---------------------------------------------------------------------------
 
 def test_create_relationship_via_event(client):
+    """The first event for a pair creates the relationship with the event's tension delta."""
     resp = _post_event(client, 1, 2, "comment_disagree", 10)
     assert resp.status_code == 200
     data = resp.get_json()
@@ -201,6 +214,7 @@ def test_create_relationship_via_event(client):
 # ---------------------------------------------------------------------------
 
 def test_tension_accumulates_to_rivals(client):
+    """Accumulated tension across events moves the pair into rivals."""
     _post_event(client, 3, 4, "disagree", 30)
     _post_event(client, 3, 4, "callout", 31)
     resp = _post_event(client, 3, 4, "hot_take", 0)  # zero-delta; just fetch
@@ -210,6 +224,7 @@ def test_tension_accumulates_to_rivals(client):
 
 
 def test_tension_accumulates_to_beef(client):
+    """Accumulated tension across events moves the pair into beef."""
     _post_event(client, 5, 6, "disagree", 90)
     resp = client.get("/api/beef/relationships")
     rels = resp.get_json()
@@ -223,6 +238,7 @@ def test_tension_accumulates_to_beef(client):
 # ---------------------------------------------------------------------------
 
 def test_get_single_relationship(client):
+    """The single-relationship endpoint returns the pair's row."""
     _post_event(client, 7, 8, "collab", 5)
     rels = client.get("/api/beef/relationships").get_json()
     rel_id = rels[0]["id"]
@@ -232,6 +248,7 @@ def test_get_single_relationship(client):
 
 
 def test_get_relationship_not_found(client):
+    """An unknown relationship id returns 404."""
     resp = client.get("/api/beef/relationships/9999")
     assert resp.status_code == 404
 
@@ -241,6 +258,7 @@ def test_get_relationship_not_found(client):
 # ---------------------------------------------------------------------------
 
 def test_admin_kill(client):
+    """The admin kill endpoint marks a relationship dead and returns ok."""
     _post_event(client, 9, 10, "callout", 90)
     rels = client.get("/api/beef/relationships").get_json()
     rel_id = rels[0]["id"]
@@ -259,6 +277,7 @@ def test_admin_kill(client):
 # ---------------------------------------------------------------------------
 
 def test_events_are_logged(client):
+    """Every posted event is recorded on the relationship's event log in order."""
     _post_event(client, 11, 12, "first_event", 10, "initial skirmish")
     _post_event(client, 11, 12, "second_event", 5, "follow-up")
     rels = client.get("/api/beef/relationships").get_json()
@@ -274,6 +293,7 @@ def test_events_are_logged(client):
 # ---------------------------------------------------------------------------
 
 def test_arc_templates_listed(client):
+    """The templates endpoint lists all built-in drama arc templates."""
     resp = client.get("/api/beef/arcs/templates")
     assert resp.status_code == 200
     templates = resp.get_json()
@@ -286,6 +306,7 @@ def test_arc_templates_listed(client):
 # ---------------------------------------------------------------------------
 
 def test_start_drama_arc(client):
+    """Starting an arc on a qualifying relationship returns the created arc."""
     _post_event(client, 13, 14, "disagree", 65)
     rels = client.get("/api/beef/relationships").get_json()
     rel_id = next(r["id"] for r in rels if r["agent_a_id"] == 13)
@@ -301,6 +322,7 @@ def test_start_drama_arc(client):
 
 
 def test_start_drama_arc_rejects_non_object_json(client):
+    """A non-object JSON body on the arcs endpoint is rejected with 400."""
     resp = client.post("/api/beef/arcs", json=["not", "an", "object"])
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "JSON object required"
@@ -324,12 +346,14 @@ def test_start_drama_arc_rejects_non_object_json(client):
     ],
 )
 def test_start_drama_arc_rejects_malformed_fields(client, payload, error):
+    """Parametrized malformed arc payloads are rejected with the matching error."""
     resp = client.post("/api/beef/arcs", json=payload)
     assert resp.status_code == 400
     assert resp.get_json()["error"] == error
 
 
 def test_list_active_arcs(client):
+    """Started arcs appear in the active-arcs listing."""
     _post_event(client, 15, 16, "callout", 70)
     rels = client.get("/api/beef/relationships").get_json()
     rel_id = next(r["id"] for r in rels if r["agent_a_id"] == 15)
@@ -346,6 +370,7 @@ def test_list_active_arcs(client):
 # ---------------------------------------------------------------------------
 
 def test_resolve_drama_arc(client):
+    """Resolving an arc closes it with a resolution note."""
     _post_event(client, 17, 18, "disagree", 70)
     rels = client.get("/api/beef/relationships").get_json()
     rel_id = next(r["id"] for r in rels if r["agent_a_id"] == 17)
@@ -360,6 +385,7 @@ def test_resolve_drama_arc(client):
 
 
 def test_resolve_drama_arc_rejects_non_object_json(client):
+    """A non-object JSON body on the resolve endpoint is rejected with 400."""
     _post_event(client, 23, 24, "disagree", 70)
     rels = client.get("/api/beef/relationships").get_json()
     rel_id = next(r["id"] for r in rels if r["agent_a_id"] == 23)
@@ -374,6 +400,7 @@ def test_resolve_drama_arc_rejects_non_object_json(client):
 
 
 def test_resolve_drama_arc_rejects_non_string_note(client):
+    """A non-string resolution note is rejected with 400."""
     _post_event(client, 25, 26, "disagree", 70)
     rels = client.get("/api/beef/relationships").get_json()
     rel_id = next(r["id"] for r in rels if r["agent_a_id"] == 25)
@@ -395,6 +422,7 @@ def test_resolve_drama_arc_rejects_non_string_note(client):
 # ---------------------------------------------------------------------------
 
 def test_drama_leaderboard(client):
+    """The leaderboard endpoint ranks relationships by tension."""
     _post_event(client, 20, 21, "beef", 90)
     _post_event(client, 20, 22, "disagree", 40)
     resp = client.get("/api/beef/leaderboard")
@@ -410,16 +438,19 @@ def test_drama_leaderboard(client):
 # ---------------------------------------------------------------------------
 
 def test_missing_agents_returns_400(client):
+    """An event missing an agent id is rejected with 400."""
     resp = client.post("/api/beef/relationships", json={"event_type": "test", "delta": 5})
     assert resp.status_code == 400
 
 
 def test_same_agent_returns_400(client):
+    """An event pairing an agent with itself is rejected with 400."""
     resp = _post_event(client, 99, 99, "self_hate", 10)
     assert resp.status_code == 400
 
 
 def test_relationship_event_rejects_non_object_json(client):
+    """A non-object JSON body on the events endpoint is rejected with 400."""
     resp = client.post("/api/beef/relationships", json=[{"agent_a_id": 1}])
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "JSON object required"
@@ -451,6 +482,7 @@ def test_relationship_event_rejects_non_object_json(client):
     ],
 )
 def test_relationship_event_rejects_malformed_fields(client, payload, error):
+    """Parametrized malformed event payloads are rejected with 400."""
     resp = client.post("/api/beef/relationships", json=payload)
     assert resp.status_code == 400
     assert resp.get_json()["error"] == error

--- a/tests/test_bottube_sdk.py
+++ b/tests/test_bottube_sdk.py
@@ -28,11 +28,13 @@ from bottube_sdk.client import (
 
 @pytest.fixture
 def client():
+    """An authenticated SDK client pointed at a test base URL."""
     return BoTTubeClient(api_key="test-key-123", base_url="https://bottube.test")
 
 
 @pytest.fixture
 def public_client():
+    """An unauthenticated SDK client for public-endpoint tests."""
     return BoTTubeClient(base_url="https://bottube.test")
 
 
@@ -51,23 +53,28 @@ def _mock_response(status_code=200, json_data=None, text=""):
 
 class TestAuthentication:
     def test_api_key_from_constructor(self):
+        """The api_key constructor argument is stored on the client."""
         c = BoTTubeClient(api_key="abc", base_url="http://x")
         assert c.api_key == "abc"
 
     def test_api_key_from_env(self, monkeypatch):
+        """BOTTUBE_API_KEY supplies the key when the constructor omits it."""
         monkeypatch.setenv("BOTTUBE_API_KEY", "env-key")
         c = BoTTubeClient(base_url="http://x")
         assert c.api_key == "env-key"
 
     def test_missing_api_key_raises_on_auth(self, public_client):
+        """Building auth headers without a key raises AuthenticationError."""
         with pytest.raises(AuthenticationError, match="API key required"):
             public_client._headers(auth=True)
 
     def test_api_key_sent_in_header(self, client):
+        """Auth headers carry the key in X-API-Key."""
         hdrs = client._headers(auth=True)
         assert hdrs["X-API-Key"] == "test-key-123"
 
     def test_public_headers_no_key(self, public_client):
+        """Non-auth headers never include an API key."""
         hdrs = public_client._headers(auth=False)
         assert "X-API-Key" not in hdrs
 
@@ -78,18 +85,21 @@ class TestAuthentication:
 
 class TestVideoOperations:
     def test_get_video(self, client):
+        """get_video returns the parsed video payload on 200."""
         mock_resp = _mock_response(200, {"video_id": "abc", "title": "Test"})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp):
             result = client.get_video("abc")
         assert result["video_id"] == "abc"
 
     def test_get_video_not_found(self, client):
+        """get_video maps a 404 to NotFoundError."""
         mock_resp = _mock_response(404, {"error": "Video not found"})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp):
             with pytest.raises(NotFoundError):
                 client.get_video("nonexistent")
 
     def test_list_videos(self, client):
+        """list_videos returns the parsed paginated payload."""
         mock_resp = _mock_response(200, {"videos": [], "page": 1})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp) as mock_get:
             result = client.list_videos(page=2, sort="views")
@@ -99,6 +109,7 @@ class TestVideoOperations:
         assert call_kwargs["params"]["sort"] == "views"
 
     def test_search_videos(self, client):
+        """search_videos returns the parsed search results."""
         mock_resp = _mock_response(200, {"results": [], "count": 0})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp) as mock_get:
             result = client.search("retro computing", category="retro")
@@ -107,10 +118,12 @@ class TestVideoOperations:
         assert call_kwargs["params"]["q"] == "retro computing"
 
     def test_upload_video_file_not_found(self, client):
+        """Uploading a nonexistent file raises a file error before any request."""
         with pytest.raises(FileNotFoundError):
             client.upload("/nonexistent/video.mp4")
 
     def test_upload_invalid_format(self, client):
+        """Uploading a disallowed file format is rejected locally."""
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
             f.write(b"not a video")
             path = f.name
@@ -121,6 +134,7 @@ class TestVideoOperations:
             os.unlink(path)
 
     def test_delete_video(self, client):
+        """delete_video returns the parsed deletion payload."""
         mock_resp = _mock_response(200, {"status": "deleted"})
         with patch("bottube_sdk.client.requests.Session.delete", return_value=mock_resp):
             result = client.delete_video("abc")
@@ -133,6 +147,7 @@ class TestVideoOperations:
 
 class TestCommentOperations:
     def test_comment(self, client):
+        """comment posts a comment and returns the parsed response."""
         mock_resp = _mock_response(200, {"id": 1, "content": "Nice!"})
         with patch("bottube_sdk.client.requests.Session.post", return_value=mock_resp) as mock_post:
             result = client.comment("abc", "Nice!")
@@ -141,12 +156,14 @@ class TestCommentOperations:
         assert call_kwargs["json"]["comment_type"] == "comment"
 
     def test_get_comments(self, client):
+        """get_comments returns the parsed comment list."""
         mock_resp = _mock_response(200, {"comments": []})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp):
             result = client.get_comments("abc")
         assert "comments" in result
 
     def test_recent_comments(self, client):
+        """recent_comments returns the parsed recent feed."""
         mock_resp = _mock_response(200, {"comments": []})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp) as mock_get:
             result = client.recent_comments(since=1000, limit=10)
@@ -161,6 +178,7 @@ class TestCommentOperations:
 
 class TestVoteOperations:
     def test_vote_video_like(self, client):
+        """Voting +1 on a video returns the parsed response."""
         mock_resp = _mock_response(200, {"status": "voted"})
         with patch("bottube_sdk.client.requests.Session.post", return_value=mock_resp) as mock_post:
             result = client.vote_video("abc", 1)
@@ -168,19 +186,23 @@ class TestVoteOperations:
         assert call_kwargs["json"]["vote"] == 1
 
     def test_vote_video_invalid(self, client):
+        """An invalid vote value raises ValidationError."""
         with pytest.raises(ValidationError, match="vote must be"):
             client.vote_video("abc", 5)
 
     def test_vote_comment(self, client):
+        """Voting on a comment returns the parsed response."""
         mock_resp = _mock_response(200, {"status": "voted"})
         with patch("bottube_sdk.client.requests.Session.post", return_value=mock_resp):
             result = client.vote_comment(42, 1)
 
     def test_vote_comment_invalid(self, client):
+        """An invalid comment vote value raises ValidationError."""
         with pytest.raises(ValidationError, match="vote must be"):
             client.vote_comment(42, 2)
 
     def test_like_video_shorthand(self, client):
+        """like_video is the +1 shorthand for vote_video."""
         mock_resp = _mock_response(200, {"status": "voted"})
         with patch("bottube_sdk.client.requests.Session.post", return_value=mock_resp) as mock_post:
             client.like_video("abc")
@@ -188,6 +210,7 @@ class TestVoteOperations:
         assert call_kwargs["json"]["vote"] == 1
 
     def test_dislike_video_shorthand(self, client):
+        """dislike_video is the -1 shorthand for vote_video."""
         mock_resp = _mock_response(200, {"status": "voted"})
         with patch("bottube_sdk.client.requests.Session.post", return_value=mock_resp) as mock_post:
             client.dislike_video("abc")
@@ -201,6 +224,7 @@ class TestVoteOperations:
 
 class TestTipOperations:
     def test_tip_video(self, client):
+        """tip_video posts a tip and returns the parsed response."""
         mock_resp = _mock_response(200, {"status": "tipped"})
         with patch("bottube_sdk.client.requests.Session.post", return_value=mock_resp) as mock_post:
             result = client.tip_video("abc", 0.5, message="Nice work!")
@@ -209,6 +233,7 @@ class TestTipOperations:
         assert call_kwargs["json"]["message"] == "Nice work!"
 
     def test_get_video_tips(self, client):
+        """get_video_tips returns the parsed tip list."""
         mock_resp = _mock_response(200, {"tips": []})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp):
             result = client.get_video_tips("abc")
@@ -221,24 +246,28 @@ class TestTipOperations:
 
 class TestErrorHandling:
     def test_rate_limit_error(self, client):
+        """A 429 response maps to RateLimitError carrying the server message."""
         mock_resp = _mock_response(429, {"error": "Rate limit exceeded"})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp):
             with pytest.raises(RateLimitError):
                 client.get_video("abc")
 
     def test_auth_error(self, public_client):
+        """A 401/403 response maps to AuthenticationError."""
         mock_resp = _mock_response(401, {"error": "Invalid API key"})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp):
             with pytest.raises(AuthenticationError):
                 public_client.list_videos()
 
     def test_server_error(self, client):
+        """A 500 response maps to BoTTubeError with the server message."""
         mock_resp = _mock_response(500, {"error": "Internal server error"})
         with patch("bottube_sdk.client.requests.Session.get", return_value=mock_resp):
             with pytest.raises(BoTTubeError, match="Internal server error"):
                 client.get_video("abc")
 
     def test_validation_error_on_400(self, client):
+        """A 400 response maps to ValidationError."""
         mock_resp = _mock_response(400, {"error": "Bad request"})
         with patch("bottube_sdk.client.requests.Session.post", return_value=mock_resp):
             with pytest.raises(ValidationError):
@@ -251,13 +280,16 @@ class TestErrorHandling:
 
 class TestURLConstruction:
     def test_base_url_trailing_slash_stripped(self):
+        """A trailing slash on base_url is stripped at construction."""
         c = BoTTubeClient(base_url="https://bottube.test/")
         assert c.base_url == "https://bottube.test"
 
     def test_url_building(self, client):
+        """_url joins the base URL and path without double slashes."""
         assert client._url("/api/videos/abc") == "https://bottube.test/api/videos/abc"
 
     def test_base_url_from_env(self, monkeypatch):
+        """BOTTUBE_BASE_URL supplies the base URL when the constructor omits it."""
         monkeypatch.setenv("BOTTUBE_BASE_URL", "https://custom.test")
         c = BoTTubeClient()
         assert c.base_url == "https://custom.test"


### PR DESCRIPTION
## Summary
Adds accurate docstrings to all 64 undocumented test functions, fixtures, and helpers in `tests/test_bottube_sdk.py` (32) and `tests/test_beef_system.py` (32), completing documentation coverage for both suites.

### Changes Implemented:
- 64 new docstrings; +64/-0 lines, comment-only — zero behavioral change.
- `py_compile` passes on both files; AST scan confirms 0 undocumented functions remain in either file.
- `pytest tests/test_bottube_sdk.py tests/test_beef_system.py` → 66 passed; the single `test_admin_kill` 403 failure is pre-existing and reproduces identically on pristine `main` (sandbox lacks the admin-key env), unrelated to this comment-only diff.

### Payout Settlement:
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`