### PR TITLE
fix(earnings): validate pagination

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11744,9 +11744,17 @@ def manage_wallet_web():
 def my_earnings():
     """Get your RTC balance and earnings history."""
     db = get_db()
-    page = max(1, request.args.get("page", 1, type=int))
-    per_page = min(100, max(1, request.args.get("per_page", 50, type=int)))
+    page, error = _parse_positive_int_query("page", 1)
+    if error:
+        return error
+    per_page, error = _parse_positive_int_query(
+        "per_page", 50, max_value=100,
+    )
+    if error:
+        return error
     offset = (page - 1) * per_page
+    if offset > _SQLITE_MAX_SIGNED_INT:
+        return jsonify({"error": "page out of range"}), 400
 
     rows = db.execute(
         """SELECT amount, reason, video_id, created_at

--- a/tests/test_earnings_pagination_validation.py
+++ b/tests/test_earnings_pagination_validation.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+"""Strict pagination regressions for the authenticated earnings ledger."""
+
+def test_earnings_pagination_contract(client, registered_agent):
+    headers = {"X-API-Key": registered_agent["api_key"]}
+    invalid_queries = [
+        {"page": "abc"},
+        {"page": "1.5"},
+        {"page": "0"},
+        {"page": "-1"},
+        {"per_page": "abc"},
+        {"per_page": "1.5"},
+        {"per_page": "0"},
+        {"per_page": "-1"},
+        {"per_page": "101"},
+        {"page": str(2 ** 63)},
+    ]
+    for query in invalid_queries:
+        response = client.get(
+            "/api/agents/me/earnings", query_string=query, headers=headers,
+        )
+        assert response.status_code == 400, (query, response.get_json())
+        assert response.get_json().get("error")
+
+    valid_queries = [
+        ({}, 1, 50),
+        ({"page": "2", "per_page": "100"}, 2, 100),
+    ]
+    for query, expected_page, expected_per_page in valid_queries:
+        response = client.get(
+            "/api/agents/me/earnings", query_string=query, headers=headers,
+        )
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["page"] == expected_page
+        assert response.get_json()["per_page"] == expected_per_page


### PR DESCRIPTION
Closes #2086

## What changed

- routes authenticated earnings pagination through the strict bounded-integer parser
- rejects malformed, fractional, non-positive, and over-100 values instead of rewriting them
- rejects page values whose computed SQLite offset exceeds the signed 64-bit bound
- preserves the default page/per-page values and valid upper boundary
- adds an integrated invalid/valid contract regression

## Verification

- `python -m pytest tests/test_earnings_pagination_validation.py -q` (1 passed; 12 request cases)
- `python -m py_compile bottube_server.py tests/test_earnings_pagination_validation.py`
- `git diff --check` (clean)

RustChain payout address: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`
