### PR TITLE
[TRAVIS] Align subscriber totals across public surfaces

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8484,6 +8484,18 @@ def web_vote_video(video_id):
 # Web Subscribe/Unsubscribe (requires login session)
 # ---------------------------------------------------------------------------
 
+def _visible_subscriber_count(db, following_id):
+    """Count followers that remain visible on public subscriber surfaces."""
+    return db.execute(
+        """SELECT COUNT(*)
+           FROM subscriptions s
+           JOIN agents follower ON s.follower_id = follower.id
+           WHERE s.following_id = ?
+             AND COALESCE(follower.is_banned, 0) = 0""",
+        (following_id,),
+    ).fetchone()[0]
+
+
 @app.route("/api/agents/<agent_name>/web-subscribe", methods=["POST"])
 def web_subscribe(agent_name):
     """Toggle subscription from the web UI (requires login session)."""
@@ -8526,12 +8538,7 @@ def web_subscribe(agent_name):
         db.commit()
         following = True
 
-    count = db.execute(
-        """SELECT COUNT(*)
-           FROM subscriptions s JOIN agents a ON s.follower_id = a.id
-           WHERE s.following_id = ? AND COALESCE(a.is_banned, 0) = 0""",
-        (target["id"],),
-    ).fetchone()[0]
+    count = _visible_subscriber_count(db, target["id"])
 
     return jsonify({"ok": True, "following": following, "subscriber_count": count})
 
@@ -8823,13 +8830,14 @@ def get_agent_analytics(agent_name):
     ).fetchone()
 
     # Subscriber count & recent growth
-    sub_total = db.execute(
-        "SELECT COUNT(*) FROM subscriptions WHERE following_id = ?", (aid,)
-    ).fetchone()[0]
+    sub_total = _visible_subscriber_count(db, aid)
 
     sub_recent = db.execute(
-        """SELECT date(created_at, 'unixepoch') AS day, COUNT(*) AS cnt
-           FROM subscriptions WHERE following_id = ? AND created_at >= ?
+        """SELECT date(s.created_at, 'unixepoch') AS day, COUNT(*) AS cnt
+           FROM subscriptions s
+           JOIN agents follower ON s.follower_id = follower.id
+           WHERE s.following_id = ? AND s.created_at >= ?
+             AND COALESCE(follower.is_banned, 0) = 0
            GROUP BY day ORDER BY day""",
         (aid, cutoff),
     ).fetchall()
@@ -10680,12 +10688,7 @@ def subscribe_agent(agent_name):
     _refresh_agent_quests(db, g.agent["id"], ["first_follow"])
     db.commit()
 
-    count = db.execute(
-        """SELECT COUNT(*)
-           FROM subscriptions s JOIN agents a ON s.follower_id = a.id
-           WHERE s.following_id = ? AND COALESCE(a.is_banned, 0) = 0""",
-        (target["id"],),
-    ).fetchone()[0]
+    count = _visible_subscriber_count(db, target["id"])
     return jsonify({"ok": True, "following": True, "agent": agent_name, "follower_count": count})
 
 
@@ -12831,10 +12834,7 @@ def watch(video_id):
     creator_ban_address = _ban_addr_row["ban_address"] if _ban_addr_row else ""
 
     # Subscription data for follow button
-    subscriber_count = db.execute(
-        "SELECT COUNT(*) FROM subscriptions WHERE following_id = ?",
-        (video["agent_id"],),
-    ).fetchone()[0]
+    subscriber_count = _visible_subscriber_count(db, video["agent_id"])
 
     is_following = False
     if g.user:
@@ -13194,10 +13194,7 @@ def channel(agent_name):
         (agent["id"],),
     ).fetchone()[0]
 
-    subscriber_count = db.execute(
-        "SELECT COUNT(*) FROM subscriptions WHERE following_id = ?",
-        (agent["id"],),
-    ).fetchone()[0]
+    subscriber_count = _visible_subscriber_count(db, agent["id"])
 
     is_following = False
     if g.user:
@@ -13535,9 +13532,7 @@ def dashboard_page():
         (uid,),
     ).fetchone()
 
-    subscriber_count = db.execute(
-        "SELECT COUNT(*) FROM subscriptions WHERE following_id = ?", (uid,)
-    ).fetchone()[0]
+    subscriber_count = _visible_subscriber_count(db, uid)
 
     total_comments = db.execute(
         """SELECT COUNT(*) FROM comments c

--- a/tests/test_subscriber_count_consistency.py
+++ b/tests/test_subscriber_count_consistency.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+"""Subscriber totals must agree with the public subscriber-list contract."""
+
+import time
+
+
+def _seed_creator_and_followers(client):
+    import bottube_server
+
+    with client.application.app_context():
+        db = bottube_server.get_db()
+        now = time.time()
+        db.executemany(
+            """INSERT INTO agents
+               (agent_name, api_key, display_name, is_banned, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            [
+                ("target_creator", "target-key", "Target Creator", 0, now),
+                ("visible_follower", "visible-key", "Visible Follower", 0, now),
+                ("banned_follower", "banned-key", "Banned Follower", 1, now),
+            ],
+        )
+        ids = {
+            row["agent_name"]: row["id"]
+            for row in db.execute(
+                """SELECT id, agent_name FROM agents
+                   WHERE agent_name IN (?, ?, ?)""",
+                ("target_creator", "visible_follower", "banned_follower"),
+            ).fetchall()
+        }
+        db.executemany(
+            """INSERT INTO subscriptions
+               (follower_id, following_id, created_at) VALUES (?, ?, ?)""",
+            [
+                (ids["visible_follower"], ids["target_creator"], now),
+                (ids["banned_follower"], ids["target_creator"], now),
+            ],
+        )
+        db.execute(
+            """INSERT INTO videos
+               (video_id, agent_id, title, filename, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("target-video", ids["target_creator"], "Target Video", "target.mp4", now),
+        )
+        db.commit()
+
+
+def test_channel_and_watch_match_public_visible_subscriber_count(client):
+    _seed_creator_and_followers(client)
+
+    subscribers = client.get("/api/agents/target_creator/subscribers").get_json()
+    channel_html = client.get("/agent/target_creator").get_data(as_text=True)
+    watch_html = client.get("/watch/target-video").get_data(as_text=True)
+
+    assert subscribers["count"] == 1
+    assert 'id="sub-count">1</strong>' in channel_html
+    assert 'id="watch-sub-count">1</span>' in watch_html
+
+
+def test_creator_analytics_excludes_banned_followers_from_total_and_growth(client):
+    _seed_creator_and_followers(client)
+
+    response = client.get("/api/agents/target_creator/analytics?days=1")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["totals"]["subscribers"] == 1
+    assert sum(day["new_subs"] for day in payload["subscriber_growth"]) == 1


### PR DESCRIPTION
## Summary
- centralize public subscriber totals behind the same banned-follower predicate as subscriber lists
- align channel, watch, analytics, dashboard, and subscribe-response counts
- exclude banned followers from daily subscriber-growth analytics
- add cross-surface contract tests

## Reproduction / mutation proof
With one visible follower and one banned follower, `/api/agents/<name>/subscribers` correctly returned `count: 1`, while the channel, watch page, and analytics reported 2. Both new regressions failed against `main` before the repair.

## Validation
- `C:\Python314\python.exe -m pytest -q tests/test_subscriber_count_consistency.py` -> 2 passed
- `C:\Python314\python.exe -m pytest -q tests/test_subscription_visibility.py` -> 5 passed
- Python compilation clean
- `git diff --check`

Closes #1895