### PR TITLE
fix(translations): label search and isolate new tabs

### DIFF
--- a/templates/translations.html
+++ b/templates/translations.html
@@ -93,14 +93,14 @@
     </div>
 
     <div class="search-box">
-        <input type="text" placeholder="Search translations by language or content..." id="searchInput">
+        <input type="text" placeholder="Search translations by language or content..." id="searchInput" aria-label="Search translations">
     </div>
 
     <div id="translationsContainer">
         {% for translation in translations %}
         <div class="translation-card">
             <div class="language-tag">{{ translation.language }}</div>
-            <p><strong>Video:</strong> <a href="{{ translation.video_url }}" class="video-link" target="_blank">{{ translation.video_url }}</a></p>
+            <p><strong>Video:</strong> <a href="{{ translation.video_url }}" class="video-link" target="_blank" rel="noopener noreferrer">{{ translation.video_url }}</a></p>
             
             <div class="original">
                 <div class="title">Original (English):</div>

--- a/tests/test_translations_template_accessibility.py
+++ b/tests/test_translations_template_accessibility.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+def _template() -> str:
+    template = Path(__file__).resolve().parents[1] / "templates" / "translations.html"
+    return template.read_text(encoding="utf-8")
+
+
+def test_translation_search_has_persistent_accessible_label():
+    html = _template()
+
+    assert 'id="searchInput" aria-label="Search translations"' in html
+
+
+def test_translation_video_links_isolate_new_tab_context():
+    html = _template()
+
+    assert 'target="_blank" rel="noopener noreferrer"' in html


### PR DESCRIPTION
## Summary
- give the translations search field a persistent programmatic name without changing its visual layout
- preserve new-tab video navigation while isolating opener and referrer context
- add focused executable regression coverage for both template contracts

## Verification
- mutation baseline against `origin/main`: both the accessible name and safe-new-tab relation were absent
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_translations_template_accessibility.py -q` (2 passed)
- staged diff check clean

Fixes #2050

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d