### PR TITLE
[TRAVIS] Keep Python SDK large uploads memory-bounded

### DIFF
--- a/python-sdk/bottube/client.py
+++ b/python-sdk/bottube/client.py
@@ -230,14 +230,12 @@ class BoTTubeClient:
                     yield chunk
             yield closing
         
-        req = Request(url, data=None, headers=headers, method="POST")
-        # Use a streaming body via a temporary file to avoid loading all into memory
-        import tempfile
-        with tempfile.SpooledTemporaryFile(max_size=10 * 1024 * 1024) as tmp:
-            for part in body_generator():
-                tmp.write(part)
-            tmp.seek(0)
-            req.data = tmp.read()
+        # urllib/http.client accepts an iterable of bytes as a request body.
+        # Supplying the generator directly keeps large uploads bounded by
+        # ``chunk_size``.  Materialising it through ``tmp.read()`` would copy
+        # the entire (potentially multi-gigabyte) multipart body back into RAM
+        # immediately before sending it, defeating this method's contract.
+        req = Request(url, data=body_generator(), headers=headers, method="POST")
 
         try:
             with urlopen(req, timeout=self.timeout) as resp:

--- a/python-sdk/tests/test_client.py
+++ b/python-sdk/tests/test_client.py
@@ -2,6 +2,8 @@
 """Unit tests for the BoTTube Python SDK."""
 
 import json
+import os
+import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
 from io import BytesIO
@@ -60,6 +62,42 @@ class TestBoTTubeClient(unittest.TestCase):
         self.assertEqual(err.status_code, 404)
         self.assertEqual(err.error, "Not found")
         self.assertIn("404", str(err))
+
+    @patch("bottube.client.urlopen")
+    def test_streaming_upload_keeps_request_body_lazy(self, mock_urlopen):
+        response = MagicMock()
+        response.read.return_value = b'{"video_id":"uploaded"}'
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+
+        captured = {}
+
+        def consume(request, timeout):
+            self.assertNotIsInstance(request.data, (bytes, bytearray))
+            parts = list(request.data)
+            captured["parts"] = parts
+            captured["content_length"] = int(request.get_header("Content-length"))
+            return response
+
+        mock_urlopen.side_effect = consume
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as upload:
+            upload.write(b"0123456789")
+            upload_path = upload.name
+
+        try:
+            result = self.client._streaming_upload(
+                "/api/upload", upload_path, {"title": "Chunked"}, chunk_size=3
+            )
+        finally:
+            os.unlink(upload_path)
+
+        body = b"".join(captured["parts"])
+        file_chunks = [part for part in captured["parts"] if part in {b"012", b"345", b"678", b"9"}]
+        self.assertEqual(file_chunks, [b"012", b"345", b"678", b"9"])
+        self.assertIn(b"0123456789", body)
+        self.assertEqual(captured["content_length"], len(body))
+        self.assertEqual(result, {"video_id": "uploaded"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- pass the existing multipart body generator directly to urllib instead of copying it back into one in-memory bytes object
- retain the explicit multipart `Content-Length`, metadata fields, file headers, and response handling
- add a regression that proves request data stays iterable, file bytes are yielded at the configured chunk size, and the declared length matches the wire body

Closes #1977

## Proof

Before this change, `_streaming_upload` wrote the multipart body to `SpooledTemporaryFile` and then called `tmp.read()`, allocating the entire upload in RAM at the irreversible send edge. The new regression fails against that behavior because `request.data` is bytes rather than a lazy iterable.

The passing regression observes file payload chunks of `3, 3, 3, 1` bytes with a test `chunk_size=3`, joins the complete wire body, and verifies its length exactly equals the request's `Content-Length`.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3 -m pytest python-sdk/tests/test_client.py -q` -> 8 passed
- `py -3 -m compileall -q python-sdk/bottube` -> passed
- `git diff --check` -> passed

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d