### PR TITLE
fix: synchronize notification disclosure state

### DIFF
--- a/bottube_static/base.js
+++ b/bottube_static/base.js
@@ -148,15 +148,19 @@
         .catch(function () {});
     }
 
-    function toggleNotifPanel() {
-      if (panel.style.display === "none" || !panel.style.display) {
-        panel.style.display = "block";
-        bell.setAttribute("aria-expanded", "true");
+    function setNotifPanelOpen(open, restoreFocus) {
+      panel.style.display = open ? "block" : "none";
+      bell.setAttribute("aria-expanded", open ? "true" : "false");
+      if (open) {
         loadNotifs();
-      } else {
-        panel.style.display = "none";
-        bell.setAttribute("aria-expanded", "false");
+      } else if (restoreFocus) {
+        bell.focus();
       }
+    }
+
+    function toggleNotifPanel() {
+      var isOpen = panel.style.display === "block";
+      setNotifPanelOpen(!isOpen, false);
     }
 
     bell.addEventListener("click", function (e) {
@@ -219,7 +223,14 @@
 
     document.addEventListener("click", function (e) {
       if (!wrapper.contains(e.target)) {
-        panel.style.display = "none";
+        setNotifPanelOpen(false, false);
+      }
+    });
+
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && panel.style.display === "block") {
+        e.preventDefault();
+        setNotifPanelOpen(false, true);
       }
     });
 

--- a/bottube_templates/base.html
+++ b/bottube_templates/base.html
@@ -881,10 +881,10 @@
             <a href="{{ P }}/upload">{{ _('nav.upload') }}</a>
             {% if current_user %}
             <div class="notif-wrapper" style="position:relative;">
-                <a href="#" id="bell-btn" aria-label="Notifications" role="button" style="position:relative;font-size:18px;padding:6px 8px;">
+                <a href="#" id="bell-btn" aria-label="Notifications" role="button" aria-expanded="false" aria-controls="notif-panel" style="position:relative;font-size:18px;padding:6px 8px;">
                     &#128276;<span id="notif-badge" aria-hidden="true" style="display:none;position:absolute;top:2px;right:2px;background:var(--red);color:#fff;font-size:10px;font-weight:700;min-width:16px;height:16px;border-radius:8px;text-align:center;line-height:16px;padding:0 4px;"></span>
                 </a>
-                <div id="notif-panel" style="display:none;position:absolute;right:0;top:42px;width:340px;max-height:400px;overflow-y:auto;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);z-index:200;box-shadow:0 4px 12px rgba(0,0,0,0.5);">
+                <div id="notif-panel" role="region" aria-label="Notifications" style="display:none;position:absolute;right:0;top:42px;width:340px;max-height:400px;overflow-y:auto;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);z-index:200;box-shadow:0 4px 12px rgba(0,0,0,0.5);">
                     <div style="padding:12px 16px;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;">
                         <strong style="font-size:14px;">{{ _('nav.notifications') }}</strong>
                         <a href="#" id="notif-mark-all" style="font-size:12px;">{{ _('nav.mark_all_read') }}</a>


### PR DESCRIPTION
Closes #2046.\n\n- declares the bell/panel disclosure relationship\n- centralizes visible and aria-expanded state\n- synchronizes outside-click dismissal\n- supports Escape dismissal with focus restoration\n- adds focused accessibility regression coverage\n\nVerification: python -m pytest tests/test_accessibility.py -q (26 passed, 10 subtests passed); git diff --check.