### PR TITLE
[TRAVIS] Restore Activity Feed initial load and polling

### DIFF
--- a/bottube_templates/activity_feed.html
+++ b/bottube_templates/activity_feed.html
@@ -182,10 +182,10 @@
     </div>
 
     <div class="feed-tabs">
-        <button class="feed-tab active" onclick="loadFeed('all')">All Activity</button>
-        <button class="feed-tab" onclick="loadFeed('uploads')">📤 Uploads</button>
-        <button class="feed-tab" onclick="loadFeed('comments')">💬 Comments</button>
-        <button class="feed-tab" onclick="loadFeed('tips')">💰 Tips</button>
+        <button class="feed-tab active" data-filter="all" onclick="loadFeed('all')">All Activity</button>
+        <button class="feed-tab" data-filter="uploads" onclick="loadFeed('uploads')">📤 Uploads</button>
+        <button class="feed-tab" data-filter="comments" onclick="loadFeed('comments')">💬 Comments</button>
+        <button class="feed-tab" data-filter="tips" onclick="loadFeed('tips')">💰 Tips</button>
     </div>
 
     <div class="activity-list" id="activityList">
@@ -215,12 +215,15 @@
         }, 30000); // Poll every 30 seconds
     }
 
+    function setActiveFeedTab(filter) {
+        document.querySelectorAll('.feed-tab').forEach(tab => {
+            tab.classList.toggle('active', tab.dataset.filter === filter);
+        });
+    }
+
     async function loadFeed(filter = 'all', isUpdate = false) {
         currentFilter = filter;
-        
-        // Update tabs
-        document.querySelectorAll('.feed-tab').forEach(tab => tab.classList.remove('active'));
-        event.target?.classList.add('active');
+        setActiveFeedTab(filter);
         
         try {
             const url = lastUpdate && isUpdate 

--- a/tests/test_activity_feed_event_contract.py
+++ b/tests/test_activity_feed_event_contract.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+import re
+from pathlib import Path
+
+
+TEMPLATE = (
+    Path(__file__).resolve().parents[1]
+    / "bottube_templates"
+    / "activity_feed.html"
+)
+
+
+def _load_feed_body() -> str:
+    source = TEMPLATE.read_text(encoding="utf-8")
+    match = re.search(
+        r"async function loadFeed\([^)]*\)\s*\{(?P<body>.*?)\n    \}",
+        source,
+        re.DOTALL,
+    )
+    assert match, "activity feed must define loadFeed"
+    return match.group("body")
+
+
+def test_load_feed_does_not_depend_on_implicit_browser_event():
+    body = _load_feed_body()
+
+    assert not re.search(r"(?<![\w.])event\s*\.", body), (
+        "loadFeed is invoked by DOMContentLoaded and setInterval without an "
+        "event; reading the implicit browser event aborts before fetch"
+    )
+
+
+def test_feed_tabs_expose_filter_state_for_programmatic_activation():
+    source = TEMPLATE.read_text(encoding="utf-8")
+
+    assert source.count('<button class="feed-tab') == 4
+    for filter_name in ("all", "uploads", "comments", "tips"):
+        assert f'data-filter="{filter_name}"' in source
+    assert "setActiveFeedTab(filter)" in _load_feed_body()


### PR DESCRIPTION
## What changed

- give each Activity Feed tab explicit filter state
- derive the active tab from the requested filter
- remove `loadFeed`'s dependency on the legacy implicit browser `event`
- add a regression for both initial/poll calls and programmatic tab activation

## Mutation and verification

Before the fix, the focused contract suite failed 2/2: `loadFeed` read undeclared `event.target` even though both DOMContentLoaded and polling call it without an event, and the tabs exposed no programmatic filter state.

After the fix:

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_activity_feed_event_contract.py` -> 2 passed
- `python -m py_compile tests/test_activity_feed_event_contract.py` -> clean
- `git diff --check` -> clean

Fixes #1903

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d