### PR TITLE
fix(receipts): reject invalid batch limits

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -24396,6 +24396,15 @@ def api_agent_receipts_zip(agent_name):
     if not re.fullmatch(r"[A-Za-z0-9_.\-]{1,64}", agent_name or ""):
         return jsonify({"ok": False, "error": "invalid agent name"}), 400
 
+    limit, error = _parse_positive_int_query(
+        "limit",
+        200,
+        min_value=1,
+        max_value=_RECEIPTS_BATCH_MAX,
+    )
+    if error:
+        return error
+
     ip = _get_client_ip()
     if not _rate_limit(f"receipts_zip:{ip}", 6, 600):
         return jsonify({"ok": False, "error": "rate limited"}), 429
@@ -24409,14 +24418,9 @@ def api_agent_receipts_zip(agent_name):
     if not agent:
         return jsonify({"ok": False, "error": "agent not found"}), 404
 
-    # Cap at a reasonable batch — agents with thousands of videos can
-    # paginate via ?since_video_id=, but the common case is "small enough
-    # to fit in one zip".
-    try:
-        limit = max(1, min(_RECEIPTS_BATCH_MAX,
-                           int(request.args.get("limit", 200))))
-    except Exception:
-        limit = 200
+    # Keep each batch bounded. Agents with thousands of videos can paginate
+    # via ?since_video_id=, but malformed bounds are rejected above rather
+    # than silently changing the archive a caller requested.
     since = (request.args.get("since_video_id") or "").strip()
 
     if since:

--- a/tests/test_receipt_zip_limit_validation.py
+++ b/tests/test_receipt_zip_limit_validation.py
@@ -1,0 +1,43 @@
+"""Regression coverage for receipt-batch limit validation (issue #2007)."""
+
+import importlib
+
+def test_receipt_zip_limit_contract(client, monkeypatch):
+    server = importlib.import_module("bottube_server")
+    rate_limit_calls = []
+
+    def unexpected_call(*_args, **_kwargs):
+        raise AssertionError("invalid pagination reached receipt side effects")
+
+    def stop_at_receipt_rate_limit(key, *_args):
+        rate_limit_calls.append(key)
+        return not key.startswith("receipts_zip:")
+
+    monkeypatch.setattr(server, "_rate_limit", stop_at_receipt_rate_limit)
+    monkeypatch.setattr(server, "_provenance_ensure_v2_columns", unexpected_call)
+    monkeypatch.setattr(server, "_build_receipt_for_video", unexpected_call)
+
+    invalid_cases = [
+        ("abc", "integer"),
+        ("0", ">= 1"),
+        ("-5", ">= 1"),
+        ("501", "<= 500"),
+        (str(2**80), "<= 500"),
+    ]
+    for raw_limit, message in invalid_cases:
+        response = client.get(
+            "/api/agents/example/receipts.zip",
+            query_string={"limit": raw_limit},
+        )
+        assert response.status_code == 400
+        assert message in response.get_json()["error"]
+    assert not any(key.startswith("receipts_zip:") for key in rate_limit_calls)
+
+    for query in ({}, {"limit": "1"}, {"limit": "500"}):
+        response = client.get("/api/agents/example/receipts.zip", query_string=query)
+        assert response.status_code == 429
+        assert response.get_json() == {"ok": False, "error": "rate limited"}
+    receipt_calls = [
+        key for key in rate_limit_calls if key.startswith("receipts_zip:")
+    ]
+    assert len(receipt_calls) == 3


### PR DESCRIPTION
## Summary
- validate receipt-batch `limit` before rate-limit, provenance, database, or ZIP work
- reject malformed, non-positive, and over-cap limits with stable HTTP 400 JSON responses
- preserve the default of 200 and valid range 1–500
- add regression coverage proving invalid inputs do not cross the receipt side-effect edge

Fixes #2007

## Proof
- mutation baseline against `origin/main`: strict pagination contract fails (broad fallback/clamping present)
- `python -m pytest -q tests/test_receipt_zip_limit_validation.py` — **1 passed** (8 request cases)
- `python -m pytest -q tests/test_receipt_watch_url.py` — **1 passed**
- `git diff --check` — clean

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d