### PR TITLE
[TRAVIS] Claim Solana wRTC withdrawals before transfer

### DIFF
--- a/tests/test_wrtc_payout_claim.py
+++ b/tests/test_wrtc_payout_claim.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+"""Regression proof for Solana wRTC payout admission."""
+
+import sqlite3
+
+import wrtc_bridge
+
+
+def test_only_one_worker_can_claim_a_pending_withdrawal():
+    db = sqlite3.connect(":memory:")
+    db.executescript(wrtc_bridge.WRTC_SCHEMA)
+    db.execute(
+        """
+        INSERT INTO wrtc_withdrawals
+            (agent_id, amount_wrtc, fee_wrtc, net_wrtc, to_address, status, created_at)
+        VALUES (?, ?, ?, ?, ?, 'pending', ?)
+        """,
+        (1, 10.0, 0.5, 9.5, "11111111111111111111111111111111", 1.0),
+    )
+    withdrawal_id = db.execute("SELECT id FROM wrtc_withdrawals").fetchone()[0]
+
+    assert wrtc_bridge._claim_wrtc_withdrawal(db, withdrawal_id) is True
+    assert wrtc_bridge._claim_wrtc_withdrawal(db, withdrawal_id) is False
+    assert db.execute(
+        "SELECT status FROM wrtc_withdrawals WHERE id = ?", (withdrawal_id,)
+    ).fetchone()[0] == "processing"

--- a/wrtc_bridge.py
+++ b/wrtc_bridge.py
@@ -168,6 +168,17 @@ def _debit_rtc(db, agent_id: int, amount: float):
     return cursor.rowcount > 0
 
 
+def _claim_wrtc_withdrawal(db, withdrawal_id: int) -> bool:
+    """Atomically reserve a queued withdrawal for one payout worker."""
+    cursor = db.execute(
+        "UPDATE wrtc_withdrawals SET status = 'processing' "
+        "WHERE id = ? AND status = 'pending'",
+        (withdrawal_id,),
+    )
+    db.commit()
+    return cursor.rowcount == 1
+
+
 # ---------------------------------------------------------------------------
 # SOLANA TX VERIFICATION
 # ---------------------------------------------------------------------------
@@ -612,6 +623,8 @@ def process_withdrawals():
     results = []
     for w in pending:
         wid = w["id"]
+        if not _claim_wrtc_withdrawal(db, wid):
+            continue
         try:
             result = subprocess.run(
                 [
@@ -629,13 +642,9 @@ def process_withdrawals():
                 error_msg = result.stderr.strip() or result.stdout.strip() or "Unknown error"
                 results.append({"id": wid, "ok": False, "error": error_msg})
                 db.execute(
-                    "UPDATE wrtc_withdrawals SET status = 'failed' WHERE id = ?",
+                    "UPDATE wrtc_withdrawals SET status = 'uncertain' "
+                    "WHERE id = ? AND status = 'processing'",
                     (wid,),
-                )
-                # Refund the agent
-                db.execute(
-                    "UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?",
-                    (w["net_wrtc"] + WITHDRAW_FEE, w["agent_id"]),
                 )
                 continue
 
@@ -643,7 +652,9 @@ def process_withdrawals():
             if out.get("ok"):
                 tx_sig = out.get("tx", "")
                 db.execute(
-                    "UPDATE wrtc_withdrawals SET status = 'completed', tx_signature = ?, completed_at = ? WHERE id = ?",
+                    "UPDATE wrtc_withdrawals SET status = 'completed', "
+                    "tx_signature = ?, completed_at = ? "
+                    "WHERE id = ? AND status = 'processing'",
                     (tx_sig, time.time(), wid),
                 )
                 results.append({"id": wid, "ok": True, "tx": tx_sig})
@@ -651,18 +662,24 @@ def process_withdrawals():
                 err = out.get("error", "Send failed")
                 results.append({"id": wid, "ok": False, "error": err})
                 db.execute(
-                    "UPDATE wrtc_withdrawals SET status = 'failed' WHERE id = ?",
+                    "UPDATE wrtc_withdrawals SET status = 'uncertain' "
+                    "WHERE id = ? AND status = 'processing'",
                     (wid,),
-                )
-                # Refund
-                db.execute(
-                    "UPDATE agents SET rtc_balance = rtc_balance + ? WHERE id = ?",
-                    (w["net_wrtc"] + WITHDRAW_FEE, w["agent_id"]),
                 )
 
         except subprocess.TimeoutExpired:
+            db.execute(
+                "UPDATE wrtc_withdrawals SET status = 'uncertain' "
+                "WHERE id = ? AND status = 'processing'",
+                (wid,),
+            )
             results.append({"id": wid, "ok": False, "error": "Timeout"})
         except Exception as e:
+            db.execute(
+                "UPDATE wrtc_withdrawals SET status = 'uncertain' "
+                "WHERE id = ? AND status = 'processing'",
+                (wid,),
+            )
             results.append({"id": wid, "ok": False, "error": str(e)})
 
     db.commit()


### PR DESCRIPTION
## Summary
- atomically claim each pending Solana wRTC withdrawal before invoking the transfer helper
- allow only the worker whose `pending -> processing` transition changed one row to reach the irreversible send edge
- scope completion and uncertainty writes to the claimed processing state
- fail closed on helper errors/timeouts as `uncertain` without restoring platform balance, because an on-chain submission may already exist

## Proof
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_wrtc_payout_claim.py -q` — 1 passed
- direct SQLite proof: first claim succeeds, second claim for the same row fails, state remains `processing`
- `python -m py_compile wrtc_bridge.py`
- `git diff --check`

Closes #1967

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d