### PR TITLE
Allow automatic mood transitions under frequent updates

### DIFF
--- a/mood_engine.py
+++ b/mood_engine.py
@@ -522,9 +522,12 @@ class MoodEngine:
             self._save_mood(agent_id, new_mood)
             return new_mood
         
-        # Check if enough time has passed for mood change
+        # Transition eligibility is based on the age of the current state.
+        # ``last_updated`` advances on every intensity refresh, so using it as
+        # the gate would let frequent callers postpone transitions forever.
+        time_in_mood = current_time - current_mood.started_at
         time_since_update = current_time - current_mood.last_updated
-        if time_since_update < self.MIN_MOOD_DURATION:
+        if time_in_mood < self.MIN_MOOD_DURATION:
             # Just update intensity (decay over time)
             hours_passed = time_since_update / 3600
             new_intensity = max(

--- a/tests/test_mood_transition_interval.py
+++ b/tests/test_mood_transition_interval.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for mood transition timing."""
+
+import mood_engine
+from mood_engine import MoodEngine, MoodState
+
+
+def test_frequent_updates_do_not_postpone_transition_forever(monkeypatch, tmp_path):
+    now = [1_000_000.0]
+    monkeypatch.setattr(mood_engine.time, "time", lambda: now[0])
+    monkeypatch.setattr(mood_engine.random, "random", lambda: 0.0)
+
+    engine = MoodEngine(str(tmp_path / "moods.db"))
+    mood = engine.update_mood(1, force_state=MoodState.ENERGETIC)
+    assert mood.state is MoodState.ENERGETIC
+
+    # A normal scheduler may call update_mood every ten minutes. Those calls
+    # should update intensity, but must not restart the one-hour state timer.
+    for interval in range(1, 6):
+        now[0] = 1_000_000.0 + interval * 600
+        mood = engine.update_mood(1)
+        assert mood.state is MoodState.ENERGETIC
+
+    now[0] = 1_000_000.0 + engine.MIN_MOOD_DURATION
+    mood = engine.update_mood(1)
+
+    assert mood.state is MoodState.EXCITED
+    assert mood.started_at == now[0]


### PR DESCRIPTION
Closes #1955.

## What changed
- gate transition eligibility on current-state age (started_at)
- keep intensity decay based on the incremental refresh age (last_updated)
- add a deterministic clock regression modeling ten-minute scheduler calls

## Mutation proof
Before the production fix, six ten-minute updates left the agent energetic after a full hour because each refresh restarted the transition timer.

## Validation
- mood regression + complete mood-engine suite: 16 passed
- git diff --check: clean

## Payout
Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d