### PR TITLE
[TRAVIS] Reconcile internal tips in BAN liabilities

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -753,6 +753,15 @@ def ban_platform_status():
         "WHERE status = 'sent' AND tx_type = 'withdrawal'"
     ).fetchone()[0]
 
+    # A tip moves an existing platform liability from one agent to another.
+    # ``total_credited`` includes the receiver leg, so reconcile the matching
+    # sender leg before reporting network liabilities or every tip invents new
+    # off-chain BAN on the operator dashboard.
+    total_internal_tips = db.execute(
+        "SELECT COALESCE(SUM(amount_ban), 0) FROM ban_transactions "
+        "WHERE status = 'credited' AND tx_type = 'tip_sent'"
+    ).fetchone()[0]
+
     total_pending = db.execute(
         "SELECT COALESCE(SUM(amount_ban), 0) FROM ban_transactions "
         "WHERE status = 'pending' AND tx_type = 'withdrawal'"
@@ -762,7 +771,10 @@ def ban_platform_status():
 
     return jsonify({
         "chain": chain_info,
-        "off_chain_liabilities_ban": round(total_credited - total_withdrawn, 4),
+        "off_chain_liabilities_ban": round(
+            total_credited - total_internal_tips - total_withdrawn, 4
+        ),
+        "internal_tips_ban": round(total_internal_tips, 4),
         "pending_withdrawals_ban": round(total_pending, 4),
         "total_wallets": wallet_count,
         "bananopie_available": _HAS_BANANOPIE,

--- a/tests/test_banano_platform_liability.py
+++ b/tests/test_banano_platform_liability.py
@@ -1,0 +1,44 @@
+"""Regression coverage for network-wide BAN liability reconciliation."""
+
+import sqlite3
+
+from flask import Flask
+
+import banano_blueprint
+
+
+def test_internal_tip_does_not_create_new_platform_liability(tmp_path, monkeypatch):
+    db_path = tmp_path / "bottube.db"
+    db = sqlite3.connect(db_path)
+    banano_blueprint.init_ban_tables(db)
+    db.executemany(
+        "INSERT INTO ban_transactions "
+        "(agent_id,tx_type,amount_ban,reason,status,created_at) VALUES(?,?,?,?,?,?)",
+        [
+            (1, "reward", 10.0, "earned", "credited", 1.0),
+            (1, "tip_sent", 4.0, "tip_to_two", "credited", 2.0),
+            (2, "tip_received", 4.0, "tip_from_one", "credited", 2.0),
+            (2, "withdrawal", 2.0, "withdraw", "sent", 3.0),
+        ],
+    )
+    db.commit()
+    db.close()
+
+    monkeypatch.setenv("BOTTUBE_DB_PATH", str(db_path))
+    monkeypatch.setattr(banano_blueprint, "ADMIN_KEY", "admin-test-key")
+    monkeypatch.setattr(
+        banano_blueprint,
+        "get_platform_balance",
+        lambda: {"balance_ban": 100.0},
+    )
+    app = Flask(__name__)
+    app.register_blueprint(banano_blueprint.ban_bp)
+
+    response = app.test_client().get(
+        "/ban/platform-status", headers={"X-Admin-Key": "admin-test-key"}
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["off_chain_liabilities_ban"] == 8.0
+    assert payload["internal_tips_ban"] == 4.0


### PR DESCRIPTION
## Summary
- reconcile the `tip_sent` sender leg before reporting network BAN liabilities
- expose internal tip volume separately for operator auditability
- preserve withdrawal and pending-withdrawal reporting
- add an endpoint-level regression proving internal transfers do not mint apparent liability

Closes #1933.

## Proof
On unmodified `main`, the regression expected 8 BAN and received 12 BAN.

With this patch:
- focused + adjacent Banano amount/tip/withdraw suites: **26 passed**
- `python -m py_compile banano_blueprint.py tests/test_banano_platform_liability.py` -> clean
- `git diff --check` -> clean

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d