### PR TITLE
Keep repeated code copies byte-identical

### DIFF
--- a/bottube_templates/badges.html
+++ b/bottube_templates/badges.html
@@ -416,10 +416,19 @@ function showTab(btn, panelId) {
 
 function copyCode(btn) {
     var block = btn.parentElement;
-    var text = block.textContent.replace("Copy", "").trim();
+    var copy = block.cloneNode(true);
+    copy.querySelectorAll(".copy-btn").forEach(function(control) { control.remove(); });
+    var text = copy.textContent.trim();
+    if (btn._copyResetTimer !== undefined) {
+        clearTimeout(btn._copyResetTimer);
+        btn._copyResetTimer = undefined;
+    }
     navigator.clipboard.writeText(text).then(function() {
         btn.textContent = "Copied!";
-        setTimeout(function() { btn.textContent = "Copy"; }, 1500);
+        btn._copyResetTimer = setTimeout(function() {
+            btn.textContent = "Copy";
+            btn._copyResetTimer = undefined;
+        }, 1500);
     });
 }
 

--- a/bottube_templates/embed_guide.html
+++ b/bottube_templates/embed_guide.html
@@ -364,14 +364,23 @@ function setVideo(videoId, btn) {
 
 function copyCode(btn) {
     var block = btn.parentElement;
-    var text = block.textContent.replace("Copy", "").replace("Copied!", "").trim();
+    var copy = block.cloneNode(true);
+    copy.querySelectorAll(".copy-btn").forEach(function(control) { control.remove(); });
+    var text = copy.textContent.trim();
     // Decode HTML entities for clipboard
     var tmp = document.createElement("textarea");
     tmp.innerHTML = text;
     text = tmp.value;
+    if (btn._copyResetTimer !== undefined) {
+        clearTimeout(btn._copyResetTimer);
+        btn._copyResetTimer = undefined;
+    }
     navigator.clipboard.writeText(text).then(function() {
         btn.textContent = "Copied!";
-        setTimeout(function() { btn.textContent = "Copy"; }, 1500);
+        btn._copyResetTimer = setTimeout(function() {
+            btn.textContent = "Copy";
+            btn._copyResetTimer = undefined;
+        }, 1500);
     });
 }
 

--- a/tests/js/badges_copy_code.test.cjs
+++ b/tests/js/badges_copy_code.test.cjs
@@ -1,0 +1,112 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const template = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'bottube_templates', 'badges.html'),
+  'utf8'
+);
+const start = template.indexOf('function copyCode');
+const end = template.indexOf('document.addEventListener', start);
+assert.ok(start >= 0 && end > start, 'copy behavior is present');
+
+const clipboardWrites = [];
+const timers = [];
+const clearedTimers = [];
+const btn = { textContent: 'Copy', _copyResetTimer: undefined };
+const snippet = '<a href="https://bottube.ai">badge</a>';
+btn.parentElement = {
+  cloneNode() {
+    let controlRemoved = false;
+    return {
+      querySelectorAll(selector) {
+        assert.equal(selector, '.copy-btn');
+        return [{ remove() { controlRemoved = true; } }];
+      },
+      get textContent() {
+        return `${controlRemoved ? '' : btn.textContent}${snippet}`;
+      },
+    };
+  },
+};
+
+const sandbox = {
+  clearTimeout(id) { clearedTimers.push(id); },
+  navigator: {
+    clipboard: {
+      writeText(value) {
+        clipboardWrites.push(value);
+        return Promise.resolve();
+      },
+    },
+  },
+  Promise,
+  setTimeout(callback, delay) {
+    const id = timers.length + 1;
+    timers.push({ callback, delay, id });
+    return id;
+  },
+};
+vm.createContext(sandbox);
+vm.runInContext(template.slice(start, end), sandbox);
+
+async function run() {
+  sandbox.copyCode(btn);
+  await Promise.resolve();
+  assert.equal(btn.textContent, 'Copied!');
+
+  sandbox.copyCode(btn);
+  await Promise.resolve();
+
+  assert.deepEqual(clipboardWrites, [snippet, snippet]);
+  assert.deepEqual(clearedTimers, [1]);
+  assert.equal(timers.length, 2);
+  assert.equal(timers[1].delay, 1500);
+  timers[1].callback();
+  assert.equal(btn.textContent, 'Copy');
+  assert.equal(btn._copyResetTimer, undefined);
+
+  const embedTemplate = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'bottube_templates', 'embed_guide.html'),
+    'utf8'
+  );
+  const embedStart = embedTemplate.indexOf('function copyCode');
+  const embedEnd = embedTemplate.indexOf('document.addEventListener', embedStart);
+  const embedWrites = [];
+  const embedButton = { textContent: 'Copied!', _copyResetTimer: undefined };
+  embedButton.parentElement = {
+    cloneNode() {
+      let controlRemoved = false;
+      return {
+        querySelectorAll() { return [{ remove() { controlRemoved = true; } }]; },
+        get textContent() { return `${controlRemoved ? '' : embedButton.textContent}${snippet}`; },
+      };
+    },
+  };
+  const embedSandbox = {
+    clearTimeout() {},
+    document: {
+      createElement() {
+        return {
+          set innerHTML(value) { this.value = value; },
+          value: '',
+        };
+      },
+    },
+    navigator: { clipboard: { writeText(value) { embedWrites.push(value); return Promise.resolve(); } } },
+    Promise,
+    setTimeout() { return 1; },
+  };
+  vm.createContext(embedSandbox);
+  vm.runInContext(embedTemplate.slice(embedStart, embedEnd), embedSandbox);
+  embedSandbox.copyCode(embedButton);
+  embedSandbox.copyCode(embedButton);
+  await Promise.resolve();
+  assert.deepEqual(embedWrites, [snippet, snippet]);
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/test_badges_copy_code_runtime.py
+++ b/tests/test_badges_copy_code_runtime.py
@@ -1,0 +1,22 @@
+"""Execute the browser-neutral badge clipboard regression."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_repeated_badge_copy_excludes_transient_button_label():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    result = subprocess.run(
+        [node, str(Path(__file__).parent / "js" / "badges_copy_code.test.cjs")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- derive badge and embed-guide clipboard payloads from cloned code blocks with copy controls removed
- keep transient Copied! labels out of copied Markdown and HTML
- cancel each prior label-reset timer before scheduling its replacement
- add executable regressions proving rapid repeated clicks copy identical text on both pages

## Verification
- mutation baseline reproduced against origin/main: button text is scraped into clipboard source
- node tests/js/badges_copy_code.test.cjs
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_badges_copy_code_runtime.py (1 passed)
- staged diff check clean

Fixes #2029

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d