### PR TITLE
fix(admin): validate report hours windows

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -15088,7 +15088,9 @@ def admin_visitors():
     if err:
         return err
 
-    hours = min(168, max(1, request.args.get("hours", 24, type=int)))
+    hours, error = _parse_positive_int_query("hours", 24, max_value=168)
+    if error:
+        return error
     cutoff = time.time() - hours * 3600
 
     stats = {
@@ -16195,7 +16197,9 @@ def admin_scan_content():
     if err:
         return err
 
-    hours = min(168, max(1, request.args.get("hours", 24, type=int)))
+    hours, error = _parse_positive_int_query("hours", 24, max_value=168)
+    if error:
+        return error
     cutoff = time.time() - hours * 3600
 
     db = get_db()

--- a/tests/test_admin_hours_query_validation.py
+++ b/tests/test_admin_hours_query_validation.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for strict admin time-window query validation."""
+
+import pytest
+
+
+ADMIN_HEADERS = {"X-Admin-Key": "test-admin"}
+ROUTES = ("/api/admin/visitors", "/api/admin/scan-content")
+
+
+@pytest.mark.parametrize("route", ROUTES)
+@pytest.mark.parametrize("hours", ("abc", "0", "-1", "169", "1.5"))
+def test_admin_hours_rejects_malformed_or_out_of_range_values(
+    client, monkeypatch, route, hours
+):
+    import bottube_server
+
+    monkeypatch.setattr(bottube_server, "ADMIN_KEY", "test-admin", raising=False)
+    response = client.get(f"{route}?hours={hours}", headers=ADMIN_HEADERS)
+
+    assert response.status_code == 400
+    assert "hours" in response.get_json()["error"]
+
+
+@pytest.mark.parametrize("route", ROUTES)
+@pytest.mark.parametrize("hours", ("1", "168"))
+def test_admin_hours_accepts_documented_boundaries(client, monkeypatch, route, hours):
+    import bottube_server
+
+    monkeypatch.setattr(bottube_server, "ADMIN_KEY", "test-admin", raising=False)
+    response = client.get(f"{route}?hours={hours}", headers=ADMIN_HEADERS)
+
+    assert response.status_code == 200


### PR DESCRIPTION
Resolves https://github.com/Scottcjn/bottube/issues/2000

## What changed

- route both documented admin `hours` windows through the existing strict positive-integer query parser
- reject malformed, fractional, non-positive, and over-168-hour values with a structured HTTP 400 response
- preserve the 24-hour default and the documented 1/168-hour boundaries
- add a 14-case integrated regression matrix across both endpoints

## How it was checked

- mutation baseline on unmodified `main`: 10 invalid-window assertions failed while 4 boundary assertions passed
- `python -m pytest tests/test_admin_hours_query_validation.py -q` -> 14 passed
- `python -m py_compile bottube_server.py tests/test_admin_hours_query_validation.py`
- `git diff --check`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d