### PR TITLE
[TRAVIS] Activate agent-directory search and sort controls

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -13145,18 +13145,40 @@ def _extract_oembed_video_id(url):
 @app.route("/agents")
 def agents_page():
     """List all agents on the platform."""
+    query = request.args.get("q", "").strip()
+    sort_map = {
+        "videos": "video_count DESC, total_views DESC, a.agent_name ASC",
+        "recent": "a.created_at DESC, a.agent_name ASC",
+        "name": "LOWER(COALESCE(a.display_name, a.agent_name)) ASC, a.agent_name ASC",
+    }
+    sort = request.args.get("sort", "videos").strip().lower()
+    if sort not in sort_map:
+        sort = "videos"
+
+    where = "COALESCE(a.is_banned, 0) = 0"
+    params = []
+    if query:
+        like_query = f"%{query}%"
+        where += (
+            " AND (a.agent_name LIKE ? OR a.display_name LIKE ? OR a.bio LIKE ?)"
+        )
+        params.extend([like_query, like_query, like_query])
+
     db = get_db()
     agents = db.execute(
-        """SELECT a.*, COUNT(v.id) as video_count,
+        f"""SELECT a.*, COUNT(v.id) as video_count,
                   COALESCE(SUM(v.views), 0) as total_views
            FROM agents a
            LEFT JOIN videos v
              ON a.id = v.agent_id AND COALESCE(v.is_removed, 0) = 0
-           WHERE COALESCE(a.is_banned, 0) = 0
+           WHERE {where}
            GROUP BY a.id
-           ORDER BY total_views DESC""",
+           ORDER BY {sort_map[sort]}""",
+        params,
     ).fetchall()
-    return render_template("agents.html", agents=agents)
+    return render_template(
+        "agents.html", agents=agents, query=query, sort=sort
+    )
 
 
 def get_agent_beacon(agent_name: str):

--- a/bottube_templates/agents.html
+++ b/bottube_templates/agents.html
@@ -145,9 +145,9 @@
 </div>
 
 <div class="sort-tabs" style="margin-bottom: 20px;">
-    <a href="{{ P }}/agents?q={{ query }}&sort=videos" class="{% if sort == 'videos' %}active{% endif %}">Most Videos</a>
-    <a href="{{ P }}/agents?q={{ query }}&sort=recent" class="{% if sort == 'recent' %}active{% endif %}">Newest</a>
-    <a href="{{ P }}/agents?q={{ query }}&sort=name" class="{% if sort == 'name' %}active{% endif %}">A-Z</a>
+    <a href="{{ P }}/agents?q={{ query | urlencode }}&sort=videos" class="{% if sort == 'videos' %}active{% endif %}">Most Videos</a>
+    <a href="{{ P }}/agents?q={{ query | urlencode }}&sort=recent" class="{% if sort == 'recent' %}active{% endif %}">Newest</a>
+    <a href="{{ P }}/agents?q={{ query | urlencode }}&sort=name" class="{% if sort == 'name' %}active{% endif %}">A-Z</a>
 </div>
 
 {% if agents %}

--- a/tests/test_agent_directory_controls.py
+++ b/tests/test_agent_directory_controls.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+"""Behavioral coverage for the public agent-directory controls."""
+
+
+def _seed_agents(client):
+    import bottube_server
+
+    with client.application.app_context():
+        db = bottube_server.get_db()
+        agents = [
+            ("alpha_creator", "alpha-key", "Alpha Creator", "Needle specialist", 100.0),
+            ("beta_creator", "beta-key", "Beta Creator", "Popular channel", 300.0),
+            ("gamma_creator", "gamma-key", "Gamma Creator", "Quiet channel", 200.0),
+        ]
+        db.executemany(
+            """INSERT INTO agents
+               (agent_name, api_key, display_name, bio, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            agents,
+        )
+        agent_ids = {
+            row["agent_name"]: row["id"]
+            for row in db.execute(
+                "SELECT id, agent_name FROM agents WHERE agent_name LIKE '%_creator'"
+            ).fetchall()
+        }
+        videos = [
+            ("alpha-one", agent_ids["alpha_creator"], "Alpha One", 1, 101.0),
+            ("alpha-two", agent_ids["alpha_creator"], "Alpha Two", 1, 102.0),
+            ("beta-one", agent_ids["beta_creator"], "Beta One", 1000, 301.0),
+        ]
+        db.executemany(
+            """INSERT INTO videos
+               (video_id, agent_id, title, filename, views, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            [
+                (video_id, agent_id, title, f"{video_id}.mp4", views, created_at)
+                for video_id, agent_id, title, views, created_at in videos
+            ],
+        )
+        db.commit()
+
+
+def _positions(html):
+    return {
+        name: html.index(f"@{name}")
+        for name in ("alpha_creator", "beta_creator", "gamma_creator")
+    }
+
+
+def test_agent_directory_search_filters_name_display_name_and_bio(client):
+    _seed_agents(client)
+
+    response = client.get("/agents?q=Needle")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "@alpha_creator" in html
+    assert "@beta_creator" not in html
+    assert "@gamma_creator" not in html
+    assert 'value="Needle"' in html
+    assert 'Agents matching "Needle"' in html
+
+
+def test_agent_directory_sort_tabs_apply_requested_order(client):
+    _seed_agents(client)
+
+    videos_html = client.get("/agents?sort=videos").get_data(as_text=True)
+    videos_positions = _positions(videos_html)
+    assert videos_positions["alpha_creator"] < videos_positions["beta_creator"]
+    assert videos_positions["beta_creator"] < videos_positions["gamma_creator"]
+
+    recent_html = client.get("/agents?sort=recent").get_data(as_text=True)
+    recent_positions = _positions(recent_html)
+    assert recent_positions["beta_creator"] < recent_positions["gamma_creator"]
+    assert recent_positions["gamma_creator"] < recent_positions["alpha_creator"]
+
+    name_html = client.get("/agents?sort=name").get_data(as_text=True)
+    name_positions = _positions(name_html)
+    assert name_positions["alpha_creator"] < name_positions["beta_creator"]
+    assert name_positions["beta_creator"] < name_positions["gamma_creator"]
+
+
+def test_agent_directory_invalid_sort_falls_back_to_video_count(client):
+    _seed_agents(client)
+
+    html = client.get("/agents?sort=not-a-sort").get_data(as_text=True)
+
+    positions = _positions(html)
+    assert positions["alpha_creator"] < positions["beta_creator"]
+    assert positions["beta_creator"] < positions["gamma_creator"]
+    assert 'sort=videos" class="active"' in html


### PR DESCRIPTION
## Summary
- wire the public agent-directory search form to name, display-name, and bio filtering
- implement the three sort modes shown in the UI with deterministic tie-breakers
- preserve normalized query/sort state in the template and encode it in links
- add behavioral regression coverage for all controls and invalid-sort fallback

## Reproduction / mutation proof
Against `main`, all three regression tests failed: `?q=Needle` still rendered unrelated agents, `?sort=videos` remained ordered by total views, and invalid sort state left no active fallback. The page handler ignored both query parameters.

## Validation
- `C:\Python314\python.exe -m pytest -q tests/test_agent_directory_controls.py` -> 3 passed
- Python compilation clean
- `git diff --check`

Closes #1893

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d