### PR TITLE
Keep provider failover rotation stable across restarts

### DIFF
--- a/tests/test_video_providers.py
+++ b/tests/test_video_providers.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MIT
+import builtins
+
 from video_providers import ProviderRegistry
 
 
@@ -71,3 +73,17 @@ def test_report_success_resets_failures_and_updates_latency_average():
     assert status["fail_count"] == 0
     assert status["success_count"] == 2
     assert status["avg_latency_ms"] == 130
+
+
+def test_provider_rotation_does_not_depend_on_process_hash_seed(monkeypatch):
+    registry = ProviderRegistry()
+    for name in ("alpha", "beta", "gamma"):
+        registry.register(name, noop_provider)
+
+    monkeypatch.setattr(builtins, "hash", lambda _value: 0)
+    first_order = [name for name, _fn in registry.get_ordered("job-42")]
+
+    monkeypatch.setattr(builtins, "hash", lambda _value: 1)
+    second_order = [name for name, _fn in registry.get_ordered("job-42")]
+
+    assert second_order == first_order

--- a/video_providers.py
+++ b/video_providers.py
@@ -7,6 +7,7 @@ backends. Self-healing: providers recover after a cooldown period.
 """
 from __future__ import annotations
 
+import hashlib
 import threading
 import time
 import os
@@ -69,7 +70,8 @@ class ProviderRegistry:
 
             # Rotate healthy providers by job_id for load distribution
             if healthy:
-                start = hash(job_id) % len(healthy)
+                digest = hashlib.sha256(job_id.encode("utf-8")).digest()
+                start = int.from_bytes(digest[:8], "big") % len(healthy)
                 healthy = healthy[start:] + healthy[:start]
 
             ordered = healthy + cooldown_ready


### PR DESCRIPTION
Closes #1945.

## What changed
- replace Python's process-randomized string hash with a stable SHA-256-derived rotation index
- preserve the existing per-job distribution and provider-order semantics
- add a regression proving process hash changes cannot alter the selected order

## Mutation proof
Before the production change, simulating two process hash seeds changed the same job's order from alpha/beta/gamma to beta/gamma/alpha and the regression failed.

## Validation
- tests/test_video_providers.py: 6 passed
- git diff --check: clean

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d