### PR TITLE
fix(seo): tolerate malformed video numerics

### DIFF
--- a/seo_routes.py
+++ b/seo_routes.py
@@ -4,7 +4,7 @@
 # AEO, GEO, E-E-A-T, Semantic Entity Mapping — 2026 Edition
 # ---------------------------------------------------------------------------
 
-import html, json, re, time
+import html, json, math, re, time
 from flask import Blueprint, current_app, request
 from datetime import datetime, timezone
 
@@ -339,6 +339,20 @@ def _iso_duration(seconds):
     return f"PT{m}M{s}S"
 
 
+def _finite_number(value, default=0.0):
+    """Coerce persisted numeric metadata without emitting NaN or infinity."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    return number if math.isfinite(number) else float(default)
+
+
+def _finite_int(value, default=0):
+    """Return an integer from persisted metadata, falling back when malformed."""
+    return int(_finite_number(value, default))
+
+
 # ---------------------------------------------------------------------------
 # Semantic Entity / Organization JSON-LD (sitewide, injected via base.html)
 # ---------------------------------------------------------------------------
@@ -487,14 +501,16 @@ def build_video_jsonld(video, agent_name, display_name, is_human):
         if thumb
         else "https://bottube.ai/static/og-banner.png"
     )
-    dur_sec = int(float(video.get("duration_sec", 0) or 0))
-    width = int(video.get("width", 0) or 720)
-    height = int(video.get("height", 0) or 720)
+    dur_sec = _finite_int(video.get("duration_sec", 0) or 0)
+    width = _finite_int(video.get("width", 0) or 720, 720)
+    height = _finite_int(video.get("height", 0) or 720, 720)
     vid = video["video_id"]
-    upload_ts = float(video.get("created_at", time.time()))
-    upload_iso = datetime.fromtimestamp(
-        upload_ts, tz=timezone.utc
-    ).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    upload_ts = _finite_number(video.get("created_at", time.time()), time.time())
+    try:
+        upload_date = datetime.fromtimestamp(upload_ts, tz=timezone.utc)
+    except (OSError, OverflowError, ValueError):
+        upload_date = datetime.now(tz=timezone.utc)
+    upload_iso = upload_date.strftime("%Y-%m-%dT%H:%M:%S+00:00")
 
     desc = video.get("description", "") or ""
     if len(desc) < 100:
@@ -525,12 +541,14 @@ def build_video_jsonld(video, agent_name, display_name, is_human):
             {
                 "@type": "InteractionCounter",
                 "interactionType": "https://schema.org/WatchAction",
-                "userInteractionCount": int(video.get("views", 0) or 0),
+                "userInteractionCount": _finite_int(video.get("views", 0) or 0),
             },
             {
                 "@type": "InteractionCounter",
                 "interactionType": "https://schema.org/CommentAction",
-                "userInteractionCount": int(video.get("comment_count", 0) or 0),
+                "userInteractionCount": _finite_int(
+                    video.get("comment_count", 0) or 0
+                ),
             },
         ],
         "author": {

--- a/tests/test_seo_video_jsonld.py
+++ b/tests/test_seo_video_jsonld.py
@@ -1,0 +1,58 @@
+"""Regression tests for video JSON-LD metadata normalization."""
+
+from datetime import datetime
+
+from seo_routes import build_video_jsonld
+
+
+def test_invalid_numeric_metadata_uses_safe_schema_defaults():
+    """One malformed legacy field must not break the entire watch page."""
+    result = build_video_jsonld(
+        {
+            "video_id": "legacy-video",
+            "title": "Legacy video",
+            "duration_sec": "unknown",
+            "width": "HD",
+            "height": None,
+            "created_at": "not-a-timestamp",
+            "views": "many",
+            "comment_count": "none",
+        },
+        agent_name="legacy-agent",
+        display_name="Legacy Agent",
+        is_human=False,
+    )
+
+    assert result["duration"] == "PT8S"
+    assert result["width"] == 720
+    assert result["height"] == 720
+    assert result["interactionStatistic"][0]["userInteractionCount"] == 0
+    assert result["interactionStatistic"][1]["userInteractionCount"] == 0
+    datetime.fromisoformat(result["uploadDate"])
+
+
+def test_non_finite_numeric_metadata_uses_safe_schema_defaults():
+    """NaN and infinity are not valid JSON-LD numeric values or timestamps."""
+    result = build_video_jsonld(
+        {
+            "video_id": "non-finite-video",
+            "duration_sec": "nan",
+            "width": "inf",
+            "height": "-inf",
+            "created_at": "nan",
+            "views": "inf",
+            "comment_count": "nan",
+        },
+        agent_name="agent",
+        display_name="Agent",
+        is_human=False,
+    )
+
+    assert result["duration"] == "PT8S"
+    assert result["width"] == 720
+    assert result["height"] == 720
+    assert [
+        counter["userInteractionCount"]
+        for counter in result["interactionStatistic"]
+    ] == [0, 0]
+    datetime.fromisoformat(result["uploadDate"])


### PR DESCRIPTION
## Summary
- normalize malformed or non-finite persisted numeric metadata before building VideoObject JSON-LD
- preserve safe duration, dimension, interaction, and upload-date defaults
- cover both invalid strings and `NaN` / infinity regressions

## Mutation proof
Before the fix, both regressions raised from `build_video_jsonld()`: invalid strings failed `float()` conversion, while `NaN` failed integer conversion. The function now returns valid schema data for both cases.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask pytest -q tests/test_seo_video_jsonld.py` (2 passed)
- `python -m py_compile seo_routes.py`
- `git diff --check`

Fixes #1969

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d