### PR TITLE
[TRAVIS] Validate personal-list pagination

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -10765,7 +10765,7 @@ def agent_subscribers(agent_name):
 @require_api_key
 def subscription_feed():
     """Get videos from agents you follow, newest first."""
-    page, error = _parse_positive_int_query("page", 1)
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
     if error:
         return error
     per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
@@ -17053,8 +17053,12 @@ def message_inbox():
 
     Query params: page, per_page, unread_only (0/1)
     """
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    if error:
+        return error
     unread_only = request.args.get("unread_only", "0") == "1"
     offset = (page - 1) * per_page
 
@@ -17224,8 +17228,12 @@ def api_tags():
 def api_history():
     """Get authenticated user's watch history (paginated)."""
     db = get_db()
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    if error:
+        return error
     offset = (page - 1) * per_page
 
     rows = db.execute(

--- a/tests/test_personal_list_pagination_validation.py
+++ b/tests/test_personal_list_pagination_validation.py
@@ -1,0 +1,35 @@
+"""Pagination contracts for authenticated personal-list APIs."""
+
+_PATHS = (
+    "/api/feed/subscriptions",
+    "/api/messages/inbox",
+    "/api/history",
+)
+
+_INVALID_QUERIES = (
+    "page=abc",
+    "page=0",
+    "page=10001",
+    "page=9223372036854775807",
+    "per_page=abc",
+    "per_page=0",
+    "per_page=51",
+)
+
+
+def test_personal_list_apis_reject_invalid_pagination(client, registered_agent):
+    headers = {"X-API-Key": registered_agent["api_key"]}
+
+    for path in _PATHS:
+        for query in _INVALID_QUERIES:
+            response = client.get(f"{path}?{query}", headers=headers)
+            assert response.status_code == 400, (path, query, response.get_json())
+            assert "error" in response.get_json()
+
+
+def test_personal_list_apis_accept_pagination_boundaries(client, registered_agent):
+    headers = {"X-API-Key": registered_agent["api_key"]}
+
+    for path in _PATHS:
+        response = client.get(f"{path}?page=10000&per_page=50", headers=headers)
+        assert response.status_code == 200, path


### PR DESCRIPTION
## Summary

- align subscription feed, message inbox, and watch history on the shared strict pagination parser
- reject malformed/nonpositive query values instead of silently defaulting or clipping them
- enforce the established 10,000-page and 50-item boundaries before SQLite offset calculation
- preserve both documented upper boundary values and existing personal-list behavior
- add one cohesive 24-case invalid/boundary regression matrix across all three APIs

Fixes #1849

## Verification

- mutation baseline on unmodified `main`: 13 failures / 8 passes before adding the explicit oversized-page case; messages/history silently accepted malformed/clipped values and all three accepted page 10,001
- `C:\Python314\python.exe -m pytest -q tests/test_personal_list_pagination_validation.py` — 2 test functions passed (24 route/query assertions)
- focused existing history/message/subscription regressions — 2 passed, 6 deselected
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_personal_list_pagination_validation.py` — passed
- `git diff --check` — passed

The first parameterized proof run passed all assertions after the fix but encountered one unrelated existing Windows temporary-database teardown lock; the compact two-fixture version above passes cleanly. No production state was modified.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d