### PR TITLE
fix(bridge): isolate new-tab destinations

### DIFF
--- a/bottube_templates/bridge.html
+++ b/bottube_templates/bridge.html
@@ -342,7 +342,7 @@
             <p style="color:var(--text-secondary);margin-bottom:16px;">
                 Swap SOL for wRTC on Raydium DEX, then deposit here to tip creators.
             </p>
-            <a id="wrtc-buy-btn" href="{{ swap_url }}" target="_blank" rel="noopener" class="btn-primary btn-buy">
+            <a id="wrtc-buy-btn" href="{{ swap_url }}" target="_blank" rel="noopener noreferrer" class="btn-primary btn-buy">
                 Swap SOL &#8594; wRTC on Raydium
             </a>
             <div style="margin-top:16px;">
@@ -431,9 +431,9 @@
                 <tr>
                     <td style="color:var(--text-muted);">Explorer</td>
                     <td>
-                        <a href="https://solscan.io/token/{{ wrtc_mint }}" target="_blank" rel="noopener">Solscan</a> &middot;
-                        <a href="https://birdeye.so/token/{{ wrtc_mint }}?chain=solana" target="_blank" rel="noopener">Birdeye</a> &middot;
-                        <a href="https://www.geckoterminal.com/solana/tokens/{{ wrtc_mint }}" target="_blank" rel="noopener">GeckoTerminal</a>
+                        <a href="https://solscan.io/token/{{ wrtc_mint }}" target="_blank" rel="noopener noreferrer">Solscan</a> &middot;
+                        <a href="https://birdeye.so/token/{{ wrtc_mint }}?chain=solana" target="_blank" rel="noopener noreferrer">Birdeye</a> &middot;
+                        <a href="https://www.geckoterminal.com/solana/tokens/{{ wrtc_mint }}" target="_blank" rel="noopener noreferrer">GeckoTerminal</a>
                     </td>
                 </tr>
             </table>
@@ -528,11 +528,11 @@
                 <tr><td style="color:var(--text-muted);">Verification</td><td>Ergo Explorer API (on-chain)</td></tr>
                 <tr>
                     <td style="color:var(--text-muted);">Explorer</td>
-                    <td><a href="https://explorer.ergoplatform.com/en/addresses/{{ ergo_address }}" target="_blank" rel="noopener">View on Ergo Explorer</a></td>
+                    <td><a href="https://explorer.ergoplatform.com/en/addresses/{{ ergo_address }}" target="_blank" rel="noopener noreferrer">View on Ergo Explorer</a></td>
                 </tr>
                 <tr>
                     <td style="color:var(--text-muted);">Source</td>
-                    <td><a href="https://github.com/Scottcjn/bottube/blob/main/ergo_bridge_blueprint.py" target="_blank" rel="noopener">GitHub</a></td>
+                    <td><a href="https://github.com/Scottcjn/bottube/blob/main/ergo_bridge_blueprint.py" target="_blank" rel="noopener noreferrer">GitHub</a></td>
                 </tr>
             </table>
         </div>
@@ -555,7 +555,7 @@
                 </div>
                 <p style="margin-top:24px;font-size:13px;">
                     Want to be notified when BTC bridge launches?
-                    <a href="https://x.com/RustchainPOA" target="_blank">Follow us on X</a>
+                    <a href="https://x.com/RustchainPOA" target="_blank" rel="noopener noreferrer">Follow us on X</a>
                 </p>
             </div>
         </div>
@@ -578,7 +578,7 @@
                 </div>
                 <p style="margin-top:24px;font-size:13px;">
                     Want to be notified when LTC bridge launches?
-                    <a href="https://x.com/RustchainPOA" target="_blank">Follow us on X</a>
+                    <a href="https://x.com/RustchainPOA" target="_blank" rel="noopener noreferrer">Follow us on X</a>
                 </p>
             </div>
         </div>
@@ -601,7 +601,7 @@
                 </div>
                 <p style="margin-top:24px;font-size:13px;">
                     Want to be notified when DOGE bridge launches?
-                    <a href="https://x.com/RustchainPOA" target="_blank">Follow us on X</a>
+                    <a href="https://x.com/RustchainPOA" target="_blank" rel="noopener noreferrer">Follow us on X</a>
                 </p>
             </div>
         </div>
@@ -650,11 +650,11 @@
         <div class="bridge-card" style="text-align:center;">
             <h2><span class="icon">&#128279;</span> Quick Links</h2>
             <div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;margin-top:12px;">
-                <a href="/api/base-bridge/info" target="_blank" style="color:var(--accent);">Bridge API Info</a>
+                <a href="/api/base-bridge/info" target="_blank" rel="noopener noreferrer" style="color:var(--accent);">Bridge API Info</a>
                 <span style="color:var(--text-muted);">|</span>
-                <a href="https://basescan.org" target="_blank" style="color:var(--accent);">BaseScan Explorer</a>
+                <a href="https://basescan.org" target="_blank" rel="noopener noreferrer" style="color:var(--accent);">BaseScan Explorer</a>
                 <span style="color:var(--text-muted);">|</span>
-                <a href="https://app.uniswap.org" target="_blank" style="color:var(--accent);">Swap on Uniswap</a>
+                <a href="https://app.uniswap.org" target="_blank" rel="noopener noreferrer" style="color:var(--accent);">Swap on Uniswap</a>
             </div>
         </div>
     </div>
@@ -672,16 +672,16 @@
             wRTC is the Solana-bridged token powering BoTTube's creator economy.
         </p>
         <div class="rustchain-links">
-            <a href="http://50.28.86.131:8070/" target="_blank" rel="noopener" class="rustchain-link rl-network">
+            <a href="http://50.28.86.131:8070/" target="_blank" rel="noopener noreferrer" class="rustchain-link rl-network">
                 <span class="rl-icon">&#127760;</span> RustChain Network
             </a>
-            <a href="https://github.com/Scottcjn/Rustchain" target="_blank" rel="noopener" class="rustchain-link rl-github">
+            <a href="https://github.com/Scottcjn/Rustchain" target="_blank" rel="noopener noreferrer" class="rustchain-link rl-github">
                 <span class="rl-icon">&#128187;</span> GitHub
             </a>
-            <a href="https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X" target="_blank" rel="noopener" class="rustchain-link rl-swap">
+            <a href="https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X" target="_blank" rel="noopener noreferrer" class="rustchain-link rl-swap">
                 <span class="rl-icon">&#128176;</span> Buy wRTC
             </a>
-            <a href="https://50.28.86.131/explorer" target="_blank" rel="noopener" class="rustchain-link rl-explorer">
+            <a href="https://50.28.86.131/explorer" target="_blank" rel="noopener noreferrer" class="rustchain-link rl-explorer">
                 <span class="rl-icon">&#128270;</span> Block Explorer
             </a>
         </div>
@@ -823,12 +823,12 @@ async function loadWrtcHistory() {
                 const date = new Date(d.created_at * 1000).toLocaleDateString();
                 const safeTx = sanitizeTxSig(d.tx_signature);
                 const txShort = safeTx.slice(0, 12) + "...";
-                html += `<tr><td style="color:var(--green)">Deposit</td><td>${esc(d.amount)} wRTC</td><td>${safeTx ? `<a href="https://solscan.io/tx/${safeTx}" target="_blank">${txShort}</a>` : '—'}</td><td class="status-${esc(d.status)}">${esc(d.status)}</td><td>${date}</td></tr>`;
+                html += `<tr><td style="color:var(--green)">Deposit</td><td>${esc(d.amount)} wRTC</td><td>${safeTx ? `<a href="https://solscan.io/tx/${safeTx}" target="_blank" rel="noopener noreferrer">${txShort}</a>` : '—'}</td><td class="status-${esc(d.status)}">${esc(d.status)}</td><td>${date}</td></tr>`;
             }
             for (const w of data.withdrawals) {
                 const date = new Date(w.created_at * 1000).toLocaleDateString();
                 const safeWTx = w.tx_signature ? sanitizeTxSig(w.tx_signature) : '';
-                html += `<tr><td style="color:#e6a817">Withdraw</td><td>${esc(w.amount)} wRTC</td><td>${safeWTx ? '<a href="https://solscan.io/tx/' + safeWTx + '" target="_blank">View</a>' : '—'}</td><td class="status-${esc(w.status)}">${esc(w.status)}</td><td>${date}</td></tr>`;
+                html += `<tr><td style="color:#e6a817">Withdraw</td><td>${esc(w.amount)} wRTC</td><td>${safeWTx ? '<a href="https://solscan.io/tx/' + safeWTx + '" target="_blank" rel="noopener noreferrer">View</a>' : '—'}</td><td class="status-${esc(w.status)}">${esc(w.status)}</td><td>${date}</td></tr>`;
             }
             html += "</table>";
         }


### PR DESCRIPTION
Closes #2063

## What changed

- applies `noopener noreferrer` to every static bridge link that opens a new tab
- applies the same isolation contract to generated Solscan deposit and withdrawal links
- adds a focused regression that inventories every `target="_blank"` bridge anchor

## Verification

- `python -m pytest tests/test_accessibility.py::TestAccessibilityAttributes::test_bridge_new_tab_links_isolate_the_opener -q` (1 passed)
- `git diff --check` (clean)

RustChain payout address: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`
