### PR TITLE
[TRAVIS] Bind BAN generation rewards to trusted completion

### DIFF
--- a/banano_blueprint.py
+++ b/banano_blueprint.py
@@ -654,15 +654,18 @@ def ban_reward_video_gen():
         "gen_method": "comfyui"  // text|gradient|particle|waveform|matrix|slideshow|comfyui|heygen
       }
 
-    Auth: Session cookie or admin key header.
+    Auth: Admin key header.  User-facing generation paths award internally
+    after their worker has produced and persisted a video; callers cannot
+    attest their own generation method.
     """
-    # Auth: either session or admin key
-    user_id = session.get("user_id")
+    # This is a privileged compatibility hook for trusted workers/operators.
+    # A session owner can prove that they own an uploaded video, but cannot
+    # prove that the platform generated it (or which cost tier produced it).
     admin_key = request.headers.get("X-Admin-Key", "")
     is_admin = _admin_ok(admin_key)
 
-    if not user_id and not is_admin:
-        return jsonify({"error": "Authentication required"}), 401
+    if not is_admin:
+        return jsonify({"error": "Admin key required"}), 401
 
     data, error = _request_json_object()
     if error:
@@ -688,19 +691,11 @@ def ban_reward_video_gen():
         agent = db.execute(
             "SELECT id FROM agents WHERE agent_name = ?", (agent_name,)
         ).fetchone()
-    elif user_id:
-        agent = db.execute(
-            "SELECT id FROM agents WHERE id = ?", (user_id,)
-        ).fetchone()
     else:
         return jsonify({"error": "agent_name required"}), 400
 
     if not agent:
         return jsonify({"error": "Agent not found"}), 404
-
-    # Non-admin users can only reward themselves
-    if not is_admin and agent["id"] != user_id:
-        return jsonify({"error": "Can only claim rewards for your own videos"}), 403
 
     # Verify video exists
     video = db.execute(
@@ -709,8 +704,9 @@ def ban_reward_video_gen():
     if not video:
         return jsonify({"error": "Video not found"}), 404
 
-    # Verify ownership (unless admin)
-    if not is_admin and video["agent_id"] != agent["id"]:
+    # Even privileged callers may not credit a different agent than the
+    # persisted video owner.
+    if video["agent_id"] != agent["id"]:
         return jsonify({"error": "Video does not belong to this agent"}), 403
 
     amount = award_ban_video_gen(db, agent["id"], video_id, gen_method)

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -6598,7 +6598,6 @@ def upload_video():
     revision_of = request.form.get("revision_of", "").strip()
     revision_note = request.form.get("revision_note", "").strip()[:MAX_DESCRIPTION_LENGTH]
     challenge_id = request.form.get("challenge_id", "").strip()
-    gen_method = request.form.get("gen_method", "").strip().lower()  # AI video gen method
     response_to = request.form.get("response_to", "").strip()  # Video ID this is a response to (Issue #2282)
     collaborator_ids_raw = request.form.get("collaborator_ids", "").strip()  # JSON array of agent_ids for co-upload (Bounty #2161)
 
@@ -6950,13 +6949,6 @@ def upload_video():
 
     # Award BAN for upload
     award_ban_upload(db, g.agent["id"], video_id)
-
-    # Award extra BAN for AI video generation (if gen_method specified)
-    ban_gen_reward = 0.0
-    if gen_method:
-        ban_gen_reward = award_ban_video_gen(db, g.agent["id"], video_id, gen_method)
-    if ban_gen_reward > 0:
-        response_data["ban_video_gen_reward"] = ban_gen_reward
 
     # Notify subscribers about the new video (background)
     _notify_subscribers_new_video(g.agent["id"], video_id, title, g.agent["agent_name"])
@@ -15636,7 +15628,7 @@ except ImportError:
 # Banano (BAN) Feeless Payments
 # ---------------------------------------------------------------------------
 try:
-    from banano_blueprint import ban_bp, init_ban_tables, award_ban_upload, check_view_milestones, award_ban_video_gen
+    from banano_blueprint import ban_bp, init_ban_tables, award_ban_upload, check_view_milestones
     init_ban_tables()
     app.register_blueprint(ban_bp)
     BANANO_ENABLED = True
@@ -15646,8 +15638,6 @@ except ImportError:
         pass
     def check_view_milestones(db, agent_id, video_id, view_count):
         pass
-    def award_ban_video_gen(db, agent_id, video_id, gen_method="text"):
-        return 0.0
 
 # ---------------------------------------------------------------------------
 # Captions Blueprint (Whisper / Google auto-captions + transcript search)

--- a/tests/test_banano_amount_validation.py
+++ b/tests/test_banano_amount_validation.py
@@ -141,10 +141,15 @@ def test_valid_ban_tip_still_records_sender_and_recipient_rows(ban_client):
     ]
 
 
-def test_ban_video_generation_reward_rejects_non_object_json(ban_client):
+def test_ban_video_generation_reward_rejects_non_object_json(ban_client, monkeypatch):
+    monkeypatch.setattr(banano_blueprint, "ADMIN_KEY", "test-admin")
     before = _ban_transaction_count(ban_client.db_path)
 
-    response = ban_client.post("/ban/reward-video-gen", json=["not", "an", "object"])
+    response = ban_client.post(
+        "/ban/reward-video-gen",
+        json=["not", "an", "object"],
+        headers={"X-Admin-Key": "test-admin"},
+    )
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "JSON object required"
@@ -152,7 +157,8 @@ def test_ban_video_generation_reward_rejects_non_object_json(ban_client):
 
 
 @pytest.mark.parametrize("field", ["agent_name", "video_id", "gen_method"])
-def test_ban_video_generation_reward_rejects_non_string_fields(ban_client, field):
+def test_ban_video_generation_reward_rejects_non_string_fields(ban_client, field, monkeypatch):
+    monkeypatch.setattr(banano_blueprint, "ADMIN_KEY", "test-admin")
     before = _ban_transaction_count(ban_client.db_path)
     payload = {
         "agent_name": "alice",
@@ -161,7 +167,9 @@ def test_ban_video_generation_reward_rejects_non_string_fields(ban_client, field
     }
     payload[field] = ["not", "a", "string"]
 
-    response = ban_client.post("/ban/reward-video-gen", json=payload)
+    response = ban_client.post(
+        "/ban/reward-video-gen", json=payload, headers={"X-Admin-Key": "test-admin"}
+    )
 
     assert response.status_code == 400
     assert response.get_json()["error"] == f"{field} must be a string"
@@ -176,10 +184,25 @@ def test_ban_transactions_rejects_non_positive_pagination(ban_client, query):
     assert response.get_json()["error"] == "Invalid pagination parameters"
 
 
-def test_valid_ban_video_generation_reward_still_records_reward(ban_client):
+def test_session_owner_cannot_self_attest_video_generation(ban_client):
+    before = _ban_transaction_count(ban_client.db_path)
+
+    response = ban_client.post(
+        "/ban/reward-video-gen",
+        json={"agent_name": "alice", "video_id": "video-1", "gen_method": "comfyui"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Admin key required"}
+    assert _ban_transaction_count(ban_client.db_path) == before
+
+
+def test_trusted_video_generation_reward_still_records_reward(ban_client, monkeypatch):
+    monkeypatch.setattr(banano_blueprint, "ADMIN_KEY", "test-admin")
     response = ban_client.post(
         "/ban/reward-video-gen",
         json={"agent_name": "alice", "video_id": "video-1", "gen_method": "text"},
+        headers={"X-Admin-Key": "test-admin"},
     )
 
     assert response.status_code == 200

--- a/video_gen_blueprint.py
+++ b/video_gen_blueprint.py
@@ -1281,6 +1281,11 @@ def _generation_worker(job_id: str, agent_id: int, prompt: str,
                 ("held_for_review: " + screening_result.get("summary", ""))[:500] if screening_status == "failed" else "",
             ),
         )
+        # Generation rewards are minted only from this trusted completion
+        # edge, using the method selected by the worker rather than caller
+        # supplied upload metadata.
+        from banano_blueprint import award_ban_video_gen
+        award_ban_video_gen(db, agent_id, video_id, gen_method)
         db.commit()
         db.close()
 


### PR DESCRIPTION
## Summary
- remove caller-controlled `gen_method` reward minting from the ordinary upload API
- require the admin key for the legacy reward hook and still enforce video-owner/recipient consistency
- award generation BAN from the trusted worker only after a generated video is persisted
- replace the old session self-attestation regression with fail-closed and trusted-worker coverage

Closes #1947.

## Proof
Before the fix, the existing session-owner test received HTTP 200 and a credited `video_gen_text` row for a plain owned video; changing the submitted method to `comfyui` selected the 5 BAN GPU tier.

After the fix:
- ordinary session self-attestation returns 401 and writes no transaction
- the trusted admin compatibility hook still awards a persisted owner's video
- `tests/test_banano_amount_validation.py`: **24 passed**
- `python -m py_compile banano_blueprint.py bottube_server.py video_gen_blueprint.py`: clean
- `git diff --check`: clean

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d