### PR TITLE
fix(wallet): announce operation results

### DIFF
--- a/bottube_templates/settings_wallet.html
+++ b/bottube_templates/settings_wallet.html
@@ -20,7 +20,7 @@
               style="background:var(--accent);color:var(--bg-primary);border:none;border-radius:8px;padding:10px 14px;font-weight:800;cursor:pointer;"
               onclick="saveLinkedWallet()" aria-label="Save linked wallet address">Save</button>
     </div>
-    <div id="linked-wallet-result" style="margin-top:10px;font-size:13px;color:var(--text-muted);"></div>
+    <div id="linked-wallet-result" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;font-size:13px;color:var(--text-muted);"></div>
   </div>
 
   <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:16px;">
@@ -30,7 +30,7 @@
       Use small amounts and back it up if you plan to keep funds here.
     </p>
 
-    <div id="local-wallet-status" style="font-size:13px;color:var(--text-muted);margin-bottom:10px;"></div>
+    <div id="local-wallet-status" role="status" aria-live="polite" aria-atomic="true" style="font-size:13px;color:var(--text-muted);margin-bottom:10px;"></div>
     <pre id="local-wallet-box" style="display:none;white-space:pre-wrap;background:var(--bg-secondary);border:1px solid var(--border);border-radius:10px;padding:12px;color:var(--text-primary);margin:10px 0;"></pre>
 
     <div style="display:flex;gap:10px;flex-wrap:wrap;">
@@ -46,7 +46,7 @@
               onclick="setProfileToLocal()" aria-label="Set profile to this wallet address">Set Profile To This Address</button>
     </div>
 
-    <div id="local-wallet-result" style="margin-top:10px;font-size:13px;color:var(--text-muted);"></div>
+    <div id="local-wallet-result" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;font-size:13px;color:var(--text-muted);"></div>
   </div>
 
   <div style="margin-top:14px;color:var(--text-muted);font-size:13px;">

--- a/tests/test_wallet_status_live_region.py
+++ b/tests/test_wallet_status_live_region.py
@@ -1,0 +1,39 @@
+"""Static and executable regressions for wallet operation feedback."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_every_wallet_result_container_is_an_atomic_live_status():
+    template = Path("bottube_templates/settings_wallet.html").read_text(
+        encoding="utf-8"
+    )
+    for element_id in (
+        "linked-wallet-result",
+        "local-wallet-status",
+        "local-wallet-result",
+    ):
+        line = next(
+            line for line in template.splitlines() if f'id="{element_id}"' in line
+        )
+        assert 'role="status"' in line
+        assert 'aria-live="polite"' in line
+        assert 'aria-atomic="true"' in line
+
+
+def test_shared_writer_updates_each_wallet_status_path():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    result = subprocess.run(
+        [node, str(Path(__file__).parent / "wallet_status_live_region.test.cjs")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/wallet_status_live_region.test.cjs
+++ b/tests/wallet_status_live_region.test.cjs
@@ -1,0 +1,31 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const template = fs.readFileSync(
+  path.join(__dirname, '..', 'bottube_templates', 'settings_wallet.html'),
+  'utf8'
+);
+const start = template.indexOf('function setText');
+const end = template.indexOf('async function refreshLocalWalletUI', start);
+assert.ok(start >= 0 && end > start, 'shared wallet status writer is present');
+
+const elements = {
+  'linked-wallet-result': { textContent: '', style: {} },
+  'local-wallet-status': { textContent: '', style: {} },
+  'local-wallet-result': { textContent: '', style: {} },
+};
+const sandbox = {
+  document: { getElementById(id) { return elements[id] || null; } },
+};
+vm.createContext(sandbox);
+vm.runInContext(template.slice(start, end), sandbox);
+
+for (const id of Object.keys(elements)) {
+  sandbox.setText(id, `${id} updated`, 'var(--green)');
+  assert.equal(elements[id].textContent, `${id} updated`);
+  assert.equal(elements[id].style.color, 'var(--green)');
+}
+
+assert.doesNotThrow(() => sandbox.setText('missing-status', 'ignored'));


### PR DESCRIPTION
Summary:
- expose linked-wallet, local-wallet state, and local-wallet action feedback as persistent atomic polite statuses
- preserve the existing layout and wallet behavior
- exercise every status container and the shared result writer

Verification:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_wallet_status_live_region.py -q (2 passed)
- git diff --check

Fixes #2069

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d