### PR TITLE
fix(trust-safety): support fresh database initialization

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -20153,24 +20153,30 @@ def _ensure_ts_schema():
                 """
             )
 
-            # Add TOS columns to agents (idempotent).
+            # Add TOS columns to agents (idempotent).  Trust-and-safety tables
+            # are also used by fresh/test deployments where the core schema
+            # may not have been initialized yet.  PRAGMA returns no columns
+            # for an absent table, so do not try to ALTER it in that state.
+            # Leave the combined readiness flag false so a later call retries
+            # the agent-column migration after the core schema is created.
             cols = {row[1] for row in conn.execute("PRAGMA table_info(agents)").fetchall()}
-            if "tos_version_accepted" not in cols:
-                conn.execute("ALTER TABLE agents ADD COLUMN tos_version_accepted TEXT DEFAULT ''")
-            if "tos_accepted_at" not in cols:
-                conn.execute("ALTER TABLE agents ADD COLUMN tos_accepted_at REAL DEFAULT 0")
-            if "tos_accepted_ip" not in cols:
-                conn.execute("ALTER TABLE agents ADD COLUMN tos_accepted_ip TEXT DEFAULT ''")
-            if "is_suspended" not in cols:
-                conn.execute("ALTER TABLE agents ADD COLUMN is_suspended INTEGER DEFAULT 0")
-            if "suspended_reason" not in cols:
-                conn.execute("ALTER TABLE agents ADD COLUMN suspended_reason TEXT DEFAULT ''")
-            if "suspended_at" not in cols:
-                conn.execute("ALTER TABLE agents ADD COLUMN suspended_at REAL DEFAULT 0")
+            if cols:
+                if "tos_version_accepted" not in cols:
+                    conn.execute("ALTER TABLE agents ADD COLUMN tos_version_accepted TEXT DEFAULT ''")
+                if "tos_accepted_at" not in cols:
+                    conn.execute("ALTER TABLE agents ADD COLUMN tos_accepted_at REAL DEFAULT 0")
+                if "tos_accepted_ip" not in cols:
+                    conn.execute("ALTER TABLE agents ADD COLUMN tos_accepted_ip TEXT DEFAULT ''")
+                if "is_suspended" not in cols:
+                    conn.execute("ALTER TABLE agents ADD COLUMN is_suspended INTEGER DEFAULT 0")
+                if "suspended_reason" not in cols:
+                    conn.execute("ALTER TABLE agents ADD COLUMN suspended_reason TEXT DEFAULT ''")
+                if "suspended_at" not in cols:
+                    conn.execute("ALTER TABLE agents ADD COLUMN suspended_at REAL DEFAULT 0")
             conn.commit()
         finally:
             conn.close()
-        _TS_SCHEMA_READY = True
+        _TS_SCHEMA_READY = bool(cols)
 
 
 def _ts_log_audit(actor, action, target_kind, target_id, reason="",

--- a/tests/test_admin_key_env.py
+++ b/tests/test_admin_key_env.py
@@ -1,4 +1,5 @@
 import importlib
+import sqlite3
 import sys
 
 import pytest
@@ -48,3 +49,30 @@ def test_trust_safety_gate_rejects_rc_only_key(monkeypatch, tmp_path):
     response = client.post('/admin/blocklist/add', headers={'X-Admin-Key': 'legacy-rc-key'}, json={})
     assert response.status_code == 401
     sys.modules.pop("bottube_server", None)
+
+
+def test_trust_safety_schema_supports_fresh_db_then_retries_agent_migration(server_module):
+    client = server_module.app.test_client()
+    response = client.post(
+        "/admin/blocklist/add",
+        headers={"X-Admin-Key": server_module.ADMIN_KEY},
+        json={"sha256": "a" * 64, "category": "malware"},
+    )
+    assert response.status_code == 200
+
+    conn = sqlite3.connect(server_module.DB_PATH)
+    try:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(agents)").fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert {
+        "tos_version_accepted",
+        "tos_accepted_at",
+        "tos_accepted_ip",
+        "is_suspended",
+        "suspended_reason",
+        "suspended_at",
+    } <= columns


### PR DESCRIPTION
## Summary
- keep trust-and-safety table creation usable before the core agents table exists
- retry the agent TOS/suspension column migration once core schema is available
- cover a complete valid blocklist write on a fresh configured database

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_admin_key_env.py tests/test_malformed_json_admin.py — 14 passed
- python -m py_compile bottube_server.py
- git diff --check

Closes #2059

Funded-program context: Scottcjn/rustchain-bounties#71.