### PR TITLE
[TRAVIS] Guard HTML search offset overflow

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14026,6 +14026,9 @@ def search_page():
     except (TypeError, ValueError):
         page = 1
     per_page = 24
+    offset = (page - 1) * per_page
+    if offset > _SQLITE_MAX_INT64:
+        return jsonify({"error": "page out of range"}), 400
     # Category checkboxes submit repeated ?cat=<id> params.
     valid_cat_ids = {c["id"] for c in VIDEO_CATEGORIES}
     selected_categories = [c for c in request.args.getlist("cat") if c in valid_cat_ids]
@@ -14055,7 +14058,7 @@ def search_page():
                WHERE {where}
                ORDER BY v.views DESC, v.created_at DESC
                LIMIT ? OFFSET ?""",
-            params + [per_page, (page - 1) * per_page],
+            params + [per_page, offset],
         ).fetchall()
 
     pages = max(1, (total + per_page - 1) // per_page)

--- a/tests/test_search_html_page_offset_overflow.py
+++ b/tests/test_search_html_page_offset_overflow.py
@@ -1,0 +1,14 @@
+"""Regression coverage for the HTML search page pagination boundary."""
+
+
+def test_search_page_rejects_offset_above_sqlite_integer_range(client):
+    response = client.get("/search?q=video&page=9223372036854775807")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "page out of range"}
+
+
+def test_search_page_allows_large_safe_page(client):
+    response = client.get("/search?q=video&page=1000000000")
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

- calculate the user-facing search offset once and reject values above SQLite's signed 64-bit integer range
- return a clear HTTP 400 response instead of allowing an `OverflowError` to surface as HTTP 500
- preserve large-but-safe pagination and normal search-page rendering
- add focused boundary regression coverage

Fixes #1845

## Verification

- mutation baseline on unmodified `main`: oversized page raised `OverflowError: Python int too large to convert to SQLite INTEGER` (1 failed, 1 passed)
- `C:\Python314\python.exe -m pytest -q tests/test_search_html_page_offset_overflow.py tests/test_discoverability.py::TestSearchPageUI::test_search_page_renders` — 3 passed
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_search_html_page_offset_overflow.py` — passed
- `git diff --check` — passed

The mutation and regression tests used the repository's isolated temporary database fixture. No production data was modified.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d