### PR TITLE
[TRAVIS] Fix Python SDK dynamic path encoding

### DIFF
--- a/python-sdk/bottube/client.py
+++ b/python-sdk/bottube/client.py
@@ -77,7 +77,11 @@ class BoTTubeClient:
         params: Optional[dict] = None,
     ) -> Any:
         # Encode path segments to safely handle special chars like / # ? spaces
-        encoded_path = "/".join(quote(seg, safe="") for seg in path.split("/"))
+        # Dynamic path values are encoded by ``_path_param`` before they are
+        # interpolated into an SDK route.  Preserve those percent escapes here;
+        # quoting ``%`` again turns e.g. ``alice/bob`` into ``alice%252Fbob``
+        # and sends the request to a different resource.
+        encoded_path = "/".join(quote(seg, safe="%") for seg in path.split("/"))
         url = f"{self.base_url}{encoded_path}"
         if params:
             url += "?" + urlencode({k: v for k, v in params.items() if v is not None})

--- a/python-sdk/tests/test_path_encoding.py
+++ b/python-sdk/tests/test_path_encoding.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: MIT
+import json
+from unittest.mock import MagicMock, patch
+
 from bottube.client import BoTTubeClient
 
 
@@ -10,3 +13,36 @@ def test_stream_url_encodes_video_id_path_segment():
 
 def test_path_param_encodes_reserved_chars():
     assert BoTTubeClient._path_param("a/b?# c") == "a%2Fb%3F%23%20c"
+
+
+@patch("bottube.client.urlopen")
+def test_request_preserves_encoded_dynamic_path_segment(mock_urlopen):
+    response = MagicMock()
+    response.read.return_value = json.dumps({"video_id": "alice/bob"}).encode()
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    mock_urlopen.return_value = response
+
+    client = BoTTubeClient(base_url="https://example.test")
+    client.get_video("alice/bob?# clip")
+
+    request = mock_urlopen.call_args.args[0]
+    assert request.full_url == (
+        "https://example.test/api/videos/alice%2Fbob%3F%23%20clip"
+    )
+    assert "%25" not in request.full_url
+
+
+@patch("bottube.client.urlopen")
+def test_literal_percent_sequence_is_not_decoded_as_a_path_escape(mock_urlopen):
+    response = MagicMock()
+    response.read.return_value = b"{}"
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    mock_urlopen.return_value = response
+
+    client = BoTTubeClient(base_url="https://example.test")
+    client.get_agent_profile("agent%2Fname")
+
+    request = mock_urlopen.call_args.args[0]
+    assert request.full_url.endswith("/api/agents/agent%252Fname")


### PR DESCRIPTION
## Summary

- preserve escapes already produced by the SDK's `_path_param` helper when `_request` assembles internal routes
- prevent reserved characters in agent/video/playlist/webhook/etc. identifiers from being double-encoded into different resources
- retain correct treatment of literal percent sequences in caller-supplied IDs
- add request-level regressions for both dynamic-ID cases

Closes #1975

## Proof

Before the fix, `get_video("alice/bob?# clip")` constructed:

`/api/videos/alice%252Fbob%253F%2523%2520clip`

The regression now proves the outgoing request is exactly:

`/api/videos/alice%2Fbob%3F%23%20clip`

It also proves an ID containing the literal text `agent%2Fname` remains `agent%252Fname`, so it cannot be reinterpreted as a slash.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3 -m pytest python-sdk/tests/test_path_encoding.py python-sdk/tests/test_client.py -q` -> 11 passed
- `py -3 -m compileall -q python-sdk/bottube` -> passed
- `git diff --check` -> passed

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d