### PR TITLE
[TRAVIS] Validate bulk notification read JSON

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -4111,6 +4111,25 @@ def _mark_notification_rows_read(db, agent_id: int, notification_ids=None, mark_
     return int(cur.rowcount or 0)
 
 
+def _notification_read_options(data):
+    """Validate notification read selection without truthy coercion."""
+    mark_all = data.get("all", False)
+    if not isinstance(mark_all, bool):
+        return None, None, (jsonify({"error": "all must be a boolean"}), 400)
+
+    notification_ids = data.get("ids", [])
+    if not isinstance(notification_ids, list):
+        return None, None, (jsonify({"error": "ids must be an array of positive integers"}), 400)
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value <= 0
+        for value in notification_ids
+    ):
+        return None, None, (jsonify({"error": "ids must be an array of positive integers"}), 400)
+    if mark_all and notification_ids:
+        return None, None, (jsonify({"error": "all and ids are mutually exclusive"}), 400)
+    return notification_ids, mark_all, None
+
+
 def _canonical_webhook_event(event: str) -> str:
     mapping = {
         "new_video": "video.uploaded",
@@ -10846,11 +10865,14 @@ def mark_notifications_read():
     data, error = _json_object_body()
     if error:
         return error
+    notification_ids, mark_all, error = _notification_read_options(data)
+    if error:
+        return error
     updated = _mark_notification_rows_read(
         db,
         int(g.agent["id"]),
-        notification_ids=data.get("ids", []),
-        mark_all=bool(data.get("all")),
+        notification_ids=notification_ids,
+        mark_all=mark_all,
     )
     db.commit()
     return jsonify({"ok": True, "updated": updated})
@@ -10908,11 +10930,14 @@ def web_mark_read():
     data, error = _json_object_body()
     if error:
         return error
+    notification_ids, mark_all, error = _notification_read_options(data)
+    if error:
+        return error
     updated = _mark_notification_rows_read(
         db,
         int(g.user["id"]),
-        notification_ids=data.get("ids", []),
-        mark_all=bool(data.get("all")),
+        notification_ids=notification_ids,
+        mark_all=mark_all,
     )
     db.commit()
     return jsonify({"ok": True, "updated": updated})

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -227,3 +227,35 @@ def test_notification_read_routes_update_unread_count_and_dashboard_bell(client)
     html = dashboard.get_data(as_text=True)
     assert 'id="bell-btn"' in html
     assert 'id="notif-badge"' in html
+
+
+def test_notification_read_routes_reject_string_false_without_marking_all(client):
+    alice_id = _insert_agent("strictread", "bottube_sk_strictread")
+    _insert_notification(alice_id, "comment", "first unread")
+    _insert_notification(alice_id, "comment", "second unread")
+
+    agent_response = client.post(
+        "/api/agents/me/notifications/read",
+        headers={"X-API-Key": "bottube_sk_strictread"},
+        json={"all": "false"},
+    )
+    assert agent_response.status_code == 400
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        assert bottube_server._notification_unread_count(db, alice_id) == 2
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = alice_id
+        sess["csrf_token"] = "strict-read-csrf"
+
+    web_response = client.post(
+        "/api/notifications/read",
+        headers={"X-CSRF-Token": "strict-read-csrf"},
+        json={"all": "false"},
+    )
+    assert web_response.status_code == 400
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        assert bottube_server._notification_unread_count(db, alice_id) == 2


### PR DESCRIPTION
## Summary

- validate bulk notification read selection for both API-key and browser/session routes
- require a real JSON boolean for `all`, so string `"false"` cannot mark the entire inbox read
- require `ids` to be an array of positive integers and reject conflicting `all` + `ids`
- share one validation contract across both interfaces
- prove invalid requests leave unread state unchanged while preserving valid read flows, auth, and CSRF

Fixes #1841

## Verification

- mutation baseline on unmodified `main`: failed as expected (`{"all":"false"}` returned 200 and selected mark-all)
- `C:\Python314\python.exe -m pytest tests/test_notifications.py -q --tb=short` — 3 passed
- `C:\Python314\python.exe -m pytest tests/test_authenticated_json_object_validation.py -q --tb=short` — 2 passed
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_notifications.py` — passed
- `git diff --check` — passed

Running the two test files in one pytest process also passed every assertion but hit an unrelated existing Windows temporary-DB teardown lock; each file passes cleanly in isolation as shown above. No production notification state was modified.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d