### PR TITLE
fix: validate discover search enums

### DIFF
--- a/search_blueprint.py
+++ b/search_blueprint.py
@@ -102,6 +102,19 @@ def api_search():
 
     if not query and not category:
         return jsonify({"error": "Query or category required"}), 400
+
+    if category and category not in VIDEO_CATEGORIES:
+        return jsonify({
+            "error": "Invalid 'category' parameter.",
+            "allowed": VIDEO_CATEGORIES,
+        }), 400
+
+    allowed_sorts = ('relevance', 'newest', 'views', 'likes')
+    if sort not in allowed_sorts:
+        return jsonify({
+            "error": "Invalid 'sort' parameter.",
+            "allowed": list(allowed_sorts),
+        }), 400
     
     db = get_db()
     
@@ -115,7 +128,7 @@ def api_search():
         where_clauses.append("""(v.title LIKE ? OR v.description LIKE ? OR v.tags LIKE ?)""")
         params.extend([search_term, search_term, search_term])
     
-    if category and category in VIDEO_CATEGORIES:
+    if category:
         where_clauses.append("v.category = ?")
         params.append(category)
     

--- a/tests/test_search_blueprint_query_validation.py
+++ b/tests/test_search_blueprint_query_validation.py
@@ -4,6 +4,7 @@
 import pytest
 from flask import Flask
 
+import search_blueprint
 from search_blueprint import search_bp
 
 
@@ -47,3 +48,27 @@ def test_discoverability_endpoints_reject_out_of_range_integer_params(discover_c
 
     assert resp.status_code == 400
     assert "Invalid" in resp.get_json()["error"]
+
+
+@pytest.mark.parametrize(
+    ("query", "field"),
+    [
+        ("category=definitely-not-a-category", "category"),
+        ("q=robot&sort=definitely-not-a-sort", "sort"),
+    ],
+)
+def test_discover_search_rejects_unknown_enum_values(
+    discover_client,
+    monkeypatch,
+    query,
+    field,
+):
+    def fail_db():
+        raise AssertionError("invalid search options must fail before querying")
+
+    monkeypatch.setattr(search_blueprint, "get_db", fail_db)
+
+    resp = discover_client.get(f"/discover/api/search?{query}")
+
+    assert resp.status_code == 400
+    assert field in resp.get_json()["error"]


### PR DESCRIPTION
## Summary
- reject unknown non-empty Discover category filters before querying
- reject unsupported Discover sort modes instead of silently treating them as relevance
- return the allowed enum values with HTTP 400 responses
- prove invalid options never reach the database

Fixes #1937

## Mutation proof
Both focused contracts failed on upstream main: the invalid category and invalid sort each reached the database query path.

## Verification
- `24 passed` — query-validation, thumbnail, and null-bio Discover suites
- `python -m py_compile search_blueprint.py tests/test_search_blueprint_query_validation.py`
- `git diff --check`

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d