### PR TITLE
fix: export creator engagement analytics

### DIFF
--- a/analytics_blueprint.py
+++ b/analytics_blueprint.py
@@ -479,7 +479,50 @@ def api_export_csv():
                 writer.writerow([row[0], row[1]])
         
         filename = f"bottube_analytics_views_{agent_id}_{datetime.now().strftime('%Y%m%d')}.csv"
-    
+
+    elif export_type == 'engagement':
+        # Export the per-video engagement metrics promised by the dashboard
+        # contract.  Aggregate before joining so multiple comments, votes, or
+        # equal-valued tips do not multiply or collapse one another.
+        writer.writerow(['video_id', 'title', 'comments', 'votes', 'tips_rtc'])
+
+        rows = db.execute("""SELECT
+                v.video_id,
+                v.title,
+                COALESCE(c.comments, 0) AS comments,
+                COALESCE(vo.votes, 0) AS votes,
+                COALESCE(e.tips, 0) AS tips
+            FROM videos v
+            LEFT JOIN (
+                SELECT video_id, COUNT(*) AS comments
+                FROM comments
+                GROUP BY video_id
+            ) c ON c.video_id = v.video_id
+            LEFT JOIN (
+                SELECT video_id, SUM(vote) AS votes
+                FROM votes
+                GROUP BY video_id
+            ) vo ON vo.video_id = v.video_id
+            LEFT JOIN (
+                SELECT agent_id, video_id, SUM(amount) AS tips
+                FROM earnings
+                WHERE reason LIKE '%tip%'
+                GROUP BY agent_id, video_id
+            ) e ON e.video_id = v.video_id AND e.agent_id = v.agent_id
+            WHERE v.agent_id = ?
+            ORDER BY v.created_at DESC""", (agent_id,)).fetchall()
+
+        for row in rows:
+            writer.writerow([
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                round(row[4] or 0, 4),
+            ])
+
+        filename = f"bottube_analytics_engagement_{agent_id}_{datetime.now().strftime('%Y%m%d')}.csv"
+
     else:
         return jsonify({"error": "Invalid export type"}), 400
     

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -356,6 +356,34 @@ class TestAnalyticsApiCoreMetrics:
         assert export_rows[0]["votes"] == "2"
         assert export_rows[0]["tips_rtc"] == "0.5"
 
+    def test_creator_analytics_exports_engagement_csv(self, client):
+        """The documented engagement export returns one row per owned video."""
+        now = time.time()
+        owner_id = _insert_agent("engagementexporter", "engagement-export-key")
+        viewer_id = _insert_agent("engagementviewer", "engagement-viewer-key")
+        video_id = _insert_video(owner_id, "engagement-export-clip", "Export Metrics")
+
+        _insert_comment(video_id, viewer_id, created_at=now)
+        _insert_vote(video_id, viewer_id, vote=1, created_at=now)
+        _insert_earning(owner_id, 1.25, "tip_received", video_id, created_at=now)
+
+        response = client.get(
+            f"/analytics/api/export/csv?agent_id={owner_id}&type=engagement"
+        )
+
+        assert response.status_code == 200
+        assert "bottube_analytics_engagement_" in response.headers["Content-Disposition"]
+        rows = list(csv.DictReader(io.StringIO(response.get_data(as_text=True))))
+        assert rows == [
+            {
+                "video_id": video_id,
+                "title": "Export Metrics",
+                "comments": "1",
+                "votes": "1",
+                "tips_rtc": "1.25",
+            }
+        ]
+
 
 # =============================================================================
 # Analytics API Tests - Time Series Data


### PR DESCRIPTION
## Summary
- implement the documented `type=engagement` creator analytics CSV export
- aggregate comments, votes, and tip earnings independently before joining
- preserve creator ownership filtering and deterministic newest-first rows
- add an end-to-end CSV regression contract

Fixes #1931

## Mutation proof
Before the implementation, the new regression failed exactly at the missing effect edge:

`assert 400 == 200`

## Verification
- `2 passed` — engagement export regression plus adjacent public-video-ID analytics/export contract
- `python -m py_compile analytics_blueprint.py tests/test_analytics_dashboard.py`
- `git diff --check`

The full existing `tests/test_analytics_dashboard.py` file currently reports 18 passed / 8 unrelated pre-existing failures on upstream main (legacy `/analytics` redirect expectations and `/api/dashboard/analytics` response-shape expectations). This change does not touch those routes or expectations; the two directly adjacent creator-blueprint/export contracts pass.

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d