### PR TITLE
[TRAVIS] Restore related-category API and UI context

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -315,6 +315,32 @@ VIDEO_CATEGORIES = [
 
 CATEGORY_MAP = {c["id"]: c for c in VIDEO_CATEGORIES}
 
+# Curated discovery neighbours for the documented Issue #425 related-category
+# surface. Order is intentional and used by both the API and category sidebar.
+_RELATED_CATEGORY_IDS = {
+    "ai-art": ("animation", "3d", "film"),
+    "music": ("meditation", "film", "retro"),
+    "comedy": ("memes", "film", "vlog"),
+    "science-tech": ("education", "gaming", "news"),
+    "gaming": ("retro", "comedy", "science-tech"),
+    "nature": ("weather", "adventure", "meditation"),
+    "education": ("science-tech", "news", "politics"),
+    "animation": ("ai-art", "3d", "film"),
+    "vlog": ("adventure", "food", "comedy"),
+    "horror": ("film", "retro", "animation"),
+    "retro": ("gaming", "music", "memes"),
+    "food": ("vlog", "education", "adventure"),
+    "meditation": ("nature", "music", "weather"),
+    "adventure": ("nature", "vlog", "weather"),
+    "film": ("animation", "horror", "ai-art"),
+    "memes": ("comedy", "retro", "politics"),
+    "3d": ("ai-art", "animation", "science-tech"),
+    "politics": ("news", "education", "memes"),
+    "news": ("politics", "weather", "science-tech"),
+    "weather": ("nature", "news", "science-tech"),
+    "other": ("education", "comedy", "nature"),
+}
+
 # ---------------------------------------------------------------------------
 # Content Moderation — Keyword blocklist for illegal/unsafe content
 # ---------------------------------------------------------------------------
@@ -8280,6 +8306,39 @@ def api_categories():
     return jsonify({"categories": result})
 
 
+def _related_category_cards(db, cat_id):
+    related_ids = _RELATED_CATEGORY_IDS.get(cat_id, ())
+    if not related_ids:
+        return []
+    placeholders = ",".join("?" for _ in related_ids)
+    rows = db.execute(
+        f"""SELECT v.category, COUNT(*) AS cnt
+            FROM videos v
+            JOIN agents a ON a.id = v.agent_id
+            WHERE v.category IN ({placeholders})
+              AND {_public_video_filter_sql()}
+            GROUP BY v.category""",
+        related_ids,
+    ).fetchall()
+    counts = {row["category"]: int(row["cnt"] or 0) for row in rows}
+    return [
+        {**CATEGORY_MAP[related_id], "video_count": counts.get(related_id, 0)}
+        for related_id in related_ids
+    ]
+
+
+@app.route("/api/categories/<cat_id>/related")
+def api_related_categories(cat_id):
+    """Return the curated related-category cards documented by Issue #425."""
+    cat_id = _CATEGORY_REDIRECTS.get(cat_id, cat_id)
+    if cat_id not in CATEGORY_MAP:
+        return jsonify({"error": "Category not found"}), 404
+    return jsonify({
+        "category": cat_id,
+        "related": _related_category_cards(get_db(), cat_id),
+    })
+
+
 # Redirects for merged/renamed categories
 _CATEGORY_REDIRECTS = {
     "music-audio": "music",
@@ -8320,6 +8379,7 @@ def category_browse(cat_id):
         category=cat,  # some templates expect `category` instead of `cat`
         videos=videos,
         sort=sort,
+        related_categories=_related_category_cards(db, cat_id),
     )
 
 

--- a/tests/test_related_categories_contract.py
+++ b/tests/test_related_categories_contract.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+"""Contract tests for the documented related-categories discovery surface."""
+
+import sys
+import time
+
+
+def _seed_animation_counts(app, agent_name):
+    server = sys.modules["bottube_server"]
+    with app.app_context():
+        db = server.get_db()
+        agent_id = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?", (agent_name,)
+        ).fetchone()["id"]
+        db.executemany(
+            """INSERT INTO videos
+               (video_id, agent_id, title, filename, category, is_removed, created_at)
+               VALUES (?, ?, ?, ?, 'animation', ?, ?)""",
+            (
+                ("related-cat-visible", agent_id, "Visible animation", "visible.mp4", 0, time.time()),
+                ("related-cat-removed", agent_id, "Removed animation", "removed.mp4", 1, time.time()),
+            ),
+        )
+        db.commit()
+
+
+def test_related_categories_endpoint_matches_documented_shape(
+    app, client, registered_agent
+):
+    _seed_animation_counts(app, registered_agent["agent_name"])
+
+    response = client.get("/api/categories/ai-art/related")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["category"] == "ai-art"
+    assert [item["id"] for item in body["related"]] == ["animation", "3d", "film"]
+    assert body["related"][0]["video_count"] == 1
+    assert {"id", "name", "icon", "desc", "video_count"} <= set(body["related"][0])
+
+
+def test_related_categories_reject_unknown_category(client):
+    response = client.get("/api/categories/not-a-category/related")
+
+    assert response.status_code == 404
+
+
+def test_category_page_receives_related_category_context(client, monkeypatch):
+    server = sys.modules["bottube_server"]
+    rendered = {}
+
+    def capture_template(_template, **context):
+        rendered.update(context)
+        return "rendered"
+
+    monkeypatch.setattr(server, "render_template", capture_template)
+    response = client.get("/category/ai-art")
+
+    assert response.status_code == 200
+    assert [item["id"] for item in rendered["related_categories"]] == [
+        "animation",
+        "3d",
+        "film",
+    ]


### PR DESCRIPTION
Closes #1887.

## What changed
- add curated related-category neighbours for the complete taxonomy
- implement the documented GET /api/categories/{cat_id}/related shape
- include public-only video counts on related cards
- provide the same cards to the existing category sidebar
- return 404 for unknown category ids

## Mutation proof
Before the patch, the documented endpoint returned 404 and category pages omitted related_categories from template context. Two of three contract tests failed; the unknown-category control already passed.

## Validation
- C:\Python314\python.exe -m pytest -q tests/test_related_categories_contract.py -> 3 passed
- C:\Python314\python.exe -m py_compile bottube_server.py
- git diff --check

This is ordinary public discovery/API/UI completeness and does not change authentication or security controls.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d