### PR TITLE
[TRAVIS] Restore related-videos response contract

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -17333,9 +17333,7 @@ def api_related_videos(video_id):
         return s
 
     scored = sorted(candidates, key=score, reverse=True)
-    return jsonify({
-        "ok": True,
-        "related": [
+    related_videos = [
             {
                 "video_id": r["video_id"],
                 "title": r["title"],
@@ -17347,7 +17345,16 @@ def api_related_videos(video_id):
                 "display_name": r["display_name"],
             }
             for r in scored[:limit]
-        ],
+        ]
+    return jsonify({
+        "ok": True,
+        "video_id": video_id,
+        # `related_videos` and `count` are the documented Issue #425 API
+        # contract. Keep `related` as an additive compatibility alias for
+        # clients built against the newer compact response.
+        "related_videos": related_videos,
+        "related": related_videos,
+        "count": len(related_videos),
     })
 
 

--- a/tests/test_related_limit_validation.py
+++ b/tests/test_related_limit_validation.py
@@ -37,6 +37,30 @@ def _make_video(app):
         db.commit()
 
 
+def _make_related_candidate(app):
+    import bottube_server
+
+    with app.app_context():
+        db = bottube_server.get_db()
+        agent_id = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?",
+            ("related-limit-owner",),
+        ).fetchone()["id"]
+        db.execute(
+            """INSERT INTO videos
+               (video_id, agent_id, title, filename, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                "related_contract_candidate",
+                agent_id,
+                "Related contract candidate",
+                "candidate.mp4",
+                time.time() + 1,
+            ),
+        )
+        db.commit()
+
+
 def test_related_rejects_non_integer_limit(app, client):
     _make_video(app)
     resp = client.get(f"/api/videos/{_VIDEO_ID}/related?limit=abc")
@@ -72,3 +96,16 @@ def test_related_accepts_default_limit(app, client):
     _make_video(app)
     resp = client.get(f"/api/videos/{_VIDEO_ID}/related")
     assert resp.status_code == 200
+
+
+def test_related_response_preserves_documented_contract(app, client):
+    _make_video(app)
+    _make_related_candidate(app)
+
+    resp = client.get(f"/api/videos/{_VIDEO_ID}/related")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["video_id"] == _VIDEO_ID
+    assert body["related_videos"] == body["related"]
+    assert body["count"] == len(body["related_videos"]) == 1


### PR DESCRIPTION
Closes #1885.

## What changed
- restore documented video_id, related_videos, and count fields
- retain related as an additive compatibility alias
- build the response items once so both collection keys remain identical

## Mutation proof
A source plus one related candidate returned 200, but the contract regression failed immediately with KeyError for video_id. The focused response-contract test now passes and verifies all fields and exact count.

## Validation
- C:\Python314\python.exe -m pytest -q tests/test_related_limit_validation.py::test_related_response_preserves_documented_contract -> 1 passed
- the full file completed 7 passing assertions; Windows then hit an unrelated temporary SQLite handle during fixture cleanup
- C:\Python314\python.exe -m py_compile bottube_server.py
- git diff --check

This is ordinary public API compatibility/data-shape correctness and does not change authentication or security controls.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d