### PR TITLE
[TRAVIS] Bound Studio generation request types

### DIFF
--- a/studio_blueprint.py
+++ b/studio_blueprint.py
@@ -242,7 +242,15 @@ def studio_info():
 @studio_bp.route("/api/studio/generate", methods=["POST"])
 def studio_generate():
     """Atomically debit RTC for the requested tier, then dispatch generation (video/i2v/model async, image/voice sync)."""
-    body = request.get_json(silent=True) or {}
+    body = request.get_json(silent=True)
+    if body is None:
+        body = {}
+    if not isinstance(body, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+    for field in ("type", "prompt", "tier", "image", "agent_api_key"):
+        value = body.get(field)
+        if value is not None and not isinstance(value, str):
+            return jsonify({"error": f"{field} must be a string"}), 400
     gtype = (body.get("type") or "video").strip()
     audio = body.get("audio")
     audio = "music" if audio is True else (audio if audio in ("music", "ambient") else "")

--- a/tests/test_studio_request_validation.py
+++ b/tests/test_studio_request_validation.py
@@ -1,0 +1,38 @@
+"""Regression coverage for Studio's public JSON request contract."""
+
+import pytest
+from flask import Flask
+
+from studio_blueprint import studio_bp
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    app.config.update(SECRET_KEY="test", PROPAGATE_EXCEPTIONS=False)
+    app.register_blueprint(studio_bp)
+    return app.test_client()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        ["not", "an", "object"],
+        {"type": ["video"], "prompt": "hello"},
+        {"type": "video", "prompt": ["hello"]},
+        {"type": "video", "prompt": "hello", "tier": ["text_card"]},
+        {"type": "i2v", "prompt": "hello", "image": ["not-base64"]},
+    ],
+)
+def test_generate_rejects_malformed_json_types_without_server_error(client, payload):
+    response = client.post("/api/studio/generate", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json()["error"]
+
+
+def test_generate_preserves_empty_object_validation(client):
+    response = client.post("/api/studio/generate", json={})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "prompt required"}


### PR DESCRIPTION
## Summary
- reject non-object Studio generation bodies before field access
- validate all string-contract fields before `.strip()` or downstream billing/auth work
- add mutation-proven regression coverage for the five independent 500 paths

Closes #1923.

## Proof
On unmodified `main`, the focused regression produced **5 failed / 1 passed**, with each failure returning 500 from `list.get` or `list.strip`.

With this patch:
- `python -m pytest -q tests/test_studio_request_validation.py -p no:cacheprovider` -> **6 passed**
- `python -m py_compile studio_blueprint.py tests/test_studio_request_validation.py` -> clean
- `git diff --check` -> clean

The validation runs before caller resolution, RTC debit, or any generation provider, so malformed requests cannot cross an effect edge.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d