### PR TITLE
Use actual watch timestamps for recommendation affinity

### DIFF
--- a/recommendation_engine.py
+++ b/recommendation_engine.py
@@ -493,7 +493,7 @@ def get_feed_recommendations(
     if mode == "recommended" and agent_id:
         # Get user's watch history for affinity
         watch_history = db.execute(
-            """SELECT v.category, v.created_at AS watched_at
+            """SELECT v.category, w.created_at AS watched_at
                FROM views w
                JOIN videos v ON w.video_id = v.video_id
                WHERE w.agent_id = ?

--- a/tests/test_recommendation_engine.py
+++ b/tests/test_recommendation_engine.py
@@ -499,6 +499,26 @@ class TestFeedRecommendationsIntegration:
         # Verify sorted by created_at desc
         for i in range(len(videos) - 1):
             assert videos[i]["created_at"] >= videos[i + 1]["created_at"]
+
+    def test_recommended_mode_uses_actual_watch_times_for_affinity(self, test_db, monkeypatch):
+        test_db.execute(
+            "UPDATE views SET created_at = CASE video_id "
+            "WHEN 'video_0' THEN 100.0 WHEN 'video_2' THEN 200.0 END"
+        )
+        test_db.commit()
+        captured = {}
+
+        def capture_recommend(
+            _engine, candidates, limit, user_watch_history=None, now=None
+        ):
+            captured["history"] = user_watch_history
+            return candidates[:limit]
+
+        monkeypatch.setattr(RecommendationEngine, "recommend", capture_recommend)
+
+        get_feed_recommendations(test_db, agent_id=3, limit=5, mode="recommended")
+
+        assert [entry["watched_at"] for entry in captured["history"]] == [200.0, 100.0]
     
     def test_get_feed_recommendations_excludes_removed(self, test_db):
         """Removed videos should be excluded."""


### PR DESCRIPTION
Closes #1957.

## What changed
- select the view event timestamp as watched_at for recommendation history
- preserve upload timestamps only for video freshness scoring
- add an integration regression capturing the exact history given to the ranker

## Mutation proof
Before the production fix, known view times 200 and 100 were replaced by the videos' much newer publication timestamps.

## Validation
- complete recommendation-engine suite: 35 passed
- git diff --check: clean

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d