### PR TITLE
fix(syndication): close poll watermark gap

### DIFF
--- a/syndication_poller.py
+++ b/syndication_poller.py
@@ -643,7 +643,10 @@ class SyndicationPoller:
                     time.sleep(min(remaining, 10))
                     continue
 
-                # Poll for new videos
+                # Capture the high-water mark before the request. Videos created
+                # while the feed is being fetched must remain eligible for the
+                # next cycle instead of falling into a timestamp gap.
+                poll_started_at = time.time()
                 new_videos = self.fetch_new_videos(
                     since=self.last_poll_time if self.last_poll_time > 0 else None
                 )
@@ -655,7 +658,7 @@ class SyndicationPoller:
                 else:
                     self.consecutive_failures = max(0, self.consecutive_failures - 1)
 
-                self.last_poll_time = time.time()
+                self.last_poll_time = poll_started_at
 
                 # Process pending queue items
                 processed = self.process_pending_items()

--- a/tests/test_syndication_poller.py
+++ b/tests/test_syndication_poller.py
@@ -152,3 +152,49 @@ schedule:
     assert poller.reload_runtime_config() is True
     assert poller.config.poll_interval == 120
     assert poller.adapters["moltbook"].api_key == "beta"
+
+
+def test_poll_watermark_does_not_skip_videos_created_during_fetch(tmp_path):
+    """The next `since` watermark must be captured before the feed request."""
+    config_path = tmp_path / "syndication.yaml"
+    _write_config(
+        config_path,
+        """
+poll_interval: 1
+platforms: {}
+schedule:
+  enabled: false
+""",
+    )
+    poller = SyndicationPoller(
+        api_key="test-key",
+        db_path=str(tmp_path / "bottube.db"),
+        config_file=str(config_path),
+    )
+
+    class Clock:
+        value = 100.0
+
+        @classmethod
+        def time(cls):
+            return cls.value
+
+    def fetch_during_upload_window(*, since):
+        assert since is None
+        Clock.value = 200.0
+        return []
+
+    def stop_after_first_cycle(_seconds):
+        poller.running = False
+
+    with (
+        patch("syndication_poller.time.time", side_effect=Clock.time),
+        patch("syndication_poller.time.sleep", side_effect=stop_after_first_cycle),
+        patch("syndication_poller.random.random", return_value=1.0),
+        patch.object(poller, "_load_known_videos"),
+        patch.object(poller, "fetch_new_videos", side_effect=fetch_during_upload_window),
+        patch.object(poller, "process_pending_items", return_value=0),
+    ):
+        poller.run()
+
+    assert poller.last_poll_time == 100.0


### PR DESCRIPTION
## Summary
- capture each feed poll's high-water mark before issuing the request
- advance `last_poll_time` to the request-start boundary after processing
- keep uploads created during an in-flight request eligible for the next cycle

## Mutation proof
The regression advances a controlled clock from 100 to 200 while `fetch_new_videos()` is in flight. Before the fix, the daemon recorded 200 and skipped that window; it now records 100.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with requests --with pyyaml pytest -q tests/test_syndication_poller.py -k poll_watermark` (1 passed)
- `python -m py_compile syndication_poller.py`
- `git diff --check`

Fixes #1973

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d