### PR TITLE
Accept finite fractional Unix query timestamps

### DIFF
--- a/bottube_validators/validators.py
+++ b/bottube_validators/validators.py
@@ -15,6 +15,7 @@ request that did not supply the parameter at all.
 
 from __future__ import annotations
 
+import math
 from datetime import datetime, timezone
 from typing import Any, Iterable, Optional, Tuple
 
@@ -274,18 +275,29 @@ def _parse_ts_param(
     try:
         value = int(raw_value)
     except (TypeError, ValueError):
-        if not accept_iso:
-            return None, _query_error(name, "must be a Unix timestamp")
         try:
-            parsed = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=timezone.utc)
-            value = parsed.timestamp()
-        except (OverflowError, OSError, TypeError, ValueError):
-            return None, _query_error(
-                name,
-                "must be a Unix timestamp or ISO-8601 datetime",
-            )
+            value = float(raw_value)
+        except (TypeError, ValueError):
+            if not accept_iso:
+                return None, _query_error(name, "must be a Unix timestamp")
+            try:
+                parsed = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                value = parsed.timestamp()
+            except (OverflowError, OSError, TypeError, ValueError):
+                return None, _query_error(
+                    name,
+                    "must be a Unix timestamp or ISO-8601 datetime",
+                )
+
+    if not math.isfinite(value):
+        detail = (
+            "must be a finite Unix timestamp or ISO-8601 datetime"
+            if accept_iso
+            else "must be a finite Unix timestamp"
+        )
+        return None, _query_error(name, detail)
 
     if min_value is not None and value < min_value:
         return None, _query_error(name, f"must be >= {min_value:g}")

--- a/tests/test_shared_query_param_validation.py
+++ b/tests/test_shared_query_param_validation.py
@@ -13,6 +13,7 @@ from bottube_validators.validators import (
     MAX_QUERY_TIMESTAMP,
     parse_enum,
     parse_positive_int,
+    parse_timestamp,
     parse_timestamp_iso,
 )
 
@@ -257,3 +258,25 @@ def test_shared_timestamp_parser_accepts_unix_and_iso_and_rejects_bounds():
         assert parse_timestamp_iso("since")[1][1] == 400
     with app.test_request_context(f"/?since={MAX_QUERY_TIMESTAMP + 1}"):
         assert parse_timestamp_iso("since")[1][1] == 400
+
+
+@pytest.mark.parametrize("parser", [parse_timestamp, parse_timestamp_iso])
+def test_shared_timestamp_parsers_preserve_fractional_unix_seconds(parser):
+    app = Flask(__name__)
+
+    with app.test_request_context("/?since=1700000000.125"):
+        value, error = parser("since")
+
+    assert error is None
+    assert value == 1_700_000_000.125
+
+
+@pytest.mark.parametrize("raw", ["nan", "inf", "-inf"])
+def test_shared_timestamp_parser_rejects_non_finite_numbers(raw):
+    app = Flask(__name__)
+
+    with app.test_request_context(f"/?since={raw}"):
+        value, error = parse_timestamp_iso("since")
+
+    assert value is None
+    assert error[1] == 400


### PR DESCRIPTION
Closes #1961.

## What changed
- preserve the fast integer path and integer return behavior
- parse finite fractional epoch values before the ISO-8601 fallback
- reject nan and infinities explicitly
- cover both public timestamp parsers and non-finite values

## Mutation proof
Before the production fix, both public parsers returned 400 for 1700000000.125.

## Validation
- complete shared query-validation suite: 15 passed
- git diff --check: clean

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d