### PR TITLE
[TRAVIS] Keep similar recommendations publicly visible

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -21214,7 +21214,9 @@ def _ue_cache_warm():
             """SELECT e.video_id, e.dim, e.bytes
                  FROM video_embeddings e
                  JOIN videos v ON v.video_id = e.video_id
+                 JOIN agents a ON a.id = v.agent_id
                 WHERE COALESCE(v.is_removed, 0) = 0
+                  AND COALESCE(a.is_banned, 0) = 0
                   AND e.model = ?
                 ORDER BY e.video_id""",
             (EMBEDDING_MODEL,),
@@ -21293,8 +21295,9 @@ def api_videos_similar(video_id):
         return error
     db = get_db()
     video = db.execute(
-        """SELECT 1 FROM videos
-           WHERE video_id = ? AND COALESCE(is_removed, 0) = 0""",
+        f"""SELECT 1
+              FROM videos v JOIN agents a ON a.id = v.agent_id
+             WHERE v.video_id = ? AND {_public_video_filter_sql()}""",
         (video_id,),
     ).fetchone()
     if not video:
@@ -21313,7 +21316,8 @@ def api_videos_similar(video_id):
         f"""SELECT v.video_id, v.title, v.thumbnail, v.duration_sec, v.views,
                    v.created_at, a.agent_name, a.display_name, a.is_human
               FROM videos v JOIN agents a ON v.agent_id = a.id
-             WHERE v.video_id IN ({placeholders})""",
+             WHERE v.video_id IN ({placeholders})
+               AND {_public_video_filter_sql()}""",
         [vid for vid, _ in pairs],
     ).fetchall()
     by_id = {r["video_id"]: r for r in rows}

--- a/tests/test_similar_public_visibility.py
+++ b/tests/test_similar_public_visibility.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: MIT
+import time
+
+
+def _insert_agent(db, name, *, banned=False):
+    cursor = db.execute(
+        """
+        INSERT INTO agents
+            (agent_name, display_name, api_key, password_hash, bio,
+             avatar_url, is_human, is_banned, created_at, last_active)
+        VALUES (?, ?, ?, '', '', '', 0, ?, ?, ?)
+        """,
+        (
+            name,
+            name.replace("_", " ").title(),
+            f"bottube_sk_{name}",
+            int(banned),
+            time.time(),
+            time.time(),
+        ),
+    )
+    return int(cursor.lastrowid)
+
+
+def _insert_video(db, video_id, agent_id, *, removed=False):
+    db.execute(
+        """
+        INSERT INTO videos
+            (video_id, agent_id, title, filename, thumbnail, created_at,
+             is_removed)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            video_id,
+            agent_id,
+            f"Video {video_id}",
+            f"{video_id}.mp4",
+            f"{video_id}.jpg",
+            time.time(),
+            int(removed),
+        ),
+    )
+
+
+def test_similar_rejects_banned_source_before_embedding_lookup(client, monkeypatch):
+    import bottube_server
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        owner_id = _insert_agent(db, "similar_banned_source", banned=True)
+        _insert_video(db, "similar_banned_source_video", owner_id)
+        db.commit()
+
+    def fail_lookup(*args, **kwargs):
+        raise AssertionError("embedding lookup should not run for a hidden video")
+
+    monkeypatch.setattr(bottube_server, "_ue_top_k_for_video", fail_lookup)
+
+    response = client.get("/api/videos/similar_banned_source_video/similar")
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "ok": False,
+        "error": "video not found",
+        "video_id": "similar_banned_source_video",
+    }
+
+
+def test_similar_results_exclude_removed_and_banned_creator_videos(
+    client, monkeypatch
+):
+    import bottube_server
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        visible_owner = _insert_agent(db, "similar_visible_owner")
+        banned_owner = _insert_agent(db, "similar_banned_owner", banned=True)
+        _insert_video(db, "similar_public_source", visible_owner)
+        _insert_video(db, "similar_visible_result", visible_owner)
+        _insert_video(db, "similar_removed_result", visible_owner, removed=True)
+        _insert_video(db, "similar_banned_result", banned_owner)
+        db.commit()
+
+    monkeypatch.setattr(
+        bottube_server,
+        "_ue_top_k_for_video",
+        lambda *args, **kwargs: [
+            ("similar_visible_result", 0.91),
+            ("similar_removed_result", 0.89),
+            ("similar_banned_result", 0.87),
+        ],
+    )
+
+    response = client.get("/api/videos/similar_public_source/similar?k=3")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["count"] == 1
+    assert [row["video_id"] for row in payload["results"]] == [
+        "similar_visible_result"
+    ]


### PR DESCRIPTION
## What changed

- exclude banned-owner videos while warming the similarity embedding cache
- validate the source video with BoTTube's shared public visibility predicate
- filter removed and banned-owner candidates again at the serialization query
- add regressions for a hidden source and mixed visible/removed/banned results

## Verification

- `python -m pytest -q tests/test_similar_public_visibility.py` -> 2 passed
- `python -m py_compile bottube_server.py tests/test_similar_public_visibility.py` -> clean
- `git diff --check` -> clean

The regression fixtures exercise the public API boundary with a visible source plus visible, removed, and banned-owner candidates; only the visible candidate remains in the response.

Fixes #1901

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d