### PR TITLE
fix(activity): synchronize feed tab state

### DIFF
--- a/bottube_templates/activity_feed.html
+++ b/bottube_templates/activity_feed.html
@@ -181,11 +181,11 @@
         <p>Real-time updates from AI agents across BoTTube</p>
     </div>
 
-    <div class="feed-tabs">
-        <button class="feed-tab active" onclick="loadFeed('all')">All Activity</button>
-        <button class="feed-tab" onclick="loadFeed('uploads')">📤 Uploads</button>
-        <button class="feed-tab" onclick="loadFeed('comments')">💬 Comments</button>
-        <button class="feed-tab" onclick="loadFeed('tips')">💰 Tips</button>
+    <div class="feed-tabs" role="tablist" aria-label="Activity type">
+        <button type="button" class="feed-tab active" data-filter="all" role="tab" aria-selected="true" tabindex="0" onclick="loadFeed('all')">All Activity</button>
+        <button type="button" class="feed-tab" data-filter="uploads" role="tab" aria-selected="false" tabindex="-1" onclick="loadFeed('uploads')">📤 Uploads</button>
+        <button type="button" class="feed-tab" data-filter="comments" role="tab" aria-selected="false" tabindex="-1" onclick="loadFeed('comments')">💬 Comments</button>
+        <button type="button" class="feed-tab" data-filter="tips" role="tab" aria-selected="false" tabindex="-1" onclick="loadFeed('tips')">💰 Tips</button>
     </div>
 
     <div class="activity-list" id="activityList">
@@ -219,8 +219,12 @@
         currentFilter = filter;
         
         // Update tabs
-        document.querySelectorAll('.feed-tab').forEach(tab => tab.classList.remove('active'));
-        event.target?.classList.add('active');
+        document.querySelectorAll('.feed-tab').forEach(tab => {
+            const selected = tab.dataset.filter === filter;
+            tab.classList.toggle('active', selected);
+            tab.setAttribute('aria-selected', String(selected));
+            tab.tabIndex = selected ? 0 : -1;
+        });
         
         try {
             const url = lastUpdate && isUpdate 

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -127,6 +127,29 @@ class TestAccessibilityAttributes(unittest.TestCase):
         self.assertGreaterEqual(thumbnail_close, 0)
         self.assertGreater(video_info, thumbnail_close)
         self.assertGreater(channel_link, video_info)
+
+    def test_activity_feed_tabs_derive_state_from_filter(self):
+        """Background refreshes must not depend on a browser-global event."""
+        content = self.read_file(self.TEMPLATE_DIR / 'activity_feed.html')
+
+        self.assertRegex(
+            content,
+            r'class="feed-tabs"[^>]*role="tablist"[^>]*aria-label=',
+            "Activity filters should expose a named tab list",
+        )
+        tabs = re.findall(r'<button[^>]*class="feed-tab[^>]*>', content)
+        self.assertEqual(len(tabs), 4, "Expected all four activity filter tabs")
+        for tab in tabs:
+            self.assertIn('type="button"', tab)
+            self.assertIn('data-filter=', tab)
+            self.assertIn('role="tab"', tab)
+            self.assertIn('aria-selected=', tab)
+
+        self.assertIn("const selected = tab.dataset.filter === filter;", content)
+        self.assertIn("tab.classList.toggle('active', selected);", content)
+        self.assertIn("tab.setAttribute('aria-selected', String(selected));", content)
+        self.assertIn("tab.tabIndex = selected ? 0 : -1;", content)
+        self.assertNotIn('event.target?.classList', content)
     
     def test_search_form_has_aria_label(self):
         """Test that search form has proper accessibility attributes."""


### PR DESCRIPTION
## Summary
- derive the selected Activity Feed filter from the explicit `filter` argument instead of browser-global `event`
- keep visual active state, `aria-selected`, and roving tab focus synchronized during clicks, initial load, and background polling
- expose the filter controls as a named tab list
- add a focused regression for the state contract

## Verification
- `python -m pytest tests/test_accessibility.py::TestAccessibilityAttributes::test_activity_feed_tabs_derive_state_from_filter -q`
- 1 passed
- `git diff --check`

Closes #2009

RustChain wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`