### PR TITLE
fix(verify): announce provenance results

### DIFF
--- a/bottube_templates/verify.html
+++ b/bottube_templates/verify.html
@@ -85,8 +85,8 @@
   </form>
 
   <div id="vrf-out" class="vrf-out" style="display:none">
-    <div id="vrf-steps"></div>
-    <div id="vrf-verdict"></div>
+    <div id="vrf-steps" role="log" aria-live="polite" aria-relevant="additions text"></div>
+    <div id="vrf-verdict" role="status" aria-live="polite" aria-atomic="true"></div>
   </div>
 
   <p class="vrf-foot">

--- a/tests/test_verify_live_region.py
+++ b/tests/test_verify_live_region.py
@@ -1,0 +1,36 @@
+"""Static and executable regressions for provenance-verification feedback."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_verification_steps_and_verdict_expose_live_semantics():
+    template = Path("bottube_templates/verify.html").read_text(encoding="utf-8")
+    assert (
+        'id="vrf-steps" role="log" aria-live="polite" '
+        'aria-relevant="additions text"'
+    ) in template
+    assert (
+        'id="vrf-verdict" role="status" aria-live="polite" '
+        'aria-atomic="true"'
+    ) in template
+    assert "stepsEl.appendChild(row);" in template
+    assert "verdEl.textContent = pass ? 'PASS' : 'FAIL';" in template
+
+
+def test_invalid_verification_updates_log_and_verdict_runtime():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    result = subprocess.run(
+        [node, str(Path(__file__).parent / "verify_live_region.test.cjs")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/verify_live_region.test.cjs
+++ b/tests/verify_live_region.test.cjs
@@ -1,0 +1,75 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { webcrypto } = require('node:crypto');
+
+const template = fs.readFileSync(
+  path.join(__dirname, '..', 'bottube_templates', 'verify.html'),
+  'utf8'
+);
+const script = template.match(/<script>([\s\S]*?)<\/script>/);
+assert.ok(script, 'verification behavior is present');
+
+function makeRow() {
+  const parts = {
+    '.ico': { className: '', textContent: '' },
+    '.title': { textContent: '' },
+    '.detail': { textContent: '' },
+  };
+  return {
+    className: '',
+    innerHTML: '',
+    querySelector(selector) { return parts[selector]; },
+    parts,
+  };
+}
+
+const steps = {
+  children: [],
+  appendChild(row) { this.children.push(row); },
+  set innerHTML(value) {
+    if (value === '') this.children = [];
+  },
+};
+const verdict = { className: '', innerHTML: '', textContent: '' };
+const output = { style: { display: 'none' } };
+const input = { value: 'bad!' };
+const verifyButton = { disabled: false };
+const assetButton = { disabled: false };
+const elements = {
+  'vrf-steps': steps,
+  'vrf-verdict': verdict,
+  'vrf-out': output,
+  'vrf-vid': input,
+  'vrf-btn': verifyButton,
+  'vrf-asset-btn': assetButton,
+};
+const sandbox = {
+  crypto: webcrypto,
+  document: {
+    createElement() { return makeRow(); },
+    getElementById(id) { return elements[id]; },
+  },
+  TextEncoder,
+  URLSearchParams,
+  Uint8Array,
+  window: { location: { search: '' } },
+};
+vm.createContext(sandbox);
+vm.runInContext(script[1], sandbox);
+
+(async () => {
+  await sandbox.window.runVerify(false);
+  assert.equal(output.style.display, 'block');
+  assert.equal(steps.children.length, 1);
+  assert.equal(steps.children[0].parts['.title'].textContent, 'Validate input');
+  assert.match(steps.children[0].parts['.detail'].textContent, /video_id must be/);
+  assert.equal(verdict.className, 'vrf-verdict fail');
+  assert.equal(verdict.textContent, 'FAIL');
+  assert.equal(verifyButton.disabled, false);
+  assert.equal(assetButton.disabled, false);
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Summary:
- expose incremental provenance checks as an additions-aware live log
- expose the final PASS/FAIL verdict as an atomic polite status
- preserve cryptographic and visual behavior while exercising the invalid-input runtime path

Verification:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_verify_live_region.py -q (2 passed)
- git diff --check

Fixes #2071

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d