### PR TITLE
fix(upload): preserve HTTP error semantics

### DIFF
--- a/bottube_templates/upload.html
+++ b/bottube_templates/upload.html
@@ -468,12 +468,18 @@ document.querySelector('.upload-form').addEventListener('submit', function(e) {
         headers: { 'X-API-Key': apiKey },
         body: formData
     })
-    .then(function(r) { return r.json(); })
-    .then(function(data) {
-        if (data.ok) {
+    .then(function(r) {
+        return r.json().catch(function() { return {}; }).then(function(data) {
+            return { ok: r.ok, status: r.status, data: data };
+        });
+    })
+    .then(function(resp) {
+        var data = resp.data || {};
+        if (resp.ok && data.ok) {
             window.location.href = '{{ P }}' + data.watch_url;
         } else {
-            alert('Upload failed: ' + (data.error || 'Unknown error'));
+            var fallback = resp.ok ? 'Unknown error' : 'HTTP ' + resp.status;
+            alert('Upload failed: ' + (data.error || fallback));
             btn.textContent = 'Upload Video';
             btn.disabled = false;
         }

--- a/tests/test_upload_http_response.py
+++ b/tests/test_upload_http_response.py
@@ -1,0 +1,22 @@
+"""Executable regression for logged-out upload response handling."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_upload_preserves_json_and_non_json_http_error_truth():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    result = subprocess.run(
+        [node, str(Path(__file__).parent / "upload_http_response.test.cjs")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/upload_http_response.test.cjs
+++ b/tests/upload_http_response.test.cjs
@@ -1,0 +1,94 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const template = fs.readFileSync(
+  path.join(__dirname, '..', 'bottube_templates', 'upload.html'),
+  'utf8'
+);
+const blockStart = template.indexOf('{% if not current_user %}');
+const scriptStart = template.indexOf('<script>', blockStart) + '<script>'.length;
+const scriptEnd = template.indexOf('</script>', scriptStart);
+assert.ok(blockStart >= 0 && scriptStart > blockStart && scriptEnd > scriptStart);
+const script = template.slice(scriptStart, scriptEnd);
+
+async function settle() {
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function exercise(fetchImpl) {
+  let submitHandler;
+  const alerts = [];
+  const button = { textContent: 'Upload Video', disabled: false };
+  const apiKey = { value: 'bottube_sk_test' };
+  const form = {
+    querySelector(selector) {
+      assert.equal(selector, 'input[type="file"]');
+      return { files: [] };
+    },
+  };
+  const sandbox = {
+    alert(message) { alerts.push(message); },
+    document: {
+      querySelector(selector) {
+        assert.equal(selector, '.upload-form');
+        return {
+          addEventListener(name, handler) {
+            assert.equal(name, 'submit');
+            submitHandler = handler;
+          },
+        };
+      },
+      getElementById(id) {
+        return id === 'apiKeyInput' ? apiKey : button;
+      },
+    },
+    fetch: fetchImpl,
+    FormData: class {
+      constructor(value) { assert.equal(value, form); }
+      delete() {}
+    },
+    JSON,
+    window: { location: { href: '' } },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(script, sandbox);
+  assert.equal(typeof submitHandler, 'function');
+
+  submitHandler({ preventDefault() {}, target: form });
+  await settle();
+  return { alerts, button, location: sandbox.window.location };
+}
+
+(async () => {
+  let result = await exercise(() => Promise.resolve({
+    ok: true,
+    status: 201,
+    json: () => Promise.resolve({ ok: true, watch_url: '/watch/video-1' }),
+  }));
+  assert.equal(result.location.href, '{{ P }}/watch/video-1');
+  assert.deepEqual(result.alerts, []);
+
+  result = await exercise(() => Promise.resolve({
+    ok: false,
+    status: 400,
+    json: () => Promise.resolve({ error: 'Unsupported file type' }),
+  }));
+  assert.deepEqual(result.alerts, ['Upload failed: Unsupported file type']);
+  assert.equal(result.button.disabled, false);
+  assert.equal(result.button.textContent, 'Upload Video');
+
+  result = await exercise(() => Promise.resolve({
+    ok: false,
+    status: 413,
+    json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+  }));
+  assert.deepEqual(result.alerts, ['Upload failed: HTTP 413']);
+  assert.equal(result.button.disabled, false);
+  assert.equal(result.button.textContent, 'Upload Video');
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Summary:
- parse upload JSON on a best-effort basis while retaining transport ok/status truth
- prefer provider JSON errors and fall back to stable HTTP status messages for HTML/empty failures
- preserve successful redirects and restore the submit button on all failure paths

Verification:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_upload_http_response.py -q (1 passed; success, JSON failure, and non-JSON HTTP failure covered)
- git diff --check

Fixes #2074

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d