### PR TITLE
[TRAVIS] Guard agent-directory offset overflow

### DIFF
--- a/agent_discovery.py
+++ b/agent_discovery.py
@@ -22,6 +22,8 @@ from flask import Blueprint, Response, current_app, jsonify, request
 
 discovery_bp = Blueprint("agent_discovery", __name__)
 
+_SQLITE_MAX_INT64 = (1 << 63) - 1
+
 
 def _parse_agent_directory_int(name: str, default: int, min_value: int, max_value: int | None = None) -> int:
     """Parse an integer query parameter with bounds checking.
@@ -607,6 +609,8 @@ def api_agents_directory():
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
     offset = (page - 1) * limit
+    if offset > _SQLITE_MAX_INT64:
+        return jsonify({"error": "page out of range"}), 400
 
     # Build query
     where_clauses = ["COALESCE(a.is_banned, 0) = 0"]

--- a/tests/test_agent_directory_offset_overflow.py
+++ b/tests/test_agent_directory_offset_overflow.py
@@ -1,0 +1,14 @@
+"""Regression coverage for agent-directory pagination boundaries."""
+
+
+def test_agent_directory_rejects_offset_above_sqlite_integer_range(client):
+    response = client.get("/api/agents?page=9223372036854775807&limit=100")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "page out of range"}
+
+
+def test_agent_directory_allows_large_safe_page(client):
+    response = client.get("/api/agents?page=1000000000&limit=100")
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

- guard the public agent-directory `OFFSET` against values above SQLite's signed 64-bit integer range
- return a structured HTTP 400 response instead of exposing an `OverflowError` as HTTP 500
- preserve existing malformed-input validation and large-but-safe pages
- add real-database boundary regression coverage

Fixes #1847

## Verification

- mutation baseline on unmodified `main`: oversized page raised `OverflowError: Python int too large to convert to SQLite INTEGER` (1 failed, 1 passed)
- `C:\Python314\python.exe -m pytest -q tests/test_agent_directory_offset_overflow.py tests/test_agent_directory_query_validation.py` — 14 passed
- `C:\Python314\python.exe -m py_compile agent_discovery.py tests/test_agent_directory_offset_overflow.py` — passed
- `git diff --check` — passed

All tests used isolated fake or temporary databases. No production data was modified.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d