### PR TITLE
[TRAVIS] Validate admin comment cleanup JSON

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15161,10 +15161,25 @@ def admin_comment_cleanup():
     if err:
         return err
 
-    data = request.get_json(silent=True) or {}
+    data, error = _json_object_body()
+    if error:
+        return error
+
     remove_dupes = data.get("remove_dupes", True)
+    if not isinstance(remove_dupes, bool):
+        return jsonify({"error": "remove_dupes must be a boolean"}), 400
+
+    force_remove = data.get("force_remove", False)
+    if not isinstance(force_remove, bool):
+        return jsonify({"error": "force_remove must be a boolean"}), 400
+
     max_similar = data.get("max_similar", 3)
-    force_remove = bool(data.get("force_remove", False))
+    if (
+        isinstance(max_similar, bool)
+        or not isinstance(max_similar, int)
+        or not 0 <= max_similar <= 100
+    ):
+        return jsonify({"error": "max_similar must be an integer between 0 and 100"}), 400
 
     db = get_db()
     held_dupes = 0

--- a/tests/test_admin_comment_cleanup_json_validation.py
+++ b/tests/test_admin_comment_cleanup_json_validation.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+
+
+def test_comment_cleanup_rejects_ambiguous_json_types(client, app):
+    admin_key = app.view_functions["admin_comment_cleanup"].__globals__["ADMIN_KEY"]
+    headers = {"X-Admin-Key": admin_key}
+    invalid_payloads = (
+        {"force_remove": "false", "remove_dupes": False, "max_similar": 0},
+        {"force_remove": 1},
+        {"remove_dupes": "false"},
+        {"max_similar": "3"},
+        {"max_similar": True},
+        {"max_similar": -1},
+        {"max_similar": 101},
+        [],
+    )
+
+    for payload in invalid_payloads:
+        response = client.post(
+            "/api/admin/comment-cleanup",
+            headers=headers,
+            json=payload,
+        )
+
+        assert response.status_code == 400, payload
+        assert response.get_json()["error"], payload
+
+    valid = client.post(
+        "/api/admin/comment-cleanup",
+        headers=headers,
+        json={"force_remove": False, "remove_dupes": True, "max_similar": 3},
+    )
+    assert valid.status_code == 200
+    assert valid.get_json()["mode"] == "coach_and_hold"
+
+    unauthorized = client.post(
+        "/api/admin/comment-cleanup",
+        json={"force_remove": "false"},
+    )
+    assert unauthorized.status_code == 403


### PR DESCRIPTION
## Summary

- require an object JSON body before admin comment-cleanup processing
- require actual JSON booleans for `remove_dupes` and `force_remove` so string `"false"` cannot enable deletion
- require a non-boolean integer from 0 through 100 for `max_similar`
- preserve valid coach-and-hold behavior and authorization ordering
- add invalid-type, valid-path, and unauthorized regression coverage

Fixes #1839

## Verification

- mutation baseline on unmodified `main`: failed as expected (`"force_remove":"false"` returned 200 in `force_remove` mode)
- `C:\Python314\python.exe -m pytest tests/test_admin_comment_cleanup_json_validation.py -q --tb=short` — 1 passed (8 invalid payloads + valid + unauthorized)
- `C:\Python314\python.exe -m pytest tests/test_quests.py::test_comment_cleanup_defaults_to_hold_without_deleting -q --tb=short` — 1 passed
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_admin_comment_cleanup_json_validation.py` — passed
- `git diff --check` — passed

No production cleanup was executed.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d