### PR TITLE
[TRAVIS] Enforce public visibility in video listings

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7160,7 +7160,7 @@ def list_videos():
     order = sort_map.get(sort, "v.created_at DESC")
 
     db = get_db()
-    where_clauses = ["v.is_removed = 0"]
+    where_clauses = [_public_video_filter_sql()]
     params = []
     if agent_name:
         where_clauses.append("a.agent_name = ?")

--- a/tests/test_video_list_public_visibility.py
+++ b/tests/test_video_list_public_visibility.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+"""Public video listings must use the canonical visibility predicate."""
+
+import time
+
+
+def _seed_visible_and_banned_videos(client):
+    import bottube_server
+
+    with client.application.app_context():
+        db = bottube_server.get_db()
+        created_at = time.time()
+        db.execute(
+            """INSERT INTO agents
+               (agent_name, api_key, display_name, is_banned, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("visible_creator", "visible-key", "Visible Creator", 0, created_at),
+        )
+        db.execute(
+            """INSERT INTO agents
+               (agent_name, api_key, display_name, is_banned, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("banned_creator", "banned-key", "Banned Creator", 1, created_at),
+        )
+        creators = {
+            row["agent_name"]: row["id"]
+            for row in db.execute(
+                "SELECT id, agent_name FROM agents WHERE agent_name IN (?, ?)",
+                ("visible_creator", "banned_creator"),
+            ).fetchall()
+        }
+        db.execute(
+            """INSERT INTO videos
+               (video_id, agent_id, title, description, filename, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                "visible-video",
+                creators["visible_creator"],
+                "Visible Video",
+                "Public fixture",
+                "visible.mp4",
+                created_at,
+            ),
+        )
+        db.execute(
+            """INSERT INTO videos
+               (video_id, agent_id, title, description, filename, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                "banned-video",
+                creators["banned_creator"],
+                "Banned Video",
+                "Non-public fixture",
+                "banned.mp4",
+                created_at + 1,
+            ),
+        )
+        db.commit()
+
+
+def test_video_list_excludes_banned_creator_from_rows_and_totals(client):
+    _seed_visible_and_banned_videos(client)
+
+    response = client.get("/api/videos?per_page=20")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["total"] == 1
+    assert payload["pages"] == 1
+    assert [video["video_id"] for video in payload["videos"]] == ["visible-video"]
+
+
+def test_video_list_agent_filter_does_not_resurface_banned_creator(client):
+    _seed_visible_and_banned_videos(client)
+
+    response = client.get("/api/videos?agent=banned_creator")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["total"] == 0
+    assert payload["pages"] == 0
+    assert payload["videos"] == []
+
+
+def test_versioned_video_list_alias_has_same_visibility(client):
+    _seed_visible_and_banned_videos(client)
+
+    response = client.get("/api/v1/videos")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["total"] == 1
+    assert [video["video_id"] for video in payload["videos"]] == ["visible-video"]


### PR DESCRIPTION
## Summary
- apply the existing canonical public-video predicate to `GET /api/videos`
- keep banned-creator videos out of response rows, totals, pages, and cache validators
- cover direct agent filtering and the `/api/v1/videos` alias

## Reproduction / mutation proof
Before the fix, a fixture with one public creator video and one banned creator video returned `total: 2`; filtering with `?agent=banned_creator` returned that non-public video, and the versioned alias exposed it as well. All three regression tests failed against `main` before the one-line predicate change.

## Validation
- `C:\Python314\python.exe -m pytest -q tests/test_video_list_public_visibility.py` -> 3 passed
- `C:\Python314\python.exe -m pytest -q tests/test_video_list_pagination.py` -> 2 passed
- Python compilation clean
- `git diff --check`

Closes #1891

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d