### PR TITLE
fix: validate transcript trigger input

### DIFF
--- a/tests/test_whisper_transcription.py
+++ b/tests/test_whisper_transcription.py
@@ -594,6 +594,49 @@ def test_trigger_transcription_video_not_found(flask_client):
     assert resp.status_code == 404
 
 
+def test_trigger_transcription_rejects_non_object_json(flask_client, monkeypatch):
+    import whisper_transcription_blueprint as wtb
+
+    monkeypatch.setattr(wtb, "_get_video_filename", lambda _video_id: "clip.mp4")
+    monkeypatch.setattr(
+        wtb.wt,
+        "enqueue_transcription",
+        lambda *_args, **_kwargs: pytest.fail("malformed body enqueued work"),
+    )
+
+    resp = flask_client.post(
+        "/api/videos/clip/transcript/trigger",
+        json=["not", "an", "object"],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+@pytest.mark.parametrize("force", ["false", 0, 1, [], {}])
+def test_trigger_transcription_requires_boolean_force(
+    flask_client,
+    monkeypatch,
+    force,
+):
+    import whisper_transcription_blueprint as wtb
+
+    monkeypatch.setattr(wtb, "_get_video_filename", lambda _video_id: "clip.mp4")
+    monkeypatch.setattr(
+        wtb.wt,
+        "enqueue_transcription",
+        lambda *_args, **_kwargs: pytest.fail("invalid force enqueued work"),
+    )
+
+    resp = flask_client.post(
+        "/api/videos/clip/transcript/trigger",
+        json={"force": force},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "force must be a boolean"
+
+
 # ---------------------------------------------------------------------------
 # /api/transcript/backfill is admin-only
 # ---------------------------------------------------------------------------

--- a/whisper_transcription_blueprint.py
+++ b/whisper_transcription_blueprint.py
@@ -260,8 +260,13 @@ def trigger_transcription(video_id: str):
     Body (JSON, optional):
         { "force": true }   — re-transcribe even if transcript already exists
     """
-    body = request.get_json(silent=True) or {}
-    force = bool(body.get("force", False))
+    body, error = _request_json_object()
+    if error:
+        return error
+
+    force = body.get("force", False)
+    if not isinstance(force, bool):
+        return jsonify({"error": "force must be a boolean"}), 400
 
     filename = _get_video_filename(video_id)
     if filename is None:


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies on the transcript trigger instead of raising `AttributeError`
- require `force` to be a JSON boolean instead of coercing strings, numbers, arrays, and objects
- ensure invalid requests never enqueue transcription work
- cover both malformed body shapes and five misleading `force` values

Fixes #1934

## Mutation proof
Before the fix, all six new contracts failed: top-level arrays raised `AttributeError`, while every invalid `force` value reached `enqueue_transcription` after truthiness coercion.

## Verification
- `50 passed, 10 skipped` — full `tests/test_whisper_transcription.py`
- `7 passed` — focused trigger input and adjacent not-found contracts
- `python -m py_compile whisper_transcription_blueprint.py tests/test_whisper_transcription.py`
- `git diff --check`

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d