### PR TITLE
[TRAVIS] Validate mood history limit values

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7523,7 +7523,9 @@ def get_mood_history(agent_name):
     if not agent:
         return jsonify({"error": "Agent not found"}), 404
     
-    limit = min(100, max(1, request.args.get("limit", 20, type=int)))
+    limit, error = _parse_positive_int_query("limit", 20, max_value=100)
+    if error:
+        return error
     
     engine = get_mood_engine(str(DB_PATH))
     history = engine.get_mood_history(agent["id"], limit)

--- a/tests/test_mood_history_limit_validation.py
+++ b/tests/test_mood_history_limit_validation.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for the public mood-history ``limit`` parameter."""
+
+import sys
+
+import pytest
+
+
+class _MoodHistoryStub:
+    def __init__(self):
+        self.limits = []
+
+    def get_mood_history(self, _agent_id, limit):
+        self.limits.append(limit)
+        return []
+
+
+@pytest.fixture
+def mood_history(client, registered_agent, monkeypatch):
+    server = sys.modules["bottube_server"]
+    engine = _MoodHistoryStub()
+    monkeypatch.setattr(server, "MOOD_ENGINE_AVAILABLE", True)
+    monkeypatch.setattr(server, "get_mood_engine", lambda _db_path: engine)
+    return registered_agent["agent_name"], engine
+
+
+@pytest.mark.parametrize("raw_limit", ("abc", "0", "101"))
+def test_mood_history_rejects_invalid_limit(client, mood_history, raw_limit):
+    agent_name, engine = mood_history
+
+    response = client.get(f"/api/v1/agents/{agent_name}/mood/history?limit={raw_limit}")
+
+    assert response.status_code == 400
+    assert "limit" in response.get_json()["error"]
+    assert engine.limits == []
+
+
+def test_mood_history_accepts_documented_limit(client, mood_history):
+    agent_name, engine = mood_history
+
+    response = client.get(f"/api/v1/agents/{agent_name}/mood/history?limit=100")
+
+    assert response.status_code == 200
+    assert response.get_json()["history"] == []
+    assert engine.limits == [100]


### PR DESCRIPTION
Closes #1875.

## What changed
- route mood-history limit through the shared positive-integer query parser
- reject malformed, zero, negative, and values above the documented maximum of 100
- preserve the default limit and valid upper bound

## Mutation proof
Before the fix, limit=abc, limit=0, and limit=101 all returned 200 and reached the mood engine. The focused regression suite failed all three rejection cases while its valid-limit control passed.

## Validation
- C:\Python314\python.exe -m pytest -q tests/test_mood_history_limit_validation.py -> 4 passed
- C:\Python314\python.exe -m py_compile bottube_server.py
- git diff --check

This is ordinary public query validation and does not change authentication or security controls.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d