### PR TITLE
fix(syndication): reject malformed partner templates

### DIFF
--- a/syndication_adapter.py
+++ b/syndication_adapter.py
@@ -11,6 +11,7 @@ Adapters are stateless and focused solely on platform-specific API calls.
 Queue management and retry logic are handled by syndication_queue.py.
 """
 
+import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -365,33 +366,37 @@ class PartnerAPIAdapter(SyndicationAdapter):
         if not self.auth_value:
             log.error("[partner_api] Missing auth_value in config")
             return False
+        if self.payload_template:
+            try:
+                json.loads(self.payload_template)
+            except (TypeError, json.JSONDecodeError) as exc:
+                log.error("[partner_api] Invalid payload_template: %s", exc)
+                return False
         return True
 
     def syndicate(self, payload: SyndicationPayload) -> SyndicationResult:
         """Post to partner API endpoint."""
         headers = {self.auth_header: self.auth_value}
         
-        # Use template if provided, otherwise use default payload
-        if self.payload_template:
-            import json
-            payload_data = json.loads(self.payload_template)
-            # Substitute variables
-            payload_data = self._substitute_template(payload_data, payload)
-        else:
-            payload_data = {
-                "title": payload.video_title,
-                "description": payload.video_description,
-                "url": payload.video_url,
-                "thumbnail": payload.thumbnail_url,
-                "tags": payload.tags,
-                "metadata": {
-                    "video_id": payload.video_id,
-                    "agent_id": payload.agent_id,
-                    "agent_name": payload.agent_name,
-                },
-            }
-
         try:
+            # Use template if provided, otherwise use default payload.
+            if self.payload_template:
+                payload_data = json.loads(self.payload_template)
+                payload_data = self._substitute_template(payload_data, payload)
+            else:
+                payload_data = {
+                    "title": payload.video_title,
+                    "description": payload.video_description,
+                    "url": payload.video_url,
+                    "thumbnail": payload.thumbnail_url,
+                    "tags": payload.tags,
+                    "metadata": {
+                        "video_id": payload.video_id,
+                        "agent_id": payload.agent_id,
+                        "agent_name": payload.agent_name,
+                    },
+                }
+
             response = self._session.post(
                 self.endpoint_url,
                 headers=headers,
@@ -407,6 +412,10 @@ class PartnerAPIAdapter(SyndicationAdapter):
                 external_url=result_data.get("url"),
                 metadata={"partner_response": result_data},
             )
+        except (TypeError, json.JSONDecodeError) as e:
+            message = f"Invalid payload_template: {e}"
+            log.error("[partner_api] %s", message)
+            return SyndicationResult(success=False, error_message=message)
         except requests.RequestException as e:
             log.error("[partner_api] Syndication failed: %s", e)
             return SyndicationResult(success=False, error_message=str(e))

--- a/tests/test_syndication_adapter.py
+++ b/tests/test_syndication_adapter.py
@@ -312,6 +312,34 @@ class TestPartnerAPIAdapter:
         assert adapter.validate_config() is False
 
     @patch('syndication_adapter.requests.Session')
+    def test_invalid_payload_template_fails_closed(self, mock_session_class):
+        """Malformed templates must not escape the result contract or make a request."""
+        mock_session = MagicMock()
+        mock_session_class.return_value = mock_session
+        adapter = PartnerAPIAdapter({
+            "endpoint_url": "https://api.partner.com/syndicate",
+            "auth_value": "secret",
+            "payload_template": '{"title": "{{video_title}}"',
+        })
+        payload = SyndicationPayload(
+            video_id="vid_123",
+            video_title="My Video",
+            video_description="Desc",
+            video_url="https://bottube.ai/videos/vid_123",
+            thumbnail_url=None,
+            agent_id=1,
+            agent_name="agent",
+            tags=[],
+        )
+
+        assert adapter.validate_config() is False
+        result = adapter.syndicate(payload)
+
+        assert result.success is False
+        assert "payload_template" in result.error_message
+        mock_session.post.assert_not_called()
+
+    @patch('syndication_adapter.requests.Session')
     def test_syndicate_with_template(self, mock_session_class):
         """Test syndication with payload template."""
         mock_session = MagicMock()


### PR DESCRIPTION
## Summary
- reject malformed partner `payload_template` JSON during adapter validation
- preserve the `SyndicationResult` failure contract for direct calls
- prove malformed templates never trigger an outbound request

## Mutation proof
Before the fix, `test_invalid_payload_template_fails_closed` failed because validation returned `True`; continuing to syndication raised an uncaught `JSONDecodeError` before the request guard.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with requests pytest -q tests/test_syndication_adapter.py` (31 passed)
- `git diff --check`

Fixes #1965

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d