### PR TITLE
[TRAVIS] Reject malformed oEmbed dimensions

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13085,14 +13085,20 @@ def oembed():
 
     source_w = max(1, int(video["width"] or 560))
     source_h = max(1, int(video["height"] or 315))
-    max_w = request.args.get("maxwidth", type=int)
-    max_h = request.args.get("maxheight", type=int)
+    max_w, error = parse_int_param(
+        "maxwidth", None, min_value=1, max_value=1920, clamp_bounds=True
+    )
+    if error:
+        return error
+    max_h, error = parse_int_param(
+        "maxheight", None, min_value=1, max_value=1080, clamp_bounds=True
+    )
+    if error:
+        return error
     if max_w is None:
         max_w = source_w
     if max_h is None:
         max_h = source_h
-    max_w = max(1, min(max_w, 1920))
-    max_h = max(1, min(max_h, 1080))
     scale = min(max_w / source_w, max_h / source_h, 1)
     w = max(1, int(round(source_w * scale)))
     h = max(1, int(round(source_h * scale)))

--- a/tests/test_oembed_dimensions.py
+++ b/tests/test_oembed_dimensions.py
@@ -115,3 +115,18 @@ def test_oembed_xml_uses_scaled_dimensions(client):
     assert "<width>400</width>" in xml
     assert "<height>225</height>" in xml
     assert 'width=&quot;400&quot; height=&quot;225&quot;' in xml
+
+
+@pytest.mark.parametrize("dimension", ("maxwidth", "maxheight"))
+def test_oembed_rejects_malformed_dimension(client, dimension):
+    """A supplied non-integer bound must not be mistaken for an omission."""
+    video_id = _insert_video(f"oembedBad{dimension[-1]}01")
+
+    response = client.get(
+        f"/oembed?url=https://bottube.ai/watch/{video_id}&{dimension}=not-a-number"
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["param"] == dimension
+    assert "integer" in payload["error"]


### PR DESCRIPTION
Closes #1877.

## What changed
- parse maxwidth and maxheight through the shared integer query validator
- reject supplied non-integer dimensions with a descriptive 400
- preserve omitted-value defaults and existing numeric clamping at 1..1920 / 1..1080

## Mutation proof
Before the fix, both maxwidth=not-a-number and maxheight=not-a-number returned 200 and silently used source dimensions. Both focused rejection tests failed.

## Validation
- C:\Python314\python.exe -m pytest -q tests/test_oembed_dimensions.py -> 5 passed
- C:\Python314\python.exe -m py_compile bottube_server.py
- git diff --check

This is ordinary public embed query validation and does not change authentication or security controls.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d