### PR TITLE
fix(grazer): isolate external resource tabs

### DIFF
--- a/bottube_templates/grazer.html
+++ b/bottube_templates/grazer.html
@@ -96,17 +96,17 @@
 </div>
 
 <div style="text-align: center; padding: 40px 0;">
-    <a href="https://github.com/Scottcjn/grazer-skill" target="_blank"
+    <a href="https://github.com/Scottcjn/grazer-skill" target="_blank" rel="noopener noreferrer"
        style="display: inline-block; padding: 12px 32px; background: var(--accent); color: #000;
               font-weight: 600; border-radius: 8px; text-decoration: none; font-size: 16px;">
         View on GitHub →
     </a>
-    <a href="https://www.npmjs.com/package/grazer-skill" target="_blank"
+    <a href="https://www.npmjs.com/package/grazer-skill" target="_blank" rel="noopener noreferrer"
        style="display: inline-block; padding: 12px 32px; background: var(--red); color: #fff;
               font-weight: 600; border-radius: 8px; text-decoration: none; font-size: 16px; margin-left: 12px;">
         NPM Package →
     </a>
-    <a href="https://pypi.org/project/grazer-skill" target="_blank"
+    <a href="https://pypi.org/project/grazer-skill" target="_blank" rel="noopener noreferrer"
        style="display: inline-block; padding: 12px 32px; background: #3775a9; color: #fff;
               font-weight: 600; border-radius: 8px; text-decoration: none; font-size: 16px; margin-left: 12px;">
         PyPI Package →

--- a/tests/test_grazer_template_navigation.py
+++ b/tests/test_grazer_template_navigation.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+def test_grazer_external_resources_isolate_new_tab_context():
+    template = Path(__file__).resolve().parents[1] / "bottube_templates" / "grazer.html"
+    html = template.read_text(encoding="utf-8")
+
+    resources = (
+        "https://github.com/Scottcjn/grazer-skill",
+        "https://www.npmjs.com/package/grazer-skill",
+        "https://pypi.org/project/grazer-skill",
+    )
+    assert html.count('target="_blank" rel="noopener noreferrer"') == len(resources)
+    for url in resources:
+        assert f'href="{url}" target="_blank" rel="noopener noreferrer"' in html


### PR DESCRIPTION
## Summary
- preserve all three Grazer resource destinations and their existing new-tab behavior
- add explicit opener and referrer isolation to the GitHub, npm, and PyPI links
- add a focused regression that covers the complete resource-link set

## Verification
- mutation baseline against `origin/main`: 3 of 3 links omitted the safe relation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_grazer_template_navigation.py -q` (1 passed)
- staged diff check clean

Fixes #2053

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d