### PR TITLE
Synchronize RTC tip preset selection

### DIFF
--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2569,16 +2569,16 @@
                 </div>
 
                 <div class="tip-panel" id="tip-panel">
-                    <div class="tip-amounts">
-                        <button class="tip-amount-btn" aria-label="Send 0.01 RTC tip" onclick="selectTipAmount(0.01)">0.01</button>
-                        <button class="tip-amount-btn" aria-label="Send 0.05 RTC tip" onclick="selectTipAmount(0.05)">0.05</button>
-                        <button class="tip-amount-btn" aria-label="Send 0.10 RTC tip" onclick="selectTipAmount(0.1)">0.10</button>
-                        <button class="tip-amount-btn" aria-label="Send 0.50 RTC tip" onclick="selectTipAmount(0.5)">0.50</button>
-                        <button class="tip-amount-btn" aria-label="Send 1.00 RTC tip" onclick="selectTipAmount(1.0)">1.00</button>
+                    <div class="tip-amounts" role="group" aria-label="Preset RTC tip amounts">
+                        <button class="tip-amount-btn" type="button" aria-label="Send 0.01 RTC tip" aria-pressed="false" onclick="selectTipAmount(0.01)">0.01</button>
+                        <button class="tip-amount-btn" type="button" aria-label="Send 0.05 RTC tip" aria-pressed="false" onclick="selectTipAmount(0.05)">0.05</button>
+                        <button class="tip-amount-btn" type="button" aria-label="Send 0.10 RTC tip" aria-pressed="false" onclick="selectTipAmount(0.1)">0.10</button>
+                        <button class="tip-amount-btn" type="button" aria-label="Send 0.50 RTC tip" aria-pressed="false" onclick="selectTipAmount(0.5)">0.50</button>
+                        <button class="tip-amount-btn" type="button" aria-label="Send 1.00 RTC tip" aria-pressed="false" onclick="selectTipAmount(1.0)">1.00</button>
                     </div>
                     <div class="tip-custom">
                         <label for="tip-amount" class="sr-only">Custom Tip Amount</label>
-                        <input type="number" id="tip-amount" aria-label="Custom Tip Amount" min="0.001" max="100" step="0.001" placeholder="Custom RTC" value="0.01">
+                        <input type="number" id="tip-amount" aria-label="Custom Tip Amount" min="0.001" max="100" step="0.001" placeholder="Custom RTC" value="0.01" oninput="clearTipPresetSelection()">
                         <span style="font-size:13px;color:var(--text-secondary)">RTC</span>
                     </div>
                     <label for="tip-message" class="sr-only">Tip Message</label>
@@ -3885,8 +3885,16 @@ function toggleTipPanel() {
 function selectTipAmount(amount) {
     document.getElementById('tip-amount').value = amount;
     document.querySelectorAll('.tip-amount-btn').forEach(function(btn) {
+        var selected = parseFloat(btn.textContent) === amount;
+        btn.classList.toggle('selected', selected);
+        btn.setAttribute('aria-pressed', selected ? 'true' : 'false');
+    });
+}
+
+function clearTipPresetSelection() {
+    document.querySelectorAll('.tip-amount-btn').forEach(function(btn) {
         btn.classList.remove('selected');
-        if (parseFloat(btn.textContent) === amount) btn.classList.add('selected');
+        btn.setAttribute('aria-pressed', 'false');
     });
 }
 

--- a/tests/js/tip_preset_state.test.cjs
+++ b/tests/js/tip_preset_state.test.cjs
@@ -1,0 +1,56 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const template = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'bottube_templates', 'watch.html'),
+  'utf8'
+);
+const start = template.indexOf('function selectTipAmount');
+const end = template.indexOf('function sendTip', start);
+assert.ok(start >= 0 && end > start, 'tip preset behavior is present');
+
+function preset(label) {
+  const classes = new Set();
+  const attributes = new Map([['aria-pressed', 'false']]);
+  return {
+    textContent: label,
+    classList: {
+      contains(name) { return classes.has(name); },
+      remove(name) { classes.delete(name); },
+      toggle(name, force) { force ? classes.add(name) : classes.delete(name); },
+    },
+    getAttribute(name) { return attributes.get(name); },
+    setAttribute(name, value) { attributes.set(name, value); },
+  };
+}
+
+const input = { value: '0.01' };
+const presets = [preset('0.01'), preset('0.10'), preset('1.00')];
+const sandbox = {
+  document: {
+    getElementById(id) {
+      assert.equal(id, 'tip-amount');
+      return input;
+    },
+    querySelectorAll(selector) {
+      assert.equal(selector, '.tip-amount-btn');
+      return presets;
+    },
+  },
+  parseFloat,
+};
+vm.createContext(sandbox);
+vm.runInContext(template.slice(start, end), sandbox);
+
+sandbox.selectTipAmount(0.1);
+assert.equal(input.value, 0.1);
+assert.deepEqual(presets.map((button) => button.getAttribute('aria-pressed')), ['false', 'true', 'false']);
+assert.deepEqual(presets.map((button) => button.classList.contains('selected')), [false, true, false]);
+
+input.value = '0.25';
+sandbox.clearTipPresetSelection();
+assert.deepEqual(presets.map((button) => button.getAttribute('aria-pressed')), ['false', 'false', 'false']);
+assert.deepEqual(presets.map((button) => button.classList.contains('selected')), [false, false, false]);
+assert.equal(input.value, '0.25', 'clearing stale preset state preserves custom amount');

--- a/tests/test_tip_preset_state_runtime.py
+++ b/tests/test_tip_preset_state_runtime.py
@@ -1,0 +1,30 @@
+"""Execute the browser-neutral RTC tip preset regression."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_tip_controls_bind_preset_and_custom_input_state():
+    template = Path("bottube_templates/watch.html").read_text(encoding="utf-8")
+    assert template.count('class="tip-amount-btn" type="button"') == 5
+    assert template.count('aria-pressed="false" onclick="selectTipAmount') == 5
+    assert 'id="tip-amount"' in template
+    assert 'oninput="clearTipPresetSelection()"' in template
+
+
+def test_custom_tip_clears_stale_preset_state():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    result = subprocess.run(
+        [node, str(Path(__file__).parent / "js" / "tip_preset_state.test.cjs")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- expose RTC tip presets as a labelled pressed-state group
- keep exactly one visual and programmatic preset selected
- clear all preset state as soon as a custom amount is entered without changing that amount
- add static input wiring and executable selection-transition regressions

## Verification
- mutation baseline reproduced against origin/main: preset visual state remained stale after custom input
- node tests/js/tip_preset_state.test.cjs
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_tip_preset_state_runtime.py (2 passed)
- staged diff check clean

Fixes #2040

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d