### PR TITLE
[TRAVIS] Keep category catalog visibility consistent

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8265,7 +8265,11 @@ def api_categories():
     db = get_db()
     counts = {}
     for row in db.execute(
-        "SELECT category, COUNT(*) as cnt FROM videos GROUP BY category"
+        f"""SELECT v.category, COUNT(*) AS cnt
+            FROM videos v
+            JOIN agents a ON a.id = v.agent_id
+            WHERE {_public_video_filter_sql()}
+            GROUP BY v.category"""
     ).fetchall():
         counts[row["category"]] = row["cnt"]
     result = []
@@ -8308,7 +8312,7 @@ def category_browse(cat_id):
     videos = db.execute(
         f"""SELECT v.*, a.agent_name, a.display_name, a.avatar_url, a.is_human
             FROM videos v JOIN agents a ON v.agent_id = a.id
-            WHERE v.category = ?
+            WHERE v.category = ? AND {_public_video_filter_sql()}
             ORDER BY {order_clause}
             LIMIT 100""",
         (cat_id,),

--- a/tests/test_public_video_visibility.py
+++ b/tests/test_public_video_visibility.py
@@ -171,3 +171,36 @@ def test_public_routes_still_return_visible_videos(client):
 
     for path in expected_ok_paths:
         assert client.get(path).status_code == 200, path
+
+
+def test_category_counts_include_only_public_videos(client):
+    visible_agent = _insert_agent("category_visible")
+    banned_agent = _insert_agent("category_banned", is_banned=1)
+    _insert_video("category-visible", visible_agent)
+    _insert_video("category-removed", visible_agent, is_removed=1)
+    _insert_video("category-banned", banned_agent)
+
+    response = client.get("/api/categories")
+
+    assert response.status_code == 200
+    categories = {item["id"]: item for item in response.get_json()["categories"]}
+    assert categories["other"]["video_count"] == 1
+
+
+def test_category_page_lists_only_public_videos(client, monkeypatch):
+    visible_agent = _insert_agent("browse_visible")
+    banned_agent = _insert_agent("browse_banned", is_banned=1)
+    _insert_video("browse-visible", visible_agent)
+    _insert_video("browse-removed", visible_agent, is_removed=1)
+    _insert_video("browse-banned", banned_agent)
+    rendered = {}
+
+    def capture_template(_template, **context):
+        rendered.update(context)
+        return "rendered"
+
+    monkeypatch.setattr(bottube_server, "render_template", capture_template)
+    response = client.get("/category/other")
+
+    assert response.status_code == 200
+    assert [row["video_id"] for row in rendered["videos"]] == ["browse-visible"]


### PR DESCRIPTION
Closes #1879.

## What changed
- join agents when aggregating category counts
- apply the shared public-video predicate to category counts and browser results
- retain existing category sorting and limits

## Mutation proof
With one visible, one removed, and one banned-owner video in `other`, the API reported 3 and the category page rendered all 3 before the fix. Both focused assertions failed. They now report/render only the visible video.

## Validation
- C:\Python314\python.exe -m pytest -q tests/test_public_video_visibility.py -> 5 passed
- C:\Python314\python.exe -m py_compile bottube_server.py
- git diff --check

This is ordinary public catalog/data consistency and does not change authentication or security controls.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d