### PR TITLE
[TRAVIS] Validate notification preference booleans

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14571,6 +14571,9 @@ def api_set_notification_preferences():
         "tips": "email_notify_tips",
         "subscriptions": "email_notify_subscriptions",
     }
+    for key in allowed:
+        if key in data and not isinstance(data[key], bool):
+            return jsonify({"error": f"{key} must be a boolean"}), 400
     updated = {}
     for key, col in allowed.items():
         if key in data:

--- a/tests/test_notification_preference_boolean_validation.py
+++ b/tests/test_notification_preference_boolean_validation.py
@@ -1,0 +1,36 @@
+"""Regression coverage for notification preference boolean contracts."""
+
+
+def test_notification_preferences_reject_non_booleans_without_mutation(client, registered_agent):
+    headers = {"X-API-Key": registered_agent["api_key"]}
+    fields = ("comments", "replies", "new_video", "tips", "subscriptions")
+
+    disabled = client.put(
+        "/api/notifications/preferences",
+        headers=headers,
+        json={field: False for field in fields},
+    )
+    assert disabled.status_code == 200
+
+    for field in fields:
+        response = client.put(
+            "/api/notifications/preferences",
+            headers=headers,
+            json={field: "false"},
+        )
+        assert response.status_code == 400, (field, response.get_json())
+
+    preferences = client.get("/api/notifications/preferences", headers=headers).get_json()["preferences"]
+    assert preferences == {field: False for field in fields}
+
+
+def test_notification_preferences_preserve_valid_partial_booleans(client, registered_agent):
+    headers = {"X-API-Key": registered_agent["api_key"]}
+    response = client.put(
+        "/api/notifications/preferences",
+        headers=headers,
+        json={"comments": False, "tips": True},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["updated"] == {"comments": False, "tips": True}


### PR DESCRIPTION
## Summary

- require exact JSON booleans for every supplied email-notification preference
- reject string, numeric, object, and array values before any database update
- prevent string `"false"` from enabling a preference through Python truthiness
- preserve valid partial boolean updates and the existing response contract
- add all-preference no-mutation and valid partial-update regression coverage

Fixes #1857

## Verification

- mutation baseline on unmodified `main`: `{"comments":"false"}` returned HTTP 200 and changed the preference to true
- `C:\Python314\python.exe -m pytest -q tests/test_notification_preference_boolean_validation.py tests/test_authenticated_json_object_validation.py::test_authenticated_utility_routes_reject_non_object_json` — 3 passed
- `C:\Python314\python.exe -m py_compile bottube_server.py tests/test_notification_preference_boolean_validation.py` — passed
- `git diff --check` — passed

Tests used an isolated temporary database. No email was sent and no production state was modified.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d