### PR TITLE
[TRAVIS] Validate earnings pagination queries

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11658,8 +11658,12 @@ def manage_wallet_web():
 def my_earnings():
     """Get your RTC balance and earnings history."""
     db = get_db()
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(100, max(1, request.args.get("per_page", 50, type=int)))
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 50, max_value=100)
+    if error:
+        return error
     offset = (page - 1) * per_page
 
     rows = db.execute(

--- a/tests/test_earnings_pagination_validation.py
+++ b/tests/test_earnings_pagination_validation.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+def test_earnings_reject_invalid_pagination(client, registered_agent):
+    invalid_queries = (
+        "page=abc",
+        "page=0",
+        "page=-1",
+        "page=10001",
+        "per_page=abc",
+        "per_page=0",
+        "per_page=101",
+    )
+
+    for query in invalid_queries:
+        response = client.get(
+            f"/api/agents/me/earnings?{query}",
+            headers={"X-API-Key": registered_agent["api_key"]},
+        )
+
+        assert response.status_code == 400, query
+        assert response.get_json()["error"], query


### PR DESCRIPTION
## Summary

- validate authenticated earnings `page` and `per_page` query parameters with the shared strict validator
- return structured HTTP 400 responses instead of silently defaulting, coercing, or clipping invalid values
- bound deep pagination at 10,000 pages
- add an authenticated regression matrix for malformed, non-positive, and over-bound values

Fixes #1833

## Verification

- mutation baseline on unmodified `main`: failed as expected (`page=abc` returned 200 instead of 400)
- `C:\Python314\python.exe -m pytest tests/test_earnings_pagination_validation.py -q --tb=short` — 1 passed (7 invalid-input cases)
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_earnings_pagination_validation.py` — passed
- `git diff --check` — passed

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d