### PR TITLE
fix: expose badge code tab state

### DIFF
--- a/bottube_templates/badges.html
+++ b/bottube_templates/badges.html
@@ -408,10 +408,43 @@
 <script>
 function showTab(btn, panelId) {
     var parent = btn.closest(".badge-card");
-    parent.querySelectorAll(".code-tab").forEach(function(t) { t.classList.remove("active"); });
-    parent.querySelectorAll(".code-panel").forEach(function(p) { p.classList.remove("active"); });
+    parent.querySelectorAll(".code-tab").forEach(function(t) {
+        t.classList.remove("active");
+        t.setAttribute("aria-selected", "false");
+    });
+    parent.querySelectorAll(".code-panel").forEach(function(p) {
+        p.classList.remove("active");
+        p.hidden = true;
+    });
     btn.classList.add("active");
-    document.getElementById(panelId).classList.add("active");
+    btn.setAttribute("aria-selected", "true");
+    var panel = document.getElementById(panelId);
+    panel.classList.add("active");
+    panel.hidden = false;
+}
+
+function initCodeTabs() {
+    document.querySelectorAll(".badge-card").forEach(function(card, cardIndex) {
+        var tablist = card.querySelector(".code-tabs");
+        if (!tablist) return;
+        tablist.setAttribute("role", "tablist");
+        tablist.setAttribute("aria-label", "Badge code format");
+
+        var tabs = Array.from(tablist.querySelectorAll(".code-tab"));
+        var panels = Array.from(card.querySelectorAll(".code-panel"));
+        tabs.forEach(function(tab, tabIndex) {
+            var panel = panels[tabIndex];
+            if (!panel) return;
+            tab.type = "button";
+            tab.id = tab.id || "badge-code-tab-" + cardIndex + "-" + tabIndex;
+            tab.setAttribute("role", "tab");
+            tab.setAttribute("aria-controls", panel.id);
+            tab.setAttribute("aria-selected", tab.classList.contains("active") ? "true" : "false");
+            panel.setAttribute("role", "tabpanel");
+            panel.setAttribute("aria-labelledby", tab.id);
+            panel.hidden = !panel.classList.contains("active");
+        });
+    });
 }
 
 function copyCode(btn) {
@@ -424,6 +457,7 @@ function copyCode(btn) {
 }
 
 document.addEventListener("DOMContentLoaded", function() {
+    initCodeTabs();
     btTrack("badges-page-view");
 });
 </script>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -76,6 +76,19 @@ class TestAccessibilityAttributes(unittest.TestCase):
                           "Notification bell missing aria-label")
             self.assertIn('role="button"', context,
                           "Notification bell should have role='button'")
+
+    def test_badge_code_tabs_expose_selected_panel_state(self):
+        """Badge format selectors must implement a complete tabs contract."""
+        content = self.read_file(self.TEMPLATE_DIR / 'badges.html')
+        self.assertIn('function initCodeTabs()', content)
+        self.assertIn('tablist.setAttribute("role", "tablist")', content)
+        self.assertIn('tab.setAttribute("role", "tab")', content)
+        self.assertIn('tab.setAttribute("aria-controls", panel.id)', content)
+        self.assertIn('panel.setAttribute("role", "tabpanel")', content)
+        self.assertIn('panel.setAttribute("aria-labelledby", tab.id)', content)
+        self.assertIn('btn.setAttribute("aria-selected", "true")', content)
+        self.assertIn('t.setAttribute("aria-selected", "false")', content)
+        self.assertIn('panel.hidden = false', content)
     
     def test_subscribe_button_has_aria_label(self):
         """Test that subscribe button has aria-label attribute."""


### PR DESCRIPTION
Closes #2056.

- initializes each badge card as an independent tab set
- binds every format tab to its code panel
- synchronizes selected and hidden state on every switch
- preserves existing visual and copy behavior
- adds focused regression coverage

Verification: focused accessibility regression passed; `git diff --check`.