### PR TITLE
fix(activity): use native video links

### DIFF
--- a/bottube_templates/activity_feed.html
+++ b/bottube_templates/activity_feed.html
@@ -111,6 +111,16 @@
         align-items: center;
     }
 
+    a.activity-video {
+        color: inherit;
+        text-decoration: none;
+    }
+
+    a.activity-video:focus-visible {
+        outline: 3px solid var(--accent);
+        outline-offset: 2px;
+    }
+
     .video-thumb {
         width: 80px;
         height: 45px;
@@ -297,12 +307,12 @@
                         <span class="activity-action">uploaded a new video</span>
                         <span class="activity-time">${activity.formatted_time}</span>
                     </div>
-                    <div class="activity-video" onclick="window.location='/watch/${activity.content.video_id}'">
+                    <a class="activity-video" href="/watch/${encodeURIComponent(activity.content.video_id)}">
                         <img src="${activity.content.thumbnail}" class="video-thumb" alt="Video thumbnail: ${activity.content.title || 'video'}" loading="lazy" decoding="async">
                         <div class="video-info">
                             <div class="video-title">${escapeHtml(activity.content.title)}</div>
                         </div>
-                    </div>
+                    </a>
                 </div>
             </div>
         `;

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -127,6 +127,34 @@ class TestAccessibilityAttributes(unittest.TestCase):
         self.assertGreaterEqual(thumbnail_close, 0)
         self.assertGreater(video_info, thumbnail_close)
         self.assertGreater(channel_link, video_info)
+
+    def test_activity_feed_upload_cards_are_native_links(self):
+        """Upload destinations must work with keyboard and assistive technology."""
+        content = self.read_file(self.TEMPLATE_DIR / 'activity_feed.html')
+        upload_renderer = re.search(
+            r'function createUploadItem\(activity\) \{(?P<body>.*?)\n    \}',
+            content,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(upload_renderer, "Activity upload renderer not found")
+        body = upload_renderer.group('body')
+
+        self.assertIn(
+            '<a class="activity-video" href="/watch/${encodeURIComponent(activity.content.video_id)}">',
+            body,
+            "Upload video card should use a native, safely encoded watch link",
+        )
+        self.assertIn('</a>', body, "Upload video link is not closed")
+        self.assertNotIn(
+            'onclick=',
+            body,
+            "Upload video destination must not depend on a mouse-only click handler",
+        )
+        self.assertRegex(
+            content,
+            r'a\.activity-video:focus-visible\s*\{[^}]*outline:',
+            "Activity video links should expose a visible keyboard focus state",
+        )
     
     def test_search_form_has_aria_label(self):
         """Test that search form has proper accessibility attributes."""


### PR DESCRIPTION
## Summary
- render activity-feed upload destinations as native links instead of mouse-only clickable divs
- safely encode video IDs in watch URLs
- preserve card styling and add an explicit keyboard focus indicator
- add a regression covering native semantics, encoding, focus visibility, and removal of the click-only handler

## Verification
- `python -m pytest tests/test_accessibility.py -q`
- 26 passed, 10 subtests passed
- `git diff --check`

Closes #2006

RustChain wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`