### PR TITLE
[TRAVIS] Personalize Discover from the signed-in session

### DIFF
--- a/bottube_templates/discover.html
+++ b/bottube_templates/discover.html
@@ -366,11 +366,7 @@
 
     async function loadForYou() {
         try {
-            // Get agent_id from session/storage if logged in
-            const agentId = localStorage.getItem('agent_id');
-            const url = agentId ? `/discover/api/for-you?agent_id=${agentId}` : '/discover/api/for-you';
-            
-            const response = await fetch(url);
+            const response = await fetch('/discover/api/for-you', { credentials: 'same-origin' });
             const data = await response.json();
             
             const container = document.getElementById('foryouVideos');

--- a/search_blueprint.py
+++ b/search_blueprint.py
@@ -401,18 +401,24 @@ def api_trending():
 def api_for_you():
     """
     Personalized "For You" feed based on viewing history.
-    Authenticate via X-API-Key header to get personalized results.
-    Falls back to trending if no key provided.
+    Uses the signed-in web session or an X-API-Key header to resolve the
+    viewer. Falls back to trending for anonymous requests.
     """
     try:
         limit = _parse_int_query('limit', 20, min_val=1, max_val=50)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
-    # Authenticate agent via API key header (not raw agent_id param)
-    api_key = request.headers.get('X-API-Key', '').strip()
     agent_id = None
-    if api_key:
+    api_key = ''
+    session_user = getattr(g, 'user', None)
+    if session_user:
+        agent_id = session_user['id']
+    else:
+        # Agent clients authenticate via API key. Never accept a raw agent_id
+        # query parameter because it would let one viewer impersonate another.
+        api_key = request.headers.get('X-API-Key', '').strip()
+    if agent_id is None and api_key:
         db_check = get_db()
         agent_row = db_check.execute(
             "SELECT id FROM agents WHERE api_key = ?", (api_key,)

--- a/tests/test_discover_for_you_session.py
+++ b/tests/test_discover_for_you_session.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+from flask import Flask, g
+
+import search_blueprint
+from search_blueprint import search_bp
+
+
+@pytest.fixture()
+def signed_in_discover_client(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY,
+            agent_name TEXT,
+            display_name TEXT,
+            api_key TEXT
+        );
+        CREATE TABLE videos (
+            id INTEGER PRIMARY KEY,
+            video_id TEXT,
+            title TEXT,
+            description TEXT,
+            thumbnail TEXT,
+            views INTEGER,
+            likes INTEGER,
+            tags TEXT,
+            category TEXT,
+            duration_sec REAL,
+            created_at REAL,
+            agent_id INTEGER
+        );
+        CREATE TABLE views (
+            video_id TEXT,
+            agent_id INTEGER,
+            created_at REAL
+        );
+        CREATE TABLE comments (
+            video_id TEXT,
+            created_at REAL
+        );
+        """
+    )
+    now = time.time()
+    conn.execute(
+        "INSERT INTO agents VALUES (1, 'signed_in_viewer', 'Signed In Viewer', 'viewer-key')"
+    )
+    conn.execute(
+        "INSERT INTO agents VALUES (2, 'creator', 'Creator', 'creator-key')"
+    )
+    conn.execute(
+        """INSERT INTO videos VALUES
+           (1, 'already-viewed', 'Already viewed', '', '', 10, 1,
+            '["python"]', 'education', 10, ?, 2)""",
+        (now - 100,),
+    )
+    conn.execute(
+        """INSERT INTO videos VALUES
+           (2, 'session-match', 'Session match', '', '', 4, 1,
+            '["python"]', 'education', 10, ?, 2)""",
+        (now,),
+    )
+    conn.execute(
+        "INSERT INTO views VALUES ('already-viewed', 1, ?)",
+        (now - 50,),
+    )
+    conn.commit()
+
+    monkeypatch.setattr(search_blueprint, "get_db", lambda: conn)
+
+    app = Flask(__name__)
+
+    @app.before_request
+    def load_signed_in_user():
+        g.user = conn.execute("SELECT * FROM agents WHERE id = 1").fetchone()
+
+    app.register_blueprint(search_bp)
+    app.config["TESTING"] = True
+
+    yield app.test_client()
+
+    conn.close()
+
+
+def test_for_you_uses_signed_in_web_session_without_api_key(
+    signed_in_discover_client,
+):
+    response = signed_in_discover_client.get("/discover/api/for-you")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["personalized"] is True
+    assert payload["based_on"]["categories"] == ["education"]
+    assert [video["id"] for video in payload["videos"]] == ["session-match"]
+
+
+def test_discover_ui_relies_on_session_credentials_not_local_storage_identity():
+    template = Path("bottube_templates/discover.html").read_text(encoding="utf-8")
+
+    assert "localStorage.getItem('agent_id')" not in template
+    assert "fetch('/discover/api/for-you', { credentials: 'same-origin' })" in template


### PR DESCRIPTION
## What changed

- resolve the Discover recommendation viewer from the signed-in web session first
- preserve API-key identity for agent clients
- preserve anonymous fallback to trending
- replace the unused/localStorage agent-id query with a same-origin credentialed request
- add a two-video history regression proving personalization and viewed-video exclusion

## Mutation and verification

Before the fix, both new regressions failed: a valid web session received the generic trending schema, and the UI tried to source identity from an unwritten localStorage key.

After the fix:

- focused and adjacent Discover suites: 17 passed
- `python -m py_compile search_blueprint.py tests/test_discover_for_you_session.py` -> clean
- `git diff --check` -> clean

Fixes #1905

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d