### PR TITLE
[TRAVIS] Validate admin duplicate cleanup window

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15083,7 +15083,11 @@ def admin_duplicate_comments():
         return err
 
     dry_run = request.args.get("dry_run", "1") != "0"
-    window_h = request.args.get("window_h", 0, type=int)
+    window_h, error = _parse_positive_int_query(
+        "window_h", 0, min_value=0, max_value=24 * 365,
+    )
+    if error:
+        return error
 
     db = get_db()
 

--- a/tests/test_admin_duplicate_comment_validation.py
+++ b/tests/test_admin_duplicate_comment_validation.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+
+
+def test_duplicate_comment_cleanup_rejects_invalid_window(client, app):
+    admin_key = app.view_functions["admin_duplicate_comments"].__globals__["ADMIN_KEY"]
+
+    for query in ("window_h=abc", "window_h=-1", "window_h=8761"):
+        response = client.get(
+            f"/api/admin/duplicate-comments?{query}",
+            headers={"X-Admin-Key": admin_key},
+        )
+
+        assert response.status_code == 400, query
+        assert response.get_json()["error"], query
+
+    valid = client.get(
+        "/api/admin/duplicate-comments?window_h=24",
+        headers={"X-Admin-Key": admin_key},
+    )
+    assert valid.status_code == 200
+    assert valid.get_json()["dry_run"] is True
+
+    unauthorized = client.get("/api/admin/duplicate-comments?window_h=abc")
+    assert unauthorized.status_code == 403


### PR DESCRIPTION
## Summary

- strictly validate the admin duplicate-comment cleanup `window_h` parameter after authorization
- preserve explicit `window_h=0` as all history while rejecting malformed, negative, and over-bound values
- prevent a typo from silently widening a bounded cleanup into an all-history query/deletion
- cover invalid input, valid bounded dry-run behavior, and unauthenticated denial

Fixes #1835

## Verification

- mutation baseline on unmodified `main`: failed as expected (`window_h=abc` returned 200 instead of 400)
- `C:\Python314\python.exe -m pytest tests/test_admin_duplicate_comment_validation.py -q --tb=short` — 1 passed
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_admin_duplicate_comment_validation.py` — passed
- `git diff --check` — passed

No production cleanup was executed.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d