### PR TITLE
fix(analytics): expose selected ranking metric

### DIFF
--- a/bottube_templates/analytics.html
+++ b/bottube_templates/analytics.html
@@ -291,10 +291,10 @@
     <div class="analytics-section">
         <div class="section-header">
             <h2>🏆 Top Videos</h2>
-            <div class="metric-tabs">
-                <button class="metric-tab active" data-metric="views">By Views</button>
-                <button class="metric-tab" data-metric="engagement">By Engagement</button>
-                <button class="metric-tab" data-metric="tips">By Tips</button>
+            <div class="metric-tabs" role="group" aria-label="Rank top videos by">
+                <button type="button" class="metric-tab active" data-metric="views" aria-pressed="true">By Views</button>
+                <button type="button" class="metric-tab" data-metric="engagement" aria-pressed="false">By Engagement</button>
+                <button type="button" class="metric-tab" data-metric="tips" aria-pressed="false">By Tips</button>
             </div>
         </div>
         <table class="analytics-table" id="topVideosTable">
@@ -516,8 +516,11 @@
     // Event listeners for metric tabs
     document.querySelectorAll('.metric-tab').forEach(tab => {
         tab.addEventListener('click', function() {
-            this.parentElement.querySelectorAll('.metric-tab').forEach(t => t.classList.remove('active'));
-            this.classList.add('active');
+            this.parentElement.querySelectorAll('.metric-tab').forEach(t => {
+                const selected = t === this;
+                t.classList.toggle('active', selected);
+                t.setAttribute('aria-pressed', String(selected));
+            });
             loadTopVideos(this.dataset.metric);
         });
     });

--- a/tests/test_analytics_metric_accessibility.py
+++ b/tests/test_analytics_metric_accessibility.py
@@ -1,0 +1,23 @@
+import re
+from pathlib import Path
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "analytics.html"
+
+
+def test_analytics_metric_controls_synchronize_pressed_state():
+    html = TEMPLATE.read_text(encoding="utf-8")
+
+    assert re.search(
+        r'class="metric-tabs"[^>]*role="group"[^>]*aria-label="Rank top videos by"',
+        html,
+    )
+    buttons = re.findall(r'<button[^>]*class="metric-tab[^>]*>', html)
+    assert len(buttons) == 3
+    assert sum('aria-pressed="true"' in button for button in buttons) == 1
+    assert sum('aria-pressed="false"' in button for button in buttons) == 2
+    assert all('type="button"' in button for button in buttons)
+
+    assert "const selected = t === this;" in html
+    assert "t.classList.toggle('active', selected);" in html
+    assert "t.setAttribute('aria-pressed', String(selected));" in html


### PR DESCRIPTION
## Summary
- expose the Top Videos ranking controls as a named toggle-button group
- synchronize the visual active class and `aria-pressed` from one selection decision
- preserve existing metric loading behavior
- add a focused regression proving exactly one selected metric

## Verification
- `python -m pytest tests/test_analytics_metric_accessibility.py -q`
- 1 passed
- `git diff --check`

Closes #2041

RustChain wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`