### PR TITLE
Preserve news RSS XML when content contains CDATA terminators

### DIFF
--- a/news_routes.py
+++ b/news_routes.py
@@ -14,6 +14,11 @@ BASE_DIR = Path(os.environ.get("BOTTUBE_BASE_DIR", str(Path(__file__).resolve().
 DB_PATH = BASE_DIR / "bottube.db"
 
 
+def _cdata_text(value) -> str:
+    """Render arbitrary text safely inside an XML CDATA section."""
+    return str(value or "").replace("]]>", "]]]]><![CDATA[>")
+
+
 def _get_db():
     """Retrieve db. Returns a SQLite database connection.
     
@@ -91,15 +96,18 @@ def news_rss():
             item["created_at"], tz=timezone.utc
         ).strftime("%a, %d %b %Y %H:%M:%S +0000")
         link = f"https://bottube.ai/watch/{item['video_id']}"
+        title = _cdata_text(item["title"])
+        description = _cdata_text((item["description"] or "")[:300])
+        creator = _cdata_text(item["display_name"] or item["agent_name"])
         items_xml.append(
             f"    <item>\n"
-            f"      <title><![CDATA[{item['title']}]]></title>\n"
+            f"      <title><![CDATA[{title}]]></title>\n"
             f"      <link>{link}</link>\n"
             f"      <guid isPermaLink=\"true\">{link}</guid>\n"
             f"      <pubDate>{pub_date}</pubDate>\n"
-            f"      <description><![CDATA[{(item['description'] or '')[:300]}]]></description>\n"
+            f"      <description><![CDATA[{description}]]></description>\n"
             f"      <category>{escape(item['category'] or 'news')}</category>\n"
-            f"      <dc:creator><![CDATA[{item['display_name'] or item['agent_name']}]]></dc:creator>\n"
+            f"      <dc:creator><![CDATA[{creator}]]></dc:creator>\n"
             f"    </item>"
         )
 

--- a/tests/test_news_routes_rss.py
+++ b/tests/test_news_routes_rss.py
@@ -39,3 +39,33 @@ def test_news_rss_escapes_category_xml(monkeypatch):
     assert response.status_code == 200
     ET.fromstring(response.text)
     assert "<category>weather &amp; climate &lt;alerts&gt;</category>" in response.text
+
+
+def test_news_rss_preserves_cdata_terminators_without_breaking_xml(monkeypatch):
+    row = Row(
+        video_id="news-2",
+        title="Markets ]]> rebound",
+        description="What closed ]]> and what reopened",
+        created_at=time.time(),
+        thumbnail="thumb.jpg",
+        duration_sec=8,
+        views=1,
+        category="news",
+        agent_name="the_daily_byte",
+        display_name="Daily ]]> Byte",
+        avatar_url="",
+    )
+    monkeypatch.setattr(news_routes, "_get_news_videos", lambda _limit=30: [row])
+    monkeypatch.setattr(news_routes, "_get_weather_videos", lambda _limit=20: [])
+
+    app = Flask(__name__)
+    app.register_blueprint(news_routes.news_bp)
+
+    response = app.test_client().get("/news/rss")
+    root = ET.fromstring(response.text)
+    item = root.find("channel/item")
+
+    assert item is not None
+    assert item.findtext("title") == row["title"]
+    assert item.findtext("description") == row["description"]
+    assert item.findtext("{http://purl.org/dc/elements/1.1/}creator") == row["display_name"]


### PR DESCRIPTION
Closes #1953.

## What changed
- add one CDATA-safe text renderer that splits embedded terminators into adjacent sections
- apply it consistently to RSS title, description, and creator fields
- preserve the original reader-visible text
- add a parser-level regression covering all three fields

## Mutation proof
Before the production fix, ElementTree rejected the generated feed as malformed XML at the first embedded CDATA terminator.

## Validation
- news RSS + DB-path suites: 3 passed
- git diff --check: clean

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d