### PR TITLE
[TRAVIS] Reject malformed agent notification pagination

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -10818,8 +10818,12 @@ def subscription_feed():
 @require_api_key
 def my_notifications():
     """List notifications for the authenticated agent."""
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    if error:
+        return error
     db = get_db()
     unread_only = request.args.get("unread", "").lower() in ("1", "true", "yes")
     notifications, total = _notification_page(db, int(g.agent["id"]), page, per_page, unread_only)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -170,6 +170,31 @@ def test_notifications_endpoint_paginates_and_returns_links(client):
     assert all(not row["is_read"] for row in unread_body["notifications"])
 
 
+@pytest.mark.parametrize(
+    "query",
+    (
+        "page=abc",
+        "page=0",
+        "page=-1",
+        "page=10001",
+        "per_page=abc",
+        "per_page=0",
+        "per_page=51",
+    ),
+)
+def test_agent_notifications_reject_malformed_pagination(client, query):
+    """Authenticated notification pagination must fail cleanly with HTTP 400."""
+    _insert_agent("api-alice", "bottube_sk_api_alice")
+
+    response = client.get(
+        f"/api/agents/me/notifications?{query}",
+        headers={"X-API-Key": "bottube_sk_api_alice"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"]
+
+
 def test_notification_read_routes_update_unread_count_and_dashboard_bell(client):
     alice_id = _insert_agent("dashalice", "bottube_sk_dashalice")
     _insert_agent("bob", "bottube_sk_bob")


### PR DESCRIPTION
## Summary

- validate `page` and `per_page` on the authenticated agent-notification endpoint with the shared integer-query validator
- return JSON HTTP 400 responses for malformed, zero, negative, and over-bound values instead of silently defaulting, coercing, or clipping them
- cap `page` at 10,000 so deep pagination has a defined bound
- add a focused regression matrix covering all invalid-input classes

Fixes #1831

## Verification

- `C:\Python314\python.exe -m pytest tests/test_notifications.py::test_agent_notifications_reject_malformed_pagination -q --tb=short` — 7 passed
- `C:\Python314\python.exe -m pytest tests/test_notifications.py -q --tb=short` — 9 passed
- `C:\Python314\python.exe -m py_compile bottube_server.py` — passed
- `git diff --check` — passed

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d