### PR TITLE
Return 404 for unknown relationship event histories

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -420,6 +420,13 @@ def get_events(rel_id: int):
         The result value.
     """
     db = get_db()
+    relationship = db.execute(
+        "SELECT 1 FROM agent_relationships WHERE id=?",
+        (rel_id,),
+    ).fetchone()
+    if relationship is None:
+        return jsonify({"error": "relationship not found"}), 404
+
     rows = db.execute(
         "SELECT * FROM relationship_events WHERE relationship_id=? ORDER BY created_at DESC",
         (rel_id,),

--- a/tests/test_beef_system.py
+++ b/tests/test_beef_system.py
@@ -269,6 +269,13 @@ def test_events_are_logged(client):
     assert "first_event" in types and "second_event" in types
 
 
+def test_events_for_unknown_relationship_return_not_found(client):
+    resp = client.get("/api/beef/relationships/999999/events")
+
+    assert resp.status_code == 404
+    assert resp.get_json() == {"error": "relationship not found"}
+
+
 # ---------------------------------------------------------------------------
 # 10. Drama arc templates
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1943.

## What changed
- verify the parent relationship exists before loading its event history
- return a stable HTTP 404 error for an unknown relationship ID
- retain the existing HTTP 200 event array for valid relationships
- add regression coverage for the missing-parent contract

## Mutation proof
Before the production fix, the new regression failed because the endpoint returned 200 instead of 404.

## Validation
- focused event contracts: 2 passed
- full tests/test_beef_system.py: 37 passed, 1 unrelated pre-existing failure in test_admin_kill because the generated admin key is not supplied by the test and the route returns 403
- git diff --check: clean

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d