### PR TITLE
[TRAVIS] Bound referral and badge review pagination

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -5871,6 +5871,8 @@ def admin_referrals():
     page = max(1, request.args.get("page", 1, type=int))
     per_page = min(100, max(1, request.args.get("per_page", 20, type=int)))
     offset = (page - 1) * per_page
+    if offset > _SQLITE_MAX_SIGNED_INT:
+        return jsonify({"error": "page out of range"}), 400
 
     where = ["1 = 1"]
     params: list[object] = []
@@ -6080,6 +6082,8 @@ def admin_badges():
     page = max(1, request.args.get("page", 1, type=int))
     per_page = min(100, max(1, request.args.get("per_page", 25, type=int)))
     offset = (page - 1) * per_page
+    if offset > _SQLITE_MAX_SIGNED_INT:
+        return jsonify({"error": "page out of range"}), 400
 
     where = ["1 = 1"]
     params: list[object] = []

--- a/tests/test_admin_review_page_offset_overflow.py
+++ b/tests/test_admin_review_page_offset_overflow.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for SQLite OFFSET overflow in admin review queues."""
+
+import pytest
+
+
+@pytest.mark.parametrize("path", ["/api/admin/referrals", "/api/admin/badges"])
+def test_admin_review_queues_reject_page_beyond_sqlite_range(
+    app, client, monkeypatch, path
+):
+    import bottube_server
+
+    monkeypatch.setattr(bottube_server, "ADMIN_KEY", "test-admin")
+
+    response = client.get(
+        f"{path}?page=9223372036854775807&per_page=100",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "page out of range"}


### PR DESCRIPTION
Closes #1867

## Problem
The referral and badge admin queues bound unbounded page-derived integers directly as SQLite `OFFSET`. Signed-64-bit-scale pages raised `OverflowError` and returned HTTP 500 after successful admin authentication.

## Fix
Return HTTP 400 when either queue calculated offset exceeds SQLite signed-integer range. Normal queue behavior is unchanged.

## Proof
- mutation baseline: both queue regressions raised `OverflowError` on unmodified `main`
- focused regressions: `2 passed`
- existing referral review/export and badge assignment/removal flows: `2 passed`
- `python -m py_compile bottube_server.py`
- `git diff --check`

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d