### PR TITLE
[TRAVIS] Keep Discover catalogs within public visibility

### DIFF
--- a/search_blueprint.py
+++ b/search_blueprint.py
@@ -74,6 +74,11 @@ def _thumbnail_url(thumbnail):
     return f"/thumbnails/{quote(thumbnail)}"
 
 
+def _public_video_filter_sql() -> str:
+    """Return the shared visibility predicate for public Discover queries."""
+    return "COALESCE(v.is_removed, 0) = 0 AND COALESCE(a.is_banned, 0) = 0"
+
+
 @search_bp.route('/')
 def discover_page():
     """Main discoverability page with search, filters, and trending."""
@@ -106,7 +111,7 @@ def api_search():
     db = get_db()
     
     # Build the query
-    where_clauses = []
+    where_clauses = [_public_video_filter_sql()]
     params = []
     
     if query:
@@ -132,7 +137,9 @@ def api_search():
         order_sql = "(v.views * 2 + v.likes * 3) DESC"
     
     # Count total
-    count_sql = f"SELECT COUNT(*) FROM videos v WHERE {where_sql}"
+    count_sql = f"""SELECT COUNT(*)
+                      FROM videos v JOIN agents a ON v.agent_id = a.id
+                     WHERE {where_sql}"""
     total = db.execute(count_sql, params).fetchone()[0]
     
     # Get results
@@ -202,7 +209,9 @@ def api_categories():
     categories = []
     for cat in VIDEO_CATEGORIES:
         count = db.execute(
-            "SELECT COUNT(*) FROM videos WHERE category = ?",
+            f"""SELECT COUNT(*)
+                  FROM videos v JOIN agents a ON v.agent_id = a.id
+                 WHERE v.category = ? AND {_public_video_filter_sql()}""",
             (cat,)
         ).fetchone()[0]
         categories.append({
@@ -232,7 +241,12 @@ def api_tags():
     db = get_db()
     
     # Get all tags from videos
-    videos = db.execute("SELECT tags FROM videos WHERE tags != '[]' AND tags != ''").fetchall()
+    videos = db.execute(
+        f"""SELECT v.tags
+              FROM videos v JOIN agents a ON v.agent_id = a.id
+             WHERE v.tags != '[]' AND v.tags != ''
+               AND {_public_video_filter_sql()}"""
+    ).fetchall()
     
     tag_counts = {}
     for row in videos:
@@ -268,11 +282,13 @@ def api_videos_by_tag(tag_name):
     search_pattern = f'%"{tag_name.lower()}"%'
     
     total = db.execute(
-        "SELECT COUNT(*) FROM videos WHERE LOWER(tags) LIKE ?",
+        f"""SELECT COUNT(*)
+              FROM videos v JOIN agents a ON v.agent_id = a.id
+             WHERE LOWER(v.tags) LIKE ? AND {_public_video_filter_sql()}""",
         (search_pattern,)
     ).fetchone()[0]
     
-    results = db.execute("""SELECT 
+    results = db.execute(f"""SELECT
             v.id,
             v.video_id,
             v.title,
@@ -289,6 +305,7 @@ def api_videos_by_tag(tag_name):
         FROM videos v
         JOIN agents a ON v.agent_id = a.id
         WHERE LOWER(v.tags) LIKE ?
+          AND {_public_video_filter_sql()}
         ORDER BY v.created_at DESC
         LIMIT ? OFFSET ?""",
         (search_pattern, limit, offset)
@@ -344,7 +361,7 @@ def api_trending():
     day_ago = (datetime.now() - timedelta(hours=24)).timestamp()
     
     # Get trending scores
-    trending = db.execute("""SELECT 
+    trending = db.execute(f"""SELECT
             v.id,
             v.video_id,
             v.title,
@@ -372,6 +389,7 @@ def api_trending():
             GROUP BY video_id
         ) cc ON cc.video_id = v.video_id
         WHERE trending_score > 0
+          AND {_public_video_filter_sql()}
         ORDER BY trending_score DESC
         LIMIT ?""", (day_ago, day_ago, limit)).fetchall()
     
@@ -427,10 +445,11 @@ def api_for_you():
     db = get_db()
     
     # Get categories and tags the agent has viewed
-    viewed = db.execute("""SELECT DISTINCT v.category, v.tags
+    viewed = db.execute(f"""SELECT DISTINCT v.category, v.tags
         FROM views vw
         JOIN videos v ON vw.video_id = v.video_id
-        WHERE vw.agent_id = ?""", (agent_id,)).fetchall()
+        JOIN agents a ON v.agent_id = a.id
+        WHERE vw.agent_id = ? AND {_public_video_filter_sql()}""", (agent_id,)).fetchall()
     
     categories = set()
     tags = set()
@@ -504,7 +523,7 @@ def api_for_you():
             ({score_sql}) as recommendation_score
         FROM videos v
         JOIN agents a ON v.agent_id = a.id
-        WHERE 1=1 {exclude_sql}
+        WHERE {_public_video_filter_sql()} {exclude_sql}
         ORDER BY recommendation_score DESC
         LIMIT ?"""
 
@@ -588,9 +607,11 @@ def api_agent_directory():
         ) s ON s.following_id = a.id
         LEFT JOIN (
             SELECT agent_id, COUNT(*) as video_count, MAX(created_at) as last_upload
-            FROM videos GROUP BY agent_id
+            FROM videos
+            WHERE COALESCE(is_removed, 0) = 0
+            GROUP BY agent_id
         ) v ON v.agent_id = a.id
-        WHERE video_count > 0
+        WHERE video_count > 0 AND COALESCE(a.is_banned, 0) = 0
         ORDER BY {order_sql}
         LIMIT ?""", (limit,)).fetchall()
     

--- a/tests/test_discover_public_visibility.py
+++ b/tests/test_discover_public_visibility.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+import time
+
+import pytest
+from flask import Flask
+
+import search_blueprint
+from search_blueprint import search_bp
+
+
+@pytest.fixture()
+def discover_visibility_client(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE agents (
+            id INTEGER PRIMARY KEY,
+            agent_name TEXT,
+            display_name TEXT,
+            avatar_url TEXT,
+            bio TEXT,
+            api_key TEXT,
+            is_banned INTEGER DEFAULT 0
+        );
+        CREATE TABLE videos (
+            id INTEGER PRIMARY KEY,
+            video_id TEXT,
+            title TEXT,
+            description TEXT,
+            thumbnail TEXT,
+            views INTEGER,
+            likes INTEGER,
+            tags TEXT,
+            category TEXT,
+            duration_sec REAL,
+            created_at REAL,
+            agent_id INTEGER,
+            is_removed INTEGER DEFAULT 0
+        );
+        CREATE TABLE views (
+            video_id TEXT,
+            agent_id INTEGER,
+            created_at REAL
+        );
+        CREATE TABLE comments (
+            video_id TEXT,
+            created_at REAL
+        );
+        CREATE TABLE subscriptions (
+            follower_id INTEGER,
+            following_id INTEGER
+        );
+        """
+    )
+    now = time.time()
+    conn.executemany(
+        "INSERT INTO agents VALUES (?, ?, ?, '', '', ?, ?)",
+        [
+            (1, "visible_creator", "Visible Creator", "visible-key", 0),
+            (2, "banned_creator", "Banned Creator", "banned-key", 1),
+        ],
+    )
+    conn.executemany(
+        """INSERT INTO videos VALUES
+           (NULL, ?, ?, '', '', 10, 2, '["shared"]', 'education',
+            10, ?, ?, ?)""",
+        [
+            ("visible-discover", "Shared visible", now, 1, 0),
+            ("removed-discover", "Shared removed", now, 1, 1),
+            ("banned-discover", "Shared banned", now, 2, 0),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO views VALUES (?, NULL, ?)",
+        [
+            ("visible-discover", now),
+            ("removed-discover", now),
+            ("banned-discover", now),
+        ],
+    )
+    conn.commit()
+
+    monkeypatch.setattr(search_blueprint, "get_db", lambda: conn)
+    app = Flask(__name__)
+    app.register_blueprint(search_bp)
+    app.config["TESTING"] = True
+
+    yield app.test_client()
+
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/discover/api/search?q=Shared",
+        "/discover/api/tag/shared",
+        "/discover/api/trending",
+        "/discover/api/for-you",
+    ],
+)
+def test_discover_video_catalogs_only_return_public_videos(
+    discover_visibility_client, path
+):
+    response = discover_visibility_client.get(path)
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert [video["id"] for video in payload["videos"]] == [
+        "visible-discover"
+    ]
+    if "total" in payload:
+        assert payload["total"] == 1
+
+
+def test_discover_facets_only_count_public_videos(discover_visibility_client):
+    categories = discover_visibility_client.get(
+        "/discover/api/categories"
+    ).get_json()["categories"]
+    education = next(row for row in categories if row["id"] == "education")
+    assert education["count"] == 1
+
+    tags = discover_visibility_client.get(
+        "/discover/api/tags"
+    ).get_json()["tags"]
+    assert tags == [{"name": "shared", "count": 1}]
+
+
+def test_discover_agent_directory_uses_public_video_counts(
+    discover_visibility_client,
+):
+    response = discover_visibility_client.get(
+        "/discover/api/agents?sort=videos"
+    )
+
+    assert response.status_code == 200
+    agents = response.get_json()["agents"]
+    assert [agent["name"] for agent in agents] == ["visible_creator"]
+    assert agents[0]["videos"] == 1

--- a/tests/test_discover_thumbnail_urls.py
+++ b/tests/test_discover_thumbnail_urls.py
@@ -21,7 +21,8 @@ def discover_thumbnail_client(monkeypatch):
         CREATE TABLE agents (
             id INTEGER PRIMARY KEY,
             agent_name TEXT,
-            display_name TEXT
+            display_name TEXT,
+            is_banned INTEGER DEFAULT 0
         );
         CREATE TABLE videos (
             id INTEGER PRIMARY KEY,
@@ -35,7 +36,8 @@ def discover_thumbnail_client(monkeypatch):
             category TEXT,
             duration_sec REAL,
             created_at REAL,
-            agent_id INTEGER
+            agent_id INTEGER,
+            is_removed INTEGER DEFAULT 0
         );
         CREATE TABLE views (
             video_id TEXT,


### PR DESCRIPTION
## Summary
- exclude removed videos and videos owned by banned agents from Discover search, tags, trending, and personalized recommendations
- keep category/tag facet counts within the same public-visibility boundary
- exclude banned creators and count only public videos in the agent directory

## Proof
- mutation baseline: 6/6 regression tests failed before the fix
- focused + adjacent regression suite: 28/28 passed after the fix
- Python compile and diff-integrity checks are clean

Fixes #1909

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d