### PR TITLE
Fix giveaway countdown timer accumulation

### DIFF
--- a/bottube_templates/giveaway.html
+++ b/bottube_templates/giveaway.html
@@ -435,6 +435,7 @@
     var el = document.getElementById("countdown");
     if (!el) return;
     var target = parseFloat(el.dataset.target) * 1000;
+    var timerId;
     function tick() {
         var diff = Math.max(0, target - Date.now());
         var d = Math.floor(diff / 86400000);
@@ -445,10 +446,15 @@
         document.getElementById("cd-hours").textContent = h < 10 ? "0" + h : h;
         document.getElementById("cd-mins").textContent = m < 10 ? "0" + m : m;
         document.getElementById("cd-secs").textContent = s < 10 ? "0" + s : s;
-        if (diff > 0) requestAnimationFrame(tick);
+        if (diff === 0 && timerId !== undefined) {
+            clearInterval(timerId);
+            timerId = undefined;
+        }
+        return diff;
     }
-    tick();
-    setInterval(tick, 1000);
+    if (tick() > 0) {
+        timerId = setInterval(tick, 1000);
+    }
 })();
 </script>
 {% endblock %}

--- a/tests/js/giveaway_countdown.test.cjs
+++ b/tests/js/giveaway_countdown.test.cjs
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const template = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'bottube_templates', 'giveaway.html'),
+  'utf8'
+);
+const start = template.lastIndexOf('(function() {');
+const end = template.indexOf('})();', start) + '})();'.length;
+assert.notEqual(start, -1, 'countdown IIFE is present');
+assert.ok(end > start, 'countdown IIFE is complete');
+
+let now = 1_000_000;
+let writes = 0;
+const intervals = [];
+const cleared = [];
+const valueElement = { set textContent(_value) { writes += 1; } };
+
+const sandbox = {
+  clearInterval(id) { cleared.push(id); },
+  Date: { now() { return now; } },
+  document: {
+    getElementById(id) {
+      if (id === 'countdown') {
+        return { dataset: { target: String((now + 5_000) / 1_000) } };
+      }
+      return valueElement;
+    },
+  },
+  Math,
+  parseFloat,
+  requestAnimationFrame() {
+    throw new Error('countdown must not create an animation-frame loop');
+  },
+  setInterval(callback, delay) {
+    intervals.push({ callback, delay });
+    return 17;
+  },
+};
+
+vm.runInNewContext(template.slice(start, end), sandbox);
+assert.equal(writes, 4, 'countdown updates four values immediately');
+assert.equal(intervals.length, 1, 'countdown creates one timer');
+assert.equal(intervals[0].delay, 1_000, 'countdown updates once per second');
+
+now += 6_000;
+intervals[0].callback();
+assert.equal(writes, 8, 'one timer tick performs one additional update');
+assert.deepEqual(cleared, [17], 'timer is cleared when countdown reaches zero');
+assert.equal(intervals.length, 1, 'timer callback does not spawn another timer');

--- a/tests/test_giveaway_countdown_runtime.py
+++ b/tests/test_giveaway_countdown_runtime.py
@@ -1,0 +1,23 @@
+"""Execute the browser-neutral giveaway countdown timer regression."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_giveaway_countdown_uses_one_bounded_timer():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    test_file = Path(__file__).parent / "js" / "giveaway_countdown.test.cjs"
+    result = subprocess.run(
+        [node, str(test_file)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- render the giveaway countdown immediately with a single one-second interval
- tear down that interval when the countdown reaches zero
- remove recursive animation-frame scheduling so callback work remains bounded
- add an executable JavaScript regression covering initial render, timer ownership, zero teardown, and no recursive scheduling

## Verification
- mutation baseline reproduced on origin/main: recursive requestAnimationFrame plus setInterval and no teardown
- node tests/js/giveaway_countdown.test.cjs
- python -m pytest -q tests/test_giveaway_countdown_runtime.py (1 passed)
- git diff --check

Fixes #2019

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d