### PR TITLE
fix: keep Beacon Atlas available on metadata failure

### DIFF
--- a/bottube_templates/beacon_atlas.html
+++ b/bottube_templates/beacon_atlas.html
@@ -256,6 +256,49 @@
 </div>
 
 <script>
+async function _atlasFetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Atlas request failed with HTTP ${response.status}`);
+  }
+  const payload = await response.json();
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Atlas request returned an invalid payload');
+  }
+  return payload;
+}
+
+async function _atlasLoadDirectoryData() {
+  const [beaconResult, agentResult] = await Promise.allSettled([
+    _atlasFetchJson('/api/beacon/directory'),
+    _atlasFetchJson('/api/agents?limit=100&sort=popular'),
+  ]);
+
+  if (beaconResult.status === 'rejected') {
+    throw beaconResult.reason;
+  }
+  if (!Array.isArray(beaconResult.value.beacons)) {
+    throw new Error('Beacon directory is missing its beacons list');
+  }
+
+  const beacons = beaconResult.value.beacons;
+  let agents = [];
+  if (agentResult.status === 'fulfilled' && Array.isArray(agentResult.value.agents)) {
+    agents = agentResult.value.agents;
+    for (const page of [2, 3]) {
+      try {
+        const pageData = await _atlasFetchJson(`/api/agents?limit=100&page=${page}&sort=popular`);
+        if (Array.isArray(pageData.agents)) {
+          agents = agents.concat(pageData.agents);
+        }
+      } catch (error) {
+        // Later agent pages are optional enrichment; retain all data loaded so far.
+      }
+    }
+  }
+  return {beacons, agents};
+}
+
 (async function() {
   const W = window.innerWidth, H = window.innerHeight;
 
@@ -286,23 +329,9 @@
   // ---- Fetch data ----
   let beacons = [], agents = [];
   try {
-    const [beaconRes, agentRes1] = await Promise.all([
-      fetch('/api/beacon/directory').then(r => r.json()),
-      fetch('/api/agents?limit=100&sort=popular').then(r => r.json()),
-    ]);
-    beacons = beaconRes.beacons || [];
-
-    agents = agentRes1.agents || [];
-    // Try to get page 2
-    try {
-      const agentRes2 = await fetch('/api/agents?limit=100&page=2&sort=popular').then(r => r.json());
-      if (agentRes2.agents) agents = agents.concat(agentRes2.agents);
-    } catch(e) {}
-    // Page 3
-    try {
-      const agentRes3 = await fetch('/api/agents?limit=100&page=3&sort=popular').then(r => r.json());
-      if (agentRes3.agents) agents = agents.concat(agentRes3.agents);
-    } catch(e) {}
+    const directoryData = await _atlasLoadDirectoryData();
+    beacons = directoryData.beacons;
+    agents = directoryData.agents;
   } catch(e) {
     console.error('Failed to fetch data:', e);
     document.querySelector('.load-text').textContent = 'Failed to load data. Retrying...';

--- a/tests/test_beacon_atlas_data_loading.py
+++ b/tests/test_beacon_atlas_data_loading.py
@@ -1,0 +1,76 @@
+"""Executable regressions for Beacon Atlas partial data-source failures."""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "beacon_atlas.html"
+
+
+def _loader_script() -> str:
+    script = TEMPLATE.read_text(encoding="utf-8").rsplit("<script>", 1)[1].split("</script>", 1)[0]
+    return script.split("(async function()", 1)[0]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
+@pytest.mark.parametrize(
+    ("responses", "expected"),
+    [
+        (
+            {
+                "/api/beacon/directory": {"ok": True, "status": 200, "payload": {"beacons": [{"agent_name": "atlas"}]}},
+                "/api/agents?limit=100&sort=popular": {"ok": False, "status": 503, "payload": None},
+            },
+            {"outcome": "resolved", "beacons": 1, "agents": 0, "calls": 2, "json_calls": 1},
+        ),
+        (
+            {
+                "/api/beacon/directory": {"ok": False, "status": 502, "payload": None},
+                "/api/agents?limit=100&sort=popular": {"ok": True, "status": 200, "payload": {"agents": []}},
+            },
+            {"outcome": "rejected", "calls": 2, "json_calls": 1},
+        ),
+        (
+            {
+                "/api/beacon/directory": {"ok": True, "status": 200, "payload": {"beacons": [{"agent_name": "atlas"}]}},
+                "/api/agents?limit=100&sort=popular": {"ok": True, "status": 200, "payload": {"agents": [{"agent_name": "one"}]}},
+                "/api/agents?limit=100&page=2&sort=popular": {"ok": True, "status": 200, "payload": {"agents": [{"agent_name": "two"}]}},
+                "/api/agents?limit=100&page=3&sort=popular": {"ok": False, "status": 500, "payload": None},
+            },
+            {"outcome": "resolved", "beacons": 1, "agents": 2, "calls": 4, "json_calls": 3},
+        ),
+    ],
+)
+def test_required_and_optional_atlas_sources_have_distinct_failure_semantics(responses, expected):
+    harness = f"""
+const configured = {json.dumps(responses)};
+let calls = 0;
+let jsonCalls = 0;
+global.fetch = async url => {{
+  calls += 1;
+  const item = configured[url];
+  if (!item) throw new Error('unexpected URL ' + url);
+  return {{
+    ok: item.ok,
+    status: item.status,
+    json: async () => {{ jsonCalls += 1; return item.payload; }}
+  }};
+}};
+eval({json.dumps(_loader_script())});
+_atlasLoadDirectoryData().then(data => {{
+  process.stdout.write(JSON.stringify({{
+    outcome: 'resolved', beacons: data.beacons.length, agents: data.agents.length,
+    calls, json_calls: jsonCalls
+  }}));
+}}).catch(() => {{
+  process.stdout.write(JSON.stringify({{outcome: 'rejected', calls, json_calls: jsonCalls}}));
+}});
+"""
+    completed = subprocess.run(
+        ["node", "-e", harness], check=True, capture_output=True, text=True, timeout=10
+    )
+    assert json.loads(completed.stdout) == expected


### PR DESCRIPTION
## Summary

- keep the canonical Beacon directory as the required Atlas data source
- treat agent-list pages as optional enrichment so their outage cannot erase the graph
- reject non-2xx and invalid JSON payload shapes explicitly
- add executable regressions for required-source failure, graceful metadata degradation, and partial pagination

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_beacon_atlas_data_loading.py tests/test_seo_audit_hygiene.py::test_template_and_beacon_atlas_assets_have_no_console_log` — 4 passed
- `git diff --check` — clean

Fixes #2085

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d
