### PR TITLE
fix: validate provenance anchor batch membership

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -23399,17 +23399,53 @@ def admin_provenance_anchor_result():
     if not _ts_admin_ok():
         return jsonify({"ok": False, "error": "unauthorized"}), 401
     _provenance_ensure_anchor_columns()
-    data = request.get_json(silent=True) or {}
-    batch_id = (data.get("batch_id") or "").strip()
-    chain = (data.get("chain") or "ergo").strip()[:32]
-    tx_hash = (data.get("tx_hash") or "").strip()[:128]
+    data, body_error = _admin_json_body()
+    if body_error:
+        return jsonify({"ok": False, "error": body_error}), 400
+
+    batch_id, field_error = _admin_text_field(data, "batch_id")
+    if field_error:
+        return jsonify({"ok": False, "error": field_error}), 400
+    chain, field_error = _admin_text_field(data, "chain", default="ergo", max_length=32)
+    if field_error:
+        return jsonify({"ok": False, "error": field_error}), 400
+    tx_hash, field_error = _admin_text_field(data, "tx_hash", max_length=128)
+    if field_error:
+        return jsonify({"ok": False, "error": field_error}), 400
     try:
         block_height = int(data.get("block_height", 0))
     except Exception:
         block_height = 0
-    manifest_hash = (data.get("merkle_root") or data.get("manifest_hash") or "").strip()[:128]
-    error_msg = (data.get("error") or "").strip()[:500]
-    video_ids = data.get("video_ids") or []
+    manifest_hash_field = "merkle_root" if "merkle_root" in data else "manifest_hash"
+    manifest_hash, field_error = _admin_text_field(
+        data, manifest_hash_field, max_length=128
+    )
+    if field_error:
+        return jsonify({"ok": False, "error": field_error}), 400
+    error_msg, field_error = _admin_text_field(data, "error", max_length=500)
+    if field_error:
+        return jsonify({"ok": False, "error": field_error}), 400
+
+    # A successful anchor is only valid for the exact member set used to
+    # compute its Merkle root. Failure callbacks intentionally omit this list
+    # because they only release the worker's failed claim.
+    callback_video_ids = None
+    if not error_msg:
+        raw_video_ids = data.get("video_ids")
+        if not isinstance(raw_video_ids, list) or not raw_video_ids:
+            return jsonify({
+                "ok": False,
+                "error": "video_ids must be a non-empty array for a success result",
+            }), 400
+        if any(not isinstance(video_id, str) or not video_id.strip()
+               for video_id in raw_video_ids):
+            return jsonify({
+                "ok": False,
+                "error": "video_ids must contain only non-empty strings",
+            }), 400
+        callback_video_ids = [video_id.strip() for video_id in raw_video_ids]
+        if len(callback_video_ids) != len(set(callback_video_ids)):
+            return jsonify({"ok": False, "error": "video_ids must be unique"}), 400
 
     if not batch_id or not re.fullmatch(r"batch_[a-f0-9]{8,32}", batch_id):
         return jsonify({"ok": False, "error": "invalid batch_id"}), 400
@@ -23428,6 +23464,17 @@ def admin_provenance_anchor_result():
         if not existing:
             conn.execute("ROLLBACK")
             return jsonify({"ok": False, "error": "batch_id has no claimed rows"}), 404
+
+        if not error_msg:
+            claimed_video_ids = {row["video_id"] for row in existing}
+            if set(callback_video_ids) != claimed_video_ids:
+                conn.execute("ROLLBACK")
+                return jsonify({
+                    "ok": False,
+                    "error": "video_ids do not match claimed batch membership",
+                    "claimed_count": len(claimed_video_ids),
+                    "callback_count": len(callback_video_ids),
+                }), 409
 
         # Idempotency: if batch already anchored, return ok.
         already = [r for r in existing if r["anchor_tx_hash"]]

--- a/tests/test_provenance_anchor_membership.py
+++ b/tests/test_provenance_anchor_membership.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("BOTTUBE_DB_PATH", "/tmp/bottube_test_anchor_membership.db")
+os.environ.setdefault("BOTTUBE_DB", "/tmp/bottube_test_anchor_membership.db")
+
+_orig_sqlite_connect = sqlite3.connect
+
+
+def _bootstrap_sqlite_connect(path, *args, **kwargs):
+    if str(path) == "/root/bottube/bottube.db":
+        path = os.environ["BOTTUBE_DB_PATH"]
+    return _orig_sqlite_connect(path, *args, **kwargs)
+
+
+sqlite3.connect = _bootstrap_sqlite_connect
+
+import bottube_server  # noqa: E402
+
+sqlite3.connect = _orig_sqlite_connect
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "anchor_membership.db"
+    monkeypatch.setattr(bottube_server, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(bottube_server, "ADMIN_KEY", "anchor-test-admin", raising=False)
+    bottube_server._PROVENANCE_SCHEMA_READY = False
+    bottube_server.init_db()
+    bottube_server._ensure_provenance_schema()
+    bottube_server._provenance_ensure_anchor_columns()
+    bottube_server.app.config["TESTING"] = True
+    yield bottube_server.app.test_client()
+
+
+def _insert_claimed_batch(batch_id="batch_0123456789abcdef"):
+    now = time.time()
+    with sqlite3.connect(str(bottube_server.DB_PATH)) as db:
+        for video_id in ("anchor-member-a", "anchor-member-b"):
+            db.execute(
+                """
+                INSERT INTO video_provenance
+                    (video_id, canonical_sha256, uploader_sig, uploaded_at,
+                     anchor_batch_id, anchor_status, updated_at)
+                VALUES (?, ?, ?, ?, ?, 'claimed', ?)
+                """,
+                (video_id, "a" * 64, "test-signature", now, batch_id, now),
+            )
+    return batch_id
+
+
+def _callback(client, batch_id, video_ids=None, **extra):
+    payload = {
+        "batch_id": batch_id,
+        "chain": "stub",
+        "tx_hash": "b" * 64,
+        "block_height": 12,
+        "merkle_root": "c" * 64,
+        **extra,
+    }
+    if video_ids is not None:
+        payload["video_ids"] = video_ids
+    return client.post(
+        "/api/admin/provenance/anchor-result",
+        headers={"X-Admin-Key": "anchor-test-admin"},
+        json=payload,
+    )
+
+
+def test_anchor_result_rejects_mismatched_batch_membership(client):
+    batch_id = _insert_claimed_batch()
+
+    response = _callback(client, batch_id, ["anchor-member-a", "different-video"])
+
+    assert response.status_code == 409
+    assert response.get_json()["error"] == "video_ids do not match claimed batch membership"
+    with sqlite3.connect(str(bottube_server.DB_PATH)) as db:
+        rows = db.execute(
+            "SELECT anchor_status, anchor_tx_hash FROM video_provenance ORDER BY video_id"
+        ).fetchall()
+    assert rows == [("claimed", ""), ("claimed", "")]
+
+
+def test_anchor_result_requires_unique_video_ids_for_success(client):
+    batch_id = _insert_claimed_batch()
+
+    missing = _callback(client, batch_id)
+    duplicate = _callback(client, batch_id, ["anchor-member-a", "anchor-member-a"])
+
+    assert missing.status_code == 400
+    assert duplicate.status_code == 400
+
+
+def test_anchor_result_accepts_exact_batch_membership(client):
+    batch_id = _insert_claimed_batch()
+
+    response = _callback(client, batch_id, ["anchor-member-b", "anchor-member-a"])
+
+    assert response.status_code == 200
+    assert response.get_json()["rows_anchored"] == 2
+    with sqlite3.connect(str(bottube_server.DB_PATH)) as db:
+        rows = db.execute(
+            "SELECT anchor_status, anchor_tx_hash FROM video_provenance ORDER BY video_id"
+        ).fetchall()
+    assert rows == [("anchored", "b" * 64), ("anchored", "b" * 64)]
+
+
+def test_anchor_failure_callback_does_not_require_video_ids(client):
+    batch_id = _insert_claimed_batch()
+
+    response = _callback(client, batch_id, error="upstream anchor failed")
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "failed"
+


### PR DESCRIPTION
## Summary
- require successful provenance anchor callbacks to carry a non-empty, unique `video_ids` list
- compare the callback member set to the rows actually claimed under `batch_id` before idempotency or mutation
- reject stale/mismatched callbacks with 409 while preserving the claimed rows
- preserve the existing failure-release path, which intentionally omits `video_ids`
- validate callback JSON/text fields instead of allowing malformed bodies to raise attribute errors

## Proof
Mutation baseline on upstream `main`:
- **2 failed, 2 passed**: mismatched membership and missing membership were both accepted and anchored rows

After fix:
- `python -m pytest -q tests/test_provenance_anchor_membership.py` -> **4 passed**
- `python -m pytest -q tests/test_provenance_anchor_membership.py tests/test_receipt_watch_url.py tests/test_admin_key_env.py` -> **8 passed**
- `python -m py_compile bottube_server.py tests/test_provenance_anchor_membership.py` -> clean
- `git diff --check` -> clean

Closes #1915

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d