### PR TITLE
fix(mood,pi): reject non-object JSON bodies on write endpoints (#1986, #1990)

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7439,10 +7439,14 @@ def update_agent_mood(agent_name):
     if err:
         return err
 
-    data = request.get_json() or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
     force_state = data.get("force_state")
     trigger_reason = data.get("trigger_reason", "")
-    
+
     result = api_update_mood(str(DB_PATH), agent["id"], force_state, trigger_reason)
     
     return jsonify(result)
@@ -7466,7 +7470,11 @@ def record_mood_signal(agent_name):
     if err:
         return err
 
-    data = request.get_json() or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
     signal_type = data.get("signal_type")
     signal_value = data.get("signal_value")
     signal_data = data.get("signal_data", "")

--- a/pi_payments.py
+++ b/pi_payments.py
@@ -140,7 +140,12 @@ def pi_approve():
     """Server-side approval leg: re-verify the payment against Pi and our product table, then call Pi /approve."""
     if not PI_API_KEY:
         return jsonify({"error": "Pi not configured (PI_API_KEY unset)"}), 503
-    payment_id = ((request.get_json(silent=True) or {}).get("payment_id") or "").strip()
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+    payment_id = (data.get("payment_id") or "").strip()
     if not payment_id:
         return jsonify({"error": "payment_id required"}), 400
     try:
@@ -184,7 +189,11 @@ def pi_complete():
     """Server-side completion leg: re-verify, call Pi /complete, then grant the entitlement idempotently."""
     if not PI_API_KEY:
         return jsonify({"error": "Pi not configured (PI_API_KEY unset)"}), 503
-    data = request.get_json(silent=True) or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
     payment_id = (data.get("payment_id") or "").strip()
     txid = (data.get("txid") or "").strip()
     if not payment_id or not txid:

--- a/tests/test_json_body_must_be_object.py
+++ b/tests/test_json_body_must_be_object.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+
+
+def _auth_headers(api_key):
+    return {"X-API-Key": api_key}
+
+
+def test_update_agent_mood_rejects_array(client, registered_agent):
+    r = client.post(
+        f"/api/v1/agents/{registered_agent['agent_name']}/mood/update",
+        headers=_auth_headers(registered_agent["api_key"]),
+        json=[1, 2],
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "JSON body must be an object"
+
+
+def test_update_agent_mood_rejects_string(client, registered_agent):
+    r = client.post(
+        f"/api/v1/agents/{registered_agent['agent_name']}/mood/update",
+        headers=_auth_headers(registered_agent["api_key"]),
+        json="bad",
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "JSON body must be an object"
+
+
+def test_record_mood_signal_rejects_number(client, registered_agent):
+    r = client.post(
+        f"/api/v1/agents/{registered_agent['agent_name']}/mood/signal",
+        headers=_auth_headers(registered_agent["api_key"]),
+        json=42,
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "JSON body must be an object"
+
+
+def test_pi_approve_rejects_array(client):
+    r = client.post("/pi/approve", json=[], headers={"Content-Type": "application/json"})
+    assert r.status_code in (400, 503)
+    if r.status_code == 400:
+        assert r.get_json()["error"] == "JSON body must be an object"
+
+
+def test_pi_complete_rejects_string(client):
+    r = client.post("/pi/complete", json="nope", headers={"Content-Type": "application/json"})
+    assert r.status_code in (400, 503)
+    if r.status_code == 400:
+        assert r.get_json()["error"] == "JSON body must be an object"


### PR DESCRIPTION
## Summary

Fixes crashes in mood and Pi payment endpoints when clients send non-object JSON bodies (arrays, strings, numbers).

### Root Cause
Endpoints used `request.get_json() or {}` which silently accepted any valid JSON, then crashed with `AttributeError` when `.get()` was called on non-dict types.

### Fix
Add explicit `isinstance(data, dict)` guard returning 400 with the standard error message used elsewhere in the codebase.

### Endpoints Fixed
- `POST /api/v1/agents/<name>/mood/update` (#1986)
- `POST /api/v1/agents/<name>/mood/signal` (#1986)
- `POST /pi/approve` (#1990)
- `POST /pi/complete` (#1990)

### Tests
5 regression tests covering array, string, and number body rejection for all four endpoints. All pass.

Closes #1986, #1990