### PR TITLE
[TRAVIS] Make BAN upload rewards idempotent

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -326,14 +326,17 @@ def get_platform_balance() -> dict:
 # ---------------------------------------------------------------------------
 
 def award_ban_upload(db, agent_id: int, video_id: str):
-    """Award BAN for a successful video upload."""
+    """Award BAN once for a successful agent/video upload pair."""
     amount = REWARDS["upload"]
-    db.execute(
+    cursor = db.execute(
         "INSERT INTO ban_transactions (agent_id, tx_type, amount_ban, reason, video_id, status, created_at) "
-        "VALUES (?, 'reward', ?, 'video_upload', ?, 'credited', ?)",
-        (agent_id, amount, video_id, time.time()),
+        "SELECT ?, 'reward', ?, 'video_upload', ?, 'credited', ? "
+        "WHERE NOT EXISTS (SELECT 1 FROM ban_transactions "
+        "WHERE agent_id=? AND video_id=? AND tx_type='reward' AND reason='video_upload')",
+        (agent_id, amount, video_id, time.time(), agent_id, video_id),
     )
     db.commit()
+    return amount if cursor.rowcount == 1 else 0.0
 
 
 def award_ban_video_gen(db, agent_id: int, video_id: str, gen_method: str = "text"):

--- a/tests/test_banano_upload_reward_idempotency.py
+++ b/tests/test_banano_upload_reward_idempotency.py
@@ -1,0 +1,37 @@
+"""Regression coverage for duplicate upload reward delivery."""
+
+import sqlite3
+
+from banano_blueprint import REWARDS, award_ban_upload, init_ban_tables
+
+
+def test_upload_reward_is_idempotent_for_one_agent_and_video():
+    db = sqlite3.connect(":memory:")
+    init_ban_tables(db)
+
+    first = award_ban_upload(db, 17, "video-public-id")
+    duplicate = award_ban_upload(db, 17, "video-public-id")
+
+    rows = db.execute(
+        "SELECT amount_ban FROM ban_transactions "
+        "WHERE agent_id=? AND video_id=? AND reason='video_upload'",
+        (17, "video-public-id"),
+    ).fetchall()
+    assert rows == [(REWARDS["upload"],)]
+    assert first == REWARDS["upload"]
+    assert duplicate == 0.0
+
+
+def test_upload_reward_remains_distinct_per_video():
+    db = sqlite3.connect(":memory:")
+    init_ban_tables(db)
+
+    award_ban_upload(db, 17, "video-a")
+    award_ban_upload(db, 17, "video-b")
+
+    total = db.execute(
+        "SELECT SUM(amount_ban) FROM ban_transactions "
+        "WHERE agent_id=? AND reason='video_upload'",
+        (17,),
+    ).fetchone()[0]
+    assert total == 2 * REWARDS["upload"]


### PR DESCRIPTION
## Summary
- make BAN upload reward delivery idempotent per agent/public-video pair
- use one atomic `INSERT ... WHERE NOT EXISTS` effect instead of a read/write split
- return the delivered amount on first execution and `0.0` on replay
- prove different videos remain independently rewardable

Closes #1929.

## Proof
On unmodified `main`, the duplicate-delivery regression failed with two identical 1 BAN rows.

With this patch:
- focused + adjacent Banano amount/tip/withdraw suites: **27 passed**
- `python -m py_compile banano_blueprint.py tests/test_banano_upload_reward_idempotency.py` -> clean
- `git diff --check` -> clean

The single SQLite insert statement keeps concurrent writers serialized at the ledger effect instead of relying on a race-prone pre-read.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d