### PR TITLE
fix(bridge): synchronize chain tab state

### DIFF
--- a/bottube_templates/bridge.html
+++ b/bottube_templates/bridge.html
@@ -289,27 +289,27 @@
 
     <!-- Chain Tabs -->
     <div class="chain-tabs" role="tablist">
-        <button class="chain-tab active" onclick="switchChain('wrtc')" role="tab" aria-label="Select wRTC (Solana) bridge" aria-selected="true">
+        <button class="chain-tab active" data-chain="wrtc" onclick="switchChain('wrtc')" role="tab" aria-label="Select wRTC (Solana) bridge" aria-selected="true" tabindex="0">
             <span class="chain-icon">&#9788;</span> wRTC (Solana)
             <span class="chain-badge badge-live">Live</span>
         </button>
-        <button class="chain-tab" onclick="switchChain('ergo')" role="tab" aria-label="Select ERG (Ergo) bridge" aria-selected="false">
+        <button class="chain-tab" data-chain="ergo" onclick="switchChain('ergo')" role="tab" aria-label="Select ERG (Ergo) bridge" aria-selected="false" tabindex="-1">
             <span class="chain-icon">&#9830;</span> ERG (Ergo)
             <span class="chain-badge badge-live">Live</span>
         </button>
-        <button class="chain-tab" onclick="switchChain('btc')" role="tab" aria-label="Select BTC bridge (coming soon)" aria-selected="false">
+        <button class="chain-tab" data-chain="btc" onclick="switchChain('btc')" role="tab" aria-label="Select BTC bridge (coming soon)" aria-selected="false" tabindex="-1">
             <span class="chain-icon">&#8383;</span> BTC
             <span class="chain-badge badge-soon">Soon</span>
         </button>
-        <button class="chain-tab" onclick="switchChain('ltc')" role="tab" aria-label="Select LTC bridge (coming soon)" aria-selected="false">
+        <button class="chain-tab" data-chain="ltc" onclick="switchChain('ltc')" role="tab" aria-label="Select LTC bridge (coming soon)" aria-selected="false" tabindex="-1">
             <span class="chain-icon">&#321;</span> LTC
             <span class="chain-badge badge-soon">Soon</span>
         </button>
-        <button class="chain-tab" onclick="switchChain('doge')" role="tab" aria-label="Select DOGE bridge (coming soon)" aria-selected="false">
+        <button class="chain-tab" data-chain="doge" onclick="switchChain('doge')" role="tab" aria-label="Select DOGE bridge (coming soon)" aria-selected="false" tabindex="-1">
             <span class="chain-icon">&#208;</span> DOGE
             <span class="chain-badge badge-soon">Soon</span>
         </button>
-        <button class="chain-tab" onclick="switchChain('base')" role="tab" aria-label="Select wRTC (Base L2) bridge" aria-selected="false">
+        <button class="chain-tab" data-chain="base" onclick="switchChain('base')" role="tab" aria-label="Select wRTC (Base L2) bridge" aria-selected="false" tabindex="-1">
             <span class="chain-icon">&#9830;</span> wRTC (Base L2)
             <span class="chain-badge badge-live">Live</span>
         </button>
@@ -707,16 +707,16 @@ function trackFunnel(name, details = {}) {
 
 // ─── Tab switching ──────────────────────────────────────────
 function switchChain(chain) {
-    document.querySelectorAll(".chain-tab").forEach(t => t.classList.remove("active"));
+    document.querySelectorAll(".chain-tab").forEach(tab => {
+        const selected = tab.dataset.chain === chain;
+        tab.classList.toggle("active", selected);
+        tab.setAttribute("aria-selected", String(selected));
+        tab.tabIndex = selected ? 0 : -1;
+    });
     document.querySelectorAll(".chain-panel").forEach(p => p.classList.remove("active"));
 
     const panel = document.getElementById("panel-" + chain);
     if (panel) panel.classList.add("active");
-
-    // Activate correct tab
-    document.querySelectorAll(".chain-tab").forEach(t => {
-        if (t.onclick.toString().includes("'" + chain + "'")) t.classList.add("active");
-    });
 
     // Update URL without reload
     const slug = chain === "wrtc" ? "/bridge/wrtc" : "/bridge/" + chain;

--- a/tests/test_bridge_template_accessibility.py
+++ b/tests/test_bridge_template_accessibility.py
@@ -117,3 +117,21 @@ def test_bridge_known_inputs_have_explicit_name_attribute():
         assert pattern.search(html), (
             f"Expected <input id='{input_id}' name='{expected_name}'> in bridge.html"
         )
+
+
+def test_bridge_tabs_synchronize_visible_and_accessible_selection():
+    """Chain changes must not leave aria-selected on the old tab."""
+    html = _load_template()
+    tabs = re.findall(r'<button\b[^>]*class="chain-tab[^>]*>', html)
+    assert len(tabs) == 6
+    for tab in tabs:
+        assert 'data-chain=' in tab
+        assert 'role="tab"' in tab
+        assert 'aria-selected=' in tab
+        assert 'tabindex=' in tab
+
+    assert 'const selected = tab.dataset.chain === chain;' in html
+    assert 'tab.classList.toggle("active", selected);' in html
+    assert 'tab.setAttribute("aria-selected", String(selected));' in html
+    assert 'tab.tabIndex = selected ? 0 : -1;' in html
+    assert 'onclick.toString()' not in html


### PR DESCRIPTION
## Summary
- identify bridge tabs through stable `data-chain` values instead of parsing inline-handler source
- synchronize visual active state, `aria-selected`, and the roving tab stop on every chain change
- preserve panel switching, URL replacement, and funnel tracking
- add a focused bridge accessibility regression

## Verification
- `python -m pytest tests/test_bridge_template_accessibility.py -q`
- 4 passed
- `git diff --check`

Closes #2021

RustChain wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`