### PR TITLE
fix(feed): preserve limit param in Atom self link

### DIFF
--- a/feed_blueprint.py
+++ b/feed_blueprint.py
@@ -260,6 +260,8 @@ def atom_feed():
         self_params.append(f"agent={escape_xml(agent)}")
     if category:
         self_params.append(f"category={escape_xml(category)}")
+    if limit is not None and limit != 20:
+        self_params.append(f"limit={limit}")
     self_qs = f"?{'&amp;'.join(self_params)}" if self_params else ""
     self_href = f"https://bottube.ai/feed/atom{self_qs}"
 

--- a/tests/test_atom_self_link_limit.py
+++ b/tests/test_atom_self_link_limit.py
@@ -1,0 +1,41 @@
+import re
+from feed_blueprint import atom_feed
+
+class FakeRequest:
+    def __init__(self, args):
+        self.args = args
+
+def test_atom_self_link_preserves_limit(monkeypatch):
+    """Regression: Atom self link must include limit when non-default."""
+    from flask import Flask
+    app = Flask(__name__)
+    
+    with app.test_request_context('/feed/atom?limit=5'):
+        # Mock _fetch_videos to avoid DB/API calls
+        import feed_blueprint as fb
+        monkeypatch.setattr(fb, '_fetch_videos', lambda **kw: [])
+        
+        resp = atom_feed()
+        body = resp.get_data(as_text=True)
+        
+        match = re.search(r'<link href="([^"]+)" rel="self"', body)
+        assert match, "Atom feed missing rel=self link"
+        url = match.group(1)
+        assert "limit=5" in url, f"Self link should preserve limit=5, got {url}"
+
+def test_atom_self_link_omits_default_limit(monkeypatch):
+    """Default limit (20) should not appear in self link."""
+    from flask import Flask
+    app = Flask(__name__)
+    
+    with app.test_request_context('/feed/atom'):
+        import feed_blueprint as fb
+        monkeypatch.setattr(fb, '_fetch_videos', lambda **kw: [])
+        
+        resp = atom_feed()
+        body = resp.get_data(as_text=True)
+        
+        match = re.search(r'<link href="([^"]+)" rel="self"', body)
+        assert match
+        url = match.group(1)
+        assert "limit=" not in url, f"Default limit should be omitted, got {url}"


### PR DESCRIPTION
Closes #1988

## Problem
The Atom feed `rel="self"` link dropped the requested `limit` filter, causing readers following the self link to resolve a different resource (default 20 items) than the one originally fetched.

## Fix
- Include `limit` in `self_params` when non-default (not 20)
- Add regression tests for limit preservation and default omission

## Verification
```bash
curl -sS 'https://bottube.ai/feed/atom?limit=5' | grep 'rel="self"'
# Should now include ?limit=5 in the self href
```

Claim: /claim (already filed in #1988)
Wallet: RTC1e9bf7a2a60aac9bcbc5a0df0c65e9501e932861