### PR TITLE
fix: expose embed picker selection

### DIFF
--- a/bottube_templates/embed_guide.html
+++ b/bottube_templates/embed_guide.html
@@ -269,15 +269,15 @@
         {% if videos %}
         <h3>Try with a real video</h3>
         <p>Click a video to generate its embed code:</p>
-        <div class="video-picker">
+        <div class="video-picker" role="group" aria-label="Choose a video for the embed preview">
             {% for v in videos %}
-            <button onclick="setVideo('{{ v.video_id }}', this)" title="{{ v.title }}" aria-label="Select {{ v.title }} for embed preview">{{ v.title }}</button>
+            <button type="button" aria-pressed="false" onclick="setVideo('{{ v.video_id }}', this)" title="{{ v.title }}" aria-label="Select {{ v.title }} for embed preview">{{ v.title }}</button>
             {% endfor %}
         </div>
 
         <div class="embed-demo" id="embed-demo" style="display:none;">
             <div class="demo-label">Preview</div>
-            <iframe id="embed-iframe" width="560" height="315" allowfullscreen></iframe>
+            <iframe id="embed-iframe" title="Selected BoTTube video preview" width="560" height="315" allowfullscreen></iframe>
         </div>
 
         <div id="embed-code-output" style="display:none;">
@@ -350,8 +350,10 @@
 function setVideo(videoId, btn) {
     document.querySelectorAll(".video-picker button").forEach(function(b) {
         b.classList.remove("active");
+        b.setAttribute("aria-pressed", "false");
     });
     btn.classList.add("active");
+    btn.setAttribute("aria-pressed", "true");
 
     var iframe = document.getElementById("embed-iframe");
     iframe.src = "https://bottube.ai/embed/" + videoId;

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -76,6 +76,18 @@ class TestAccessibilityAttributes(unittest.TestCase):
                           "Notification bell missing aria-label")
             self.assertIn('role="button"', context,
                           "Notification bell should have role='button'")
+
+    def test_embed_picker_exposes_selection_and_preview_name(self):
+        """The embed chooser must announce both selection and preview content."""
+        content = self.read_file(self.TEMPLATE_DIR / 'embed_guide.html')
+        self.assertIn('class="video-picker" role="group"', content)
+        self.assertIn('type="button" aria-pressed="false"', content)
+        self.assertIn('b.setAttribute("aria-pressed", "false")', content)
+        self.assertIn('btn.setAttribute("aria-pressed", "true")', content)
+        self.assertRegex(
+            content,
+            r'<iframe[^>]*id="embed-iframe"[^>]*title="[^"]+"',
+        )
     
     def test_subscribe_button_has_aria_label(self):
         """Test that subscribe button has aria-label attribute."""


### PR DESCRIPTION
Closes #2060.

- exposes the video picker as a named single-choice control
- synchronizes each picker's pressed state with its visible active state
- gives the generated preview iframe a stable descriptive title
- preserves existing preview and embed-code behavior
- adds focused accessibility regression coverage

Verification: focused regression passed; `git diff --check`.