### PR TITLE
fix(generate): make completed history results accessible

### DIFF
--- a/bottube_templates/generate.html
+++ b/bottube_templates/generate.html
@@ -130,6 +130,17 @@
         padding: 10px 14px; background: var(--bg-secondary);
         border-radius: 6px; margin-bottom: 6px;
         border: 1px solid var(--border);
+        color: inherit; text-decoration: none;
+    }
+    a.gen-history-item {
+        cursor: pointer;
+    }
+    a.gen-history-item:hover {
+        border-color: var(--accent);
+    }
+    a.gen-history-item:focus-visible {
+        outline: 3px solid var(--accent);
+        outline-offset: 2px;
     }
     .gen-history-item .prompt-text {
         flex: 1; color: var(--text-primary); font-size: 0.9rem;
@@ -491,12 +502,23 @@ async function loadHistory() {
             container.innerHTML = '<p style="color:var(--text-muted);">No generations yet. Create your first one!</p>';
             return;
         }
-        container.innerHTML = data.jobs.map(j => `
-            <div class="gen-history-item" onclick="if('${j.status}'==='completed') window.open(P+'/api/gemini/job/${j.job_id}','_blank')">
+        container.innerHTML = data.jobs.map(j => {
+            const status = escHtml(String(j.status || 'unknown'));
+            const content = `
                 <div class="prompt-text">${escHtml(j.prompt)}</div>
-                <span class="status-badge ${j.status}">${j.status}</span>
-            </div>
-        `).join('');
+                <span class="status-badge ${status}">${status}</span>
+            `;
+
+            if (j.status === 'completed') {
+                return `
+                    <a class="gen-history-item" href="${P}/api/gemini/job/${encodeURIComponent(j.job_id)}" target="_blank" rel="noopener noreferrer" aria-label="Open completed generation: ${escHtml(j.prompt)}">
+                        ${content}
+                    </a>
+                `;
+            }
+
+            return `<div class="gen-history-item">${content}</div>`;
+        }).join('');
     } catch (e) {
         document.getElementById('history-list').innerHTML =
             '<p style="color:var(--text-muted);">Could not load history.</p>';

--- a/tests/test_generation_history_keyboard.py
+++ b/tests/test_generation_history_keyboard.py
@@ -1,0 +1,30 @@
+"""Regression coverage for issue #2004 generation-history semantics."""
+
+from pathlib import Path
+
+
+TEMPLATE = (
+    Path(__file__).resolve().parents[1]
+    / "bottube_templates"
+    / "generate.html"
+).read_text(encoding="utf-8")
+
+
+def test_completed_history_rows_are_native_safe_links():
+    assert "if (j.status === 'completed')" in TEMPLATE
+    assert '<a class="gen-history-item"' in TEMPLATE
+    assert 'href="${P}/api/gemini/job/${encodeURIComponent(j.job_id)}"' in TEMPLATE
+    assert 'target="_blank" rel="noopener noreferrer"' in TEMPLATE
+    assert 'aria-label="Open completed generation: ${escHtml(j.prompt)}"' in TEMPLATE
+
+
+def test_incomplete_history_rows_are_truthful_non_actions():
+    assert 'return `<div class="gen-history-item">${content}</div>`;' in TEMPLATE
+    assert '<div class="gen-history-item" onclick=' not in TEMPLATE
+    assert 'onkeydown=' not in TEMPLATE
+    assert 'onkeyup=' not in TEMPLATE
+
+
+def test_completed_history_links_have_visible_focus():
+    assert 'a.gen-history-item:focus-visible' in TEMPLATE
+    assert 'outline: 3px solid var(--accent);' in TEMPLATE


### PR DESCRIPTION
## Summary
- render completed generation-history jobs as native links with safe new-tab behavior
- leave pending/generating/failed rows as truthful non-interactive status records
- preserve existing visual styling and add visible focus treatment to actionable rows
- encode job IDs and add focused regression coverage for both semantic branches

Fixes #2004

## Proof
- mutation baseline against `origin/main`: native-link/non-action contract fails
- `python -m pytest -q tests/test_generation_history_keyboard.py` — **3 passed**
- combined accessibility run — **34 passed, 1 unrelated pre-existing failure** (`explore.html:126`, untouched)
- `git diff --check` — clean

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d