### PR TITLE
fix: preserve failed generation jobs for retry

### DIFF
--- a/generation/routes.py
+++ b/generation/routes.py
@@ -268,7 +268,11 @@ def cancel_generation_job(job_id: str):
         return jsonify({"error": "Job not found"}), 404
     if job.get("owner_user_id") != str(g.agent["id"]):
         return jsonify({"error": "Not your job"}), 403
-    if job["status"] in (JobStatus.completed.value, JobStatus.canceled.value):
+    if job["status"] in (
+        JobStatus.completed.value,
+        JobStatus.failed.value,
+        JobStatus.canceled.value,
+    ):
         return jsonify({"error": f"Job already {job['status']}"}), 409
 
     update_job(job_id, status=JobStatus.canceled.value)

--- a/tests/test_generation_routes.py
+++ b/tests/test_generation_routes.py
@@ -162,3 +162,34 @@ def test_legacy_generate_video_rejects_non_string_body_api_key(
 
     assert resp.status_code == 400
     assert resp.get_json() == {"error": "agent_api_key must be a string"}
+
+
+def test_failed_generation_job_cannot_be_canceled(
+    generation_client,
+    monkeypatch,
+):
+    """A failed job must remain retryable instead of becoming canceled."""
+    import generation.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_job",
+        lambda _job_id: {
+            "job_id": "failed-job",
+            "owner_user_id": "1",
+            "status": "failed",
+        },
+    )
+    monkeypatch.setattr(
+        routes,
+        "update_job",
+        lambda *_args, **_kwargs: pytest.fail("terminal job was mutated"),
+    )
+
+    resp = generation_client.post(
+        "/api/generation/jobs/failed-job/cancel",
+        headers={"X-API-Key": "test-key"},
+    )
+
+    assert resp.status_code == 409
+    assert resp.get_json() == {"error": "Job already failed"}


### PR DESCRIPTION
## Summary
- treat `failed` as a terminal state for cancellation
- preserve the documented failed -> retry transition
- return the same idempotent HTTP 409 contract used for completed/canceled jobs
- prove no state mutation occurs for a failed job

Fixes #1941

## Mutation proof
On upstream main, the regression reached `update_job(... status="canceled")` and failed because the terminal job was mutated.

## Verification
- `8 passed` — full `tests/test_generation_routes.py`
- `python -m py_compile generation/routes.py tests/test_generation_routes.py`
- `git diff --check`

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d