### PR TITLE
[TRAVIS] Restore bounded public search suggestions

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -14090,6 +14090,88 @@ def join_page():
     return render_template("join.html")
 
 
+@app.route("/api/search/suggestions")
+def api_search_suggestions():
+    """Return bounded public catalog suggestions for a partial query."""
+    query = request.args.get("q", "").strip()
+    empty_result = {"suggestions": [], "categories": [], "agents": [], "tags": []}
+    if len(query) < 2:
+        return jsonify(empty_result)
+    if len(query) > 64:
+        return jsonify({"error": "q must be at most 64 characters"}), 400
+
+    # Treat wildcard characters as ordinary query text. Besides producing more
+    # useful suggestions, this prevents a partial-query request from turning
+    # into an unbounded catalog wildcard scan.
+    escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{escaped}%"
+    db = get_db()
+
+    videos = db.execute(
+        """SELECT v.video_id, v.title
+             FROM videos v
+             JOIN agents a ON a.id = v.agent_id
+            WHERE v.is_removed = 0
+              AND COALESCE(a.is_banned, 0) = 0
+              AND v.title LIKE ? ESCAPE '\\'
+            ORDER BY v.views DESC, v.created_at DESC
+            LIMIT 8""",
+        (pattern,),
+    ).fetchall()
+    agents = db.execute(
+        """SELECT agent_name, COALESCE(display_name, agent_name) AS display_name
+             FROM agents
+            WHERE COALESCE(is_banned, 0) = 0
+              AND (agent_name LIKE ? ESCAPE '\\' OR display_name LIKE ? ESCAPE '\\')
+            ORDER BY COALESCE(last_active, created_at) DESC
+            LIMIT 5""",
+        (pattern, pattern),
+    ).fetchall()
+    tag_rows = db.execute(
+        """SELECT v.tags
+             FROM videos v
+             JOIN agents a ON a.id = v.agent_id
+            WHERE v.is_removed = 0
+              AND COALESCE(a.is_banned, 0) = 0
+              AND v.tags LIKE ? ESCAPE '\\'
+            ORDER BY v.views DESC, v.created_at DESC
+            LIMIT 25""",
+        (pattern,),
+    ).fetchall()
+
+    query_folded = query.casefold()
+    tags = []
+    seen_tags = set()
+    for row in tag_rows:
+        for tag in parse_tags(row["tags"]):
+            tag_text = str(tag).strip()
+            folded = tag_text.casefold()
+            if query_folded in folded and folded not in seen_tags:
+                seen_tags.add(folded)
+                tags.append(tag_text)
+                if len(tags) == 8:
+                    break
+        if len(tags) == 8:
+            break
+
+    return jsonify({
+        "suggestions": [
+            {"type": "video", "label": row["title"], "value": row["title"], "video_id": row["video_id"]}
+            for row in videos
+        ],
+        "categories": [
+            {"id": category["id"], "name": category["name"]}
+            for category in VIDEO_CATEGORIES
+            if query_folded in category["id"].casefold() or query_folded in category["name"].casefold()
+        ][:5],
+        "agents": [
+            {"agent_name": row["agent_name"], "display_name": row["display_name"]}
+            for row in agents
+        ],
+        "tags": tags,
+    })
+
+
 @app.route("/search")
 def search_page():
     """Search results page (paginated, optional category filter).

--- a/tests/test_search_suggestions_contract.py
+++ b/tests/test_search_suggestions_contract.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MIT
+"""Contract tests for public search suggestions."""
+
+import time
+
+
+def _seed_video(app, *, title="Python Patterns", tags='["python", "typing"]'):
+    with app.app_context():
+        import bottube_server
+
+        db = bottube_server.get_db()
+        agent = db.execute(
+            """INSERT INTO agents (agent_name, display_name, api_key, bio, created_at, last_active)
+               VALUES (?, ?, ?, '', ?, ?) RETURNING id""",
+            ("python_guide", "Python Guide", "search-suggestions-key", time.time(), time.time()),
+        ).fetchone()
+        db.execute(
+            """INSERT INTO videos (
+                   video_id, agent_id, title, description, filename, tags,
+                   category, created_at, is_removed
+               ) VALUES (?, ?, ?, '', ?, ?, 'education', ?, 0)""",
+            ("suggestion-video", agent["id"], title, "suggestion.mp4", tags, time.time()),
+        )
+        db.commit()
+
+
+def test_search_suggestions_return_public_catalog_matches(app, client):
+    _seed_video(app)
+
+    response = client.get("/api/search/suggestions?q=Py")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["suggestions"][0]["label"] == "Python Patterns"
+    assert body["agents"][0]["agent_name"] == "python_guide"
+    assert body["tags"] == ["python"]
+
+
+def test_search_suggestions_are_bounded_for_non_queries(client):
+    assert client.get("/api/search/suggestions?q=P").get_json() == {
+        "suggestions": [],
+        "categories": [],
+        "agents": [],
+        "tags": [],
+    }
+    assert client.get("/api/search/suggestions", query_string={"q": "x" * 65}).status_code == 400
+
+
+def test_search_suggestions_treat_like_wildcards_as_text(app, client):
+    _seed_video(app)
+
+    response = client.get("/api/search/suggestions", query_string={"q": "%_"})
+
+    assert response.status_code == 200
+    assert response.get_json()["suggestions"] == []


### PR DESCRIPTION
## Summary

- restore the shipped `GET /api/search/suggestions` discoverability contract
- return bounded public video, category, creator, and tag matches
- exclude removed content and banned creators
- escape SQL LIKE metacharacters and avoid catalog scans for sub-two-character queries
- add focused response, bounds, and wildcard regressions

Closes #1998

## Mutation proof

On current `main`, `GET /api/search/suggestions?q=Py` returns HTTP 404 and the existing discoverability regression fails at the route edge. This patch returns the documented result groups from seeded public catalog data.

## Validation

```text
python -m pytest tests/test_search_suggestions_contract.py -q
3 passed
python -m py_compile bottube_server.py
git diff --check
```

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d