### PR TITLE
[TRAVIS] Keep Pi completion retries live after transport failure

### DIFF
--- a/pi_payments.py
+++ b/pi_payments.py
@@ -244,6 +244,15 @@ def pi_complete():
             return jsonify({"error": "payment settled but entitlement failed; will reconcile",
                             "payment_id": payment_id, "status": "completed_ungranted"}), 500
     except requests.RequestException as e:
+        # The row was already claimed as ``completing`` before the remote
+        # request.  Release that claim on transport failure so the client's
+        # retry can actually resume instead of returning 202 forever.
+        conn.execute(
+            "UPDATE pi_payments SET status='approved', updated_at=? "
+            "WHERE payment_id=? AND status='completing'",
+            (time.time(), payment_id),
+        )
+        conn.commit()
         print(f"[pi] complete error: {e}", flush=True)
         return jsonify({"error": "Pi complete failed, try again"}), 502
     finally:

--- a/tests/test_pi_completion_retry.py
+++ b/tests/test_pi_completion_retry.py
@@ -1,0 +1,61 @@
+"""Pi completion transport failures must leave a retryable payment row."""
+
+import sqlite3
+
+import requests
+from flask import Flask
+
+import pi_payments
+
+
+class _SuccessResponse:
+    status_code = 200
+    text = "ok"
+
+
+def test_transport_failure_releases_completion_claim_for_retry(tmp_path, monkeypatch):
+    db_path = tmp_path / "pi-payments.db"
+    pi_payments.init_pi_payment_tables(str(db_path))
+    monkeypatch.setattr(pi_payments, "PI_API_KEY", "test-key")
+    monkeypatch.setattr(pi_payments, "_db_path", lambda: str(db_path))
+    monkeypatch.setattr(
+        pi_payments,
+        "_pi_get_payment",
+        lambda _payment_id: {
+            "metadata": {"product": "test_payment"},
+            "amount": 0.1,
+            "user_uid": "pi-user-1",
+        },
+    )
+
+    calls = iter([requests.Timeout("Pi timed out"), _SuccessResponse()])
+
+    def complete_request(*_args, **_kwargs):
+        result = next(calls)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(pi_payments.requests, "post", complete_request)
+
+    app = Flask(__name__)
+    app.register_blueprint(pi_payments.pi_pay_bp)
+    client = app.test_client()
+    payload = {"payment_id": "payment-1", "txid": "tx-1"}
+
+    failed = client.post("/pi/complete", json=payload)
+    assert failed.status_code == 502
+
+    with sqlite3.connect(db_path) as db:
+        assert db.execute(
+            "SELECT status FROM pi_payments WHERE payment_id='payment-1'"
+        ).fetchone()[0] == "approved"
+
+    retried = client.post("/pi/complete", json=payload)
+    assert retried.status_code == 200
+    assert retried.get_json()["status"] == "completed"
+
+    with sqlite3.connect(db_path) as db:
+        assert db.execute(
+            "SELECT status, granted FROM pi_payments WHERE payment_id='payment-1'"
+        ).fetchone() == ("completed", 1)


### PR DESCRIPTION
## Summary
- release a Pi payment's local `completing` claim when the remote completion request fails in transport
- return the row to `approved` before responding 502 so the same payment can be retried
- prove a timeout followed by a successful retry reaches `completed` with `granted=1`

Closes #1951.

## Proof
The regression drives one valid payment through a forced `requests.Timeout`, verifies the durable row is retryable (`approved`), retries with a successful Pi response, and verifies final state `('completed', 1)`.

- focused retry regression: **1 passed**
- `python -m py_compile pi_payments.py tests/test_pi_completion_retry.py`: clean
- `git diff --check`: clean

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d