### PR TITLE
fix(channel): synchronize subscribe semantics

### DIFF
--- a/bottube_templates/channel.html
+++ b/bottube_templates/channel.html
@@ -707,6 +707,7 @@
         {% if current_user and current_user.agent_name != agent.agent_name %}
         <button id="subscribe-btn" class="subscribe-btn {{ 'following' if is_following else 'not-following' }}"
                 onclick="toggleSubscribe()" type="button"
+                data-agent-label="{{ agent.display_name or agent.agent_name }}"
                 aria-label="{{ 'Unfollow ' + (agent.display_name or agent.agent_name) if is_following else 'Subscribe to ' + (agent.display_name or agent.agent_name) }}"
                 aria-pressed="{{ 'true' if is_following else 'false' }}">
             {{ 'Following' if is_following else 'Subscribe' }}
@@ -792,6 +793,11 @@ function toggleSubscribe() {
         if (d.ok) {
             btn.textContent = d.following ? "Following" : "Subscribe";
             btn.className = "subscribe-btn " + (d.following ? "following" : "not-following");
+            btn.setAttribute("aria-pressed", String(d.following));
+            btn.setAttribute(
+                "aria-label",
+                (d.following ? "Unfollow " : "Subscribe to ") + btn.dataset.agentLabel
+            );
             var sc = document.getElementById("sub-count");
             if (sc) sc.textContent = d.subscriber_count;
         } else if (d.login_required) {

--- a/tests/test_channel_subscribe_accessibility.py
+++ b/tests/test_channel_subscribe_accessibility.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "channel.html"
+
+
+def test_channel_subscribe_toggle_synchronizes_accessible_state():
+    html = TEMPLATE.read_text(encoding="utf-8")
+
+    assert 'id="subscribe-btn"' in html
+    assert 'data-agent-label="{{ agent.display_name or agent.agent_name }}"' in html
+    assert 'aria-pressed="{{ \'true\' if is_following else \'false\' }}"' in html
+    assert 'btn.setAttribute("aria-pressed", String(d.following));' in html
+    assert '(d.following ? "Unfollow " : "Subscribe to ") + btn.dataset.agentLabel' in html


### PR DESCRIPTION
## Summary
- synchronize `aria-pressed` with the server-returned following state
- update the action-specific accessible label after subscribe and unfollow
- preserve current text, class, subscriber-count, login, and retry behavior
- add a focused regression for the full visible/accessibility state contract

## Verification
- `python -m pytest tests/test_channel_subscribe_accessibility.py -q`
- 1 passed
- `git diff --check`

Closes #2035

RustChain wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`