### PR TITLE
fix(generate): synchronize tab state

### DIFF
--- a/bottube_templates/generate.html
+++ b/bottube_templates/generate.html
@@ -179,22 +179,22 @@
     </div>
 
     <!-- Tabs -->
-    <div class="gen-tabs">
-        <button class="gen-tab active" onclick="switchTab('video')" id="tab-video" aria-label="Switch to video generation tab" role="tab" aria-selected="true">
+    <div class="gen-tabs" role="tablist" aria-label="Generation type">
+        <button class="gen-tab active" onclick="switchTab('video')" id="tab-video" aria-label="Switch to video generation tab" role="tab" aria-controls="panel-video" aria-selected="true" tabindex="0">
             Video <span class="tab-badge free">FREE</span>
         </button>
-        <button class="gen-tab" onclick="switchTab('image')" id="tab-image" aria-label="Switch to image generation tab" role="tab" aria-selected="false">
+        <button class="gen-tab" onclick="switchTab('image')" id="tab-image" aria-label="Switch to image generation tab" role="tab" aria-controls="panel-image" aria-selected="false" tabindex="-1">
             Image <span class="tab-badge free">FREE</span>
         </button>
         {% if current_user %}
-        <button class="gen-tab" onclick="switchTab('history')" id="tab-history" aria-label="Switch to generation history tab" role="tab" aria-selected="false">
+        <button class="gen-tab" onclick="switchTab('history')" id="tab-history" aria-label="Switch to generation history tab" role="tab" aria-controls="panel-history" aria-selected="false" tabindex="-1">
             My History
         </button>
         {% endif %}
     </div>
 
     <!-- VIDEO PANEL -->
-    <div class="gen-panel active" id="panel-video">
+    <div class="gen-panel active" id="panel-video" role="tabpanel" aria-labelledby="tab-video">
         <div class="gen-card">
             <h3>Text to Video</h3>
             <div class="subtitle">Generate an 8-second video clip from a text description. Powered by Google Veo 3.</div>
@@ -263,7 +263,7 @@
     </div>
 
     <!-- IMAGE PANEL -->
-    <div class="gen-panel" id="panel-image">
+    <div class="gen-panel" id="panel-image" role="tabpanel" aria-labelledby="tab-image" hidden>
         <div class="gen-card">
             <h3>Text to Image</h3>
             <div class="subtitle">Generate an image from a text description. Powered by Google Nano Banana (Gemini Flash Image).</div>
@@ -312,7 +312,7 @@
 
     <!-- HISTORY PANEL -->
     {% if current_user %}
-    <div class="gen-panel" id="panel-history">
+    <div class="gen-panel" id="panel-history" role="tabpanel" aria-labelledby="tab-history" hidden>
         <div class="gen-card">
             <h3>Generation History</h3>
             <div class="subtitle">Your recent AI generations.</div>
@@ -336,10 +336,17 @@ let activeTab = 'video';
 let pollInterval = null;
 
 function switchTab(tab) {
-    document.querySelectorAll('.gen-tab').forEach(t => t.classList.remove('active'));
-    document.querySelectorAll('.gen-panel').forEach(p => p.classList.remove('active'));
-    document.getElementById('tab-' + tab).classList.add('active');
-    document.getElementById('panel-' + tab).classList.add('active');
+    document.querySelectorAll('.gen-tab').forEach(t => {
+        const selected = t.id === 'tab-' + tab;
+        t.classList.toggle('active', selected);
+        t.setAttribute('aria-selected', String(selected));
+        t.tabIndex = selected ? 0 : -1;
+    });
+    document.querySelectorAll('.gen-panel').forEach(p => {
+        const selected = p.id === 'panel-' + tab;
+        p.classList.toggle('active', selected);
+        p.hidden = !selected;
+    });
     activeTab = tab;
     if (tab === 'history') loadHistory();
 }

--- a/tests/test_generate_tab_accessibility.py
+++ b/tests/test_generate_tab_accessibility.py
@@ -1,0 +1,30 @@
+import re
+from pathlib import Path
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "generate.html"
+
+
+def test_generator_tabs_synchronize_accessible_and_visible_state():
+    html = TEMPLATE.read_text(encoding="utf-8")
+
+    assert re.search(
+        r'class="gen-tabs"[^>]*role="tablist"[^>]*aria-label="Generation type"',
+        html,
+    )
+    for mode in ("video", "image", "history"):
+        tab = re.search(rf'<button[^>]*id="tab-{mode}"[^>]*>', html)
+        assert tab
+        assert 'role="tab"' in tab.group(0)
+        assert f'aria-controls="panel-{mode}"' in tab.group(0)
+        assert 'aria-selected=' in tab.group(0)
+        assert 'tabindex=' in tab.group(0)
+
+        panel = re.search(rf'<div[^>]*id="panel-{mode}"[^>]*>', html)
+        assert panel
+        assert 'role="tabpanel"' in panel.group(0)
+        assert f'aria-labelledby="tab-{mode}"' in panel.group(0)
+
+    assert "t.setAttribute('aria-selected', String(selected));" in html
+    assert 't.tabIndex = selected ? 0 : -1;' in html
+    assert 'p.hidden = !selected;' in html


### PR DESCRIPTION
## Summary
- expose Generator modes as a named tab list with linked tab panels
- synchronize visual active state, `aria-selected`, roving focus, and panel hidden state
- preserve current video, image, and history loading behavior
- add a focused accessibility regression for all three modes

## Verification
- `python -m pytest tests/test_generate_tab_accessibility.py -q`
- 1 passed
- `git diff --check`

Closes #2031

RustChain wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`