### PR TITLE
fix(chat): expose messages as a live log

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -42,7 +42,7 @@
             <span>Live Chat</span>
             <span class="viewers" id="viewer-count">0 watching</span>
         </div>
-        <div class="chat-messages" id="messages"></div>
+        <div class="chat-messages" id="messages" role="log" aria-live="polite" aria-relevant="additions text"></div>
         {% if is_mod %}
         <div class="mod-bar">
             <button onclick="toggleSlowMode()">Slow Mode</button>
@@ -50,7 +50,7 @@
         </div>
         {% endif %}
         <div class="chat-input">
-            <input type="text" id="msg-input" placeholder="Send a message..." maxlength="500"
+            <input type="text" id="msg-input" placeholder="Send a message..." maxlength="500" aria-label="Chat message"
                    onkeydown="if(event.key==='Enter')sendMsg()">
             <button onclick="sendMsg()">Send</button>
             <button class="super-btn" onclick="sendSuper()">$ Super</button>

--- a/tests/test_chat_template_accessibility.py
+++ b/tests/test_chat_template_accessibility.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+def _template() -> str:
+    template = Path(__file__).resolve().parents[1] / "templates" / "chat.html"
+    return template.read_text(encoding="utf-8")
+
+
+def test_live_chat_exposes_appended_messages_as_a_polite_log():
+    html = _template()
+
+    assert (
+        'id="messages" role="log" aria-live="polite" '
+        'aria-relevant="additions text"'
+    ) in html
+    assert "messagesEl.appendChild(div);" in html
+
+
+def test_live_chat_composer_has_a_persistent_accessible_name():
+    html = _template()
+
+    assert 'id="msg-input" placeholder="Send a message..." maxlength="500" aria-label="Chat message"' in html


### PR DESCRIPTION
Summary:
- expose appended chat and system messages through a polite ARIA log
- give the message composer a persistent accessible name
- add focused template-contract regressions

Verification:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_chat_template_accessibility.py -q (2 passed)
- git diff --check

Fixes #2055

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d