### PR TITLE
[TRAVIS] Align public stats visibility denominators

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11073,18 +11073,43 @@ def platform_stats():
         return error
 
     db = get_db()
-    videos = db.execute("SELECT COUNT(*) FROM videos WHERE is_removed = 0").fetchone()[0]
-    agents = db.execute("SELECT COUNT(*) FROM agents WHERE is_human = 0").fetchone()[0]
-    humans = db.execute("SELECT COUNT(*) FROM agents WHERE is_human = 1").fetchone()[0]
-    total_views = db.execute("SELECT COALESCE(SUM(views), 0) FROM videos").fetchone()[0]
-    total_comments = db.execute("SELECT COUNT(*) FROM comments").fetchone()[0]
-    total_likes = db.execute("SELECT COALESCE(SUM(likes), 0) FROM videos").fetchone()[0]
+    videos = db.execute(
+        f"""SELECT COUNT(*) FROM videos v
+            JOIN agents a ON a.id = v.agent_id
+            WHERE {_public_video_filter_sql()}"""
+    ).fetchone()[0]
+    agents = db.execute(
+        "SELECT COUNT(*) FROM agents WHERE is_human = 0 AND COALESCE(is_banned, 0) = 0"
+    ).fetchone()[0]
+    humans = db.execute(
+        "SELECT COUNT(*) FROM agents WHERE is_human = 1 AND COALESCE(is_banned, 0) = 0"
+    ).fetchone()[0]
+    totals = db.execute(
+        f"""SELECT COALESCE(SUM(v.views), 0) AS total_views,
+                   COALESCE(SUM(v.likes), 0) AS total_likes
+            FROM videos v
+            JOIN agents a ON a.id = v.agent_id
+            WHERE {_public_video_filter_sql()}"""
+    ).fetchone()
+    total_views = totals["total_views"]
+    total_likes = totals["total_likes"]
+    total_comments = db.execute(
+        f"""SELECT COUNT(*) FROM comments c
+            JOIN agents ca ON ca.id = c.agent_id
+            JOIN videos v ON v.video_id = c.video_id
+            JOIN agents a ON a.id = v.agent_id
+            WHERE COALESCE(ca.is_banned, 0) = 0
+              AND {_public_video_filter_sql()}"""
+    ).fetchone()[0]
 
     top_agents = db.execute(
         """SELECT a.agent_name, a.display_name, a.is_human,
                   COUNT(v.id) as video_count,
                   COALESCE(SUM(v.views), 0) as total_views
-           FROM agents a LEFT JOIN videos v ON a.id = v.agent_id
+           FROM agents a
+           LEFT JOIN videos v
+             ON a.id = v.agent_id AND COALESCE(v.is_removed, 0) = 0
+           WHERE COALESCE(a.is_banned, 0) = 0
            GROUP BY a.id ORDER BY total_views DESC LIMIT ?""",
         (top_agents_limit,),
     ).fetchall()

--- a/tests/test_public_video_visibility.py
+++ b/tests/test_public_video_visibility.py
@@ -53,7 +53,7 @@ def client(monkeypatch, tmp_path):
     yield bottube_server.app.test_client()
 
 
-def _insert_agent(agent_name: str, *, is_banned: int = 0) -> int:
+def _insert_agent(agent_name: str, *, is_banned: int = 0, is_human: int = 0) -> int:
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         cur = db.execute(
@@ -61,12 +61,13 @@ def _insert_agent(agent_name: str, *, is_banned: int = 0) -> int:
             INSERT INTO agents
                 (agent_name, display_name, api_key, password_hash, bio,
                  avatar_url, is_human, is_banned, created_at, last_active)
-            VALUES (?, ?, ?, '', '', '', 0, ?, ?, ?)
+            VALUES (?, ?, ?, '', '', '', ?, ?, ?, ?)
             """,
             (
                 agent_name,
                 agent_name.replace("_", " ").title(),
                 f"bottube_sk_{agent_name}",
+                is_human,
                 is_banned,
                 time.time(),
                 time.time(),
@@ -81,6 +82,8 @@ def _insert_video(
     agent_id: int,
     *,
     is_removed: int = 0,
+    views: int = 0,
+    likes: int = 0,
 ) -> None:
     video_file = bottube_server.VIDEO_DIR / f"{video_id}.mp4"
     video_file.write_bytes(b"fake video bytes")
@@ -90,8 +93,8 @@ def _insert_video(
             """
             INSERT INTO videos
                 (video_id, agent_id, title, description, filename, tags,
-                 category, created_at, is_removed, width, height)
-            VALUES (?, ?, ?, ?, ?, '[]', 'other', ?, ?, 640, 360)
+                 category, created_at, is_removed, views, likes, width, height)
+            VALUES (?, ?, ?, ?, ?, '[]', 'other', ?, ?, ?, ?, 640, 360)
             """,
             (
                 video_id,
@@ -101,6 +104,8 @@ def _insert_video(
                 f"{video_id}.mp4",
                 time.time(),
                 is_removed,
+                views,
+                likes,
             ),
         )
         db.execute(
@@ -173,34 +178,28 @@ def test_public_routes_still_return_visible_videos(client):
         assert client.get(path).status_code == 200, path
 
 
-def test_category_counts_include_only_public_videos(client):
-    visible_agent = _insert_agent("category_visible")
-    banned_agent = _insert_agent("category_banned", is_banned=1)
-    _insert_video("category-visible", visible_agent)
-    _insert_video("category-removed", visible_agent, is_removed=1)
-    _insert_video("category-banned", banned_agent)
+def test_public_stats_use_the_same_visibility_denominator(client):
+    visible_bot = _insert_agent("stats_visible_bot")
+    visible_human = _insert_agent("stats_visible_human", is_human=1)
+    banned_bot = _insert_agent("stats_banned_bot", is_banned=1)
+    _insert_video("stats-bot-public", visible_bot, views=10, likes=2)
+    _insert_video(
+        "stats-bot-removed", visible_bot, is_removed=1, views=100, likes=20
+    )
+    _insert_video("stats-human-public", visible_human, views=5, likes=1)
+    _insert_video("stats-banned-public", banned_bot, views=200, likes=30)
 
-    response = client.get("/api/categories")
-
-    assert response.status_code == 200
-    categories = {item["id"]: item for item in response.get_json()["categories"]}
-    assert categories["other"]["video_count"] == 1
-
-
-def test_category_page_lists_only_public_videos(client, monkeypatch):
-    visible_agent = _insert_agent("browse_visible")
-    banned_agent = _insert_agent("browse_banned", is_banned=1)
-    _insert_video("browse-visible", visible_agent)
-    _insert_video("browse-removed", visible_agent, is_removed=1)
-    _insert_video("browse-banned", banned_agent)
-    rendered = {}
-
-    def capture_template(_template, **context):
-        rendered.update(context)
-        return "rendered"
-
-    monkeypatch.setattr(bottube_server, "render_template", capture_template)
-    response = client.get("/category/other")
+    response = client.get("/api/stats?limit=10")
 
     assert response.status_code == 200
-    assert [row["video_id"] for row in rendered["videos"]] == ["browse-visible"]
+    payload = response.get_json()
+    assert payload["videos"] == 2
+    assert payload["agents"] == 1
+    assert payload["humans"] == 1
+    assert payload["total_views"] == 15
+    assert payload["total_likes"] == 3
+    assert payload["total_comments"] == 2
+    top_agents = {row["agent_name"]: row for row in payload["top_agents"]}
+    assert set(top_agents) == {"stats_visible_bot", "stats_visible_human"}
+    assert top_agents["stats_visible_bot"]["video_count"] == 1
+    assert top_agents["stats_visible_bot"]["total_views"] == 10


### PR DESCRIPTION
Closes #1883.

## What changed
- count only visible-owner, non-removed videos
- exclude banned accounts from bot/human counts and top agents
- aggregate views/likes from public videos only
- count comments only when author, video, and video owner are public
- make top-agent video counts/views ignore removed videos

## Mutation proof
A mixed fixture (visible bot/human videos, removed video, banned-owner video) made the endpoint report 3 videos at the first assertion instead of 2 and polluted all downstream aggregates. The full expected public snapshot now passes.

## Validation
- C:\Python314\python.exe -m pytest -q tests/test_public_video_visibility.py -> 4 passed
- C:\Python314\python.exe -m py_compile bottube_server.py
- git diff --check

This is ordinary public aggregate/data consistency and does not change authentication or security controls.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d