### PR TITLE
perf: remove discarded profile aggregates

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8740,40 +8740,6 @@ def get_agent(agent_name):
     )
     agent_badges = _list_agent_badges(db, int(agent["id"]))
 
-    # Agent-to-agent interaction data
-    aid = agent["id"]
-    interaction_commenters = db.execute(
-        """SELECT a2.agent_name, a2.display_name, a2.avatar_url, COUNT(*) AS cnt
-           FROM comments c JOIN videos v ON c.video_id = v.video_id
-           JOIN agents a2 ON c.agent_id = a2.id
-           WHERE v.agent_id = ? AND c.agent_id != ?
-             AND COALESCE(v.is_removed, 0) = 0
-             AND COALESCE(a2.is_banned, 0) = 0
-           GROUP BY a2.id ORDER BY cnt DESC LIMIT 8""",
-        (aid, aid)).fetchall()
-    interaction_likers = db.execute(
-        """SELECT a2.agent_name, a2.display_name, a2.avatar_url, COUNT(*) AS cnt
-           FROM votes vt JOIN videos v ON vt.video_id = v.video_id
-           JOIN agents a2 ON vt.agent_id = a2.id
-           WHERE v.agent_id = ? AND vt.vote = 1 AND vt.agent_id != ?
-             AND COALESCE(v.is_removed, 0) = 0
-             AND COALESCE(a2.is_banned, 0) = 0
-           GROUP BY a2.id ORDER BY cnt DESC LIMIT 8""",
-        (aid, aid)).fetchall()
-    interaction_outgoing = db.execute(
-        """SELECT a2.agent_name, a2.display_name, a2.avatar_url,
-               (SELECT COUNT(*) FROM comments c2 JOIN videos v2 ON c2.video_id=v2.video_id
-                WHERE c2.agent_id=? AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) AS comments_given,
-               (SELECT COUNT(*) FROM votes vt2 JOIN videos v2 ON vt2.video_id=v2.video_id
-                WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) AS likes_given
-           FROM agents a2
-           WHERE a2.id != ? AND COALESCE(a2.is_banned, 0) = 0 AND (
-               (SELECT COUNT(*) FROM comments c2 JOIN videos v2 ON c2.video_id=v2.video_id
-                WHERE c2.agent_id=? AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) > 0
-               OR (SELECT COUNT(*) FROM votes vt2 JOIN videos v2 ON vt2.video_id=v2.video_id
-                   WHERE vt2.agent_id=? AND vt2.vote=1 AND v2.agent_id=a2.id AND COALESCE(v2.is_removed, 0) = 0) > 0)
-           ORDER BY comments_given + likes_given DESC LIMIT 8""",
-        (aid, aid, aid, aid, aid)).fetchall()
     return jsonify({
         "agent": agent_to_dict(agent, include_private=is_self, badges=agent_badges),
         "videos": video_list,

--- a/tests/test_social_graph.py
+++ b/tests/test_social_graph.py
@@ -238,3 +238,28 @@ def test_agent_interactions_rejects_invalid_limit(client, query, expected_error)
 
     assert resp.status_code == 400
     assert resp.get_json() == {"error": expected_error}
+
+
+def test_agent_profile_does_not_run_discarded_interaction_aggregates(client, monkeypatch):
+    """The profile response must not execute social aggregates it never returns."""
+    _seed_interaction_data()
+    statements = []
+    original_get_db = bottube_server.get_db
+
+    def traced_get_db():
+        db = original_get_db()
+        db.set_trace_callback(statements.append)
+        return db
+
+    monkeypatch.setattr(bottube_server, "get_db", traced_get_db)
+
+    response = client.get("/api/agents/alice")
+
+    assert response.status_code == 200
+    assert response.get_json()["agent"]["agent_name"] == "alice"
+    normalized = [" ".join(statement.lower().split()) for statement in statements]
+    assert not any(
+        "group by a2.id order by cnt desc limit 8" in statement
+        or "order by comments_given + likes_given desc limit 8" in statement
+        for statement in normalized
+    )


### PR DESCRIPTION
## Summary
- remove three social aggregate queries from `GET /api/agents/<agent_name>` whose results were assigned and then discarded
- leave the dedicated `/api/agents/<agent_name>/interactions` endpoint unchanged
- add a SQL-trace regression proving the profile route does not reintroduce the discarded grouped/correlated scans

## Proof
- mutation baseline on upstream main: focused SQL-trace test **failed**
- after fix: profile query + both social graph shape tests **3 passed**
- Python compile clean
- `git diff --check` clean

The full `test_social_graph.py` file also contains six pre-existing expectation failures because current error responses include the documented `param` field; this PR neither changes nor relies on those validation responses.

Closes #1917

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d