### PR TITLE
[TRAVIS] Bound HTML search pagination offsets

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14104,6 +14104,9 @@ def search_page():
     except (TypeError, ValueError):
         page = 1
     per_page = 24
+    offset = (page - 1) * per_page
+    if offset > _SQLITE_MAX_INT64:
+        abort(400, description="page out of range")
     # Category checkboxes submit repeated ?cat=<id> params.
     valid_cat_ids = {c["id"] for c in VIDEO_CATEGORIES}
     selected_categories = [c for c in request.args.getlist("cat") if c in valid_cat_ids]
@@ -14133,7 +14136,7 @@ def search_page():
                WHERE {where}
                ORDER BY v.views DESC, v.created_at DESC
                LIMIT ? OFFSET ?""",
-            params + [per_page, (page - 1) * per_page],
+            params + [per_page, offset],
         ).fetchall()
 
     pages = max(1, (total + per_page - 1) // per_page)

--- a/tests/test_search_page_html_offset_overflow.py
+++ b/tests/test_search_page_html_offset_overflow.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for HTML search pagination bounds."""
+
+
+def test_search_page_rejects_offset_overflow(client):
+    response = client.get("/search?q=video&page=9223372036854775807")
+
+    assert response.status_code == 400
+    assert b"page" in response.data.lower()
+
+
+def test_search_page_keeps_large_safe_pages(client):
+    response = client.get("/search?q=video&page=1000000000")
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

- bound the server-rendered search page's SQLite OFFSET before query execution
- reuse the validated offset in the query
- add regressions for the crashing int64 boundary and a large safe page

Closes #1996

## Mutation proof

Before the fix, this request raises `OverflowError: Python int too large to convert to SQLite INTEGER` in `search_page` before a response is produced:

```text
GET /search?q=video&page=9223372036854775807
```

After the fix it returns HTTP 400, while `page=1000000000` still renders HTTP 200.

## Validation

```text
python -m pytest tests/test_search_page_html_offset_overflow.py -q
2 passed
python -m py_compile bottube_server.py
git diff --check
```

A broader discoverability run also exposed six failures already present on current main (uploads not entering search results, two missing routes, and a legacy template expectation); they are unrelated to this two-line pagination guard.

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d