### PR TITLE
fix(chat): validate JSON types on send, ban, and settings routes

### DIFF
--- a/chat_handlers.py
+++ b/chat_handlers.py
@@ -5,6 +5,7 @@ Real-time chat for video playback, premieres, super chat, and moderation.
 Uses Flask + Flask-SocketIO, SQLite via get_db(), session/g.user patterns.
 """
 from flask import Blueprint, render_template, request, jsonify, g, session
+import math
 import sqlite3
 import time
 import uuid as _uuid
@@ -67,6 +68,27 @@ def _json_object_body():
     return data, None
 
 
+def _coerce_chat_flag(value, field_name):
+    """Return a safe 0/1 int for chat boolean-like fields."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int) and value in (0, 1):
+        return value
+    return None
+
+
+def _coerce_non_negative_number(value, field_name):
+    """Return a finite non-negative float or None when invalid."""
+    if value is None:
+        return 0.0
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    value = float(value)
+    if not math.isfinite(value) or value < 0:
+        return None
+    return value
+
+
 # ── Routes ──────────────────────────────────────────────────────
 @chat_bp.route("/chat/<video_id>")
 def chat_page(video_id):
@@ -118,8 +140,12 @@ def send_message(video_id):
         return jsonify({"error": "You are banned from this chat"}), 403
 
     msg_id = str(_uuid.uuid4())
-    is_super = int(data.get("is_super", 0))
-    tip = float(data.get("tip_amount", 0))
+    is_super = _coerce_chat_flag(data.get("is_super", 0), "is_super")
+    tip = _coerce_non_negative_number(data.get("tip_amount", 0), "tip_amount")
+    if is_super is None:
+        return jsonify({"error": "is_super must be 0/1 or boolean"}), 400
+    if tip is None:
+        return jsonify({"error": "tip_amount must be a finite non-negative number"}), 400
 
     db.execute(
         "INSERT INTO chat_messages (id, video_id, user_id, username, message, is_super, tip_amount, created_at)"
@@ -135,10 +161,16 @@ def ban_user(video_id):
     """Moderator: ban a user from chat."""
     if not session.get("is_mod"):
         return jsonify({"error": "Moderator only"}), 403
-    data = request.get_json(force=True)
+    data, error = _json_object_body()
+    if error:
+        return error
     db = get_db()
     init_chat_tables(db)
     duration = data.get("duration")  # seconds, None = permanent
+    if duration is not None:
+        duration = _coerce_non_negative_number(duration, "duration")
+        if duration is None:
+            return jsonify({"error": "duration must be a finite non-negative number"}), 400
     expires = time.time() + duration if duration else None
     db.execute(
         "INSERT INTO chat_bans (id, video_id, user_id, banned_by, reason, expires_at, created_at)"
@@ -158,12 +190,23 @@ def chat_settings(video_id):
     if request.method == "POST":
         if not session.get("is_mod"):
             return jsonify({"error": "Moderator only"}), 403
-        data = request.get_json(force=True)
+        data, error = _json_object_body()
+        if error:
+            return error
+        slow_mode = _coerce_chat_flag(data.get("slow_mode", 0), "slow_mode")
+        sub_only = _coerce_chat_flag(data.get("sub_only", 0), "sub_only")
+        premiere = _coerce_chat_flag(data.get("premiere", 0), "premiere")
+        premiere_at = data.get("premiere_at")
+        if slow_mode is None or sub_only is None or premiere is None:
+            return jsonify({"error": "slow_mode, sub_only, and premiere must be 0/1 or boolean"}), 400
+        if premiere_at is not None:
+            premiere_at = _coerce_non_negative_number(premiere_at, "premiere_at")
+            if premiere_at is None:
+                return jsonify({"error": "premiere_at must be a finite non-negative number"}), 400
         db.execute(
             "INSERT OR REPLACE INTO chat_settings (video_id, slow_mode, sub_only, premiere, premiere_at)"
             " VALUES (?,?,?,?,?)",
-            (video_id, int(data.get("slow_mode", 0)), int(data.get("sub_only", 0)),
-             int(data.get("premiere", 0)), data.get("premiere_at")),
+            (video_id, slow_mode, sub_only, premiere, premiere_at),
         )
         db.commit()
         return jsonify({"status": "updated"})

--- a/tests/test_chat_handlers_validation.py
+++ b/tests/test_chat_handlers_validation.py
@@ -62,3 +62,39 @@ def test_send_message_still_records_valid_json_object(chat_client):
     assert resp.status_code == 200
     assert resp.get_json()["status"] == "sent"
     assert _chat_message_count(chat_client.db_path) == 1
+
+
+def test_send_message_rejects_non_finite_tip_without_insert(chat_client):
+    resp = chat_client.post(
+        "/api/chat/video-1/send",
+        json={"username": "Ada", "message": "Hello chat", "tip_amount": float("inf")},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "tip_amount must be a finite non-negative number"}
+    assert _chat_message_count(chat_client.db_path) == 0
+
+
+def test_ban_rejects_non_numeric_duration(chat_client):
+    with chat_client.session_transaction() as sess:
+        sess["is_mod"] = True
+        sess["username"] = "mod"
+    resp = chat_client.post(
+        "/api/chat/video-1/ban",
+        json={"user_id": "user-1", "duration": "forever"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "duration must be a finite non-negative number"}
+
+
+def test_settings_reject_non_boolean_like_flags(chat_client):
+    with chat_client.session_transaction() as sess:
+        sess["is_mod"] = True
+    resp = chat_client.post(
+        "/api/chat/video-1/settings",
+        json={"slow_mode": 2, "sub_only": 0, "premiere": 1},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "slow_mode, sub_only, and premiere must be 0/1 or boolean"}

--- a/tests/test_websocket_server_validation.py
+++ b/tests/test_websocket_server_validation.py
@@ -98,3 +98,59 @@ def test_chat_message_accepts_valid_string_message(monkeypatch, tmp_path):
             ("video-1",),
         ).fetchone()
     assert row == ("hello",)
+
+
+def test_chat_message_rejects_non_finite_tip(monkeypatch):
+    websocket_server, events = _load_websocket_server(monkeypatch)
+    app = Flask(__name__)
+    websocket_server._last_message_time.clear()
+
+    with app.app_context():
+        websocket_server.on_chat_message(
+            {
+                "video_id": "video-1",
+                "username": "alice",
+                "user_id": "user-1",
+                "message": "hello",
+                "tip_amount": float("nan"),
+            }
+        )
+
+    assert events == [
+        (("error", {"message": "tip_amount must be a finite non-negative number"}), {})
+    ]
+
+
+def test_super_chat_rejects_zero_tip(monkeypatch):
+    websocket_server, events = _load_websocket_server(monkeypatch)
+
+    websocket_server.on_super_chat(
+        {
+            "video_id": "video-1",
+            "username": "alice",
+            "user_id": "user-1",
+            "message": "hello",
+            "tip_amount": 0,
+        }
+    )
+
+    assert events == [
+        (("error", {"message": "tip_amount must be a finite positive number"}), {})
+    ]
+
+
+def test_mod_action_timeout_rejects_non_numeric_duration(monkeypatch):
+    websocket_server, events = _load_websocket_server(monkeypatch)
+
+    websocket_server.on_mod_action(
+        {
+            "action": "timeout",
+            "video_id": "video-1",
+            "target_user_id": "user-1",
+            "duration": "later",
+        }
+    )
+
+    assert events == [
+        (("error", {"message": "duration must be a finite non-negative number"}), {})
+    ]

--- a/websocket_server.py
+++ b/websocket_server.py
@@ -5,6 +5,7 @@ Real-time WebSocket events for chat, super chat, and moderation.
 Integrates with Flask-SocketIO.
 """
 from flask_socketio import SocketIO, emit, join_room, leave_room
+import math
 import time
 import uuid as _uuid
 import sqlite3
@@ -28,6 +29,27 @@ def _get_db(app):
     db = sqlite3.connect(app.config.get("CHAT_DB_PATH", "bottube.db"))
     db.row_factory = sqlite3.Row
     return db
+
+
+def _coerce_flag(value):
+    """Return safe 0/1 int from bool/int values or None when invalid."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int) and value in (0, 1):
+        return value
+    return None
+
+
+def _coerce_non_negative_number(value, default=0.0):
+    """Return finite non-negative float or None when invalid."""
+    if value is None:
+        value = default
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    value = float(value)
+    if not math.isfinite(value) or value < 0:
+        return None
+    return value
 
 
 # ── SocketIO Events ────────────────────────────────────────────
@@ -75,6 +97,15 @@ def on_chat_message(data):
         return
     _last_message_time[key] = now
 
+    is_super = _coerce_flag(data.get("is_super", 0))
+    tip = _coerce_non_negative_number(data.get("tip_amount", 0), default=0.0)
+    if is_super is None:
+        emit("error", {"message": "is_super must be 0/1 or boolean"})
+        return
+    if tip is None:
+        emit("error", {"message": "tip_amount must be a finite non-negative number"})
+        return
+
     # Check ban
     db = _get_db(current_app)
     ban = db.execute(
@@ -88,9 +119,6 @@ def on_chat_message(data):
 
     # Save and broadcast
     msg_id = str(_uuid.uuid4())
-    is_super = int(data.get("is_super", 0))
-    tip = float(data.get("tip_amount", 0))
-
     db = _get_db(current_app)
     db.execute(
         "INSERT INTO chat_messages (id, video_id, user_id, username, message, is_super, tip_amount, created_at)"
@@ -114,8 +142,12 @@ def on_chat_message(data):
 @socketio.on("super_chat")
 def on_super_chat(data):
     """Handle super chat (highlighted message with RTC tip)."""
+    tip = _coerce_non_negative_number(data.get("tip_amount", 1), default=1.0)
+    if tip is None or tip <= 0:
+        emit("error", {"message": "tip_amount must be a finite positive number"})
+        return
     data["is_super"] = 1
-    data["tip_amount"] = float(data.get("tip_amount", 1))
+    data["tip_amount"] = tip
     on_chat_message(data)
 
 
@@ -129,6 +161,11 @@ def on_mod_action(data):
     if action == "ban":
         user_id = data.get("target_user_id", "")
         duration = data.get("duration")  # None = permanent
+        if duration is not None:
+            duration = _coerce_non_negative_number(duration, default=0.0)
+            if duration is None:
+                emit("error", {"message": "duration must be a finite non-negative number"})
+                return
         expires = time.time() + duration if duration else None
         db = _get_db(current_app)
         db.execute(
@@ -143,7 +180,11 @@ def on_mod_action(data):
     
     elif action == "timeout":
         user_id = data.get("target_user_id", "")
-        timeout_sec = int(data.get("duration", 300))
+        timeout_sec = _coerce_non_negative_number(data.get("duration", 300), default=300.0)
+        if timeout_sec is None:
+            emit("error", {"message": "duration must be a finite non-negative number"})
+            return
+        timeout_sec = int(timeout_sec)
         key = f"{user_id}:{room}"
         _last_message_time[key] = time.time() + timeout_sec
         emit("system", {"message": f"User timed out for {timeout_sec}s", "type": "timeout"}, room=room)


### PR DESCRIPTION
## Summary
- validate `is_super`, `tip_amount`, moderator `duration`, and chat settings flags before they reach SQLite or float/int coercion
- reject malformed JSON objects on ban/settings routes instead of relying on `force=True` and Python coercion errors
- add regression coverage for REST chat handlers and Socket.IO chat/moderation paths

## Testing
- `pytest -q tests/test_chat_handlers_validation.py tests/test_websocket_server_validation.py`

/claim #1780