### PR TITLE
[TRAVIS] Claim Base wRTC withdrawals before minting

### DIFF
--- a/base_wrtc_bridge_blueprint.py
+++ b/base_wrtc_bridge_blueprint.py
@@ -133,6 +133,20 @@ def init_base_wrtc_tables(db):
     db.commit()
 
 
+def _claim_base_withdrawal(db, withdrawal_id):
+    """Atomically claim one queued withdrawal before any on-chain side effect."""
+    cursor = db.execute(
+        """
+        UPDATE base_wrtc_withdrawals
+        SET status = 'processing'
+        WHERE id = ? AND status = 'pending'
+        """,
+        (withdrawal_id,),
+    )
+    db.commit()
+    return cursor.rowcount == 1
+
+
 def _json_object_body():
     """Return request JSON when it is an object, or a 400 response tuple."""
     data = request.get_json(silent=True)
@@ -298,7 +312,8 @@ def base_bridge_info():
     wd = db.execute(
         """
         SELECT COUNT(*) AS cnt, COALESCE(SUM(amount_wrtc), 0) AS total
-        FROM base_wrtc_withdrawals WHERE status IN ('pending', 'processing', 'sent', 'completed')
+        FROM base_wrtc_withdrawals
+        WHERE status IN ('pending', 'processing', 'uncertain', 'sent', 'completed')
         """
     ).fetchone()
 
@@ -649,13 +664,10 @@ def base_bridge_process_withdrawals():
     results = []
     for wd in pending:
         wd = dict(wd)
+        if not _claim_base_withdrawal(db, wd["id"]):
+            continue
+        send_attempted = False
         try:
-            db.execute(
-                "UPDATE base_wrtc_withdrawals SET status = 'processing' WHERE id = ?",
-                (wd["id"],),
-            )
-            db.commit()
-
             amount_raw = int(wd["net_wrtc"] * (10 ** WRTC_DECIMALS))
             to_addr = Web3.to_checksum_address(wd["to_address"])
 
@@ -670,6 +682,7 @@ def base_bridge_process_withdrawals():
                 }
             )
             signed = account.sign_transaction(tx)
+            send_attempted = True
             tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
             receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
 
@@ -678,7 +691,7 @@ def base_bridge_process_withdrawals():
                     """
                     UPDATE base_wrtc_withdrawals
                     SET status = 'completed', tx_hash = ?, completed_at = ?
-                    WHERE id = ?
+                    WHERE id = ? AND status = 'processing'
                     """,
                     (receipt.transactionHash.hex(), time.time(), wd["id"]),
                 )
@@ -691,7 +704,8 @@ def base_bridge_process_withdrawals():
                 )
             else:
                 db.execute(
-                    "UPDATE base_wrtc_withdrawals SET status = 'failed' WHERE id = ?",
+                    "UPDATE base_wrtc_withdrawals SET status = 'failed' "
+                    "WHERE id = ? AND status = 'processing'",
                     (wd["id"],),
                 )
                 results.append(
@@ -699,12 +713,20 @@ def base_bridge_process_withdrawals():
                 )
 
         except Exception as exc:
+            # Once submission was attempted, a transport timeout cannot prove the
+            # transaction was not accepted by the node.  Never requeue that row.
+            terminal_status = "uncertain" if send_attempted else "failed"
             db.execute(
-                "UPDATE base_wrtc_withdrawals SET status = 'failed' WHERE id = ?",
-                (wd["id"],),
+                "UPDATE base_wrtc_withdrawals SET status = ? "
+                "WHERE id = ? AND status = 'processing'",
+                (terminal_status, wd["id"]),
             )
             results.append(
-                {"withdrawal_id": wd["withdrawal_id"], "status": "failed", "reason": str(exc)}
+                {
+                    "withdrawal_id": wd["withdrawal_id"],
+                    "status": terminal_status,
+                    "reason": str(exc),
+                }
             )
 
         db.commit()

--- a/tests/test_base_wrtc_bridge_validation.py
+++ b/tests/test_base_wrtc_bridge_validation.py
@@ -160,3 +160,76 @@ def test_rejected_base_bridge_withdrawal_does_not_queue_or_debit(client):
 
     assert queued == 0
     assert balance == 1000.0
+
+
+def test_base_withdrawal_claim_is_atomic(client):
+    with client.application.app_context():
+        import base_wrtc_bridge_blueprint as bridge
+
+        db = bridge.get_db()
+        bridge.init_base_wrtc_tables(db)
+        db.execute(
+            """
+            INSERT INTO base_wrtc_withdrawals
+                (withdrawal_id, agent_id, agent_name, to_address, amount_wrtc,
+                 fee_wrtc, net_wrtc, status, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            (
+                "base_claim_test",
+                1,
+                "bridgeuser",
+                "0x2222222222222222222222222222222222222222",
+                10.0,
+                0.5,
+                9.5,
+                1.0,
+            ),
+        )
+        db.commit()
+        withdrawal_id = db.execute(
+            "SELECT id FROM base_wrtc_withdrawals WHERE withdrawal_id = ?",
+            ("base_claim_test",),
+        ).fetchone()[0]
+
+        assert bridge._claim_base_withdrawal(db, withdrawal_id) is True
+        assert bridge._claim_base_withdrawal(db, withdrawal_id) is False
+        status = db.execute(
+            "SELECT status FROM base_wrtc_withdrawals WHERE id = ?",
+            (withdrawal_id,),
+        ).fetchone()[0]
+
+    assert status == "processing"
+
+
+def test_uncertain_base_withdrawal_remains_in_bridge_liabilities(client):
+    with client.application.app_context():
+        import base_wrtc_bridge_blueprint as bridge
+
+        db = bridge.get_db()
+        bridge.init_base_wrtc_tables(db)
+        db.execute(
+            """
+            INSERT INTO base_wrtc_withdrawals
+                (withdrawal_id, agent_id, agent_name, to_address, amount_wrtc,
+                 fee_wrtc, net_wrtc, status, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'uncertain', ?)
+            """,
+            (
+                "base_uncertain_test",
+                1,
+                "bridgeuser",
+                "0x2222222222222222222222222222222222222222",
+                10.0,
+                0.5,
+                9.5,
+                1.0,
+            ),
+        )
+        db.commit()
+
+    response = client.get("/api/base-bridge/info")
+
+    assert response.status_code == 200
+    assert response.get_json()["stats"]["withdrawals_count"] == 1
+    assert response.get_json()["stats"]["total_withdrawn_wrtc"] == 10.0


### PR DESCRIPTION
## Summary - atomically claim each pending Base wRTC withdrawal before building or broadcasting its mint transaction - allow only the worker whose `pending -> processing` transition changed one row to reach the irreversible send edge - scope completion/failure writes to that claimed processing state - preserve ambiguous post-submission failures as `uncertain` for reconciliation instead of treating them as safely retryable  ## Proof - `python -m pytest tests/test_base_wrtc_bridge_validation.py test_bridge_admin_auth.py -q` — 25 passed - `python -m py_compile base_wrtc_bridge_blueprint.py` - `git diff --check` - regression proves a second claim for the same queued withdrawal cannot win  Closes #1963  Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d 
Follow-up integration proof: ambiguous `uncertain` withdrawals remain included in bridge liability count and volume instead of disappearing from operator statistics. The focused/adjacent gate is now 26 passed.