### PR TITLE
[TRAVIS] Restore authenticated push subscriptions

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15711,15 +15711,34 @@ except Exception as _forge3d_e:
 # ---------------------------------------------------------------------------
 
 @app.route("/api/push/subscribe", methods=["POST"])
+@require_api_key
 def push_subscribe():
     """Store a push notification subscription."""
-    if not g.get("agent"):
-        return jsonify({"error": "Login required"}), 401
-    data = request.get_json(silent=True) or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+
     endpoint = data.get("endpoint", "")
+    if not isinstance(endpoint, str):
+        return jsonify({"error": "endpoint must be a string"}), 400
+    endpoint = endpoint.strip()
+
     keys = data.get("keys", {})
+    if not isinstance(keys, dict):
+        return jsonify({"error": "keys must be a JSON object"}), 400
+
     p256dh = keys.get("p256dh", "")
+    if not isinstance(p256dh, str):
+        return jsonify({"error": "p256dh must be a string"}), 400
+    p256dh = p256dh.strip()
+
     auth = keys.get("auth", "")
+    if not isinstance(auth, str):
+        return jsonify({"error": "auth must be a string"}), 400
+    auth = auth.strip()
+
     if not endpoint or not p256dh or not auth:
         return jsonify({"error": "Missing subscription data"}), 400
     db = get_db()

--- a/tests/test_push_subscription_input_validation.py
+++ b/tests/test_push_subscription_input_validation.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+
+
+def _auth_headers(api_key):
+    return {"X-API-Key": api_key}
+
+
+def test_push_subscribe_rejects_non_object_json(client, registered_agent):
+    response = client.post(
+        "/api/push/subscribe",
+        headers=_auth_headers(registered_agent["api_key"]),
+        json=["not", "an", "object"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON body must be an object"}
+
+
+def test_push_subscribe_rejects_non_object_keys(client, registered_agent):
+    response = client.post(
+        "/api/push/subscribe",
+        headers=_auth_headers(registered_agent["api_key"]),
+        json={"endpoint": "https://push.example/subscription", "keys": "not-an-object"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "keys must be a JSON object"}
+
+
+def test_push_subscribe_rejects_non_string_fields(client, registered_agent):
+    headers = _auth_headers(registered_agent["api_key"])
+    cases = [
+        ({"endpoint": 7, "keys": {"p256dh": "public", "auth": "secret"}}, "endpoint"),
+        ({"endpoint": "https://push.example/subscription", "keys": {"p256dh": 7, "auth": "secret"}}, "p256dh"),
+        ({"endpoint": "https://push.example/subscription", "keys": {"p256dh": "public", "auth": 7}}, "auth"),
+    ]
+
+    for payload, field in cases:
+        response = client.post("/api/push/subscribe", headers=headers, json=payload)
+        assert response.status_code == 400
+        assert response.get_json() == {"error": f"{field} must be a string"}
+
+
+def test_push_subscribe_persists_valid_subscription(client, registered_agent, app):
+    payload = {
+        "endpoint": "https://push.example/subscription",
+        "keys": {"p256dh": "public-key", "auth": "auth-secret"},
+    }
+
+    response = client.post(
+        "/api/push/subscribe",
+        headers=_auth_headers(registered_agent["api_key"]),
+        json=payload,
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True}
+
+    with app.app_context():
+        import bottube_server
+
+        row = bottube_server.get_db().execute(
+            "SELECT endpoint, p256dh, auth FROM push_subscriptions"
+        ).fetchone()
+        assert dict(row) == {
+            "endpoint": payload["endpoint"],
+            "p256dh": payload["keys"]["p256dh"],
+            "auth": payload["keys"]["auth"],
+        }


### PR DESCRIPTION
## Summary

- authenticate push-subscription writes through the existing API-key contract
- reject non-object request bodies and nested key payloads with bounded `400` responses
- validate subscription fields before persistence
- cover the formerly dead valid path, malformed shapes, scalar fields, and database persistence

## Proof

Mutation baseline on upstream `main`: all four focused tests failed because even a valid registered API-key client received `401`; malformed bodies were therefore unreachable through the advertised agent contract.

After the fix:

```text
4 passed, 1 warning in 94.82s
```

Additional checks:

```text
python -m py_compile bottube_server.py tests/test_push_subscription_input_validation.py
git diff --check
```

Closes #1899

RustChain ongoing bug-bounty program: Scottcjn/rustchain-bounties#71
