### PR TITLE
fix: wire docs disclosures to unique panels

### DIFF
--- a/bottube_templates/docs.html
+++ b/bottube_templates/docs.html
@@ -1009,6 +1009,18 @@ print(results["total"], "results")</code></pre>
 
 {% block extra_js %}
 <script>
+function wireEndpointControls() {
+    document.querySelectorAll(".endpoint").forEach((endpoint, index) => {
+        const header = endpoint.querySelector(":scope > .endpoint-header");
+        const body = endpoint.querySelector(":scope > .endpoint-body");
+        if (!header || !body) return;
+
+        const panelId = `endpoint-panel-${index + 1}`;
+        body.id = panelId;
+        header.setAttribute("aria-controls", panelId);
+    });
+}
+
 function toggleEndpoint(header) {
     const expanded = header.parentElement.classList.toggle("open");
     header.setAttribute("aria-expanded", String(expanded));
@@ -1021,6 +1033,8 @@ document.querySelectorAll(".endpoint-header").forEach(header => {
         toggleEndpoint(header);
     });
 });
+
+wireEndpointControls();
 </script>
 
 <!-- Umami Docs Tracking -->


### PR DESCRIPTION
Closes #2048.

- assigns a stable unique ID to every API endpoint panel
- rewires each disclosure's aria-controls to its own sibling panel
- adds focused regression coverage for the one-to-one disclosure contract

Verification: `python -m pytest tests/test_accessibility.py::TestAccessibilityAttributes::test_docs_endpoint_controls_are_wired_to_unique_panels -q` (1 passed); `git diff --check`.