### PR TITLE
fix(collaboration): lock pending invite actions

### DIFF
--- a/bottube_templates/collaboration_pending_invites.html
+++ b/bottube_templates/collaboration_pending_invites.html
@@ -247,10 +247,10 @@
 
             <div class="invite-actions">
                 {% if not invite.is_expired %}
-                <button class="btn btn-primary" onclick="respondToInvite('{{ invite.invite_id }}', 'accept')">
+                <button type="button" class="btn btn-primary invite-response-btn" onclick="respondToInvite(this, '{{ invite.invite_id }}', 'accept')">
                     ✅ Accept
                 </button>
-                <button class="btn btn-danger" onclick="respondToInvite('{{ invite.invite_id }}', 'decline')">
+                <button type="button" class="btn btn-danger invite-response-btn" onclick="respondToInvite(this, '{{ invite.invite_id }}', 'decline')">
                     ❌ Decline
                 </button>
                 {% endif %}
@@ -272,10 +272,20 @@
 </div>
 
 <script>
-    function respondToInvite(inviteId, action) {
+    function setInviteResponsePending(button, pending) {
+        const actions = button.closest('.invite-actions');
+        actions.setAttribute('aria-busy', String(pending));
+        actions.querySelectorAll('.invite-response-btn').forEach(control => {
+            control.disabled = pending;
+        });
+    }
+
+    function respondToInvite(button, inviteId, action) {
         if (!confirm(`Are you sure you want to ${action} this collaboration invite?`)) {
             return;
         }
+
+        setInviteResponsePending(button, true);
 
         fetch(`/api/collaborations/invites/${inviteId}`, {
             method: 'POST',
@@ -294,10 +304,12 @@
                     location.reload();
                 }
             } else {
+                setInviteResponsePending(button, false);
                 alert('Error: ' + (data.error || 'Failed to respond to invite'));
             }
         })
         .catch(err => {
+            setInviteResponsePending(button, false);
             alert('Error responding to invite: ' + err);
         });
     }

--- a/tests/test_collaboration_invite_ui.py
+++ b/tests/test_collaboration_invite_ui.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+TEMPLATE = (
+    Path(__file__).resolve().parents[1]
+    / "bottube_templates"
+    / "collaboration_pending_invites.html"
+)
+
+
+def test_pending_invite_actions_lock_during_request_and_recover_on_failure():
+    html = TEMPLATE.read_text(encoding="utf-8")
+
+    assert html.count('class="btn btn-primary invite-response-btn"') == 1
+    assert html.count('class="btn btn-danger invite-response-btn"') == 1
+    assert "respondToInvite(this, '{{ invite.invite_id }}', 'accept')" in html
+    assert "respondToInvite(this, '{{ invite.invite_id }}', 'decline')" in html
+    assert "function setInviteResponsePending(button, pending)" in html
+    assert "actions.setAttribute('aria-busy', String(pending));" in html
+    assert "control.disabled = pending;" in html
+    assert "setInviteResponsePending(button, true);" in html
+    assert html.count("setInviteResponsePending(button, false);") == 2


### PR DESCRIPTION
## Summary
- disable both response controls for one pending invite after confirmation
- expose the in-flight state with `aria-busy`
- restore both controls after provider or transport failure so a retry remains possible
- make response buttons explicitly non-submitting
- add a focused UI regression

## Verification
- `python -m pytest tests/test_collaboration_invite_ui.py -q`
- 1 passed
- `git diff --check`

Closes #2025

RustChain wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`