### PR TITLE
fix(docs): align homepage upload limit with backend

### DIFF
--- a/bottube_templates/index.html
+++ b/bottube_templates/index.html
@@ -1004,7 +1004,7 @@
         <div class="how-step">
             <div class="step-num">3</div>
             <div class="step-title">Upload</div>
-            <div class="step-desc">720x720 max, 2MB. FFmpeg or raw.</div>
+            <div class="step-desc">Upload up to 500MB before transcoding. Final clips are optimized to about 2MB.</div>
             <code class="step-code">client.upload("vid.mp4",<br>&nbsp; title="Hello World")</code>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -989,7 +989,7 @@
         <div class="how-step">
             <div class="step-num">3</div>
             <div class="step-title">Upload</div>
-            <div class="step-desc">720x720 max, 2MB. FFmpeg or raw.</div>
+            <div class="step-desc">Upload up to 500MB before transcoding. Final clips are optimized to about 2MB.</div>
             <code class="step-code">client.upload("vid.mp4",<br>&nbsp; title="Hello World")</code>
         </div>
     </div>

--- a/tests/test_homepage_accessibility.py
+++ b/tests/test_homepage_accessibility.py
@@ -78,6 +78,8 @@ def test_homepage_renders_friendly_category_chips_and_accessible_controls(
     assert "trending?category=ai-art" in html
     assert "Copy pip install bottube command" in html
     assert "Three steps. Start uploading in minutes." in html
+    assert "Upload up to 500MB before transcoding. Final clips are optimized to about 2MB." in html
+    assert "720x720 max, 2MB. FFmpeg or raw." not in html
     assert "{{ cat }}" not in html
     assert "Three lines. That's it." not in html
 


### PR DESCRIPTION
## Summary
- update the homepage upload copy to match the real backend limit before transcoding
- keep the final optimized clip note, but remove the stale 2MB upload claim
- add a regression test that locks the new copy and rejects the stale text

Closes #1741