### PR TITLE
[TRAVIS] Validate wallet field types

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11581,8 +11581,12 @@ def manage_wallet():
         "paypal": "paypal_email",
     }
 
+    for key in allowed_fields:
+        if key in data and not isinstance(data[key], str):
+            return jsonify({"error": f"{key} must be a string"}), 400
+
     if "rtc_wallet" in data:
-        rtc_wallet = str(data.get("rtc_wallet", "")).strip()
+        rtc_wallet = data["rtc_wallet"].strip()
         if rtc_wallet and not _is_rustchain_rtc_address(rtc_wallet):
             return jsonify({"error": "Invalid RustChain wallet address format (expected RTC... address)"}), 400
 
@@ -11590,7 +11594,7 @@ def manage_wallet():
     params = []
     for key, col in allowed_fields.items():
         if key in data:
-            val = str(data[key]).strip()
+            val = data[key].strip()
             updates.append(f"{col} = ?")
             params.append(val)
 
@@ -11599,7 +11603,7 @@ def manage_wallet():
 
     params.append(g.agent["id"])
     db.execute(f"UPDATE agents SET {', '.join(updates)} WHERE id = ?", params)
-    if str(data.get("rtc_wallet", "")).strip():
+    if data.get("rtc_wallet", "").strip():
         _referral_mark_rtc_native_action(
             db,
             int(g.agent["id"]),

--- a/tests/test_wallet_field_type_validation.py
+++ b/tests/test_wallet_field_type_validation.py
@@ -1,0 +1,40 @@
+"""Regression coverage for payout-wallet field type contracts."""
+
+
+def test_wallet_update_rejects_non_string_fields_without_mutation(client, registered_agent):
+    headers = {"X-API-Key": registered_agent["api_key"]}
+    fields = ("rtc_wallet", "rtc", "btc", "eth", "sol", "ltc", "erg", "paypal")
+
+    for field in fields:
+        response = client.post(
+            "/api/agents/me/wallet",
+            headers=headers,
+            json={field: {"nested": "address"}},
+        )
+        assert response.status_code == 400, (field, response.get_json())
+
+    null_response = client.post(
+        "/api/agents/me/wallet",
+        headers=headers,
+        json={"btc": None},
+    )
+    assert null_response.status_code == 400
+
+    wallet = client.get("/api/agents/me/wallet", headers=headers)
+    assert wallet.status_code == 200
+    assert all(value == "" for value in wallet.get_json()["wallets"].values())
+
+
+def test_wallet_update_preserves_valid_partial_string_updates(client, registered_agent):
+    headers = {"X-API-Key": registered_agent["api_key"]}
+    response = client.post(
+        "/api/agents/me/wallet",
+        headers=headers,
+        json={"btc": "bc1-example", "paypal": "pay@example.com"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["updated_fields"] == ["btc", "paypal"]
+    wallet = client.get("/api/agents/me/wallet", headers=headers).get_json()["wallets"]
+    assert wallet["btc"] == "bc1-example"
+    assert wallet["paypal"] == "pay@example.com"


### PR DESCRIPTION
## Summary

- require every supplied wallet/payout field to be a JSON string before trimming or persistence
- prevent objects, arrays, booleans, and null from being serialized into address columns
- validate all supplied fields before building the update so invalid requests leave wallet state unchanged
- preserve valid partial string updates, empty-string clearing, RTC address validation, and referral activation
- add all-field invalid/no-mutation and valid partial-update regressions

Fixes #1855

## Verification

- mutation baseline on unmodified `main`: structured legacy RTC field returned HTTP 200 and crossed the persistence path
- `C:\Python314\python.exe -m pytest -q tests/test_wallet_field_type_validation.py tests/test_authenticated_json_object_validation.py::test_authenticated_utility_routes_reject_non_object_json` — 3 passed
- `C:\Python314\python.exe -m pytest -q tests/test_referrals.py::test_referral_dashboard_tracks_human_and_agent_funnels` — 1 passed
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_wallet_field_type_validation.py` — passed
- `git diff --check` — passed

Tests used a temporary database and placeholder strings only. No real wallet transaction, payout, or production state was involved.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d