### PR TITLE
[TRAVIS] Preserve JavaScript SDK HTTP response semantics

### DIFF
--- a/js-sdk/dist/index.js
+++ b/js-sdk/dist/index.js
@@ -76,6 +76,21 @@ var BoTTubeClient = class {
     if (this.apiKey) h["X-API-Key"] = this.apiKey;
     return h;
   }
+  async responseData(res) {
+    let data;
+    try {
+      data = await res.json();
+    } catch (err) {
+      if (res.ok && res.status === 204) return void 0;
+      if (!res.ok) {
+        const message = res.statusText?.trim() || `HTTP ${res.status}`;
+        throw new BoTTubeError(res.status, { error: message });
+      }
+      throw err;
+    }
+    if (!res.ok) throw new BoTTubeError(res.status, data);
+    return data;
+  }
   async request(method, path, body) {
     const url = `${this.baseUrl}${path}`;
     const controller = new AbortController();
@@ -88,9 +103,7 @@ var BoTTubeClient = class {
         signal: controller.signal
       });
       clearTimeout(timer);
-      const data = await res.json();
-      if (!res.ok) throw new BoTTubeError(res.status, data);
-      return data;
+      return await this.responseData(res);
     } catch (err) {
       clearTimeout(timer);
       if (err instanceof BoTTubeError) throw err;
@@ -112,9 +125,7 @@ var BoTTubeClient = class {
         signal: controller.signal
       });
       clearTimeout(timer);
-      const data = await res.json();
-      if (!res.ok) throw new BoTTubeError(res.status, data);
-      return data;
+      return await this.responseData(res);
     } catch (err) {
       clearTimeout(timer);
       if (err instanceof BoTTubeError) throw err;

--- a/js-sdk/dist/index.mjs
+++ b/js-sdk/dist/index.mjs
@@ -39,6 +39,21 @@ var BoTTubeClient = class {
     if (this.apiKey) h["X-API-Key"] = this.apiKey;
     return h;
   }
+  async responseData(res) {
+    let data;
+    try {
+      data = await res.json();
+    } catch (err) {
+      if (res.ok && res.status === 204) return void 0;
+      if (!res.ok) {
+        const message = res.statusText?.trim() || `HTTP ${res.status}`;
+        throw new BoTTubeError(res.status, { error: message });
+      }
+      throw err;
+    }
+    if (!res.ok) throw new BoTTubeError(res.status, data);
+    return data;
+  }
   async request(method, path, body) {
     const url = `${this.baseUrl}${path}`;
     const controller = new AbortController();
@@ -51,9 +66,7 @@ var BoTTubeClient = class {
         signal: controller.signal
       });
       clearTimeout(timer);
-      const data = await res.json();
-      if (!res.ok) throw new BoTTubeError(res.status, data);
-      return data;
+      return await this.responseData(res);
     } catch (err) {
       clearTimeout(timer);
       if (err instanceof BoTTubeError) throw err;
@@ -75,9 +88,7 @@ var BoTTubeClient = class {
         signal: controller.signal
       });
       clearTimeout(timer);
-      const data = await res.json();
-      if (!res.ok) throw new BoTTubeError(res.status, data);
-      return data;
+      return await this.responseData(res);
     } catch (err) {
       clearTimeout(timer);
       if (err instanceof BoTTubeError) throw err;

--- a/js-sdk/src/client.ts
+++ b/js-sdk/src/client.ts
@@ -87,6 +87,28 @@ export class BoTTubeClient {
     return h;
   }
 
+  private async responseData<T>(res: Response): Promise<T> {
+    let data: unknown;
+    try {
+      data = await res.json();
+    } catch (err) {
+      // Successful DELETE-style operations may legitimately return no body.
+      if (res.ok && res.status === 204) return undefined as T;
+
+      // Gateways and upstream proxies often return an empty or HTML error
+      // body.  Preserve the HTTP status as a typed SDK error instead of
+      // leaking a JSON SyntaxError that callers cannot classify or retry.
+      if (!res.ok) {
+        const message = res.statusText?.trim() || `HTTP ${res.status}`;
+        throw new BoTTubeError(res.status, { error: message });
+      }
+      throw err;
+    }
+
+    if (!res.ok) throw new BoTTubeError(res.status, data as ApiError);
+    return data as T;
+  }
+
   private async request<T>(
     method: string,
     path: string,
@@ -104,9 +126,7 @@ export class BoTTubeClient {
         signal: controller.signal,
       });
       clearTimeout(timer);
-      const data = await res.json();
-      if (!res.ok) throw new BoTTubeError(res.status, data as ApiError);
-      return data as T;
+      return await this.responseData<T>(res);
     } catch (err) {
       clearTimeout(timer);
       if (err instanceof BoTTubeError) throw err;
@@ -130,9 +150,7 @@ export class BoTTubeClient {
         signal: controller.signal,
       });
       clearTimeout(timer);
-      const data = await res.json();
-      if (!res.ok) throw new BoTTubeError(res.status, data as ApiError);
-      return data as T;
+      return await this.responseData<T>(res);
     } catch (err) {
       clearTimeout(timer);
       if (err instanceof BoTTubeError) throw err;

--- a/js-sdk/tests/client.test.ts
+++ b/js-sdk/tests/client.test.ts
@@ -107,6 +107,17 @@ describe('BoTTubeClient', () => {
         expect.objectContaining({ method: 'DELETE' }),
       );
     });
+
+    it('accepts a successful empty 204 response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        json: async () => { throw new SyntaxError('Unexpected end of JSON input'); },
+      });
+
+      await expect(client.deleteVideo('v1')).resolves.toBeUndefined();
+    });
   });
 
   // -- search / trending / feed -------------------------------------------
@@ -257,6 +268,23 @@ describe('BoTTubeClient', () => {
   });
 
   // -- errors -------------------------------------------------------------
+
+  describe('non-JSON HTTP errors', () => {
+    it('preserves the status as a typed SDK error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        json: async () => { throw new SyntaxError('Unexpected token <'); },
+      });
+
+      await expect(client.health()).rejects.toMatchObject({
+        name: 'BoTTubeError',
+        statusCode: 502,
+        apiError: { error: 'Bad Gateway' },
+      });
+    });
+  });
 
   describe('error handling', () => {
     it('throws BoTTubeError on 401', async () => {


### PR DESCRIPTION
## Summary

- centralize JavaScript SDK response decoding for both JSON and multipart requests
- allow successful empty `204 No Content` responses for void operations
- preserve non-JSON HTTP failures as typed `BoTTubeError` values with the original status and status-text fallback
- keep malformed successful non-204 JSON fail-fast
- add regressions for the empty-204 and HTML/empty-gateway-error paths
- refresh committed CJS and ESM bundles

Closes #1979

## Proof

Before this change both cases failed at `res.json()` before status handling:

- a successful `204` rejected with `SyntaxError: Unexpected end of JSON input`
- a `502 Bad Gateway` with an HTML body rejected with `SyntaxError` and lost status 502

Focused mutations now prove the delete resolves and the gateway response rejects as `BoTTubeError { statusCode: 502, apiError: { error: "Bad Gateway" } }`.

## Validation

- `npx vitest run tests/client.test.ts -t "accepts a successful empty 204 response|preserves the status as a typed SDK error"` -> 2 passed
- CJS and ESM bundle stages completed successfully
- `git diff --check` -> passed

Repository baseline notes: the broad suite's existing timeout mock never reacts to `AbortSignal` and times out; declaration bundling/typecheck is currently blocked by the repository's TypeScript 7 + removed `moduleResolution=node10` configuration. Neither failure intersects this response-decoding change; upstream CI remains authoritative.

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d