### PR TITLE
fix(pi): validate authentication payloads

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -5252,8 +5252,13 @@ def pi_auth():
     find-or-create a BoTTube agents account keyed on pi_uid and establish a session.
     No Pi API key is required for this flow (mirrors /auth/google). Username scope
     only -- this never initiates a Pi payment."""
-    data = request.get_json(silent=True) or {}
-    access_token = (data.get("access_token") or "").strip()
+    data, body_error = _json_object_body()
+    if body_error:
+        return body_error
+    access_token = data.get("access_token") or ""
+    if not isinstance(access_token, str):
+        return jsonify({"error": "access_token must be a string"}), 400
+    access_token = access_token.strip()
     if not access_token:
         return jsonify({"error": "access_token required"}), 400
     try:

--- a/tests/test_pi_auth_input_validation.py
+++ b/tests/test_pi_auth_input_validation.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+"""Input-contract regressions for the Pi authentication endpoint."""
+
+import json
+
+
+def test_pi_auth_rejects_non_object_json(client):
+    response = client.post("/pi/auth", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON body must be an object"}
+
+
+def test_pi_auth_rejects_non_string_access_token(client):
+    response = client.post("/pi/auth", json={"access_token": 7})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "access_token must be a string"}
+
+
+def test_pi_auth_preserves_required_token_error(client):
+    response = client.post("/pi/auth", json={"access_token": "   "})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "access_token required"}
+
+
+def test_pi_auth_preserves_valid_string_flow(client, monkeypatch):
+    import bottube_server
+
+    class PiResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps({"uid": "pi-uid-2075", "username": "pi-tester"}).encode()
+
+    def fake_urlopen(request, timeout):
+        assert request.full_url == "https://api.minepi.com/v2/me"
+        assert request.headers["Authorization"] == "Bearer valid-token"
+        assert timeout == 10
+        return PiResponse()
+
+    monkeypatch.setattr(bottube_server.urllib.request, "urlopen", fake_urlopen)
+
+    response = client.post("/pi/auth", json={"access_token": " valid-token "})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "username": "pi-tester", "created": True}


### PR DESCRIPTION
## Summary
- validate `/pi/auth` request bodies as JSON objects before field access
- reject non-string `access_token` values with a deterministic 400 response
- cover malformed bodies, typed tokens, required-token behavior, and the valid Pi `/v2/me` flow

## Validation
- `python -m pytest tests/test_pi_auth_input_validation.py -q` (4 passed)
- `python -m py_compile bottube_server.py tests/test_pi_auth_input_validation.py`
- `git diff --check`

Fixes #2075
