### PR TITLE
fix(report): announce submission outcomes

### DIFF
--- a/bottube_templates/report.html
+++ b/bottube_templates/report.html
@@ -90,7 +90,7 @@
 
     <div class="form-row">By submitting you confirm the report is made in good faith. Knowingly false reports may result in account suspension.</div>
 
-    <div id="r-toast" class="toast"><span id="r-toast-message">Report received. Thank you. Reference:</span> <code id="r-ref"></code></div>
+    <div id="r-toast" class="toast" role="status" aria-live="polite" aria-atomic="true"><span id="r-toast-message">Report received. Thank you. Reference:</span> <code id="r-ref"></code></div>
 
     <div class="submit-row">
       <a href="{{ P }}/aup" style="color:var(--text-secondary);font-size:13px;">Read the AUP →</a>
@@ -126,16 +126,16 @@ function submitReport(ev) {
   }).then(function (r) { return r.json().then(function (j) { return {ok: r.ok, body: j}; }); })
     .then(function (resp) {
       if (resp.ok && resp.body && resp.body.ok) {
-        toast.classList.add('show');
         ref.textContent = resp.body.report_id || '—';
+        toast.classList.add('show');
         document.getElementById('report-form').reset();
       } else {
-        toast.classList.add('show', 'error');
         message.textContent = (resp.body && resp.body.error) ? resp.body.error : 'Submission failed. Please email abuse@elyanlabs.ai if urgent.';
+        toast.classList.add('show', 'error');
       }
     }).catch(function () {
-      toast.classList.add('show', 'error');
       message.textContent = 'Network error. Please try again or email abuse@elyanlabs.ai.';
+      toast.classList.add('show', 'error');
     }).finally(function () {
       btn.disabled = false;
       btn.textContent = 'Submit report';

--- a/tests/report_status_live_region.test.cjs
+++ b/tests/report_status_live_region.test.cjs
@@ -1,0 +1,83 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const template = fs.readFileSync(
+  path.join(__dirname, '..', 'bottube_templates', 'report.html'),
+  'utf8'
+);
+const script = template.match(/<script>([\s\S]*?)<\/script>/);
+assert.ok(script, 'report behavior is present');
+
+function classList() {
+  const tokens = new Set();
+  return {
+    add(...names) { names.forEach((name) => tokens.add(name)); },
+    remove(...names) { names.forEach((name) => tokens.delete(name)); },
+    contains(name) { return tokens.has(name); },
+  };
+}
+
+function createSandbox(fetchImpl) {
+  const elements = {
+    'r-submit': { disabled: false, textContent: 'Submit report' },
+    'r-toast': { classList: classList() },
+    'r-toast-message': { textContent: '' },
+    'r-ref': { textContent: '' },
+    'r-category': { value: 'spam' },
+    'r-target': { value: 'video-1' },
+    'r-detail': { value: 'Repeated promotion' },
+    'r-email': { value: '' },
+    'report-form': { resetCount: 0, reset() { this.resetCount += 1; } },
+  };
+  const sandbox = {
+    document: { getElementById(id) { return elements[id]; } },
+    fetch: fetchImpl,
+    JSON,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(script[1], sandbox);
+  return { sandbox, elements };
+}
+
+async function settle() {
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+(async () => {
+  let current = createSandbox(() => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ ok: true, report_id: 'rep-42' }),
+  }));
+  current.sandbox.submitReport({ preventDefault() {} });
+  await settle();
+  assert.equal(current.elements['r-ref'].textContent, 'rep-42');
+  assert.equal(current.elements['r-toast'].classList.contains('show'), true);
+  assert.equal(current.elements['r-toast'].classList.contains('error'), false);
+  assert.equal(current.elements['report-form'].resetCount, 1);
+  assert.equal(current.elements['r-submit'].disabled, false);
+
+  current = createSandbox(() => Promise.resolve({
+    ok: false,
+    json: () => Promise.resolve({ error: 'Invalid target' }),
+  }));
+  current.sandbox.submitReport({ preventDefault() {} });
+  await settle();
+  assert.equal(current.elements['r-toast-message'].textContent, 'Invalid target');
+  assert.equal(current.elements['r-toast'].classList.contains('show'), true);
+  assert.equal(current.elements['r-toast'].classList.contains('error'), true);
+  assert.equal(current.elements['r-ref'].textContent, '');
+
+  current = createSandbox(() => Promise.reject(new Error('offline')));
+  current.sandbox.submitReport({ preventDefault() {} });
+  await settle();
+  assert.match(current.elements['r-toast-message'].textContent, /Network error/);
+  assert.equal(current.elements['r-toast'].classList.contains('show'), true);
+  assert.equal(current.elements['r-toast'].classList.contains('error'), true);
+  assert.equal(current.elements['r-submit'].disabled, false);
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/test_report_status_live_region.py
+++ b/tests/test_report_status_live_region.py
@@ -1,0 +1,30 @@
+"""Static and executable regressions for public report outcomes."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_report_result_is_a_persistent_atomic_live_status():
+    template = Path("bottube_templates/report.html").read_text(encoding="utf-8")
+    assert (
+        'id="r-toast" class="toast" role="status" '
+        'aria-live="polite" aria-atomic="true"'
+    ) in template
+
+
+def test_report_result_announces_success_and_failure_paths():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    result = subprocess.run(
+        [node, str(Path(__file__).parent / "report_status_live_region.test.cjs")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Summary:
- expose the report outcome container as a persistent atomic polite status
- finalize success/error text before revealing the live region
- exercise success, API-error, and network-error behavior in Node plus static markup coverage

Verification:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_report_status_live_region.py -q (2 passed)
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_public_report_input_validation.py tests/test_report_input_validation.py -q (13 passed)
- git diff --check

Fixes #2066

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d