### PR TITLE
fix(feed): preserve limit in Atom self link (#1988)

### DIFF
--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -5,6 +5,7 @@
 import datetime
 import os
 from email.utils import format_datetime
+from urllib.parse import urlencode
 
 import requests
 from flask import Blueprint, Response, jsonify, request
@@ -254,13 +255,16 @@ def atom_feed():
     now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
     feed_title = escape_xml(agent or category or "Global Feed")
 
-    # Build self-link with current query params
+    # Build a self-link that identifies the representation actually served.
     self_params = []
     if agent:
-        self_params.append(f"agent={escape_xml(agent)}")
+        self_params.append(("agent", agent))
     if category:
-        self_params.append(f"category={escape_xml(category)}")
-    self_qs = f"?{'&amp;'.join(self_params)}" if self_params else ""
+        self_params.append(("category", category))
+    if request.args.get("limit") is not None:
+        self_params.append(("limit", str(limit)))
+    self_query = urlencode(self_params)
+    self_qs = f"?{escape_xml(self_query)}" if self_query else ""
     self_href = f"https://bottube.ai/feed/atom{self_qs}"
 
     lines = [

--- a/tests/test_feed_atom_self_link.py
+++ b/tests/test_feed_atom_self_link.py
@@ -1,0 +1,48 @@
+from flask import Flask
+
+import feed_blueprint
+
+
+def _client(monkeypatch):
+    app = Flask(__name__)
+    app.register_blueprint(feed_blueprint.feed_bp)
+    monkeypatch.setattr(feed_blueprint, "_fetch_videos", lambda **kwargs: [])
+    return app.test_client()
+
+
+def test_atom_self_link_preserves_explicit_limit(monkeypatch):
+    response = _client(monkeypatch).get("/feed/atom?limit=5")
+
+    assert response.status_code == 200
+    assert (
+        '<link href="https://bottube.ai/feed/atom?limit=5" rel="self" />'
+        in response.get_data(as_text=True)
+    )
+
+
+def test_atom_self_link_url_encodes_combined_filters(monkeypatch):
+    response = _client(monkeypatch).get(
+        "/feed/atom",
+        query_string={
+            "agent": "alice bob",
+            "category": "music & ai",
+            "limit": "7",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        'href="https://bottube.ai/feed/atom?agent=alice+bob&amp;'
+        'category=music+%26+ai&amp;limit=7" rel="self"'
+        in response.get_data(as_text=True)
+    )
+
+
+def test_atom_self_link_keeps_default_url_when_limit_is_omitted(monkeypatch):
+    response = _client(monkeypatch).get("/feed/atom")
+
+    assert response.status_code == 200
+    assert (
+        '<link href="https://bottube.ai/feed/atom" rel="self" />'
+        in response.get_data(as_text=True)
+    )


### PR DESCRIPTION
## Summary

Fixes #1988.

The global Atom feed accepts `?limit=N` and serves that representation, but its `rel="self"` URL previously omitted the explicit limit. Feed readers following the self link could therefore resolve the default 20-item feed instead of the representation they fetched.

## Changes

- preserve an explicitly supplied `limit` in the Atom self link;
- URL-encode agent/category/limit query parameters before XML escaping the self-link attribute;
- preserve the existing canonical URL when `limit` is omitted;
- add focused regression coverage for explicit limit, combined filters with reserved characters, and the no-limit default.

## Validation

Focused GitHub Actions validation passed:

`python -m pytest -q tests/test_feed_atom_self_link.py`

Result: 3 passed.

Final branch is rebuilt as one clean commit on current upstream `main`, with only `feed_blueprint.py` and `tests/test_feed_atom_self_link.py` changed.

AI assistance was used in identifying, implementing, and testing this contribution.