### PR TITLE
Validate admin list pagination

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -5864,12 +5864,17 @@ def admin_referrals():
     if err:
         return err
 
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=100)
+    if error:
+        return error
+
     db = get_db()
     status_filter = (request.args.get("status", "") or "").strip().lower()
     track_filter = (request.args.get("track", "") or "").strip().lower()
     ref_code = _normalize_ref_code(request.args.get("code", ""))
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(100, max(1, request.args.get("per_page", 20, type=int)))
     offset = (page - 1) * per_page
 
     where = ["1 = 1"]
@@ -6073,12 +6078,17 @@ def admin_badges():
     if err:
         return err
 
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 25, max_value=100)
+    if error:
+        return error
+
     db = get_db()
     badge_key = (request.args.get("badge_key", "") or "").strip()
     agent_name = (request.args.get("agent_name", "") or "").strip()
     active_filter = (request.args.get("active", "1") or "1").strip().lower()
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(100, max(1, request.args.get("per_page", 25, type=int)))
     offset = (page - 1) * per_page
 
     where = ["1 = 1"]

--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -58,6 +58,43 @@ def client(monkeypatch, tmp_path):
     yield bottube_server.app.test_client()
 
 
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("page=abc", {"error": "page must be an integer", "param": "page"}),
+        ("page=0", {"error": "page must be >= 1", "param": "page"}),
+        ("page=10001", {"error": "page must be <= 10000", "param": "page"}),
+        ("per_page=bad", {"error": "per_page must be an integer", "param": "per_page"}),
+        ("per_page=0", {"error": "per_page must be >= 1", "param": "per_page"}),
+        ("per_page=101", {"error": "per_page must be <= 100", "param": "per_page"}),
+    ],
+)
+def test_admin_badges_rejects_invalid_pagination_before_db(client, monkeypatch, query, expected):
+    def unexpected_db_access():
+        raise AssertionError("invalid pagination must be rejected before database access")
+
+    monkeypatch.setattr(bottube_server, "get_db", unexpected_db_access)
+    response = client.get(
+        f"/api/admin/badges?{query}",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == expected
+
+
+@pytest.mark.parametrize(("query", "page", "per_page"), [("", 1, 25), ("?page=2&per_page=1", 2, 1)])
+def test_admin_badges_preserves_valid_pagination(client, query, page, per_page):
+    response = client.get(
+        f"/api/admin/badges{query}",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["page"] == page
+    assert response.get_json()["per_page"] == per_page
+
+
 def _insert_agent(agent_name: str, api_key: str, *, is_human: bool = False) -> int:
     with bottube_server.app.app_context():
         db = bottube_server.get_db()

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -58,6 +58,43 @@ def client(monkeypatch, tmp_path):
     yield bottube_server.app.test_client()
 
 
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("page=abc", {"error": "page must be an integer", "param": "page"}),
+        ("page=0", {"error": "page must be >= 1", "param": "page"}),
+        ("page=10001", {"error": "page must be <= 10000", "param": "page"}),
+        ("per_page=bad", {"error": "per_page must be an integer", "param": "per_page"}),
+        ("per_page=0", {"error": "per_page must be >= 1", "param": "per_page"}),
+        ("per_page=101", {"error": "per_page must be <= 100", "param": "per_page"}),
+    ],
+)
+def test_admin_referrals_rejects_invalid_pagination_before_db(client, monkeypatch, query, expected):
+    def unexpected_db_access():
+        raise AssertionError("invalid pagination must be rejected before database access")
+
+    monkeypatch.setattr(bottube_server, "get_db", unexpected_db_access)
+    response = client.get(
+        f"/api/admin/referrals?{query}",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == expected
+
+
+@pytest.mark.parametrize(("query", "page", "per_page"), [("", 1, 20), ("?page=2&per_page=1", 2, 1)])
+def test_admin_referrals_preserves_valid_pagination(client, query, page, per_page):
+    response = client.get(
+        f"/api/admin/referrals{query}",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["page"] == page
+    assert response.get_json()["per_page"] == per_page
+
+
 def _insert_agent(agent_name: str, api_key: str, *, is_human: bool = False) -> int:
     with bottube_server.app.app_context():
         db = bottube_server.get_db()


### PR DESCRIPTION
## Summary
- route referral and badge admin pagination through the canonical strict integer parser
- reject malformed, non-positive, over-cap per-page, and excessively deep page values before database access
- preserve omitted defaults and valid pagination values
- add 16 route regressions covering both endpoints and the no-database-work failure edge

## Verification
- mutation baseline reproduced against origin/main: both routes default/clamp Flask typed query values
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_badges.py -k 'admin_badges_rejects_invalid_pagination_before_db or admin_badges_preserves_valid_pagination' (8 passed)
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_referrals.py -k 'admin_referrals_rejects_invalid_pagination_before_db or admin_referrals_preserves_valid_pagination' (8 passed)
- python -m py_compile bottube_server.py tests/test_badges.py tests/test_referrals.py
- staged diff check clean

Fixes #2043

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d