### PR TITLE
[TRAVIS] Validate video-tip pagination queries

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -12100,8 +12100,12 @@ def get_video_tips(video_id):
     if not v:
         return jsonify({"error": "Video not found"}), 404
     _sync_pending_tips(db)
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 10, type=int)))
+    page, error = _parse_positive_int_query("page", 1)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 10, max_value=50)
+    if error:
+        return error
     offset = (page - 1) * per_page
     # An astronomically large ?page makes offset exceed SQLite's signed 64-bit
     # INTEGER range, which raises OperationalError on "LIMIT ? OFFSET ?" and

--- a/tests/test_video_tips_page_offset_overflow.py
+++ b/tests/test_video_tips_page_offset_overflow.py
@@ -73,3 +73,21 @@ def test_tips_large_but_safe_page_ok(app, client):
     _make_video(app)
     resp = client.get(f"/api/videos/{_VIDEO_ID}/tips?page=1000000000")
     assert resp.status_code == 200
+
+
+def test_tips_reject_invalid_pagination_values(app, client):
+    """Malformed and out-of-range values must not be silently coerced."""
+    _make_video(app)
+
+    for query in (
+        "page=abc",
+        "page=0",
+        "page=-1",
+        "per_page=abc",
+        "per_page=0",
+        "per_page=51",
+    ):
+        response = client.get(f"/api/videos/{_VIDEO_ID}/tips?{query}")
+
+        assert response.status_code == 400, query
+        assert response.get_json()["error"], query


### PR DESCRIPTION
## Summary

- strictly validate public video-tip `page` and `per_page` query parameters
- return structured HTTP 400 responses instead of silently defaulting, coercing, or clipping invalid values
- preserve the existing large-but-safe page behavior and SQLite offset-overflow guard from #1461
- extend the existing overflow regression suite with six malformed/range cases

Fixes #1837

## Verification

- mutation baseline on unmodified `main`: failed as expected (`page=abc` returned 200 instead of 400)
- `C:\Python314\python.exe -m pytest tests/test_video_tips_page_offset_overflow.py -q --tb=short` — 5 passed
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_video_tips_page_offset_overflow.py` — passed
- `git diff --check` — passed

No production data was modified.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d