### PR TITLE
fix(news): use deployed hyphenated logo in RSS channel image

### DIFF
--- a/news_routes.py
+++ b/news_routes.py
@@ -116,7 +116,7 @@ def news_rss():
         f'    <lastBuildDate>{build_date}</lastBuildDate>\n'
         '    <atom:link href="https://bottube.ai/news/rss" rel="self" type="application/rss+xml"/>\n'
         '    <image>\n'
-        '      <url>https://bottube.ai/static/bottube_logo.png</url>\n'
+        '      <url>https://bottube.ai/static/bottube-logo.png</url>\n'
         '      <title>BoTTube News</title>\n'
         '      <link>https://bottube.ai/news</link>\n'
         '    </image>\n'

--- a/tests/test_rss_logo.py
+++ b/tests/test_rss_logo.py
@@ -1,0 +1,11 @@
+import re
+from news_routes import generate_rss_feed
+
+def test_rss_channel_logo_url_resolves():
+    """Regression: RSS channel image must point to deployed hyphenated asset."""
+    feed = generate_rss_feed(items=[])
+    match = re.search(r"<url>(https://bottube\.ai/static/[^<]+)</url>", feed)
+    assert match, "RSS feed missing <image><url>"
+    url = match.group(1)
+    assert url.endswith("bottube-logo.png"), f"Expected hyphenated logo, got {url}"
+    assert "bottube_logo.png" not in url, "Underscore variant is 404; use hyphenated path"


### PR DESCRIPTION
Closes #1991

## Problem
The News RSS feed advertises `https://bottube.ai/static/bottube_logo.png` as the channel image, but that URL returns 404. The deployed asset exists at the hyphenated path `bottube-logo.png`.

## Fix
- Update `news_routes.py` L120 to reference the correct hyphenated filename
- Add regression test `tests/test_rss_logo.py` asserting the generated feed points to a valid asset path

## Verification
```bash
curl -sS -o /dev/null -w '%{http_code}' https://bottube.ai/static/bottube-logo.png
# 200
```

Claim: /claim (already filed in #1991)
Wallet: RTC1e9bf7a2a60aac9bcbc5a0df0c65e9501e932861