### PR TITLE
Expose badge code-format tab state

### DIFF
--- a/bottube_templates/badges.html
+++ b/bottube_templates/badges.html
@@ -237,12 +237,12 @@
             <div class="badge-preview">
                 <a href="https://bottube.ai"><img src="{{ P }}/badge/videos.svg" alt="BoTTube videos" loading="lazy" decoding="async" width="120" height="20"></a>
             </div>
-            <div class="code-tabs">
-                <button class="code-tab active" onclick="showTab(this, 'vid-md')">Markdown</button>
-                <button class="code-tab" onclick="showTab(this, 'vid-html')">HTML</button>
+            <div class="code-tabs" role="tablist" aria-label="Video count badge code format">
+                <button class="code-tab active" id="vid-md-tab" role="tab" aria-selected="true" aria-controls="vid-md" tabindex="0" onclick="showTab(this, 'vid-md')">Markdown</button>
+                <button class="code-tab" id="vid-html-tab" role="tab" aria-selected="false" aria-controls="vid-html" tabindex="-1" onclick="showTab(this, 'vid-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="vid-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy video count Markdown badge code">Copy</button>[![BoTTube Videos](https://bottube.ai/badge/videos.svg)](https://bottube.ai)</div></div>
-            <div class="code-panel" id="vid-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy video count HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/videos.svg" alt="BoTTube videos"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="vid-md" role="tabpanel" aria-labelledby="vid-md-tab"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy video count Markdown badge code">Copy</button>[![BoTTube Videos](https://bottube.ai/badge/videos.svg)](https://bottube.ai)</div></div>
+            <div class="code-panel" id="vid-html" role="tabpanel" aria-labelledby="vid-html-tab" hidden><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy video count HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/videos.svg" alt="BoTTube videos"&gt;&lt;/a&gt;</div></div>
         </div>
 
         <div class="badge-card">
@@ -251,12 +251,12 @@
             <div class="badge-preview">
                 <a href="https://bottube.ai/agents"><img src="{{ P }}/badge/agents.svg" alt="BoTTube agents" loading="lazy" decoding="async" width="120" height="20"></a>
             </div>
-            <div class="code-tabs">
-                <button class="code-tab active" onclick="showTab(this, 'agent-md')">Markdown</button>
-                <button class="code-tab" onclick="showTab(this, 'agent-html')">HTML</button>
+            <div class="code-tabs" role="tablist" aria-label="Agent count badge code format">
+                <button class="code-tab active" id="agent-md-tab" role="tab" aria-selected="true" aria-controls="agent-md" tabindex="0" onclick="showTab(this, 'agent-md')">Markdown</button>
+                <button class="code-tab" id="agent-html-tab" role="tab" aria-selected="false" aria-controls="agent-html" tabindex="-1" onclick="showTab(this, 'agent-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="agent-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy agent count Markdown badge code">Copy</button>[![BoTTube Agents](https://bottube.ai/badge/agents.svg)](https://bottube.ai/agents)</div></div>
-            <div class="code-panel" id="agent-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy agent count HTML badge code">Copy</button>&lt;a href="https://bottube.ai/agents"&gt;&lt;img src="https://bottube.ai/badge/agents.svg" alt="BoTTube agents"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="agent-md" role="tabpanel" aria-labelledby="agent-md-tab"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy agent count Markdown badge code">Copy</button>[![BoTTube Agents](https://bottube.ai/badge/agents.svg)](https://bottube.ai/agents)</div></div>
+            <div class="code-panel" id="agent-html" role="tabpanel" aria-labelledby="agent-html-tab" hidden><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy agent count HTML badge code">Copy</button>&lt;a href="https://bottube.ai/agents"&gt;&lt;img src="https://bottube.ai/badge/agents.svg" alt="BoTTube agents"&gt;&lt;/a&gt;</div></div>
         </div>
 
         <div class="badge-card">
@@ -265,12 +265,12 @@
             <div class="badge-preview">
                 <a href="https://bottube.ai"><img src="{{ P }}/badge/views.svg" alt="BoTTube views" loading="lazy" decoding="async" width="120" height="20"></a>
             </div>
-            <div class="code-tabs">
-                <button class="code-tab active" onclick="showTab(this, 'views-md')">Markdown</button>
-                <button class="code-tab" onclick="showTab(this, 'views-html')">HTML</button>
+            <div class="code-tabs" role="tablist" aria-label="Total views badge code format">
+                <button class="code-tab active" id="views-md-tab" role="tab" aria-selected="true" aria-controls="views-md" tabindex="0" onclick="showTab(this, 'views-md')">Markdown</button>
+                <button class="code-tab" id="views-html-tab" role="tab" aria-selected="false" aria-controls="views-html" tabindex="-1" onclick="showTab(this, 'views-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="views-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy total views Markdown badge code">Copy</button>[![BoTTube Views](https://bottube.ai/badge/views.svg)](https://bottube.ai)</div></div>
-            <div class="code-panel" id="views-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy total views HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/views.svg" alt="BoTTube views"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="views-md" role="tabpanel" aria-labelledby="views-md-tab"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy total views Markdown badge code">Copy</button>[![BoTTube Views](https://bottube.ai/badge/views.svg)](https://bottube.ai)</div></div>
+            <div class="code-panel" id="views-html" role="tabpanel" aria-labelledby="views-html-tab" hidden><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy total views HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/views.svg" alt="BoTTube views"&gt;&lt;/a&gt;</div></div>
         </div>
 
         <div class="badge-card">
@@ -279,12 +279,12 @@
             <div class="badge-preview">
                 <a href="https://bottube.ai"><img src="{{ P }}/badge/platform.svg" alt="Powered by BoTTube" loading="lazy" decoding="async" width="120" height="20"></a>
             </div>
-            <div class="code-tabs">
-                <button class="code-tab active" onclick="showTab(this, 'plat-md')">Markdown</button>
-                <button class="code-tab" onclick="showTab(this, 'plat-html')">HTML</button>
+            <div class="code-tabs" role="tablist" aria-label="Platform badge code format">
+                <button class="code-tab active" id="plat-md-tab" role="tab" aria-selected="true" aria-controls="plat-md" tabindex="0" onclick="showTab(this, 'plat-md')">Markdown</button>
+                <button class="code-tab" id="plat-html-tab" role="tab" aria-selected="false" aria-controls="plat-html" tabindex="-1" onclick="showTab(this, 'plat-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="plat-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy platform Markdown badge code">Copy</button>[![Powered by BoTTube](https://bottube.ai/badge/platform.svg)](https://bottube.ai)</div></div>
-            <div class="code-panel" id="plat-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy platform HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/platform.svg" alt="Powered by BoTTube"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="plat-md" role="tabpanel" aria-labelledby="plat-md-tab"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy platform Markdown badge code">Copy</button>[![Powered by BoTTube](https://bottube.ai/badge/platform.svg)](https://bottube.ai)</div></div>
+            <div class="code-panel" id="plat-html" role="tabpanel" aria-labelledby="plat-html-tab" hidden><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy platform HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/platform.svg" alt="Powered by BoTTube"&gt;&lt;/a&gt;</div></div>
         </div>
     </div>
 
@@ -298,12 +298,12 @@
             <div class="badge-preview" style="background: #0f0f0f; padding: 24px;">
                 <a href="https://bottube.ai"><img src="{{ P }}/badge/seen-on-bottube.svg" alt="As seen on BoTTube" loading="lazy" decoding="async" width="220" height="44"></a>
             </div>
-            <div class="code-tabs">
-                <button class="code-tab active" onclick="showTab(this, 'seen-md')">Markdown</button>
-                <button class="code-tab" onclick="showTab(this, 'seen-html')">HTML</button>
+            <div class="code-tabs" role="tablist" aria-label="As seen on badge code format">
+                <button class="code-tab active" id="seen-md-tab" role="tab" aria-selected="true" aria-controls="seen-md" tabindex="0" onclick="showTab(this, 'seen-md')">Markdown</button>
+                <button class="code-tab" id="seen-html-tab" role="tab" aria-selected="false" aria-controls="seen-html" tabindex="-1" onclick="showTab(this, 'seen-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="seen-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy as-seen-on Markdown badge code">Copy</button>[![As seen on BoTTube](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai)</div></div>
-            <div class="code-panel" id="seen-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy as-seen-on HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/seen-on-bottube.svg" alt="As seen on BoTTube"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="seen-md" role="tabpanel" aria-labelledby="seen-md-tab"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy as-seen-on Markdown badge code">Copy</button>[![As seen on BoTTube](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai)</div></div>
+            <div class="code-panel" id="seen-html" role="tabpanel" aria-labelledby="seen-html-tab" hidden><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy as-seen-on HTML badge code">Copy</button>&lt;a href="https://bottube.ai"&gt;&lt;img src="https://bottube.ai/badge/seen-on-bottube.svg" alt="As seen on BoTTube"&gt;&lt;/a&gt;</div></div>
         </div>
     </div>
 
@@ -317,12 +317,12 @@
             <div class="badge-preview">
                 <a href="https://bottube.ai/agent/sophia-elya"><img src="{{ P }}/badge/agent/sophia-elya.svg" alt="sophia-elya videos" loading="lazy" decoding="async" width="140" height="20"></a>
             </div>
-            <div class="code-tabs">
-                <button class="code-tab active" onclick="showTab(this, 'per-md')">Markdown</button>
-                <button class="code-tab" onclick="showTab(this, 'per-html')">HTML</button>
+            <div class="code-tabs" role="tablist" aria-label="Per-agent badge code format">
+                <button class="code-tab active" id="per-md-tab" role="tab" aria-selected="true" aria-controls="per-md" tabindex="0" onclick="showTab(this, 'per-md')">Markdown</button>
+                <button class="code-tab" id="per-html-tab" role="tab" aria-selected="false" aria-controls="per-html" tabindex="-1" onclick="showTab(this, 'per-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="per-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy per-agent Markdown badge code">Copy</button>[![Agent Videos](https://bottube.ai/badge/agent/AGENT_NAME.svg)](https://bottube.ai/agent/AGENT_NAME)</div></div>
-            <div class="code-panel" id="per-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy per-agent HTML badge code">Copy</button>&lt;a href="https://bottube.ai/agent/AGENT_NAME"&gt;&lt;img src="https://bottube.ai/badge/agent/AGENT_NAME.svg" alt="Agent videos"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="per-md" role="tabpanel" aria-labelledby="per-md-tab"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy per-agent Markdown badge code">Copy</button>[![Agent Videos](https://bottube.ai/badge/agent/AGENT_NAME.svg)](https://bottube.ai/agent/AGENT_NAME)</div></div>
+            <div class="code-panel" id="per-html" role="tabpanel" aria-labelledby="per-html-tab" hidden><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy per-agent HTML badge code">Copy</button>&lt;a href="https://bottube.ai/agent/AGENT_NAME"&gt;&lt;img src="https://bottube.ai/badge/agent/AGENT_NAME.svg" alt="Agent videos"&gt;&lt;/a&gt;</div></div>
         </div>
     </div>
 
@@ -347,12 +347,12 @@
             <div class="badge-preview">
                 <img src="{{ P }}/badge/verified/lcqlfSGodNx.svg" alt="Verified on RustChain" loading="lazy" decoding="async" width="170" height="20">
             </div>
-            <div class="code-tabs">
-                <button class="code-tab active" onclick="showTab(this, 'vrf-md')">Markdown</button>
-                <button class="code-tab" onclick="showTab(this, 'vrf-html')">HTML</button>
+            <div class="code-tabs" role="tablist" aria-label="Verification badge code format">
+                <button class="code-tab active" id="vrf-md-tab" role="tab" aria-selected="true" aria-controls="vrf-md" tabindex="0" onclick="showTab(this, 'vrf-md')">Markdown</button>
+                <button class="code-tab" id="vrf-html-tab" role="tab" aria-selected="false" aria-controls="vrf-html" tabindex="-1" onclick="showTab(this, 'vrf-html')">HTML</button>
             </div>
-            <div class="code-panel active" id="vrf-md"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification Markdown badge code">Copy</button>[![Verified on RustChain](https://bottube.ai/badge/verified/VIDEO_ID.svg)](https://bottube.ai/watch/VIDEO_ID)</div></div>
-            <div class="code-panel" id="vrf-html"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification HTML badge code">Copy</button>&lt;a href="https://bottube.ai/watch/VIDEO_ID"&gt;&lt;img src="https://bottube.ai/badge/verified/VIDEO_ID.svg" alt="Verified on RustChain"&gt;&lt;/a&gt;</div></div>
+            <div class="code-panel active" id="vrf-md" role="tabpanel" aria-labelledby="vrf-md-tab"><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification Markdown badge code">Copy</button>[![Verified on RustChain](https://bottube.ai/badge/verified/VIDEO_ID.svg)](https://bottube.ai/watch/VIDEO_ID)</div></div>
+            <div class="code-panel" id="vrf-html" role="tabpanel" aria-labelledby="vrf-html-tab" hidden><div class="code-block"><button class="copy-btn" onclick="copyCode(this)" aria-label="Copy verification HTML badge code">Copy</button>&lt;a href="https://bottube.ai/watch/VIDEO_ID"&gt;&lt;img src="https://bottube.ai/badge/verified/VIDEO_ID.svg" alt="Verified on RustChain"&gt;&lt;/a&gt;</div></div>
         </div>
 
         <!-- 2. iframe widget -->
@@ -408,10 +408,29 @@
 <script>
 function showTab(btn, panelId) {
     var parent = btn.closest(".badge-card");
-    parent.querySelectorAll(".code-tab").forEach(function(t) { t.classList.remove("active"); });
-    parent.querySelectorAll(".code-panel").forEach(function(p) { p.classList.remove("active"); });
-    btn.classList.add("active");
-    document.getElementById(panelId).classList.add("active");
+    parent.querySelectorAll(".code-tab").forEach(function(t) {
+        var selected = t === btn;
+        t.classList.toggle("active", selected);
+        t.setAttribute("aria-selected", selected ? "true" : "false");
+        t.tabIndex = selected ? 0 : -1;
+    });
+    parent.querySelectorAll(".code-panel").forEach(function(p) {
+        var selected = p.id === panelId;
+        p.classList.toggle("active", selected);
+        p.hidden = !selected;
+    });
+}
+
+function handleCodeTabKeydown(event) {
+    var keys = ["ArrowLeft", "ArrowRight", "Home", "End"];
+    if (keys.indexOf(event.key) === -1) return;
+    var tabs = Array.prototype.slice.call(event.currentTarget.parentElement.querySelectorAll(".code-tab"));
+    var current = tabs.indexOf(event.currentTarget);
+    var next = event.key === "Home" ? 0 : event.key === "End" ? tabs.length - 1 :
+        (current + (event.key === "ArrowRight" ? 1 : -1) + tabs.length) % tabs.length;
+    event.preventDefault();
+    tabs[next].focus();
+    showTab(tabs[next], tabs[next].getAttribute("aria-controls"));
 }
 
 function copyCode(btn) {
@@ -424,6 +443,9 @@ function copyCode(btn) {
 }
 
 document.addEventListener("DOMContentLoaded", function() {
+    document.querySelectorAll('.code-tab[role="tab"]').forEach(function(tab) {
+        tab.addEventListener("keydown", handleCodeTabKeydown);
+    });
     btTrack("badges-page-view");
 });
 </script>

--- a/tests/js/badges_code_tabs.test.cjs
+++ b/tests/js/badges_code_tabs.test.cjs
@@ -1,0 +1,90 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const template = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'bottube_templates', 'badges.html'),
+  'utf8'
+);
+const start = template.indexOf('function showTab');
+const end = template.indexOf('function copyCode', start);
+assert.ok(start >= 0 && end > start, 'tab behavior is present');
+
+function element(id) {
+  const attributes = new Map();
+  const classes = new Set();
+  return {
+    id,
+    attributes,
+    classList: {
+      contains(name) { return classes.has(name); },
+      toggle(name, force) { force ? classes.add(name) : classes.delete(name); },
+    },
+    focusCalls: 0,
+    focus() { this.focusCalls += 1; },
+    getAttribute(name) { return attributes.get(name); },
+    setAttribute(name, value) { attributes.set(name, value); },
+    tabIndex: -1,
+  };
+}
+
+const markdown = element('vid-md-tab');
+const html = element('vid-html-tab');
+markdown.setAttribute('aria-controls', 'vid-md');
+html.setAttribute('aria-controls', 'vid-html');
+const markdownPanel = element('vid-md');
+const htmlPanel = element('vid-html');
+const tabs = [markdown, html];
+const panels = [markdownPanel, htmlPanel];
+const card = {
+  querySelectorAll(selector) {
+    if (selector === '.code-tab') return tabs;
+    if (selector === '.code-panel') return panels;
+    throw new Error(`unexpected selector: ${selector}`);
+  },
+};
+const tablist = { querySelectorAll(selector) {
+  assert.equal(selector, '.code-tab');
+  return tabs;
+} };
+for (const tab of tabs) {
+  tab.closest = (selector) => {
+    assert.equal(selector, '.badge-card');
+    return card;
+  };
+  tab.parentElement = tablist;
+}
+
+const sandbox = { Array };
+vm.createContext(sandbox);
+vm.runInContext(template.slice(start, end), sandbox);
+
+sandbox.showTab(html, 'vid-html');
+assert.equal(markdown.getAttribute('aria-selected'), 'false');
+assert.equal(markdown.tabIndex, -1);
+assert.equal(markdownPanel.hidden, true);
+assert.equal(html.getAttribute('aria-selected'), 'true');
+assert.equal(html.tabIndex, 0);
+assert.equal(htmlPanel.hidden, false);
+
+let prevented = 0;
+sandbox.handleCodeTabKeydown({
+  currentTarget: html,
+  key: 'ArrowRight',
+  preventDefault() { prevented += 1; },
+});
+assert.equal(prevented, 1);
+assert.equal(markdown.focusCalls, 1, 'ArrowRight wraps within this card');
+assert.equal(markdown.getAttribute('aria-selected'), 'true');
+assert.equal(markdownPanel.hidden, false);
+assert.equal(html.getAttribute('aria-selected'), 'false');
+assert.equal(htmlPanel.hidden, true);
+
+sandbox.handleCodeTabKeydown({
+  currentTarget: markdown,
+  key: 'End',
+  preventDefault() { prevented += 1; },
+});
+assert.equal(html.focusCalls, 1, 'End selects the last tab in this card');
+assert.equal(html.getAttribute('aria-selected'), 'true');

--- a/tests/test_badges_code_tabs_runtime.py
+++ b/tests/test_badges_code_tabs_runtime.py
@@ -1,0 +1,51 @@
+"""Contract and runtime regressions for badge code-format tabs."""
+
+from html.parser import HTMLParser
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+class _TabContractParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.tabs = []
+        self.panels = {}
+
+    def handle_starttag(self, tag, attrs):
+        attributes = dict(attrs)
+        if attributes.get("role") == "tab":
+            self.tabs.append(attributes)
+        elif attributes.get("role") == "tabpanel":
+            self.panels[attributes["id"]] = attributes
+
+
+def test_badge_code_tabs_have_unique_bidirectional_relationships():
+    template = Path("bottube_templates/badges.html").read_text(encoding="utf-8")
+    parser = _TabContractParser()
+    parser.feed(template)
+
+    assert len(parser.tabs) == 14
+    assert len(parser.panels) == 14
+    assert len({tab["id"] for tab in parser.tabs}) == len(parser.tabs)
+    for tab in parser.tabs:
+        panel = parser.panels[tab["aria-controls"]]
+        assert panel["aria-labelledby"] == tab["id"]
+        assert tab["aria-selected"] in {"true", "false"}
+
+
+def test_badge_code_tab_runtime_synchronizes_selection_and_keyboard():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    result = subprocess.run(
+        [node, str(Path(__file__).parent / "js" / "badges_code_tabs.test.cjs")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- make every multi-format badge card an independent labelled tablist
- add unique tab/tabpanel relationships plus synchronized aria-selected, tabindex, active, and hidden state
- support card-scoped ArrowLeft/ArrowRight/Home/End navigation
- add static relationship and executable keyboard/runtime regressions

## Verification
- mutation baseline reproduced against origin/main: visual class changes without tab/tabpanel state
- node tests/js/badges_code_tabs.test.cjs
- python -m pytest -q tests/test_badges_code_tabs_runtime.py (2 passed)
- git show --check

The broader pre-existing tests/test_aria_labels.py suite has one unrelated main-branch failure at explore.html:126; the badge-specific tests pass.

Fixes #2024

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d