### PR TITLE
fix(discover): make result cards keyboard accessible

### DIFF
--- a/bottube_templates/discover.html
+++ b/bottube_templates/discover.html
@@ -104,17 +104,34 @@
     }
 
     .video-card {
+        display: block;
+        width: 100%;
         background: var(--bg-secondary);
         border: 1px solid var(--border);
         border-radius: 12px;
         overflow: hidden;
         cursor: pointer;
+        color: inherit;
+        font: inherit;
+        text-align: left;
+        text-decoration: none;
         transition: transform 0.2s, box-shadow 0.2s;
     }
 
     .video-card:hover {
         transform: translateY(-2px);
         box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    }
+
+    .video-card:focus-visible,
+    .agent-card:focus-visible {
+        outline: 3px solid var(--accent);
+        outline-offset: 3px;
+    }
+
+    .category-card {
+        text-align: center;
+        padding: 20px;
     }
 
     .video-thumbnail {
@@ -209,11 +226,14 @@
     }
 
     .agent-card {
+        display: block;
         background: var(--bg-secondary);
         border: 1px solid var(--border);
         border-radius: 12px;
+        color: inherit;
         padding: 16px;
         text-align: center;
+        text-decoration: none;
     }
 
     .agent-avatar {
@@ -404,14 +424,14 @@
                 const avatarUrl = safeImageUrl(agent.avatar || '/static/default-avatar.png');
 
                 return `
-                <div class="agent-card" onclick="window.location='/agent/${encodeURIComponent(agentName)}'">
+                <a class="agent-card" href="/agent/${encodeURIComponent(agentName)}" aria-label="View creator ${escapeAttribute(displayName)}">
                     <img src="${escapeAttribute(avatarUrl)}" class="agent-avatar" alt="${escapeAttribute(displayName)}" loading="lazy" decoding="async">
                     <div class="agent-name">${escapeHtml(displayName)}</div>
                     <div class="agent-stats">
                         ${agent.videos} videos • ${agent.subscribers} subscribers
                     </div>
                     <div style="font-size:12px;color:var(--text-muted);margin-top:4px;">${escapeHtml(agent.bio || '')}</div>
-                </div>
+                </a>
                 `;
             }).join('');
         } catch (err) {
@@ -476,13 +496,13 @@
                 catGrid.innerHTML = `
                     <div class="video-grid">
                         ${data.categories.map(cat => `
-                            <div class="video-card" style="text-align:center;padding:20px;cursor:pointer;" onclick="searchByCategory('${cat.id}')">
+                            <button type="button" class="video-card category-card" onclick="searchByCategory('${cat.id}')" aria-label="Browse ${escapeAttribute(cat.name)} videos">
                                 <div style="font-size:24px;margin-bottom:8px;">
                                     ${getCategoryIcon(cat.id)}
                                 </div>
                                 <div style="font-weight:600;">${cat.name}</div>
                                 <div style="font-size:12px;color:var(--text-muted);margin-top:4px;">${cat.count} videos</div>
-                            </div>
+                            </button>
                         `).join('')}
                     </div>
                 `;
@@ -528,7 +548,7 @@
     function createVideoCard(video) {
         const thumbnailUrl = video.thumbnail_url || (video.thumbnail ? `/thumbnails/${encodeURIComponent(video.thumbnail)}` : '/static/default-thumb.jpg');
         return `
-            <div class="video-card" onclick="window.location='/watch/${video.id}'">
+            <a class="video-card" href="/watch/${encodeURIComponent(video.id)}" aria-label="Watch ${escapeAttribute(video.title || 'video')}">
                 <div class="video-thumbnail">
                     <img src="${thumbnailUrl}" alt="${escapeHtml(video.title)}" loading="lazy" decoding="async">
                     ${video.duration ? `<span class="video-duration">${formatDuration(video.duration)}</span>` : ''}
@@ -544,7 +564,7 @@
                         </div>
                     </div>
                 </div>
-            </div>
+            </a>
         `;
     }
 

--- a/tests/test_discover_keyboard_cards.py
+++ b/tests/test_discover_keyboard_cards.py
@@ -1,0 +1,36 @@
+"""Regression coverage for issue #2002 Discover keyboard navigation."""
+
+from pathlib import Path
+
+
+TEMPLATE = (
+    Path(__file__).resolve().parents[1]
+    / "bottube_templates"
+    / "discover.html"
+).read_text(encoding="utf-8")
+
+
+def test_discover_navigation_cards_use_native_links():
+    """Creator and video navigation must work with native Enter activation."""
+    assert '<a class="agent-card" href="/agent/${encodeURIComponent(agentName)}"' in TEMPLATE
+    assert '<a class="video-card" href="/watch/${encodeURIComponent(video.id)}"' in TEMPLATE
+    assert 'aria-label="View creator ${escapeAttribute(displayName)}"' in TEMPLATE
+    assert 'aria-label="Watch ${escapeAttribute(video.title || \'video\')}"' in TEMPLATE
+
+    assert '<div class="agent-card" onclick=' not in TEMPLATE
+    assert '<div class="video-card" onclick="window.location=' not in TEMPLATE
+
+
+def test_discover_category_cards_use_native_buttons_once():
+    """Native buttons provide Enter/Space without a duplicate key handler."""
+    assert '<button type="button" class="video-card category-card"' in TEMPLATE
+    assert 'onclick="searchByCategory(\'${cat.id}\')"' in TEMPLATE
+    assert 'aria-label="Browse ${escapeAttribute(cat.name)} videos"' in TEMPLATE
+    assert 'onkeydown=' not in TEMPLATE
+    assert 'onkeyup=' not in TEMPLATE
+
+
+def test_discover_interactive_cards_have_visible_focus():
+    assert '.video-card:focus-visible' in TEMPLATE
+    assert '.agent-card:focus-visible' in TEMPLATE
+    assert 'outline: 3px solid var(--accent);' in TEMPLATE


### PR DESCRIPTION
## Summary
- replace mouse-only Discover creator/video result `<div>`s with native navigation links
- render category actions as native buttons so Enter and Space work without custom key handlers or double activation
- preserve card styling and add a visible `:focus-visible` treatment
- add focused regression coverage for semantics, labels, single activation path, and focus visibility

Fixes #2002

## Proof
- mutation baseline against `origin/main`: semantic-card contract fails
- `python -m pytest -q tests/test_discover_keyboard_cards.py tests/test_discover_agent_card_escaping.py tests/test_discover_thumbnail_urls.py` — **11 passed**
- `python -m pytest -q tests/test_accessibility.py tests/test_aria_labels.py` — **31 passed, 1 unrelated pre-existing failure** (`explore.html:126`, untouched by this PR)
- `git diff --check` — clean

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d