### PR TITLE
docs(tests): add docstrings to 65 test functions (shared-validation, generation-reliability, gemini, tip-split, banano, batch 64)

### DIFF
--- a/tests/test_banano_amount_validation.py
+++ b/tests/test_banano_amount_validation.py
@@ -16,6 +16,7 @@ if not hasattr(werkzeug, "__version__"):
 
 @pytest.fixture
 def ban_client(tmp_path):
+    """Banano blueprint app with an isolated SQLite DB and per-request connection hooks."""
     db_path = tmp_path / "bottube.db"
     app = Flask(__name__)
     app.secret_key = "test-secret-key"
@@ -24,11 +25,13 @@ def ban_client(tmp_path):
 
     @app.before_request
     def before_request():
+        """Open and store the per-request test DB connection."""
         g.db = sqlite3.connect(db_path)
         g.db.row_factory = sqlite3.Row
 
     @app.teardown_request
     def teardown_request(_exc):
+        """Close the per-request test DB connection after each request."""
         db = getattr(g, "db", None)
         if db is not None:
             db.close()
@@ -68,11 +71,13 @@ def ban_client(tmp_path):
 
 
 def _ban_transaction_count(db_path):
+    """Row count of ban_transactions, to assert no write occurred."""
     with sqlite3.connect(db_path) as db:
         return db.execute("SELECT COUNT(*) FROM ban_transactions").fetchone()[0]
 
 
 def test_banano_info_endpoint_is_public(ban_client):
+    """The chain-info endpoint is public and reports the banano chain."""
     response = ban_client.get("/api/banano/info")
 
     assert response.status_code == 200
@@ -86,6 +91,7 @@ def test_banano_info_endpoint_is_public(ban_client):
 
 @pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True, 0, -1])
 def test_ban_tip_rejects_invalid_amounts_without_writes(ban_client, amount):
+    """Invalid tip amounts are rejected with 400 and no transaction is written."""
     before = _ban_transaction_count(ban_client.db_path)
 
     response = ban_client.post("/ban/tip", json={"to_agent": "bob", "amount": amount})
@@ -97,6 +103,7 @@ def test_ban_tip_rejects_invalid_amounts_without_writes(ban_client, amount):
 
 @pytest.mark.parametrize("amount", ["abc", "NaN", "Infinity", True, 0, -1])
 def test_ban_withdraw_rejects_invalid_amounts_without_writes(ban_client, amount):
+    """Invalid withdraw amounts are rejected with 400 and no transaction is written."""
     before = _ban_transaction_count(ban_client.db_path)
 
     response = ban_client.post(
@@ -110,6 +117,7 @@ def test_ban_withdraw_rejects_invalid_amounts_without_writes(ban_client, amount)
 
 
 def test_ban_tip_rejects_non_object_json_body(ban_client):
+    """A non-object tip JSON body is rejected with 400 and no transaction is written."""
     before = _ban_transaction_count(ban_client.db_path)
 
     response = ban_client.post("/ban/tip", json=["not", "an", "object"])
@@ -120,6 +128,7 @@ def test_ban_tip_rejects_non_object_json_body(ban_client):
 
 
 def test_valid_ban_tip_still_records_sender_and_recipient_rows(ban_client):
+    """A well-formed tip still records the sender/recipient transaction rows."""
     response = ban_client.post("/ban/tip", json={"to_agent": "bob", "amount": "1.25"})
 
     assert response.status_code == 200
@@ -142,6 +151,7 @@ def test_valid_ban_tip_still_records_sender_and_recipient_rows(ban_client):
 
 
 def test_ban_video_generation_reward_rejects_non_object_json(ban_client):
+    """A non-object reward body is rejected with 400 and no transaction is written."""
     before = _ban_transaction_count(ban_client.db_path)
 
     response = ban_client.post("/ban/reward-video-gen", json=["not", "an", "object"])
@@ -153,6 +163,7 @@ def test_ban_video_generation_reward_rejects_non_object_json(ban_client):
 
 @pytest.mark.parametrize("field", ["agent_name", "video_id", "gen_method"])
 def test_ban_video_generation_reward_rejects_non_string_fields(ban_client, field):
+    """Non-string reward fields are rejected with 400 and no transaction is written."""
     before = _ban_transaction_count(ban_client.db_path)
     payload = {
         "agent_name": "alice",
@@ -170,6 +181,7 @@ def test_ban_video_generation_reward_rejects_non_string_fields(ban_client, field
 
 @pytest.mark.parametrize("query", ["limit=0", "limit=-1", "offset=-1"])
 def test_ban_transactions_rejects_non_positive_pagination(ban_client, query):
+    """Non-positive transaction pagination is rejected with 400."""
     response = ban_client.get(f"/ban/transactions/alice?{query}")
 
     assert response.status_code == 400
@@ -177,6 +189,7 @@ def test_ban_transactions_rejects_non_positive_pagination(ban_client, query):
 
 
 def test_valid_ban_video_generation_reward_still_records_reward(ban_client):
+    """A well-formed video-generation reward still records the reward transaction."""
     response = ban_client.post(
         "/ban/reward-video-gen",
         json={"agent_name": "alice", "video_id": "video-1", "gen_method": "text"},

--- a/tests/test_bounty_2161_collab_tip_split.py
+++ b/tests/test_bounty_2161_collab_tip_split.py
@@ -24,6 +24,7 @@ def _live():
 
 
 def _conn():
+    """A direct SQLite connection to the live server DB for seeding/asserts."""
     import os
     server = _live()
     path = str(server.DB_PATH)
@@ -34,6 +35,7 @@ def _conn():
 
 
 def _register(app, name):
+    """Register an agent via the API and return its API key."""
     server = _live()
     client = app.test_client()
     resp = client.post(
@@ -45,6 +47,7 @@ def _register(app, name):
 
 
 def _accept_terms(app, name):
+    """Register an agent and accept ToS, returning the API key."""
     server = _live()
     api_key = _register(app, name)
     client = app.test_client()
@@ -58,6 +61,7 @@ def _accept_terms(app, name):
 
 
 def _set_balance(name, balance):
+    """Set an agent's RTC balance directly."""
     conn = _conn()
     conn.execute(
         "UPDATE agents SET rtc_balance = ? WHERE agent_name = ?",
@@ -68,6 +72,7 @@ def _set_balance(name, balance):
 
 
 def _get_balance(name):
+    """Read an agent's RTC balance directly."""
     conn = _conn()
     row = conn.execute(
         "SELECT rtc_balance FROM agents WHERE agent_name = ?", (name,)
@@ -77,6 +82,7 @@ def _get_balance(name):
 
 
 def _get_id(name):
+    """Read an agent's row id directly."""
     conn = _conn()
     row = conn.execute(
         "SELECT id FROM agents WHERE agent_name = ?", (name,)
@@ -86,6 +92,7 @@ def _get_id(name):
 
 
 def _insert_video_with_collabs(owner_name, collaborator_names, video_id):
+    """Insert a video owned by one agent with the given collaborator ids."""
     owner_id = _get_id(owner_name)
     collab_ids = [_get_id(n) for n in collaborator_names]
     conn = _conn()
@@ -108,6 +115,7 @@ def _insert_video_with_collabs(owner_name, collaborator_names, video_id):
 
 
 def _query(sql, params=()):
+    """Run a read-only SQL query and return the rows."""
     conn = _conn()
     cur = conn.execute(sql, params)
     rows = cur.fetchall()
@@ -119,6 +127,7 @@ class TestCollabTipSplit:
     """Bounty #2161: split-tip behavior on co-uploaded videos."""
 
     def test_tip_with_no_collaborators_full_to_primary(self, app, client):
+        """A tip on a video with no collaborators goes entirely to the primary owner."""
         _accept_terms(app, "test_2161_p_nc")
         tipper_key = _accept_terms(app, "test_2161_t_nc")
         _set_balance("test_2161_p_nc", 0)
@@ -139,6 +148,7 @@ class TestCollabTipSplit:
         assert tips[0][1] == pytest.approx(0.12, abs=1e-6)
 
     def test_tip_with_two_collaborators_splits_evenly(self, app, client):
+        """A tip on a video with two collaborators splits evenly among all three."""
         _accept_terms(app, "test_2161_p_2c")
         _accept_terms(app, "test_2161_ca_2c")
         _accept_terms(app, "test_2161_cb_2c")
@@ -176,6 +186,7 @@ class TestCollabTipSplit:
         assert reasons[_get_id("test_2161_cb_2c")] == "tip_split_collab"
 
     def test_tip_rounding_diff_to_primary(self, app, client):
+        """Rounding remainder from an even split is assigned to the primary owner."""
         _accept_terms(app, "test_2161_p_r")
         _accept_terms(app, "test_2161_ca_r")
         _accept_terms(app, "test_2161_cb_r")
@@ -205,6 +216,7 @@ class TestCollabTipSplit:
         assert total == pytest.approx(0.10, abs=1e-6)
 
     def test_self_in_collaborators_filtered_out(self, app, client):
+        """A tipper registered as a collaborator on the video is excluded from their own split."""
         _accept_terms(app, "test_2161_p_s")
         _accept_terms(app, "test_2161_ca_s")
         tipper_key = _accept_terms(app, "test_2161_t_s")
@@ -229,6 +241,7 @@ class TestCollabTipSplit:
         assert self_tips[0][0] == 0
 
     def test_insufficient_balance_no_partial_split(self, app, client):
+        """An insufficient tipper balance fails the whole tip with no partial split."""
         _accept_terms(app, "test_2161_p_ib")
         _accept_terms(app, "test_2161_ca_ib")
         tipper_key = _accept_terms(app, "test_2161_t_ib")

--- a/tests/test_gemini_request_validation.py
+++ b/tests/test_gemini_request_validation.py
@@ -16,6 +16,7 @@ if not hasattr(werkzeug, "__version__"):
 
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
+    """Gemini app with an isolated test DB, wired get_db, and a seeded agent."""
     db_path = tmp_path / "gemini.db"
     conn = sqlite3.connect(str(db_path))
     conn.executescript(
@@ -39,6 +40,7 @@ def client(tmp_path, monkeypatch):
     app.register_blueprint(gemini_blueprint.gemini_bp)
 
     def _test_get_db():
+        """Per-test SQLite connection swapped in for the blueprint's get_db."""
         if "test_db" in g:
             return g.test_db
         db = sqlite3.connect(str(db_path))
@@ -48,6 +50,7 @@ def client(tmp_path, monkeypatch):
 
     @app.teardown_appcontext
     def _close_db(_exc):
+        """Close the per-request test connection on teardown."""
         db = g.pop("test_db", None)
         if db is not None:
             db.close()
@@ -74,15 +77,18 @@ def client(tmp_path, monkeypatch):
 
 
 def _auth_headers():
+    """X-API-Key headers for the seeded test agent."""
     return {"X-API-Key": "bottube_sk_gemini_agent"}
 
 
 def _job_count(db_path):
+    """Row count of gemini_jobs, to assert no job was created."""
     with sqlite3.connect(str(db_path)) as db:
         return db.execute("SELECT COUNT(*) FROM gemini_jobs").fetchone()[0]
 
 
 def _insert_jobs(db_path, count):
+    """Insert N gemini_jobs rows directly."""
     with sqlite3.connect(str(db_path)) as db:
         for idx in range(count):
             db.execute(
@@ -97,6 +103,7 @@ def _insert_jobs(db_path, count):
 
 
 def test_authenticated_video_rejects_non_object_json_without_job(client):
+    """A non-object generate-video body is rejected with 400 and no job is created."""
     resp = client.post(
         "/api/gemini/generate-video",
         json=["not", "an", "object"],
@@ -109,6 +116,7 @@ def test_authenticated_video_rejects_non_object_json_without_job(client):
 
 
 def test_authenticated_video_rejects_non_string_prompt_without_job(client):
+    """A non-string video prompt is rejected with 400 and no job is created."""
     resp = client.post(
         "/api/gemini/generate-video",
         json={"prompt": ["draw this"]},
@@ -121,6 +129,7 @@ def test_authenticated_video_rejects_non_string_prompt_without_job(client):
 
 
 def test_authenticated_video_rejects_non_string_negative_prompt_without_job(client):
+    """A non-string negative_prompt is rejected with 400 and no job is created."""
     resp = client.post(
         "/api/gemini/generate-video",
         json={"prompt": "draw this", "negative_prompt": ["bad"]},
@@ -133,6 +142,7 @@ def test_authenticated_video_rejects_non_string_negative_prompt_without_job(clie
 
 
 def test_authenticated_image_rejects_non_string_prompt_before_generation(client):
+    """A non-string image prompt is rejected before any generation work."""
     resp = client.post(
         "/api/gemini/generate-image",
         json={"prompt": {"text": "draw this"}},
@@ -145,6 +155,7 @@ def test_authenticated_image_rejects_non_string_prompt_before_generation(client)
 
 
 def test_jobs_rejects_malformed_limit(client):
+    """A non-integer jobs limit is rejected with 400."""
     resp = client.get("/api/gemini/jobs?limit=not-an-int", headers=_auth_headers())
 
     assert resp.status_code == 400
@@ -152,6 +163,7 @@ def test_jobs_rejects_malformed_limit(client):
 
 
 def test_jobs_clamps_limit(client):
+    """A zero/out-of-range jobs limit is clamped to a safe bound."""
     _insert_jobs(client.db_path, 60)
 
     resp = client.get("/api/gemini/jobs?limit=0", headers=_auth_headers())
@@ -184,6 +196,7 @@ def test_jobs_clamps_limit(client):
 def test_free_gemini_routes_reject_malformed_json_without_quota_or_job(
     client, path, payload, expected_error
 ):
+    """Free Gemini routes reject malformed JSON without touching quota or creating jobs."""
     resp = client.post(path, json=payload)
 
     assert resp.status_code == 400

--- a/tests/test_generation_reliability.py
+++ b/tests/test_generation_reliability.py
@@ -4,6 +4,7 @@ from generation.reliability import RetryPolicy, classify_error, provider_metrics
 
 
 def test_classify_error_categories():
+    """classify_error maps auth/throttle/transient/permanent markers to their categories."""
     assert classify_error("401 unauthorized api key") == "auth"
     assert classify_error("429 rate limit exceeded") == "throttled"
     assert classify_error(TimeoutError("request timed out")) == "transient"
@@ -11,9 +12,11 @@ def test_classify_error_categories():
 
 
 def test_run_with_retries_retries_transient_then_succeeds():
+    """A transient failure is retried and the run succeeds on a later attempt."""
     calls = {"count": 0}
 
     def flaky():
+        """Callable that raises transiently for the first attempt then succeeds."""
         calls["count"] += 1
         if calls["count"] < 2:
             raise TimeoutError("temporary provider timeout")
@@ -37,9 +40,11 @@ def test_run_with_retries_retries_transient_then_succeeds():
 
 
 def test_run_with_retries_does_not_retry_auth_errors():
+    """Auth errors are not retried; the run fails immediately in the auth category."""
     calls = {"count": 0}
 
     def auth_failure():
+        """Callable that always raises an auth-classified error."""
         calls["count"] += 1
         raise RuntimeError("403 forbidden: invalid API key")
 
@@ -62,6 +67,7 @@ def test_run_with_retries_does_not_retry_auth_errors():
 
 
 def test_run_with_retries_records_semantic_false_result_as_failure():
+    """A (False, reason) result is recorded as a semantic failure rather than success."""
     ok, value, category, latency_s, attempts = run_with_retries(
         "unit_provider_semantic_false",
         "submit",
@@ -82,11 +88,14 @@ def test_run_with_retries_records_semantic_false_result_as_failure():
 
 
 def test_run_with_retries_classifies_semantic_failure_reason_not_tuple_repr():
+    """The semantic failure reason is used for classification, not the tuple repr."""
     class NoisyFalse:
         def __bool__(self):
+            """Falsy value that prevents the tuple itself from being truthy."""
             return False
 
         def __repr__(self):
+            """Readable repr carrying the classification marker ('api key noise')."""
             return "api key noise"
 
     ok, value, category, latency_s, attempts = run_with_retries(
@@ -105,9 +114,11 @@ def test_run_with_retries_classifies_semantic_failure_reason_not_tuple_repr():
 
 
 def test_run_with_retries_latency_includes_semantic_retry_sleep():
+    """Latency accounts for the sleep before a semantic retry, not just the exceptions."""
     calls = {"count": 0}
 
     def semantic_then_permanent():
+        """Callable returning a semantic failure first, then a permanent one."""
         calls["count"] += 1
         if calls["count"] == 1:
             return (False, "quota exhausted")
@@ -129,9 +140,11 @@ def test_run_with_retries_latency_includes_semantic_retry_sleep():
 
 
 def test_run_with_retries_does_not_reuse_stale_semantic_failure_after_exception():
+    """A stale semantic failure is not reused for classification after a later exception."""
     calls = {"count": 0}
 
     def semantic_then_exception():
+        """Callable returning a semantic failure first, then raising a transient exception."""
         calls["count"] += 1
         if calls["count"] == 1:
             return (False, "quota exhausted")

--- a/tests/test_shared_query_param_validation.py
+++ b/tests/test_shared_query_param_validation.py
@@ -71,6 +71,7 @@ def app(tmp_path, monkeypatch):
 
 
 def _assert_invalid_matrix(client, path, cases):
+    """Assert every (param, value) case across an endpoint returns 400."""
     for param, values in cases.items():
         for value in values:
             response = client.get(path, query_string={param: value})
@@ -83,6 +84,7 @@ def _assert_invalid_matrix(client, path, cases):
 
 
 def _assert_valid_matrix(client, path, cases):
+    """Assert every (param, value) case across an endpoint returns 200."""
     for param, value in cases.items():
         response = client.get(path, query_string={param: value})
         assert response.status_code == 200, (
@@ -92,6 +94,7 @@ def _assert_valid_matrix(client, path, cases):
 
 
 def _insert_related_video(app):
+    """Insert a video row so the related endpoint has a target to resolve."""
     import bottube_server
 
     with app.app_context():
@@ -115,6 +118,7 @@ def _insert_related_video(app):
 
 
 def test_feed_validates_every_reported_parameter(client):
+    """The feed endpoint rejects every invalid value for each pagination parameter."""
     _assert_invalid_matrix(
         client,
         "/api/feed",
@@ -131,6 +135,7 @@ def test_feed_validates_every_reported_parameter(client):
 
 
 def test_feed_accepts_valid_values_and_preserves_defaults(client):
+    """The feed endpoint accepts valid values and keeps defaults unchanged."""
     baseline = client.get("/api/feed")
     assert baseline.status_code == 200
     baseline_body = baseline.get_json()
@@ -156,6 +161,7 @@ def test_feed_accepts_valid_values_and_preserves_defaults(client):
 
 
 def test_trending_validates_limit_days_and_since(client):
+    """Trending rejects invalid limit/days/since values with 400."""
     _assert_invalid_matrix(
         client,
         "/api/trending",
@@ -168,6 +174,7 @@ def test_trending_validates_limit_days_and_since(client):
 
 
 def test_trending_accepts_valid_values_and_preserves_defaults(client):
+    """Trending accepts valid values and preserves its defaults."""
     assert client.get("/api/trending").status_code == 200
     _assert_valid_matrix(
         client,
@@ -181,6 +188,7 @@ def test_trending_accepts_valid_values_and_preserves_defaults(client):
 
 
 def test_videos_validates_page(client):
+    """The videos endpoint rejects invalid page values."""
     _assert_invalid_matrix(
         client,
         "/api/videos",
@@ -191,6 +199,7 @@ def test_videos_validates_page(client):
 
 
 def test_related_validates_limit_before_database_lookup(client):
+    """Related validates limit before touching the DB, so invalid limits 400 even for unknown videos."""
     _assert_invalid_matrix(
         client,
         "/api/videos/not_present/related",
@@ -199,6 +208,7 @@ def test_related_validates_limit_before_database_lookup(client):
 
 
 def test_related_accepts_valid_limit_and_preserves_default(app, client):
+    """Related accepts a valid limit and leaves the default in effect when omitted."""
     _insert_related_video(app)
     path = "/api/videos/shared_validator_video/related"
     assert client.get(path).status_code == 200
@@ -206,6 +216,7 @@ def test_related_accepts_valid_limit_and_preserves_default(app, client):
 
 
 def test_shared_int_parser_covers_default_type_and_bounds():
+    """The shared int parser handles default, type, and min/max bounds."""
     app = Flask(__name__)
 
     with app.test_request_context("/?limit="):
@@ -224,6 +235,7 @@ def test_shared_int_parser_covers_default_type_and_bounds():
 
 
 def test_shared_enum_parser_normalizes_and_names_bad_parameter():
+    """The shared enum parser normalizes case and names the bad parameter in its error."""
     app = Flask(__name__)
 
     with app.test_request_context("/?sort=LATEST"):
@@ -241,6 +253,7 @@ def test_shared_enum_parser_normalizes_and_names_bad_parameter():
 
 
 def test_shared_timestamp_parser_accepts_unix_and_iso_and_rejects_bounds():
+    """The shared timestamp parser accepts unix and ISO values and rejects out-of-range ones."""
     app = Flask(__name__)
 
     with app.test_request_context("/?since=1700000000"):


### PR DESCRIPTION
## Summary
Adds accurate docstrings to all 65 undocumented test functions, fixtures, mocks, and helpers across five suites:
- `tests/test_shared_query_param_validation.py` (13) — cross-endpoint pagination validation matrices, shared int/enum/timestamp parsers
- `tests/test_generation_reliability.py` (13) — error classification, retry policy (transient retry, auth no-retry, semantic failures, latency accounting)
- `tests/test_gemini_request_validation.py` (13) — strict body typing before job creation, jobs limit handling, free-route rejection
- `tests/test_bounty_2161_collab_tip_split.py` (13) — collaborative tip split (even split, rounding remainder to primary, self-exclusion, insufficient-balance atomicity)
- `tests/test_banano_amount_validation.py` (13) — BAN tip/withdraw/reward amount typing with no-write assertions

### Changes Implemented:
- 65 new docstrings; +65/-0 lines, comment-only — zero behavioral change.
- `py_compile` passes on all five files; AST scan confirms 0 undocumented functions remain.
- `pytest` on the five suites → **56 passed, 0 failed**.

### Payout Settlement:
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`