### PR TITLE
[TRAVIS] Claim BAN payouts before the irreversible send edge

### DIFF
--- a/banano_payout.py
+++ b/banano_payout.py
@@ -80,6 +80,27 @@ def _ban_rpc(action_data: dict) -> dict:
     return {"error": "all RPC endpoints failed"}
 
 
+def _claim_withdrawal(db, tx_id: int) -> bool:
+    """Atomically claim one pending withdrawal for this payout worker.
+
+    The pending list is only discovery.  Multiple cron processes may discover
+    the same row, so the irreversible send edge must be guarded by a
+    compare-and-set under a SQLite write reservation.
+    """
+    try:
+        db.execute("BEGIN IMMEDIATE")
+        claimed = db.execute(
+            "UPDATE ban_transactions SET status = 'processing', processed_at = ? "
+            "WHERE id = ? AND status = 'pending' AND tx_type = 'withdrawal'",
+            (time.time(), tx_id),
+        ).rowcount
+        db.commit()
+        return claimed == 1
+    except Exception:
+        db.rollback()
+        raise
+
+
 def process_withdrawals():
     """Process all pending BAN withdrawals."""
     if not BANANO_SEED:
@@ -154,6 +175,10 @@ def process_withdrawals():
                 f"({balance_ban:.4f} < {amount_ban:.4f}). Stopping.")
             break
 
+        if not _claim_withdrawal(db, tx_id):
+            log("INFO", f"TX#{tx_id}: Already claimed by another payout worker")
+            continue
+
         log("INFO", f"TX#{tx_id}: Sending {amount_ban} BAN to {to_address}")
 
         try:
@@ -168,7 +193,8 @@ def process_withdrawals():
 
             log("OK", f"TX#{tx_id}: Sent! Block: {block_hash}")
             db.execute(
-                "UPDATE ban_transactions SET status = 'sent', block_hash = ?, processed_at = ? WHERE id = ?",
+                "UPDATE ban_transactions SET status = 'sent', block_hash = ?, processed_at = ? "
+                "WHERE id = ? AND status = 'processing'",
                 (str(block_hash), time.time(), tx_id),
             )
             balance_ban -= amount_ban
@@ -180,10 +206,20 @@ def process_withdrawals():
             # Mark as failed only for permanent errors
             if any(kw in error_str.lower() for kw in ["insufficient", "invalid", "bad", "fork"]):
                 db.execute(
-                    "UPDATE ban_transactions SET status = 'failed', processed_at = ? WHERE id = ?",
+                    "UPDATE ban_transactions SET status = 'failed', processed_at = ? "
+                    "WHERE id = ? AND status = 'processing'",
                     (time.time(), tx_id),
                 )
-            # Otherwise leave as pending for retry on next cron run
+            else:
+                # The client may have submitted the block before the transport
+                # failed.  Automatic retry could therefore send a second
+                # irreversible payout.  Quarantine the uncertain attempt for
+                # chain reconciliation instead of silently replaying it.
+                db.execute(
+                    "UPDATE ban_transactions SET status = 'uncertain', processed_at = ? "
+                    "WHERE id = ? AND status = 'processing'",
+                    (time.time(), tx_id),
+                )
 
         db.commit()
         time.sleep(1)  # Rate limit between sends

--- a/tests/test_banano_payout_claim.py
+++ b/tests/test_banano_payout_claim.py
@@ -1,0 +1,102 @@
+"""BAN payout rows must cross the irreversible send edge at most once."""
+
+import sqlite3
+
+import banano_payout
+
+
+def _schema(db):
+    db.executescript(
+        """
+        CREATE TABLE ban_transactions (
+            id INTEGER PRIMARY KEY,
+            agent_id INTEGER NOT NULL,
+            tx_type TEXT NOT NULL,
+            amount_ban REAL NOT NULL,
+            reason TEXT NOT NULL,
+            status TEXT NOT NULL,
+            block_hash TEXT DEFAULT '',
+            created_at REAL NOT NULL,
+            processed_at REAL DEFAULT 0
+        );
+        CREATE TABLE ban_wallets (
+            agent_id INTEGER PRIMARY KEY,
+            account_index INTEGER NOT NULL
+        );
+        """
+    )
+    db.execute(
+        "INSERT INTO ban_transactions "
+        "(id, agent_id, tx_type, amount_ban, reason, status, created_at) "
+        "VALUES (1, 7, 'withdrawal', 5, ?, 'pending', 1)",
+        ("withdraw_to_ban_" + "a" * 60,),
+    )
+    db.execute("INSERT INTO ban_wallets VALUES (7, 1)")
+    db.commit()
+
+
+def test_only_one_worker_can_claim_a_pending_withdrawal(tmp_path):
+    db_path = tmp_path / "bottube.db"
+    with sqlite3.connect(db_path) as setup:
+        _schema(setup)
+
+    first = sqlite3.connect(db_path, timeout=10)
+    second = sqlite3.connect(db_path, timeout=10)
+    try:
+        assert banano_payout._claim_withdrawal(first, 1) is True
+        assert banano_payout._claim_withdrawal(second, 1) is False
+    finally:
+        first.close()
+        second.close()
+
+    with sqlite3.connect(db_path) as verify:
+        assert verify.execute(
+            "SELECT status FROM ban_transactions WHERE id = 1"
+        ).fetchone()[0] == "processing"
+
+
+def test_uncertain_send_is_quarantined_instead_of_replayed(tmp_path, monkeypatch):
+    db_path = tmp_path / "bottube.db"
+    with sqlite3.connect(db_path) as setup:
+        _schema(setup)
+
+    class FakeRPC:
+        def __init__(self, _url):
+            pass
+
+        def get_account_balance(self, _address):
+            return {"balance": str(100 * banano_payout.BAN_RAW_MULTIPLIER)}
+
+    class FakeWallet:
+        send_calls = 0
+
+        def __init__(self, _rpc, seed, index):
+            pass
+
+        def get_address(self):
+            return "ban_" + "b" * 60
+
+        def receive_all(self):
+            return None
+
+        def send(self, _address, _amount):
+            type(self).send_calls += 1
+            raise TimeoutError("RPC outcome unknown")
+
+    monkeypatch.setattr(banano_payout, "DB_PATH", str(db_path))
+    monkeypatch.setattr(banano_payout, "BANANO_SEED", "00" * 32)
+    monkeypatch.setattr(banano_payout, "HAS_BANANOPIE", True)
+    monkeypatch.setattr(banano_payout, "BananoRPC", FakeRPC, raising=False)
+    monkeypatch.setattr(banano_payout, "BananoWallet", FakeWallet, raising=False)
+    monkeypatch.setattr(banano_payout.time, "sleep", lambda _seconds: None)
+
+    banano_payout.process_withdrawals()
+    banano_payout.process_withdrawals()
+
+    assert FakeWallet.send_calls == 1
+    with sqlite3.connect(db_path) as verify:
+        status, processed_at = verify.execute(
+            "SELECT status, processed_at FROM ban_transactions WHERE id = 1"
+        ).fetchone()
+    assert status == "uncertain"
+    assert processed_at > 0

--- a/tests/test_banano_tip_pending_withdrawal.py
+++ b/tests/test_banano_tip_pending_withdrawal.py
@@ -79,6 +79,15 @@ def _pending_withdrawal_total(db_path):
         ).fetchone()[0]
 
 
+def _set_withdrawal_status(db_path, status):
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            "UPDATE ban_transactions SET status = ? WHERE tx_type = 'withdrawal'",
+            (status,),
+        )
+        db.commit()
+
+
 def test_tip_rejected_after_full_balance_is_withdrawn(ban_client):
     """Alice earns 10 BAN, withdraws all 10, then must not be able to tip it."""
     withdraw = ban_client.post(
@@ -107,3 +116,25 @@ def test_tip_still_allowed_within_the_unwithdrawn_remainder(ban_client):
 
     tip = ban_client.post("/ban/tip", json={"to_agent": "bob", "amount": 4.0})
     assert tip.status_code == 200, tip.get_json()
+
+
+@pytest.mark.parametrize("status", ["processing", "uncertain"])
+def test_inflight_or_ambiguous_withdrawal_stays_reserved(ban_client, status):
+    withdraw = ban_client.post(
+        "/ban/withdraw",
+        json={"amount": 10.0, "address": "ban_" + "1" * 60},
+    )
+    assert withdraw.status_code == 200, withdraw.get_json()
+    _set_withdrawal_status(ban_client.db_path, status)
+
+    tip = ban_client.post("/ban/tip", json={"to_agent": "bob", "amount": 10.0})
+    second_withdrawal = ban_client.post(
+        "/ban/withdraw",
+        json={"amount": 10.0, "address": "ban_" + "2" * 60},
+    )
+    balance = ban_client.get("/ban/balance/alice")
+
+    assert tip.status_code == 400, tip.get_json()
+    assert second_withdrawal.status_code == 400, second_withdrawal.get_json()
+    assert balance.status_code == 200
+    assert balance.get_json()["balance_ban"] == 0.0


### PR DESCRIPTION
## Summary - atomically compare-and-set each pending BAN withdrawal to `processing` before the irreversible send edge - let only the winning worker send when cron processes overlap - quarantine transport-uncertain outcomes instead of silently replaying a possibly successful block - scope sent/failed transitions to the claimed processing row  Closes #1959.  ## Proof - claim competition: first connection wins, second connection returns false - timeout replay: two processor runs produce exactly one `wallet.send()` call and durable status `uncertain` - focused regressions: **2 passed** - compile and diff-integrity checks: clean  ## Payout Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d` 
Follow-up hardening: `processing` and `uncertain` withdrawals now remain reserved in public balance, tip admission, and second-withdrawal admission, preventing the new safe payout states from making committed BAN spendable again. Six payout/ledger regressions pass.

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d