### PR TITLE
[TRAVIS] Activate the translation runtime end to end

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15546,6 +15546,15 @@ app.register_blueprint(store_bp)
 
 # USDC Payment Integration (Base Chain)
 from bottube_db import resolve_db_path
+
+# Translation API and UI. Keep its table initializer beside registration so a
+# route cannot be advertised without the storage contract it needs.
+from translation_routes import init_translation_tables, translation_bp
+_translation_db = sqlite3.connect(resolve_db_path())
+init_translation_tables(_translation_db)
+_translation_db.close()
+app.register_blueprint(translation_bp)
+
 from usdc_blueprint import usdc_bp, init_usdc_tables
 import sqlite3 as _usdc_sqlite3
 _usdc_db = _usdc_sqlite3.connect(resolve_db_path())

--- a/tests/test_translation_route_validation.py
+++ b/tests/test_translation_route_validation.py
@@ -26,16 +26,33 @@ def client(monkeypatch, tmp_path):
     with sqlite3.connect(db_path) as db:
         db.execute(
             """
-            CREATE TABLE video_translations (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                video_id INTEGER NOT NULL,
-                language TEXT NOT NULL,
-                title TEXT NOT NULL,
-                description TEXT NOT NULL,
-                translator_id INTEGER NOT NULL,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            CREATE TABLE agents (
+                id INTEGER PRIMARY KEY,
+                agent_name TEXT NOT NULL,
+                is_banned INTEGER DEFAULT 0
             )
             """
+        )
+        db.execute(
+            """
+            CREATE TABLE videos (
+                id INTEGER PRIMARY KEY,
+                video_id TEXT UNIQUE NOT NULL,
+                agent_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                is_removed INTEGER DEFAULT 0
+            )
+            """
+        )
+        db.executemany(
+            "INSERT INTO agents (id, agent_name) VALUES (?, ?)",
+            [(1, "creator"), (7, "translator")],
+        )
+        db.execute(
+            """INSERT INTO videos
+               (id, video_id, agent_id, title, description)
+               VALUES (42, 'public-video-id', 1, 'Original', 'Original description')"""
         )
         db.commit()
 
@@ -47,18 +64,21 @@ def client(monkeypatch, tmp_path):
         g.test_db = db
         return db
 
-    def require_auth(fn):
+    def require_api_key(fn):
         def wrapper(*args, **kwargs):
-            g.user = {"id": 7}
+            g.agent = {"id": 7}
             return fn(*args, **kwargs)
 
         wrapper.__name__ = fn.__name__
         return wrapper
 
-    fake_server = types.SimpleNamespace(get_db=get_db, require_auth=require_auth)
+    fake_server = types.SimpleNamespace(get_db=get_db, require_api_key=require_api_key)
     monkeypatch.setitem(sys.modules, "bottube_server", fake_server)
 
     import translation_routes
+
+    with sqlite3.connect(db_path) as db:
+        translation_routes.init_translation_tables(db)
 
     app = Flask(__name__)
     app.config["TESTING"] = True
@@ -90,4 +110,37 @@ def test_add_translation_preserves_missing_field_error_for_objects(client):
 
     assert resp.status_code == 400
     assert resp.get_json() == {"error": "Missing required fields"}
+    assert _translation_count(client) == 0
+
+
+def test_translation_round_trip_uses_public_video_id(client):
+    created = client.post(
+        "/api/translations",
+        json={
+            "video_id": "public-video-id",
+            "language": "French",
+            "title": "Titre",
+            "description": "Description traduite",
+        },
+    )
+
+    assert created.status_code == 200
+    response = client.get("/api/translations/public-video-id/French")
+    assert response.status_code == 200
+    assert response.get_json()["title"] == "Titre"
+
+
+def test_translation_write_rejects_unknown_video(client):
+    response = client.post(
+        "/api/translations",
+        json={
+            "video_id": "missing-video",
+            "language": "French",
+            "title": "Titre",
+            "description": "Description traduite",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Video not found"}
     assert _translation_count(client) == 0

--- a/tests/test_translation_runtime_registration.py
+++ b/tests/test_translation_runtime_registration.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_production_app_registers_translation_routes(tmp_path):
+    env = os.environ.copy()
+    env["BOTTUBE_BASE_DIR"] = str(tmp_path)
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(Path(__file__).resolve().parents[1]), env.get("PYTHONPATH")])
+    )
+    script = (
+        "import bottube_server; "
+        "routes={r.rule for r in bottube_server.app.url_map.iter_rules()}; "
+        "assert '/translations' in routes; "
+        "assert '/api/translations/<video_id>' in routes"
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=os.fspath(tmp_path),
+        env=env,
+        check=True,
+        timeout=60,
+    )

--- a/translation_routes.py
+++ b/translation_routes.py
@@ -1,10 +1,37 @@
 # SPDX-License-Identifier: MIT
 from flask import Blueprint, render_template, request, jsonify, g, session
-from bottube_server import get_db, require_auth
+from bottube_server import get_db, require_api_key
 import sqlite3
 import json
 
 translation_bp = Blueprint('translation', __name__)
+
+
+def init_translation_tables(db):
+    """Create the durable translation store on the canonical BoTTube database."""
+    db.execute('''
+        CREATE TABLE IF NOT EXISTS video_translations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            video_id TEXT NOT NULL,
+            language TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT NOT NULL,
+            translator_id INTEGER NOT NULL,
+            created_at REAL NOT NULL DEFAULT (unixepoch()),
+            UNIQUE(video_id, language, translator_id),
+            FOREIGN KEY (video_id) REFERENCES videos(video_id),
+            FOREIGN KEY (translator_id) REFERENCES agents(id)
+        )
+    ''')
+    db.execute('''
+        CREATE INDEX IF NOT EXISTS idx_video_translations_language_created
+        ON video_translations(language, created_at DESC)
+    ''')
+    db.execute('''
+        CREATE INDEX IF NOT EXISTS idx_video_translations_video_created
+        ON video_translations(video_id, created_at DESC)
+    ''')
+    db.commit()
 
 
 def _request_json_object():
@@ -35,9 +62,13 @@ def translations_page():
     
     # Get recent translations
     recent_translations = db.execute('''
-        SELECT vt.*, v.original_title, v.original_description, v.video_id
+        SELECT vt.*, v.title AS original_title,
+               v.description AS original_description, v.video_id
         FROM video_translations vt
-        JOIN videos v ON vt.video_id = v.id
+        JOIN videos v ON vt.video_id = v.video_id
+        JOIN agents a ON a.id = v.agent_id
+        WHERE COALESCE(v.is_removed, 0) = 0
+          AND COALESCE(a.is_banned, 0) = 0
         ORDER BY vt.created_at DESC
         LIMIT 20
     ''').fetchall()
@@ -46,7 +77,7 @@ def translations_page():
                          languages=languages,
                          recent_translations=recent_translations)
 
-@translation_bp.route('/api/translations/<int:video_id>')
+@translation_bp.route('/api/translations/<video_id>')
 def get_translations(video_id):
     """Retrieve translations.
     
@@ -59,15 +90,19 @@ def get_translations(video_id):
     db = get_db()
     
     translations = db.execute('''
-        SELECT language, title, description, translator_id, created_at
-        FROM video_translations 
-        WHERE video_id = ?
-        ORDER BY created_at DESC
+        SELECT vt.language, vt.title, vt.description, vt.translator_id, vt.created_at
+        FROM video_translations vt
+        JOIN videos v ON v.video_id = vt.video_id
+        JOIN agents a ON a.id = v.agent_id
+        WHERE vt.video_id = ?
+          AND COALESCE(v.is_removed, 0) = 0
+          AND COALESCE(a.is_banned, 0) = 0
+        ORDER BY vt.created_at DESC
     ''', (video_id,)).fetchall()
     
     return jsonify([dict(t) for t in translations])
 
-@translation_bp.route('/api/translations/<int:video_id>/<language>')
+@translation_bp.route('/api/translations/<video_id>/<language>')
 def get_translation_by_language(video_id, language):
     """Retrieve translation by language.
     
@@ -78,9 +113,14 @@ def get_translation_by_language(video_id, language):
     db = get_db()
     
     translation = db.execute('''
-        SELECT * FROM video_translations 
-        WHERE video_id = ? AND language = ?
-        ORDER BY created_at DESC
+        SELECT vt.*
+        FROM video_translations vt
+        JOIN videos v ON v.video_id = vt.video_id
+        JOIN agents a ON a.id = v.agent_id
+        WHERE vt.video_id = ? AND vt.language = ?
+          AND COALESCE(v.is_removed, 0) = 0
+          AND COALESCE(a.is_banned, 0) = 0
+        ORDER BY vt.created_at DESC
         LIMIT 1
     ''', (video_id, language)).fetchone()
     
@@ -89,7 +129,7 @@ def get_translation_by_language(video_id, language):
     return jsonify({'error': 'Translation not found'}), 404
 
 @translation_bp.route('/api/translations', methods=['POST'])
-@require_auth
+@require_api_key
 def add_translation():
     """Add translation.
     
@@ -102,14 +142,41 @@ def add_translation():
     
     if not all(k in data for k in ['video_id', 'language', 'title', 'description']):
         return jsonify({'error': 'Missing required fields'}), 400
+
+    video_id = data['video_id']
+    language = data['language']
+    title = data['title']
+    description = data['description']
+    if not isinstance(video_id, str) or not video_id.strip() or len(video_id) > 128:
+        return jsonify({'error': 'video_id must be a non-empty string'}), 400
+    if not isinstance(language, str) or not language.strip() or len(language) > 64:
+        return jsonify({'error': 'language must be a non-empty string'}), 400
+    if not isinstance(title, str) or not title.strip() or len(title) > 500:
+        return jsonify({'error': 'title must be a non-empty string'}), 400
+    if not isinstance(description, str) or len(description) > 10000:
+        return jsonify({'error': 'description must be a string'}), 400
+
+    video_id = video_id.strip()
+    language = language.strip()
+    title = title.strip()
     
     db = get_db()
+    video = db.execute('''
+        SELECT v.video_id
+        FROM videos v
+        JOIN agents a ON a.id = v.agent_id
+        WHERE v.video_id = ?
+          AND COALESCE(v.is_removed, 0) = 0
+          AND COALESCE(a.is_banned, 0) = 0
+    ''', (video_id,)).fetchone()
+    if not video:
+        return jsonify({'error': 'Video not found'}), 404
     
     # Check if translation already exists
     existing = db.execute('''
         SELECT id FROM video_translations 
         WHERE video_id = ? AND language = ? AND translator_id = ?
-    ''', (data['video_id'], data['language'], g.user['id'])).fetchone()
+    ''', (video_id, language, g.agent['id'])).fetchone()
     
     if existing:
         # Update existing translation
@@ -117,13 +184,13 @@ def add_translation():
             UPDATE video_translations 
             SET title = ?, description = ?, created_at = CURRENT_TIMESTAMP
             WHERE id = ?
-        ''', (data['title'], data['description'], existing['id']))
+        ''', (title, description, existing['id']))
     else:
         # Create new translation
         db.execute('''
             INSERT INTO video_translations (video_id, language, title, description, translator_id)
             VALUES (?, ?, ?, ?, ?)
-        ''', (data['video_id'], data['language'], data['title'], data['description'], g.user['id']))
+        ''', (video_id, language, title, description, g.agent['id']))
     
     db.commit()
     return jsonify({'success': True})
@@ -140,8 +207,11 @@ def get_videos_by_language(language):
     videos = db.execute('''
         SELECT v.*, vt.title as translated_title, vt.description as translated_description
         FROM videos v
-        JOIN video_translations vt ON v.id = vt.video_id
+        JOIN video_translations vt ON v.video_id = vt.video_id
+        JOIN agents a ON a.id = v.agent_id
         WHERE vt.language = ?
+          AND COALESCE(v.is_removed, 0) = 0
+          AND COALESCE(a.is_banned, 0) = 0
         ORDER BY vt.created_at DESC
     ''', (language,)).fetchall()
     


### PR DESCRIPTION
Fixes #1913

## What changed
- registers the existing translation blueprint in the production Flask app and initializes its durable SQLite store at the same activation edge
- uses canonical public `videos.video_id` text identifiers throughout instead of internal integer row IDs
- replaces the nonexistent `require_auth` dependency with BoTTube's real API-key guard
- rejects invalid or nonexistent video writes and keeps removed videos / banned creators off public translation reads
- adds idempotent schema/index initialization and public-ID round-trip regressions

## Proof
- production mutation baseline: importing current `main` exposed **zero** translation routes
- `tests/test_translation_route_validation.py`: **4 passed**
- `tests/test_translation_runtime_registration.py`: **1 passed** (real production app import, isolated database, 52.55s)
- existing `tests/test_translations.py`: **18 passed**
- changed files compile cleanly; `git diff --check` passes

This closes the complete runtime gap: registration, authentication, schema, canonical identifiers, read visibility, and tests are activated together.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d