### PR TITLE
fix(admin): validate moderation queue pagination

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -17620,11 +17620,15 @@ def admin_reports():
     if not ADMIN_KEY or admin_key != ADMIN_KEY:
         return jsonify({"error": "Unauthorized"}), 401
 
-    db = get_db()
     status_filter = request.args.get("status", "pending")
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(50, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=50)
+    if error:
+        return error
     offset = (page - 1) * per_page
+    db = get_db()
 
     rows = db.execute(
         """SELECT r.*, a.agent_name AS reporter_name
@@ -17666,11 +17670,15 @@ def admin_reward_holds():
     if err:
         return err
 
-    db = get_db()
     status_filter = request.args.get("status", "pending")
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(100, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=100)
+    if error:
+        return error
     offset = (page - 1) * per_page
+    db = get_db()
 
     rows = db.execute(
         """
@@ -17776,11 +17784,15 @@ def admin_moderation_holds():
     if err:
         return err
 
-    db = get_db()
     status_filter = request.args.get("status", "pending")
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(100, max(1, request.args.get("per_page", 20, type=int)))
+    page, error = _parse_positive_int_query("page", 1, max_value=10000)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query("per_page", 20, max_value=100)
+    if error:
+        return error
     offset = (page - 1) * per_page
+    db = get_db()
 
     rows = db.execute(
         """

--- a/tests/test_admin_queue_pagination_validation.py
+++ b/tests/test_admin_queue_pagination_validation.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+"""Pagination contracts shared by the admin moderation queues."""
+
+_PATHS = (
+    "/api/admin/reports",
+    "/api/admin/reward-holds",
+    "/api/admin/moderation-holds",
+)
+
+_INVALID_QUERIES = (
+    "page=abc",
+    "page=0",
+    "page=10001",
+    "page=9223372036854775807",
+    "per_page=abc",
+    "per_page=0",
+)
+
+
+def test_admin_queue_pagination_contract(client, app, monkeypatch):
+    import bottube_server
+
+    monkeypatch.setattr(bottube_server, "ADMIN_KEY", "test-admin", raising=False)
+    headers = {"X-Admin-Key": "test-admin"}
+    real_get_db = bottube_server.get_db
+
+    def fail_if_queried():
+        raise AssertionError("invalid pagination reached the database")
+
+    with monkeypatch.context() as invalid_context:
+        invalid_context.setattr(bottube_server, "get_db", fail_if_queried)
+        for path in _PATHS:
+            for query in _INVALID_QUERIES:
+                response = client.get(f"{path}?{query}", headers=headers)
+                assert response.status_code == 400, (path, query)
+                assert response.get_json()["error"], (path, query)
+
+    assert bottube_server.get_db is real_get_db
+
+    valid_bounds = (
+        ("/api/admin/reports", 50),
+        ("/api/admin/reward-holds", 100),
+        ("/api/admin/moderation-holds", 100),
+    )
+    for path, max_per_page in valid_bounds:
+        assert client.get(path, headers=headers).status_code == 200, path
+        response = client.get(
+            f"{path}?page=10000&per_page={max_per_page}",
+            headers=headers,
+        )
+        assert response.status_code == 200, path
+
+        response = client.get(
+            f"{path}?per_page={max_per_page + 1}",
+            headers=headers,
+        )
+        assert response.status_code == 400, path


### PR DESCRIPTION
Summary:
- apply the canonical bounded positive-integer parser to reports, reward holds, and moderation holds
- reject malformed, non-positive, route-over-cap, and overflow pagination before database work
- preserve omitted defaults and each route's existing valid maximum

Verification:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_admin_queue_pagination_validation.py -q (1 passed; all endpoint/value cases covered in one fixture)
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_quests.py::test_report_threshold_queues_hold_without_auto_removal tests/test_quests.py::test_admin_resolve_report_defaults_to_coach_without_deleting_comment tests/test_quests.py::test_like_reward_hold_can_be_credited_by_admin tests/test_quests.py::test_moderation_hold_release_restores_video -q (4 passed)
- git diff --check

Fixes #2062

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d