### PR TITLE
[TRAVIS] Activate creator-directory pagination

### DIFF
--- a/search_blueprint.py
+++ b/search_blueprint.py
@@ -558,6 +558,7 @@ def api_agent_directory():
     sort = request.args.get('sort', 'subscribers')
     try:
         limit = _parse_int_query('limit', 20, min_val=1, max_val=50)
+        offset = _parse_int_query('offset', 0, min_val=0)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -592,7 +593,7 @@ def api_agent_directory():
         ) v ON v.agent_id = a.id
         WHERE video_count > 0
         ORDER BY {order_sql}
-        LIMIT ?""", (limit,)).fetchall()
+        LIMIT ? OFFSET ?""", (limit, offset)).fetchall()
     
     results = []
     for row in agents:
@@ -609,5 +610,7 @@ def api_agent_directory():
     
     return jsonify({
         "sort": sort,
+        "limit": limit,
+        "offset": offset,
         "agents": results
     })

--- a/tests/test_discover_agent_directory_pagination.py
+++ b/tests/test_discover_agent_directory_pagination.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+import time
+
+import pytest
+from flask import Flask
+
+import search_blueprint
+from search_blueprint import search_bp
+
+
+@pytest.fixture()
+def agent_directory_client(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY,
+            agent_name TEXT,
+            display_name TEXT,
+            avatar_url TEXT,
+            bio TEXT
+        );
+        CREATE TABLE videos (
+            id INTEGER PRIMARY KEY,
+            video_id TEXT,
+            agent_id INTEGER,
+            created_at REAL
+        );
+        CREATE TABLE subscriptions (
+            follower_id INTEGER,
+            following_id INTEGER
+        );
+        """
+    )
+    now = time.time()
+    for agent_id, name, video_count in (
+        (1, "three_videos", 3),
+        (2, "two_videos", 2),
+        (3, "one_video", 1),
+    ):
+        conn.execute(
+            "INSERT INTO agents VALUES (?, ?, ?, '', '')",
+            (agent_id, name, name.replace("_", " ").title()),
+        )
+        for index in range(video_count):
+            conn.execute(
+                "INSERT INTO videos VALUES (NULL, ?, ?, ?)",
+                (f"{name}-{index}", agent_id, now - index),
+            )
+    conn.commit()
+
+    monkeypatch.setattr(search_blueprint, "get_db", lambda: conn)
+    app = Flask(__name__)
+    app.register_blueprint(search_bp)
+    app.config["TESTING"] = True
+
+    yield app.test_client()
+
+    conn.close()
+
+
+def test_agent_directory_applies_documented_offset(agent_directory_client):
+    response = agent_directory_client.get(
+        "/discover/api/agents?sort=videos&limit=1&offset=1"
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["limit"] == 1
+    assert payload["offset"] == 1
+    assert [agent["name"] for agent in payload["agents"]] == ["two_videos"]
+
+
+@pytest.mark.parametrize("offset", ["bad", "-1"])
+def test_agent_directory_rejects_invalid_offset(
+    agent_directory_client, offset
+):
+    response = agent_directory_client.get(
+        f"/discover/api/agents?offset={offset}"
+    )
+
+    assert response.status_code == 400
+    assert "offset" in response.get_json()["error"]


### PR DESCRIPTION
## What changed

- parse and validate the documented creator-directory `offset`
- apply it to the sorted SQL page with `LIMIT ? OFFSET ?`
- return effective pagination values in the response
- add ordered multi-page and invalid-offset regressions

## Mutation and verification

Before the fix, all 3 focused regressions failed: `offset=1` still returned page zero, while malformed and negative offsets returned 200.

After the fix:

- focused plus adjacent Discover/query suites: 20 passed
- `python -m py_compile search_blueprint.py tests/test_discover_agent_directory_pagination.py` -> clean
- `git diff --check` -> clean

Fixes #1907

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d