### PR TITLE
[TRAVIS] Validate video metadata field types before update

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -6980,10 +6980,23 @@ def update_video(video_id):
     if row['agent_id'] != g.agent['id']:
         return jsonify({'error': 'Not your video'}), 403
     
-    data = request.get_json(silent=True) or {}
+    data, error = _json_object_body()
+    if error:
+        return error
     updates = []
     params = []
-    
+
+    if 'title' in data and not isinstance(data['title'], str):
+        return jsonify({'error': 'title must be a string'}), 400
+    if 'description' in data and not isinstance(data['description'], str):
+        return jsonify({'error': 'description must be a string'}), 400
+    if 'tags' in data:
+        tags = data['tags']
+        if not isinstance(tags, (str, list)) or (
+            isinstance(tags, list) and any(not isinstance(tag, str) for tag in tags)
+        ):
+            return jsonify({'error': 'tags must be a string or an array of strings'}), 400
+
     if 'title' in data and data['title'].strip():
         updates.append('title = ?')
         params.append(data['title'].strip()[:200])
@@ -6992,9 +7005,9 @@ def update_video(video_id):
         params.append(data['description'].strip()[:5000])
     if 'tags' in data:
         if isinstance(data['tags'], list):
-            tag_str = ','.join(t.strip() for t in data['tags'] if t.strip())
+            tag_str = ','.join(tag.strip() for tag in data['tags'] if tag.strip())
         else:
-            tag_str = str(data['tags']).strip()
+            tag_str = data['tags'].strip()
         updates.append('tags = ?')
         params.append(tag_str)
     

--- a/tests/test_video_metadata_json_validation.py
+++ b/tests/test_video_metadata_json_validation.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for structured JSON in video metadata updates."""
+
+import time
+
+import pytest
+
+
+def _insert_video(app, agent_name, video_id="metadata01AB"):
+    with app.app_context():
+        import bottube_server
+
+        db = bottube_server.get_db()
+        agent = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?", (agent_name,)
+        ).fetchone()
+        db.execute(
+            """INSERT INTO videos
+                   (video_id, agent_id, title, description, tags, filename, created_at)
+               VALUES (?, ?, 'Original title', 'Original description', 'one,two', ?, ?)""",
+            (video_id, agent["id"], f"{video_id}.mp4", time.time()),
+        )
+        db.commit()
+    return video_id
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        ({"title": {"nested": "title"}}, "title must be a string"),
+        ({"description": ["structured"]}, "description must be a string"),
+        ({"tags": {"unexpected": "mapping"}}, "tags must be a string or an array of strings"),
+        ({"tags": ["valid", {"unexpected": "item"}]}, "tags must be a string or an array of strings"),
+    ],
+)
+def test_video_metadata_rejects_structured_fields_without_mutation(
+    app, client, registered_agent, payload, expected_error
+):
+    video_id = _insert_video(app, registered_agent["agent_name"])
+
+    response = client.patch(
+        f"/api/videos/{video_id}",
+        headers={"X-API-Key": registered_agent["api_key"]},
+        json=payload,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": expected_error}
+    with app.app_context():
+        import bottube_server
+
+        row = bottube_server.get_db().execute(
+            "SELECT title, description, tags FROM videos WHERE video_id = ?",
+            (video_id,),
+        ).fetchone()
+        assert tuple(row) == ("Original title", "Original description", "one,two")
+
+
+def test_video_metadata_accepts_supported_text_and_tag_array(app, client, registered_agent):
+    video_id = _insert_video(app, registered_agent["agent_name"])
+
+    response = client.patch(
+        f"/api/videos/{video_id}",
+        headers={"X-API-Key": registered_agent["api_key"]},
+        json={
+            "title": "  Revised title  ",
+            "description": "  Revised description  ",
+            "tags": [" first ", "second"],
+        },
+    )
+
+    assert response.status_code == 200
+    with app.app_context():
+        import bottube_server
+
+        row = bottube_server.get_db().execute(
+            "SELECT title, description, tags FROM videos WHERE video_id = ?",
+            (video_id,),
+        ).fetchone()
+        assert tuple(row) == ("Revised title", "Revised description", "first,second")


### PR DESCRIPTION
Closes #1863

## Problem
The video metadata PATCH route called `.strip()` directly on `title`, `description`, and each list item in `tags`. Structured JSON produced HTTP 500, while a tags mapping was silently stringified and stored as corrupt metadata.

## Fix
- require a JSON object body
- require title/description to be strings when supplied
- allow tags only as a string or an array containing only strings
- reject malformed fields before any database mutation
- preserve trimming and supported text/tag-array updates

## Proof
- mutation baseline: 4 malformed-field cases failed on unmodified `main` (three exceptions plus one invalid mutation); valid update control passed
- after fix: `5 passed`
- `python -m py_compile bottube_server.py`
- `git diff --check`

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d