### PR TITLE
[TRAVIS] Validate playlist field contracts

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -10936,6 +10936,28 @@ def web_mark_single_notification_read(notification_id: int):
 # Playlists (API + Web)
 # ---------------------------------------------------------------------------
 
+
+def _playlist_text_field(data, field, *, default="", max_length, required=False):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, f"{field} must be a string"
+    value = value.strip()[:max_length]
+    if required and not value:
+        return None, f"{field} is required"
+    return value, None
+
+
+def _playlist_visibility(data, *, default="public"):
+    value = data.get("visibility", default)
+    if not isinstance(value, str):
+        return None, "visibility must be a string"
+    if value not in ("public", "unlisted", "private"):
+        return None, "visibility must be one of: public, unlisted, private"
+    return value, None
+
+
 @app.route("/api/playlists", methods=["POST"])
 @require_api_key
 def api_create_playlist():
@@ -10943,13 +10965,15 @@ def api_create_playlist():
     data, error = _json_object_body()
     if error:
         return error
-    title = str(data.get("title", "")).strip()[:200]
-    if not title:
-        return jsonify({"error": "title is required"}), 400
-    description = str(data.get("description", "")).strip()[:2000]
-    visibility = data.get("visibility", "public")
-    if visibility not in ("public", "unlisted", "private"):
-        visibility = "public"
+    title, error = _playlist_text_field(data, "title", max_length=200, required=True)
+    if error:
+        return jsonify({"error": error}), 400
+    description, error = _playlist_text_field(data, "description", max_length=2000)
+    if error:
+        return jsonify({"error": error}), 400
+    visibility, error = _playlist_visibility(data)
+    if error:
+        return jsonify({"error": error}), 400
 
     playlist_id = gen_video_id()
     now = time.time()
@@ -11038,16 +11062,23 @@ def api_update_playlist(playlist_id):
         return error
     sets, vals = [], []
     if "title" in data:
-        title = str(data["title"]).strip()[:200]
-        if title:
-            sets.append("title = ?")
-            vals.append(title)
+        title, error = _playlist_text_field(data, "title", max_length=200, required=True)
+        if error:
+            return jsonify({"error": error}), 400
+        sets.append("title = ?")
+        vals.append(title)
     if "description" in data:
+        description, error = _playlist_text_field(data, "description", max_length=2000)
+        if error:
+            return jsonify({"error": error}), 400
         sets.append("description = ?")
-        vals.append(str(data["description"]).strip()[:2000])
-    if "visibility" in data and data["visibility"] in ("public", "unlisted", "private"):
+        vals.append(description)
+    if "visibility" in data:
+        visibility, error = _playlist_visibility(data)
+        if error:
+            return jsonify({"error": error}), 400
         sets.append("visibility = ?")
-        vals.append(data["visibility"])
+        vals.append(visibility)
 
     if sets:
         sets.append("updated_at = ?")

--- a/tests/test_playlist_field_validation.py
+++ b/tests/test_playlist_field_validation.py
@@ -1,0 +1,64 @@
+"""Regression coverage for playlist field types and enum values."""
+
+
+def _headers(agent):
+    return {"X-API-Key": agent["api_key"]}
+
+
+def test_playlist_create_rejects_invalid_field_types(client, registered_agent):
+    headers = _headers(registered_agent)
+    invalid_payloads = (
+        {"title": {"nested": "title"}},
+        {"title": "Mix", "description": ["nested"]},
+        {"title": "Mix", "visibility": "friends"},
+        {"title": "Mix", "visibility": ["public"]},
+    )
+
+    for payload in invalid_payloads:
+        response = client.post("/api/playlists", headers=headers, json=payload)
+        assert response.status_code == 400, (payload, response.get_json())
+
+
+def test_playlist_patch_rejects_invalid_fields_without_mutation(app, client, registered_agent):
+    headers = _headers(registered_agent)
+    created = client.post(
+        "/api/playlists",
+        headers=headers,
+        json={"title": "Original", "description": "Original body", "visibility": "private"},
+    )
+    assert created.status_code == 201
+    playlist_id = created.get_json()["playlist_id"]
+
+    invalid_payloads = (
+        {"title": {"nested": "title"}},
+        {"description": ["nested"]},
+        {"visibility": "friends"},
+        {"visibility": ["public"]},
+    )
+    for payload in invalid_payloads:
+        response = client.patch(f"/api/playlists/{playlist_id}", headers=headers, json=payload)
+        assert response.status_code == 400, (payload, response.get_json())
+
+    import bottube_server
+
+    with app.app_context():
+        row = bottube_server.get_db().execute(
+            "SELECT title, description, visibility FROM playlists WHERE playlist_id = ?",
+            (playlist_id,),
+        ).fetchone()
+    assert row["title"] == "Original"
+    assert row["description"] == "Original body"
+    assert row["visibility"] == "private"
+
+    valid = client.patch(
+        f"/api/playlists/{playlist_id}",
+        headers=headers,
+        json={"title": "Updated", "description": "Updated body", "visibility": "unlisted"},
+    )
+    assert valid.status_code == 200
+    with app.app_context():
+        row = bottube_server.get_db().execute(
+            "SELECT title, description, visibility FROM playlists WHERE playlist_id = ?",
+            (playlist_id,),
+        ).fetchone()
+    assert tuple(row) == ("Updated", "Updated body", "unlisted")


### PR DESCRIPTION
## Summary

- validate playlist title/description as strings instead of serializing lists or objects into stored text
- validate visibility as exactly one of the documented enum strings instead of silently defaulting/ignoring invalid values
- require a nonempty title on both create and supplied-title updates
- reject malformed PATCH requests before mutation and preserve valid create/update behavior
- add invalid-create, no-mutation, and valid-update regression coverage

Fixes #1851

## Verification

- mutation baseline on unmodified `main`: both new tests failed; structured title returned HTTP 201 and PATCH returned HTTP 200 after accepting it
- `C:\Python314\python.exe -m pytest -q tests/test_playlist_field_validation.py` — 2 passed (4 invalid create cases, 4 invalid/no-mutation patch cases, valid update)
- `C:\Python314\python.exe -m pytest -q tests/test_playlist_field_validation.py tests/test_authenticated_json_object_validation.py::test_playlist_routes_reject_non_object_json` — 3 passed before the final valid-update assertion was added
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_playlist_field_validation.py` — passed
- `git diff --check` — passed

All mutation checks used the repository temporary-database fixture. No production data was modified.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d