### PR TITLE
[TRAVIS] Reject earnings pagination beyond SQLite range

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11661,6 +11661,8 @@ def my_earnings():
     page = max(1, request.args.get("page", 1, type=int))
     per_page = min(100, max(1, request.args.get("per_page", 50, type=int)))
     offset = (page - 1) * per_page
+    if offset > _SQLITE_MAX_SIGNED_INT:
+        return jsonify({"error": "page out of range"}), 400
 
     rows = db.execute(
         """SELECT amount, reason, video_id, created_at

--- a/tests/test_earnings_page_offset_overflow.py
+++ b/tests/test_earnings_page_offset_overflow.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for SQLite OFFSET overflow in the earnings ledger."""
+
+
+def _headers(agent):
+    return {"X-API-Key": agent["api_key"]}
+
+
+def test_earnings_rejects_page_whose_offset_exceeds_sqlite_integer(client, registered_agent):
+    response = client.get(
+        "/api/agents/me/earnings?page=9223372036854775807&per_page=100",
+        headers=_headers(registered_agent),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "page out of range"}
+
+
+def test_earnings_allows_largest_page_with_safe_offset(client, registered_agent):
+    max_safe_page = ((2 ** 63 - 1) // 100) + 1
+    response = client.get(
+        f"/api/agents/me/earnings?page={max_safe_page}&per_page=100",
+        headers=_headers(registered_agent),
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["earnings"] == []


### PR DESCRIPTION
Closes #1861

## Problem
`/api/agents/me/earnings` multiplied an unbounded page by `per_page` and bound that result directly as SQLite `OFFSET`. At signed-64-bit page scale this raises `OverflowError` and returns HTTP 500.

## Fix
Reject only calculated offsets beyond SQLite signed-integer range with a clear HTTP 400. The largest safe page and all normal pagination behavior remain unchanged.

## Proof
- mutation baseline: oversized-page regression raised `OverflowError` on unmodified `main`; safe-boundary case passed
- after fix: `2 passed`
- `python -m py_compile bottube_server.py`
- `git diff --check`

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d