### PR TITLE
fix(collaboration): manage invite modal focus

### DIFF
--- a/bottube_templates/collaboration.html
+++ b/bottube_templates/collaboration.html
@@ -412,7 +412,7 @@
             {% if is_owner or is_participant %}
             <div class="collab-actions">
                 {% if is_owner or can_invite %}
-                <button class="btn btn-primary" onclick="openInviteModal()">
+                <button type="button" class="btn btn-primary" onclick="openInviteModal(this)">
                     ✉️ Invite Collaborator
                 </button>
                 {% endif %}
@@ -519,9 +519,9 @@
 </div>
 
 <!-- Invite Modal -->
-<div class="invite-modal" id="inviteModal">
+<div class="invite-modal" id="inviteModal" role="dialog" aria-modal="true" aria-labelledby="inviteModalTitle">
     <div class="invite-modal-content">
-        <h3>Invite to Collaboration</h3>
+        <h3 id="inviteModalTitle">Invite to Collaboration</h3>
         <form id="inviteForm" onsubmit="sendInvite(event)">
             <div class="form-group">
                 <label for="agentName">Agent Name</label>
@@ -540,13 +540,21 @@
 </div>
 
 <script>
-    function openInviteModal() {
+    let inviteModalTrigger = null;
+
+    function openInviteModal(trigger) {
+        inviteModalTrigger = trigger || document.activeElement;
         document.getElementById('inviteModal').classList.add('active');
+        document.getElementById('agentName').focus();
     }
 
     function closeInviteModal() {
         document.getElementById('inviteModal').classList.remove('active');
         document.getElementById('inviteForm').reset();
+        if (inviteModalTrigger) {
+            inviteModalTrigger.focus();
+            inviteModalTrigger = null;
+        }
     }
 
     function sendInvite(event) {


### PR DESCRIPTION
## Summary
- expose the collaboration invite overlay as a named modal dialog
- focus the required Agent Name field when the dialog opens
- remember the actual opening control and restore focus on every close path
- make the opening control explicitly non-submitting
- add a focused accessibility regression

## Verification
- `python -m pytest tests/test_accessibility.py::TestAccessibilityAttributes::test_collaboration_invite_modal_has_focus_lifecycle -q`
- 1 passed
- `git diff --check`

Closes #2018

RustChain wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`