### PR TITLE
fix(media): tolerate metadata embedding timeouts

### DIFF
--- a/media_prep.py
+++ b/media_prep.py
@@ -503,7 +503,7 @@ class MediaPrepPipeline:
         try:
             subprocess.run(cmd, capture_output=True, timeout=120, check=True)
             temp_path.replace(video_path)
-        except subprocess.CalledProcessError as e:
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             log.warning(f"Metadata embedding failed: {e}")
             if temp_path.exists():
                 temp_path.unlink()

--- a/tests/test_media_prep.py
+++ b/tests/test_media_prep.py
@@ -12,6 +12,7 @@ issues in bottube_server.
 import json
 import os
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import time
@@ -270,6 +271,28 @@ class TestMediaPrepPipeline:
         assert PrepStage.VALIDATE.value in pipeline.progress
         assert pipeline.progress[PrepStage.VALIDATE.value].status == "running"
         assert pipeline.progress[PrepStage.VALIDATE.value].message == "Validating"
+
+    @patch("media_prep.subprocess.run")
+    def test_metadata_timeout_is_best_effort_and_cleans_temp_file(
+        self, mock_run, temp_db, temp_dirs
+    ):
+        """A metadata timeout must not discard an otherwise prepared video."""
+        video_dir, thumb_dir = temp_dirs
+        pipeline = MediaPrepPipeline(
+            db=temp_db, video_dir=video_dir, thumb_dir=thumb_dir
+        )
+        video_path = video_dir / "prepared.mp4"
+        temp_path = video_dir / "prepared.tmp.mp4"
+        video_path.write_bytes(b"prepared video")
+        temp_path.write_bytes(b"partial metadata output")
+        mock_run.side_effect = subprocess.TimeoutExpired("ffmpeg", 120)
+
+        pipeline._embed_metadata(
+            video_path, "Prepared video", "Description", agent_id=1
+        )
+
+        assert video_path.read_bytes() == b"prepared video"
+        assert not temp_path.exists()
 
 
 class TestSyndicationTables:


### PR DESCRIPTION
## Summary
- handle FFmpeg metadata timeouts through the existing best-effort failure path
- preserve the already-prepared video instead of failing the entire pipeline
- remove partial metadata output after either timeout or process failure

## Mutation proof
Before the fix, the new regression raised `subprocess.TimeoutExpired` from `_embed_metadata()` and left `prepared.tmp.mp4` behind. It now returns normally, preserves the original video bytes, and removes the partial file.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest pytest -q tests/test_media_prep.py` (22 passed)
- `python -m py_compile media_prep.py`
- `git diff --check`

Fixes #1971

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d