### PR TITLE
[TRAVIS] Keep feeds available for invalid epoch timestamps

### DIFF
--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -3,6 +3,7 @@
 # Author: @AUTHENSOR
 # BCOS-Tier: L1
 import datetime
+import math
 import os
 from email.utils import format_datetime
 
@@ -59,6 +60,17 @@ def _video_description_html(fields):
     return f'<img src="{thumb}" /><p>{desc}</p>'
 
 
+def _epoch_datetime_or_now(value):
+    """Return a bounded UTC datetime for an epoch-like value."""
+    try:
+        epoch = float(value)
+        if not math.isfinite(epoch):
+            raise ValueError("epoch must be finite")
+        return datetime.datetime.fromtimestamp(epoch, tz=datetime.timezone.utc)
+    except (OverflowError, OSError, TypeError, ValueError):
+        return datetime.datetime.now(datetime.timezone.utc)
+
+
 def _to_rfc2822(value):
     """Convert various timestamp formats to RFC 2822 for RSS pubDate."""
     if value is None or value == "":
@@ -66,7 +78,7 @@ def _to_rfc2822(value):
         return format_datetime(dt)
 
     if isinstance(value, (int, float)):
-        dt = datetime.datetime.fromtimestamp(float(value), tz=datetime.timezone.utc)
+        dt = _epoch_datetime_or_now(value)
         return format_datetime(dt)
 
     s = str(value).strip()
@@ -75,7 +87,7 @@ def _to_rfc2822(value):
         return format_datetime(dt)
 
     if s.replace(".", "", 1).isdigit():
-        dt = datetime.datetime.fromtimestamp(float(s), tz=datetime.timezone.utc)
+        dt = _epoch_datetime_or_now(s)
         return format_datetime(dt)
 
     try:
@@ -94,18 +106,14 @@ def _to_iso8601(value):
         return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
     if isinstance(value, (int, float)):
-        return datetime.datetime.fromtimestamp(
-            float(value), tz=datetime.timezone.utc
-        ).isoformat()
+        return _epoch_datetime_or_now(value).isoformat()
 
     s = str(value).strip()
     if not s:
         return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
     if s.replace(".", "", 1).isdigit():
-        return datetime.datetime.fromtimestamp(
-            float(s), tz=datetime.timezone.utc
-        ).isoformat()
+        return _epoch_datetime_or_now(s).isoformat()
 
     try:
         dt = datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))

--- a/tests/test_feed_blueprint.py
+++ b/tests/test_feed_blueprint.py
@@ -45,6 +45,16 @@ def test_timestamp_helpers_normalize_epoch_and_iso_values():
     )
 
 
+@pytest.mark.parametrize("value", ["9" * 400, float("inf"), float("-inf")])
+def test_timestamp_helpers_fall_back_for_out_of_range_epochs(value):
+    """Persisted bad timestamps must not take the entire feed offline."""
+    rfc_value = feed_blueprint._to_rfc2822(value)
+    iso_value = feed_blueprint._to_iso8601(value)
+
+    assert parsedate_to_datetime(rfc_value).tzinfo is not None
+    assert dt.datetime.fromisoformat(iso_value).tzinfo is not None
+
+
 def test_normalize_videos_filters_non_dict_entries_from_supported_shapes():
     video_a = {"id": "a"}
     video_b = {"id": "b"}
@@ -197,6 +207,32 @@ def test_feed_routes_escape_url_attributes_and_cdata(monkeypatch):
         response = client.get(path)
         assert response.status_code == 200
         ET.fromstring(response.get_data(as_text=True))
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/feed/rss", "/feed/atom", "/feed/rss/test-agent", "/feed/atom/test-agent"],
+)
+def test_feed_routes_survive_out_of_range_video_timestamps(monkeypatch, path):
+    app = Flask(__name__)
+    app.register_blueprint(feed_blueprint.feed_bp)
+
+    monkeypatch.setattr(
+        feed_blueprint,
+        "_fetch_videos",
+        lambda **_kwargs: [
+            {
+                "video_id": "badtime01",
+                "title": "Still available",
+                "created_at": "9" * 400,
+            }
+        ],
+    )
+
+    response = app.test_client().get(path)
+
+    assert response.status_code == 200
+    ET.fromstring(response.get_data(as_text=True))
 
 
 def test_base_api_url_uses_request_host_when_env_unset():


### PR DESCRIPTION
## Summary

- bound epoch conversion for RSS and Atom timestamps
- reject non-finite and platform-out-of-range epochs through the existing current-time fallback
- cover both timestamp helpers and all four public feed routes

## Mutation proof

Before the fix, `_to_rfc2822("9" * 400)` raised `OverflowError: timestamp out of range for platform time_t`. The new route regression exercises that same value through RSS, Atom, and both per-agent variants.

## Tests

```text
8 passed in 3.21s
python -m py_compile feed_blueprint.py tests/test_feed_blueprint.py
```

The complete existing `tests/test_feed_blueprint.py` run is 29 passing tests plus one unrelated pre-existing failure in `test_fetch_videos_builds_filtered_request_and_normalizes_response`; that test calls `_fetch_videos` without a Flask request context even though current `main` reads `request.host` before invoking its mocked HTTP client. This patch does not touch that path.

Closes #1981

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d
