### PR TITLE
[TRAVIS] Validate cross-post fields before side effects

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -12253,9 +12253,15 @@ def tipper_leaderboard():
 @require_api_key
 def crosspost_moltbook():
     """Cross-post a video link to Moltbook."""
-    data = request.get_json(silent=True) or {}
-    video_id = data.get("video_id", "")
-    submolt = data.get("submolt", "bottube")
+    data, error = _json_object_body()
+    if error:
+        return error
+    if not isinstance(data.get("video_id", ""), str):
+        return jsonify({"error": "video_id must be a string"}), 400
+    if not isinstance(data.get("submolt", "bottube"), str):
+        return jsonify({"error": "submolt must be a string"}), 400
+    video_id = data.get("video_id", "").strip()
+    submolt = data.get("submolt", "bottube").strip()
 
     db = get_db()
     video = db.execute(
@@ -12293,9 +12299,15 @@ def crosspost_x():
     Uses the server's X credentials (from TWITTER_* env vars or .env.twitter).
     Posts: "New on BoTTube: [title] by @agent — [url]"
     """
-    data = request.get_json(silent=True) or {}
-    video_id = data.get("video_id", "")
-    custom_text = data.get("text", "")
+    data, error = _json_object_body()
+    if error:
+        return error
+    if not isinstance(data.get("video_id", ""), str):
+        return jsonify({"error": "video_id must be a string"}), 400
+    if not isinstance(data.get("text", ""), str):
+        return jsonify({"error": "text must be a string"}), 400
+    video_id = data.get("video_id", "").strip()
+    custom_text = data.get("text", "").strip()
 
     db = get_db()
     video = db.execute(

--- a/tests/test_crosspost_json_validation.py
+++ b/tests/test_crosspost_json_validation.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for structured JSON in cross-post requests."""
+
+import time
+
+import pytest
+
+
+def _insert_video(app, agent_name, video_id="crosspost01A"):
+    with app.app_context():
+        import bottube_server
+
+        db = bottube_server.get_db()
+        agent = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?", (agent_name,)
+        ).fetchone()
+        db.execute(
+            """INSERT INTO videos
+                   (video_id, agent_id, title, filename, created_at)
+               VALUES (?, ?, 'Cross-post source', ?, ?)""",
+            (video_id, agent["id"], f"{video_id}.mp4", time.time()),
+        )
+        db.commit()
+    return video_id
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "expected_error"),
+    [
+        ("/api/crosspost/moltbook", ["not", "an", "object"], "JSON body must be an object"),
+        ("/api/crosspost/moltbook", {"video_id": {"nested": "id"}}, "video_id must be a string"),
+        (
+            "/api/crosspost/moltbook",
+            {"video_id": "crosspost01A", "submolt": {"nested": "name"}},
+            "submolt must be a string",
+        ),
+        ("/api/crosspost/x", {"video_id": {"nested": "id"}}, "video_id must be a string"),
+        (
+            "/api/crosspost/x",
+            {"video_id": "crosspost01A", "text": {"nested": "tweet"}},
+            "text must be a string",
+        ),
+    ],
+)
+def test_crosspost_routes_reject_structured_fields_before_side_effects(
+    app, client, registered_agent, monkeypatch, path, payload, expected_error
+):
+    import bottube_server
+
+    _insert_video(app, registered_agent["agent_name"])
+
+    def unexpected_post(_text):
+        raise AssertionError("X client must not run for malformed JSON")
+
+    monkeypatch.setattr(bottube_server, "_post_to_x", unexpected_post)
+    response = client.post(
+        path,
+        headers={"X-API-Key": registered_agent["api_key"]},
+        json=payload,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": expected_error}
+    with app.app_context():
+        assert bottube_server.get_db().execute(
+            "SELECT COUNT(*) FROM crossposts"
+        ).fetchone()[0] == 0
+
+
+def test_supported_crosspost_payloads_preserve_existing_flows(
+    app, client, registered_agent, monkeypatch
+):
+    import bottube_server
+
+    video_id = _insert_video(app, registered_agent["agent_name"])
+    headers = {"X-API-Key": registered_agent["api_key"]}
+    monkeypatch.setattr(bottube_server, "_post_to_x", lambda text: "tweet-123")
+
+    moltbook = client.post(
+        "/api/crosspost/moltbook",
+        headers=headers,
+        json={"video_id": video_id, "submolt": "bottube"},
+    )
+    x_post = client.post(
+        "/api/crosspost/x",
+        headers=headers,
+        json={"video_id": video_id, "text": "A valid announcement"},
+    )
+
+    assert moltbook.status_code == 200
+    assert x_post.status_code == 200
+    assert x_post.get_json()["tweet_id"] == "tweet-123"
+    with app.app_context():
+        rows = bottube_server.get_db().execute(
+            "SELECT platform, external_id FROM crossposts ORDER BY id"
+        ).fetchall()
+        assert [tuple(row) for row in rows] == [
+            ("moltbook", None),
+            ("x", "tweet-123"),
+        ]


### PR DESCRIPTION
Closes #1869

## Problem
Moltbook and X cross-post routes assumed object bodies and scalar strings. Structured values raised server exceptions or reached database/outbound posting side effects.

## Fix
- require object bodies on both routes
- require `video_id`, `submolt`, and custom X `text` to be strings
- normalize supported text before lookup/posting
- reject malformed payloads before database or external effects

## Proof
- mutation baseline: all 5 malformed cases failed on unmodified `main` (three exceptions, one SQLite binding failure after an attempted insert, one outbound adapter call)
- after fix: `6 passed`, including valid Moltbook and mocked-X flow controls
- `python -m py_compile bottube_server.py`
- `git diff --check`

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d