### PR TITLE
Expose selected embed-preview video

### DIFF
--- a/bottube_templates/embed_guide.html
+++ b/bottube_templates/embed_guide.html
@@ -269,15 +269,15 @@
         {% if videos %}
         <h3>Try with a real video</h3>
         <p>Click a video to generate its embed code:</p>
-        <div class="video-picker">
+        <div class="video-picker" role="group" aria-label="Choose a video for the embed preview">
             {% for v in videos %}
-            <button onclick="setVideo('{{ v.video_id }}', this)" title="{{ v.title }}" aria-label="Select {{ v.title }} for embed preview">{{ v.title }}</button>
+            <button onclick="setVideo('{{ v.video_id }}', this)" title="{{ v.title }}" aria-label="Select {{ v.title }} for embed preview" aria-pressed="false">{{ v.title }}</button>
             {% endfor %}
         </div>
 
         <div class="embed-demo" id="embed-demo" style="display:none;">
             <div class="demo-label">Preview</div>
-            <iframe id="embed-iframe" width="560" height="315" allowfullscreen></iframe>
+            <iframe id="embed-iframe" width="560" height="315" title="BoTTube video preview" allowfullscreen></iframe>
         </div>
 
         <div id="embed-code-output" style="display:none;">
@@ -349,12 +349,14 @@
 <script>
 function setVideo(videoId, btn) {
     document.querySelectorAll(".video-picker button").forEach(function(b) {
-        b.classList.remove("active");
+        var selected = b === btn;
+        b.classList.toggle("active", selected);
+        b.setAttribute("aria-pressed", selected ? "true" : "false");
     });
-    btn.classList.add("active");
 
     var iframe = document.getElementById("embed-iframe");
     iframe.src = "https://bottube.ai/embed/" + videoId;
+    iframe.title = "BoTTube video preview: " + btn.textContent.trim();
     document.getElementById("embed-demo").style.display = "block";
 
     var codeText = '&lt;iframe src="https://bottube.ai/embed/' + videoId + '" width="560" height="315" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;';

--- a/tests/js/embed_preview_selection.test.cjs
+++ b/tests/js/embed_preview_selection.test.cjs
@@ -1,0 +1,67 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const template = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'bottube_templates', 'embed_guide.html'),
+  'utf8'
+);
+const start = template.indexOf('function setVideo');
+const end = template.indexOf('function copyCode', start);
+assert.ok(start >= 0 && end > start, 'preview selection behavior is present');
+
+function pickerButton(title) {
+  const attributes = new Map([['aria-pressed', 'false']]);
+  const classes = new Set();
+  return {
+    textContent: title,
+    classList: {
+      contains(name) { return classes.has(name); },
+      toggle(name, force) { force ? classes.add(name) : classes.delete(name); },
+    },
+    getAttribute(name) { return attributes.get(name); },
+    setAttribute(name, value) { attributes.set(name, value); },
+  };
+}
+
+const first = pickerButton(' First video ');
+const second = pickerButton('Second video');
+const iframe = { src: '', title: '' };
+const demo = { style: { display: 'none' } };
+const codeText = { innerHTML: '' };
+const output = { style: { display: 'none' } };
+const sandbox = {
+  document: {
+    getElementById(id) {
+      return {
+        'embed-iframe': iframe,
+        'embed-demo': demo,
+        'embed-code-text': codeText,
+        'embed-code-output': output,
+      }[id];
+    },
+    querySelectorAll(selector) {
+      assert.equal(selector, '.video-picker button');
+      return [first, second];
+    },
+  },
+};
+vm.createContext(sandbox);
+vm.runInContext(template.slice(start, end), sandbox);
+
+sandbox.setVideo('video-1', first);
+assert.equal(first.getAttribute('aria-pressed'), 'true');
+assert.equal(second.getAttribute('aria-pressed'), 'false');
+assert.equal(first.classList.contains('active'), true);
+assert.equal(iframe.src, 'https://bottube.ai/embed/video-1');
+assert.equal(iframe.title, 'BoTTube video preview: First video');
+
+sandbox.setVideo('video-2', second);
+assert.equal(first.getAttribute('aria-pressed'), 'false');
+assert.equal(second.getAttribute('aria-pressed'), 'true');
+assert.equal(first.classList.contains('active'), false);
+assert.equal(second.classList.contains('active'), true);
+assert.equal(iframe.title, 'BoTTube video preview: Second video');
+assert.equal(demo.style.display, 'block');
+assert.equal(output.style.display, 'block');

--- a/tests/test_embed_preview_selection_runtime.py
+++ b/tests/test_embed_preview_selection_runtime.py
@@ -1,0 +1,22 @@
+"""Execute the browser-neutral embed-preview selection regression."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_embed_preview_exposes_exactly_one_selected_video():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    result = subprocess.run(
+        [node, str(Path(__file__).parent / "js" / "embed_preview_selection.test.cjs")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- expose the video picker as a labelled pressed-state group
- keep exactly one picker button visually and programmatically selected
- update the iframe title from safe button text so its accessible name identifies the current preview
- add an executable regression covering repeated selection transitions

## Verification
- mutation baseline reproduced against origin/main: visual active class had no programmatic selection or preview-name state
- node tests/js/embed_preview_selection.test.cjs
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_embed_preview_selection_runtime.py (1 passed)
- staged diff check clean

Fixes #2034

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d