### PR TITLE
[TRAVIS] Validate webhook registration fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11402,13 +11402,20 @@ def create_webhook():
     data, error = _json_object_body()
     if error:
         return error
-    url = str(data.get("url", "")).strip()
+    url = data.get("url", "")
+    if not isinstance(url, str):
+        return jsonify({"error": "url must be a string"}), 400
+    url = url.strip()
     if not url or not url.startswith("https://"):
         return jsonify({"error": "url must be a valid HTTPS URL"}), 400
 
     events = data.get("events", "*")
     if isinstance(events, list):
+        if not all(isinstance(event, str) for event in events):
+            return jsonify({"error": "events must contain only strings"}), 400
         events = ",".join(events)
+    elif not isinstance(events, str):
+        return jsonify({"error": "events must be a string or array of strings"}), 400
     # Validate event names
     for ev in events.split(","):
         ev = ev.strip()

--- a/tests/test_webhook_field_validation.py
+++ b/tests/test_webhook_field_validation.py
@@ -1,0 +1,44 @@
+"""Regression coverage for webhook registration field contracts."""
+
+
+def test_webhook_registration_rejects_structured_fields_before_insert(app, client, registered_agent):
+    headers = {"X-API-Key": registered_agent["api_key"]}
+    invalid_payloads = (
+        {"url": {"href": "https://example.com/hook"}},
+        {"url": "https://example.com/hook", "events": {"name": "video.uploaded"}},
+        {"url": "https://example.com/hook", "events": 7},
+        {"url": "https://example.com/hook", "events": ["video.uploaded", 7]},
+    )
+
+    for payload in invalid_payloads:
+        response = client.post("/api/webhooks", headers=headers, json=payload)
+        assert response.status_code == 400, (payload, response.get_json())
+
+    import bottube_server
+
+    with app.app_context():
+        count = bottube_server.get_db().execute(
+            "SELECT COUNT(*) FROM webhooks WHERE agent_id = (SELECT id FROM agents WHERE agent_name = ?)",
+            (registered_agent["agent_name"],),
+        ).fetchone()[0]
+    assert count == 0
+
+
+def test_webhook_registration_preserves_string_and_string_list_events(client, registered_agent):
+    headers = {"X-API-Key": registered_agent["api_key"]}
+
+    first = client.post(
+        "/api/webhooks",
+        headers=headers,
+        json={"url": "https://example.com/first", "events": "video.uploaded"},
+    )
+    second = client.post(
+        "/api/webhooks",
+        headers=headers,
+        json={"url": "https://example.com/second", "events": ["video.uploaded", "comment.created"]},
+    )
+
+    assert first.status_code == 201
+    assert first.get_json()["events"] == "video.uploaded"
+    assert second.status_code == 201
+    assert second.get_json()["events"] == "video.uploaded,comment.created"


### PR DESCRIPTION
## Summary

- require webhook URL input to be a JSON string before applying the existing HTTPS check
- require events to be a string or an array containing strings only
- return structured HTTP 400 responses instead of raising from `split()` or `join()`
- prove every invalid request leaves the webhook table unchanged
- preserve both documented valid event forms

Fixes #1853

## Verification

- mutation baseline on unmodified `main`: object-valued events raised `AttributeError: 'dict' object has no attribute 'split'`; valid controls passed
- `C:\Python314\python.exe -m pytest -q tests/test_webhook_field_validation.py tests/test_authenticated_json_object_validation.py::test_authenticated_utility_routes_reject_non_object_json` — 3 passed
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_webhook_field_validation.py` — passed
- `git diff --check` — passed

Tests used an isolated temporary database and example HTTPS URLs only. No outbound callback or production state was used.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d