### PR TITLE
docs(tests): add docstrings to 76 test functions (query-param validation, telegram bot, quests, batch 60)

### DIFF
--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -19,6 +19,7 @@ _orig_sqlite_connect = sqlite3.connect
 
 
 def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    """Redirect the bootstrap DB path to the per-test BOTTUBE_DB_PATH so imports never touch prod data."""
     if str(path) == "/root/bottube/bottube.db":
         path = os.environ["BOTTUBE_DB_PATH"]
     return _orig_sqlite_connect(path, *args, **kwargs)
@@ -33,6 +34,7 @@ _orig_init_store_db = paypal_packages.init_store_db
 
 
 def _test_init_store_db(db_path=None):
+    """Point init_store_db at the test DB path."""
     bootstrap_path = os.environ["BOTTUBE_DB_PATH"]
     Path(bootstrap_path).parent.mkdir(parents=True, exist_ok=True)
     return _orig_init_store_db(bootstrap_path)
@@ -47,6 +49,7 @@ sqlite3.connect = _orig_sqlite_connect
 
 @pytest.fixture()
 def client(monkeypatch, tmp_path):
+    """Fresh app + DB per test with rate-limit buckets cleared and TESTING enabled."""
     db_path = tmp_path / "bottube_test.db"
     monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
     bottube_server._rate_buckets.clear()
@@ -57,6 +60,7 @@ def client(monkeypatch, tmp_path):
 
 
 def _insert_agent(agent_name: str, api_key: str) -> int:
+    """Insert an agent row directly and return its id."""
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         cur = db.execute(
@@ -72,6 +76,7 @@ def _insert_agent(agent_name: str, api_key: str) -> int:
 
 
 def _insert_video(agent_id: int, video_id: str) -> None:
+    """Insert a video row for an agent directly."""
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
@@ -85,6 +90,7 @@ def _insert_video(agent_id: int, video_id: str) -> None:
 
 
 def _insert_comment(agent_id: int, video_id: str, content: str, created_at: float = 3.0) -> int:
+    """Insert a comment row and return its id."""
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         cur = db.execute(
@@ -99,10 +105,12 @@ def _insert_comment(agent_id: int, video_id: str, content: str, created_at: floa
 
 
 def _quest_reward(quest_key: str) -> float:
+    """Look up the configured RTC reward for a quest key."""
     return next(q["reward_rtc"] for q in bottube_server.DEFAULT_QUESTS if q["quest_key"] == quest_key)
 
 
 def test_quests_endpoint_unlocks_onboarding_flow(client):
+    """The quests endpoint unlocks onboarding quests as the prerequisites (uploads, interactions) are completed."""
     alice_id = _insert_agent("alice", "bottube_sk_alice")
     bob_id = _insert_agent("bob", "bottube_sk_bob")
     _insert_video(alice_id, "alicevideo1A")
@@ -163,6 +171,7 @@ def test_quests_endpoint_unlocks_onboarding_flow(client):
 
 
 def test_quest_rewards_are_idempotent_and_leaderboard_updates(client):
+    """A quest reward is granted exactly once even if the completion event replays, and the leaderboard reflects it."""
     alice_id = _insert_agent("alice2", "bottube_sk_alice2")
     bob_id = _insert_agent("bob2", "bottube_sk_bob2")
     _insert_video(alice_id, "alicevide2A")
@@ -196,6 +205,7 @@ def test_quest_rewards_are_idempotent_and_leaderboard_updates(client):
 
 
 def test_dashboard_renders_quest_board_and_streak(client):
+    """The dashboard renders the quest board with streak information."""
     alice_id = _insert_agent("dashalice", "bottube_sk_dashalice")
     _insert_video(alice_id, "dashvideo01A")
     with bottube_server.app.app_context():
@@ -230,6 +240,7 @@ def test_dashboard_renders_quest_board_and_streak(client):
 
 
 def test_dashboard_shows_onboarding_card_before_referral_for_zero_video_creator(client):
+    """Creators with no uploads see the onboarding card before referral prompts."""
     alice_id = _insert_agent("freshdash", "bottube_sk_freshdash")
 
     with client.session_transaction() as sess:
@@ -252,6 +263,7 @@ def test_dashboard_shows_onboarding_card_before_referral_for_zero_video_creator(
 
 
 def test_dashboard_hides_onboarding_card_after_first_upload(client):
+    """The onboarding card disappears once the creator has an upload."""
     alice_id = _insert_agent("dashready", "bottube_sk_dashready")
     _insert_video(alice_id, "dashready01A")
 
@@ -266,6 +278,7 @@ def test_dashboard_hides_onboarding_card_after_first_upload(client):
 
 
 def test_suspicious_comment_reward_is_held_for_review(client):
+    """Quest rewards triggered by suspicious-looking comments are held for review, not auto-paid."""
     commenter_id = _insert_agent("holdalice", "bottube_sk_holdalice")
     target_id = _insert_agent("holdbob", "bottube_sk_holdbob")
     _insert_video(target_id, "holdvideo01A")
@@ -304,6 +317,7 @@ def test_suspicious_comment_reward_is_held_for_review(client):
 
 
 def test_web_comment_rejects_malformed_parent_id(client):
+    """The web comment route rejects malformed parent_id values with 400."""
     commenter_id = _insert_agent("replyalice", "bottube_sk_replyalice")
     owner_id = _insert_agent("replybob", "bottube_sk_replybob")
     _insert_video(owner_id, "replyvideo01A")
@@ -336,6 +350,7 @@ def test_web_comment_rejects_malformed_parent_id(client):
 
 
 def test_api_comment_rejects_fractional_parent_id(client):
+    """The API comment route rejects fractional parent_id values with 400."""
     commenter_id = _insert_agent("replyapi", "bottube_sk_replyapi")
     owner_id = _insert_agent("replyowner", "bottube_sk_replyowner")
     _insert_video(owner_id, "replyvideo02A")
@@ -364,6 +379,7 @@ def test_api_comment_rejects_fractional_parent_id(client):
 
 
 def test_web_comment_rejects_fractional_parent_id(client):
+    """The web comment route rejects fractional parent_id values with 400."""
     commenter_id = _insert_agent("replyweb", "bottube_sk_replyweb")
     owner_id = _insert_agent("replytarget", "bottube_sk_replytarget")
     _insert_video(owner_id, "replyvideo03A")
@@ -396,6 +412,7 @@ def test_web_comment_rejects_fractional_parent_id(client):
 
 
 def test_admin_ban_defaults_to_coaching_hold_instead_of_ban(client):
+    """An admin ban without force queues a coaching hold rather than banning outright."""
     agent_id = _insert_agent("coachme", "bottube_sk_coachme")
 
     resp = client.post(
@@ -429,6 +446,7 @@ def test_admin_ban_defaults_to_coaching_hold_instead_of_ban(client):
 
 
 def test_admin_moderation_routes_reject_malformed_json_fields(client):
+    """Admin moderation routes reject malformed JSON field types with 400."""
     agent_id = _insert_agent("jsonadmin", "bottube_sk_jsonadmin")
     _insert_video(agent_id, "jsonadmin01A")
 
@@ -482,6 +500,7 @@ def test_admin_moderation_routes_reject_malformed_json_fields(client):
 
 
 def test_report_threshold_queues_hold_without_auto_removal(client):
+    """Reaching the report threshold queues a moderation hold without auto-deleting the content."""
     owner_id = _insert_agent("ownerbot", "bottube_sk_ownerbot")
     _insert_video(owner_id, "ownerclip01A")
     _insert_agent("reporter1", "bottube_sk_reporter1")
@@ -526,6 +545,7 @@ def test_report_threshold_queues_hold_without_auto_removal(client):
 
 
 def test_admin_resolve_report_defaults_to_coach_without_deleting_comment(client):
+    """Resolving a report defaults to coaching and preserves the comment."""
     owner_id = _insert_agent("commentowner", "bottube_sk_commentowner")
     reporter_id = _insert_agent("commentreporter", "bottube_sk_commentreporter")
     _insert_video(owner_id, "commentclip1A")
@@ -585,6 +605,7 @@ def test_admin_resolve_report_defaults_to_coach_without_deleting_comment(client)
 
 
 def test_comment_cleanup_defaults_to_hold_without_deleting(client):
+    """Comment cleanup defaults to a hold instead of deleting the flagged comments."""
     agent_id = _insert_agent("cleanupbot", "bottube_sk_cleanupbot")
     target_id = _insert_agent("cleanupowner", "bottube_sk_cleanupowner")
     _insert_video(target_id, "cleanupvid1A")
@@ -624,6 +645,7 @@ def test_comment_cleanup_defaults_to_hold_without_deleting(client):
 
 
 def test_self_view_reward_is_held_for_review(client):
+    """A self-view does not auto-pay the view reward; it is held for review."""
     owner_id = _insert_agent("viewowner", "bottube_sk_viewowner")
     _insert_video(owner_id, "viewhold01A")
 
@@ -654,6 +676,7 @@ def test_self_view_reward_is_held_for_review(client):
 
 
 def test_like_reward_hold_can_be_credited_by_admin(client):
+    """A held like reward can later be credited explicitly by an admin."""
     owner_id = _insert_agent("likeowner", "bottube_sk_likeowner")
     voter_id = _insert_agent("likevoter", "bottube_sk_likevoter")
     assert voter_id > 0
@@ -720,6 +743,7 @@ def test_like_reward_hold_can_be_credited_by_admin(client):
 
 
 def test_moderation_hold_release_restores_video(client):
+    """Releasing a moderation hold restores the video to public visibility."""
     owner_id = _insert_agent("releaseowner", "bottube_sk_releaseowner")
     _insert_video(owner_id, "releasevid1A")
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -22,6 +22,7 @@ from telegram_bot import (
 # ---------------------------------------------------------------------------
 
 def make_video(**kwargs):
+    """Build a Video model instance with test defaults, overridable via kwargs."""
     defaults = dict(
         id="v1", title="Test Video", description="A great video about testing",
         views=100, likes=10, thumbnail="https://img.test/thumb.jpg",
@@ -32,6 +33,7 @@ def make_video(**kwargs):
 
 
 def make_agent(**kwargs):
+    """Build an Agent model instance with test defaults, overridable via kwargs."""
     defaults = dict(
         name="testbot", display_name="TestBot",
         bio="I make test videos", avatar_url="", video_count=42,
@@ -42,13 +44,16 @@ def make_agent(**kwargs):
 
 class MockResponse:
     def __init__(self, json_data, status_code=200):
+        """Store the canned JSON payload and status code."""
         self._json = json_data
         self.status_code = status_code
 
     def json(self):
+        """Return the canned JSON payload."""
         return self._json
 
     def raise_for_status(self):
+        """Raise on HTTP >= 400 like a real requests response."""
         if self.status_code >= 400:
             raise Exception(f"HTTP {self.status_code}")
 
@@ -59,18 +64,22 @@ class MockResponse:
 
 class TestVideo:
     def test_url(self):
+        """Video.url builds the canonical watch-page link from the id."""
         v = make_video(id="abc123")
         assert v.url == "https://bottube.ai/watch/abc123"
 
     def test_short_desc_truncation(self):
+        """Long descriptions are truncated to fit the Telegram message budget."""
         v = make_video(description="x" * 200)
         assert len(v.short_desc) <= 124
 
     def test_short_desc_no_truncation(self):
+        """Short descriptions pass through unchanged."""
         v = make_video(description="Short desc")
         assert v.short_desc == "Short desc"
 
     def test_to_text(self):
+        """Video.to_text renders title, author, and view count for the Telegram message."""
         v = make_video(title="My Video", agent_name="Bot", views=50, likes=5)
         text = v.to_text(1)
         assert "My Video" in text
@@ -78,6 +87,7 @@ class TestVideo:
         assert "50" in text
 
     def test_to_text_escapes_html(self):
+        """to_text escapes HTML in user-controlled fields so Telegram parse mode cannot be abused."""
         v = make_video(title="<script>alert(1)</script>")
         text = v.to_text()
         assert "<script>" not in text
@@ -90,12 +100,14 @@ class TestVideo:
 
 class TestAgent:
     def test_to_text(self):
+        """Agent.to_text renders display name, bio, and video count."""
         a = make_agent(display_name="CosmoBot", bio="Space videos", video_count=100)
         text = a.to_text()
         assert "CosmoBot" in text
         assert "100 videos" in text
 
     def test_to_text_url(self):
+        """Agent.to_text URL-encodes agent names with spaces."""
         a = make_agent(name="cosmo bot")
         text = a.to_text()
         assert "cosmo%20bot" in text
@@ -107,12 +119,15 @@ class TestAgent:
 
 class TestEscape:
     def test_escapes_lt_gt(self):
+        """_escape escapes angle brackets."""
         assert _escape("<b>") == "&lt;b&gt;"
 
     def test_escapes_ampersand(self):
+        """_escape escapes ampersands."""
         assert _escape("A & B") == "A &amp; B"
 
     def test_clean_text_unchanged(self):
+        """_escape leaves already-safe text unchanged."""
         assert _escape("Hello World") == "Hello World"
 
 
@@ -123,6 +138,7 @@ class TestEscape:
 class TestBoTTubeAPI:
     @patch("telegram_bot.requests.Session")
     def test_latest(self, mock_session_cls):
+        """BoTTubeAPI.latest fetches and formats the latest-videos payload."""
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
         mock_session.get.return_value = MockResponse({
@@ -140,6 +156,7 @@ class TestBoTTubeAPI:
 
     @patch("telegram_bot.requests.Session")
     def test_search(self, mock_session_cls):
+        """BoTTubeAPI.search fetches and formats search results."""
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
         mock_session.get.return_value = MockResponse([
@@ -155,6 +172,7 @@ class TestBoTTubeAPI:
 
     @patch("telegram_bot.requests.Session")
     def test_get_video(self, mock_session_cls):
+        """BoTTubeAPI.get_video fetches a single video's payload."""
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
         mock_session.get.return_value = MockResponse({
@@ -171,6 +189,7 @@ class TestBoTTubeAPI:
 
     @patch("telegram_bot.requests.Session")
     def test_get_video_not_found(self, mock_session_cls):
+        """get_video returns None for a 404 instead of raising."""
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
         mock_session.get.return_value = MockResponse({}, 404)
@@ -181,6 +200,7 @@ class TestBoTTubeAPI:
 
     @patch("telegram_bot.requests.Session")
     def test_get_agent(self, mock_session_cls):
+        """BoTTubeAPI.get_agent fetches an agent profile payload."""
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
         mock_session.get.return_value = MockResponse({
@@ -196,16 +216,19 @@ class TestBoTTubeAPI:
 
     @patch("telegram_bot.requests.Session")
     def test_items_handles_list(self, mock_session_cls):
+        """_items passes a bare list response straight through."""
         api = BoTTubeAPI("http://test")
         assert api._items([1, 2, 3]) == [1, 2, 3]
 
     @patch("telegram_bot.requests.Session")
     def test_items_handles_dict_with_videos(self, mock_session_cls):
+        """_items unwraps a {'videos': [...]} response shape."""
         api = BoTTubeAPI("http://test")
         assert api._items({"videos": [1]}) == [1]
 
     @patch("telegram_bot.requests.Session")
     def test_items_handles_dict_with_data(self, mock_session_cls):
+        """_items unwraps a {'data': [...]} response shape."""
         api = BoTTubeAPI("http://test")
         assert api._items({"data": [2]}) == [2]
 
@@ -230,6 +253,7 @@ class TestBotIntegration:
         assert result.count("🎬") == 5
 
     def test_agent_with_videos_formatting(self):
+        """End-to-end formatting of an agent card plus recent-upload lines for a Telegram post."""
         agent = make_agent(display_name="CosmoBot", video_count=100)
         videos = [make_video(title=f"Vid {i}") for i in range(3)]
 

--- a/tests/test_videos_list_query_param_validation.py
+++ b/tests/test_videos_list_query_param_validation.py
@@ -17,6 +17,7 @@ Fix: shared `_parse_positive_int_query` helper in bottube_server.py.
 
 
 def test_list_videos_rejects_non_integer_page(client):
+    """A non-integer page param is rejected with 400 naming the field."""
     response = client.get("/api/videos?page=abc")
     assert response.status_code == 400
     data = response.get_json()
@@ -25,6 +26,7 @@ def test_list_videos_rejects_non_integer_page(client):
 
 
 def test_list_videos_rejects_non_integer_per_page(client):
+    """A non-integer per_page param is rejected with 400 naming the field."""
     response = client.get("/api/videos?per_page=xyz")
     assert response.status_code == 400
     data = response.get_json()
@@ -32,6 +34,7 @@ def test_list_videos_rejects_non_integer_per_page(client):
 
 
 def test_list_videos_rejects_zero_page(client):
+    """page=0 is invalid (pages are 1-based) and returns 400."""
     response = client.get("/api/videos?page=0")
     assert response.status_code == 400
     data = response.get_json()
@@ -39,6 +42,7 @@ def test_list_videos_rejects_zero_page(client):
 
 
 def test_list_videos_rejects_negative_page(client):
+    """A negative page returns 400."""
     response = client.get("/api/videos?page=-5")
     assert response.status_code == 400
     data = response.get_json()
@@ -46,6 +50,7 @@ def test_list_videos_rejects_negative_page(client):
 
 
 def test_list_videos_rejects_zero_per_page(client):
+    """per_page=0 is invalid and returns 400."""
     response = client.get("/api/videos?per_page=0")
     assert response.status_code == 400
     data = response.get_json()
@@ -53,11 +58,13 @@ def test_list_videos_rejects_zero_per_page(client):
 
 
 def test_list_videos_rejects_negative_per_page(client):
+    """A negative per_page returns 400."""
     response = client.get("/api/videos?per_page=-1")
     assert response.status_code == 400
 
 
 def test_list_videos_rejects_per_page_above_max(client):
+    """per_page above the 50 cap is rejected with 400 instead of being silently clamped."""
     # cap is 50; 100 was silently clamped before the fix
     response = client.get("/api/videos?per_page=100")
     assert response.status_code == 400
@@ -67,21 +74,25 @@ def test_list_videos_rejects_per_page_above_max(client):
 
 
 def test_list_videos_rejects_float_page(client):
+    """A float page value returns 400."""
     response = client.get("/api/videos?page=1.5")
     assert response.status_code == 400
 
 
 def test_list_videos_rejects_null_page(client):
+    """page=null is rejected with 400."""
     response = client.get("/api/videos?page=null")
     assert response.status_code == 400
 
 
 def test_list_videos_rejects_nan_page(client):
+    """page=NaN is rejected with 400."""
     response = client.get("/api/videos?page=NaN")
     assert response.status_code == 400
 
 
 def test_list_videos_accepts_valid_pagination(client):
+    """Valid page/per_page values return 200 and echo the requested pagination."""
     response = client.get("/api/videos?page=1&per_page=10")
     assert response.status_code == 200
     data = response.get_json()
@@ -90,6 +101,7 @@ def test_list_videos_accepts_valid_pagination(client):
 
 
 def test_list_videos_omits_defaults_when_unset(client):
+    """With no query params the endpoint defaults to page 1, per_page 20."""
     # No page/per_page in the query string -> both default
     response = client.get("/api/videos")
     assert response.status_code == 200
@@ -99,6 +111,7 @@ def test_list_videos_omits_defaults_when_unset(client):
 
 
 def test_list_videos_per_page_boundary_values(client):
+    """per_page 1 and 50 are accepted; 51 and above are rejected."""
     # min valid = 1, max valid = 50
     for pp in (1, 50):
         r = client.get(f"/api/videos?per_page={pp}")
@@ -112,6 +125,7 @@ def test_list_videos_per_page_boundary_values(client):
 
 
 def test_search_videos_rejects_non_integer_page(client):
+    """Search rejects a non-integer page with 400 naming the field."""
     response = client.get("/api/search?q=test&page=abc")
     assert response.status_code == 400
     data = response.get_json()
@@ -119,6 +133,7 @@ def test_search_videos_rejects_non_integer_page(client):
 
 
 def test_search_videos_rejects_non_integer_per_page(client):
+    """Search rejects a non-integer per_page with 400 naming the field."""
     response = client.get("/api/search?q=test&per_page=xyz")
     assert response.status_code == 400
     data = response.get_json()
@@ -126,16 +141,19 @@ def test_search_videos_rejects_non_integer_per_page(client):
 
 
 def test_search_videos_rejects_zero_page(client):
+    """Search rejects page=0 with 400."""
     response = client.get("/api/search?q=test&page=0")
     assert response.status_code == 400
 
 
 def test_search_videos_rejects_per_page_above_max(client):
+    """Search rejects per_page above the cap with 400."""
     response = client.get("/api/search?q=test&per_page=100")
     assert response.status_code == 400
 
 
 def test_search_videos_rejects_non_integer_min_views(client):
+    """Search rejects a non-integer min_views with 400 naming the field."""
     response = client.get("/api/search?q=test&min_views=abc")
     assert response.status_code == 400
     data = response.get_json()
@@ -144,6 +162,7 @@ def test_search_videos_rejects_non_integer_min_views(client):
 
 
 def test_search_videos_rejects_negative_min_views(client):
+    """Search rejects negative min_views with 400 noting the >= 0 bound."""
     response = client.get("/api/search?q=test&min_views=-1")
     assert response.status_code == 400
     data = response.get_json()
@@ -152,6 +171,7 @@ def test_search_videos_rejects_negative_min_views(client):
 
 
 def test_search_videos_accepts_zero_min_views(client):
+    """min_views=0 is valid and treated as no filter."""
     response = client.get("/api/search?q=nonexistent_query_xyz&min_views=0")
     assert response.status_code == 200
     data = response.get_json()
@@ -159,6 +179,7 @@ def test_search_videos_accepts_zero_min_views(client):
 
 
 def test_search_videos_accepts_positive_min_views(client):
+    """A positive min_views is accepted and echoed in the response filters."""
     response = client.get("/api/search?q=nonexistent_query_xyz&min_views=10")
     assert response.status_code == 200
     data = response.get_json()
@@ -166,6 +187,7 @@ def test_search_videos_accepts_positive_min_views(client):
 
 
 def test_search_videos_accepts_valid_pagination(client):
+    """Valid search pagination returns 200."""
     # Empty results is fine, the point is that pagination parsing passed
     response = client.get("/api/search?q=nonexistent_query_xyz&page=1&per_page=10")
     assert response.status_code == 200
@@ -175,6 +197,7 @@ def test_search_videos_accepts_valid_pagination(client):
 
 
 def test_search_videos_page_validation_runs_before_query_execution(client):
+    """Invalid pagination is caught before the search query runs (fail fast, no wasted work)."""
     # Validation should reject the malformed page param *before* the
     # search-rate-limit is consumed, so a buggy client gets a clear 400
     # instead of a confusing 429.
@@ -187,6 +210,7 @@ def test_search_videos_page_validation_runs_before_query_execution(client):
 
 
 def test_parse_helper_allows_missing_param(app):
+    """The shared int-param parser returns the default when the param is absent."""
     with app.test_request_context("/api/videos"):
         from bottube_server import _parse_positive_int_query
         value, error = _parse_positive_int_query("absent", 7)
@@ -195,6 +219,7 @@ def test_parse_helper_allows_missing_param(app):
 
 
 def test_parse_helper_allows_empty_string(app):
+    """The shared parser treats an empty param value as missing."""
     with app.test_request_context("/api/videos?page="):
         from bottube_server import _parse_positive_int_query
         value, error = _parse_positive_int_query("page", 1)
@@ -203,6 +228,7 @@ def test_parse_helper_allows_empty_string(app):
 
 
 def test_parse_helper_rejects_non_integer(app):
+    """The shared parser rejects non-integer values with an error."""
     with app.test_request_context("/api/videos?page=abc"):
         from bottube_server import _parse_positive_int_query
         value, error = _parse_positive_int_query("page", 1)
@@ -213,6 +239,7 @@ def test_parse_helper_rejects_non_integer(app):
 
 
 def test_parse_helper_enforces_min(app):
+    """The shared parser enforces the configured minimum."""
     with app.test_request_context("/api/videos?page=0"):
         from bottube_server import _parse_positive_int_query
         value, error = _parse_positive_int_query("page", 1)
@@ -221,6 +248,7 @@ def test_parse_helper_enforces_min(app):
 
 
 def test_parse_helper_enforces_max(app):
+    """The shared parser enforces the configured maximum."""
     with app.test_request_context("/api/videos?per_page=999"):
         from bottube_server import _parse_positive_int_query
         value, error = _parse_positive_int_query("per_page", 20, max_value=50)


### PR DESCRIPTION
## Summary
Adds accurate docstrings to all 76 undocumented test functions, fixtures, and helpers across three suites:
- `tests/test_videos_list_query_param_validation.py` (28) — /api/videos + /api/search pagination/filter rejection and acceptance tests
- `tests/test_telegram_bot.py` (24) — model formatting, HTML escaping, API client response-shape handling
- `tests/test_quests.py` (24) — quest unlock/reward idempotency, reward-hold review paths, moderation hold/resolve flows

### Changes Implemented:
- 76 new docstrings; +76/-0 lines, comment-only — zero behavioral change.
- `py_compile` passes on all three files; AST scan confirms 0 undocumented functions remain.
- `pytest` on the three suites → **65 passed, 0 failed**.

### Payout Settlement:
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`