### PR TITLE
Validate Sophia chat JSON input

### DIFF
--- a/sophia_blueprint.py
+++ b/sophia_blueprint.py
@@ -174,12 +174,11 @@ def _conn():
     return c
 
 
-def _resolve_caller():
+def _resolve_caller(body):
     """Return (agent_id, api_key, name, is_human) for an API agent or a logged-in human,
     or ('__error__', ...) on DB failure, else None for genuine no-auth."""
     api_key = request.headers.get("X-API-Key", "")
     if not api_key:
-        body = request.get_json(silent=True) or {}
         api_key = (body.get("agent_api_key") or "").strip()
     uid = session.get("user_id")
     try:
@@ -295,7 +294,21 @@ def sophia_chat():
     if request.method == "OPTIONS":
         return ("", 204)  # CORS preflight (headers added in after_request)
 
-    caller = _resolve_caller()
+    body = request.get_json(silent=True)
+    if body is None:
+        body = {}
+    elif not isinstance(body, dict):
+        return jsonify({"error": "JSON body must be an object"}), 400
+
+    agent_api_key = body.get("agent_api_key")
+    if agent_api_key is not None and not isinstance(agent_api_key, str):
+        return jsonify({"error": "agent_api_key must be a string"}), 400
+
+    raw_message = body.get("message")
+    if raw_message is not None and not isinstance(raw_message, str):
+        return jsonify({"error": "message must be a string"}), 400
+
+    caller = _resolve_caller(body)
     if caller and caller[0] == "__error__":
         return jsonify({"error": "temporary backend error, retry shortly"}), 503
 
@@ -309,8 +322,7 @@ def sophia_chat():
     else:
         return jsonify({"error": "auth required (X-API-Key or login)"}), 401
 
-    body = request.get_json(silent=True) or {}
-    message = (body.get("message") or "").strip()
+    message = (raw_message or "").strip()
     if not message:
         return jsonify({"error": "message required"}), 400
     if len(message) > SOPHIA_MAX_MESSAGE:

--- a/tests/test_sophia_input_validation.py
+++ b/tests/test_sophia_input_validation.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+"""Request-contract regressions for the Sophia chat endpoint."""
+
+from flask import Flask
+
+import sophia_blueprint
+
+
+def _client():
+    app = Flask(__name__)
+    app.config.update(TESTING=True, SECRET_KEY="sophia-contract-test")
+    app.register_blueprint(sophia_blueprint.sophia_bp)
+    return app.test_client()
+
+
+def test_malformed_fields_are_rejected_before_authentication_or_inference(monkeypatch):
+    def unexpected_call(*_args, **_kwargs):
+        raise AssertionError("malformed input reached authentication or inference")
+
+    monkeypatch.setattr(sophia_blueprint, "_resolve_caller", unexpected_call)
+    monkeypatch.setattr(sophia_blueprint, "_call_sophia", unexpected_call)
+    client = _client()
+
+    cases = [
+        (["hello"], "JSON body must be an object"),
+        ({"agent_api_key": 42, "message": "hello"}, "agent_api_key must be a string"),
+        ({"message": ["hello"]}, "message must be a string"),
+        ({"message": 42}, "message must be a string"),
+    ]
+    for payload, expected_error in cases:
+        response = client.post("/api/sophia", json=payload)
+        assert response.status_code == 400
+        assert response.get_json() == {"error": expected_error}
+
+
+def test_valid_public_message_preserves_chat_and_cors_behavior(monkeypatch):
+    monkeypatch.setattr(sophia_blueprint, "_resolve_caller", lambda body: None)
+    monkeypatch.setattr(sophia_blueprint, "_call_sophia", lambda message, history: f"reply:{message}")
+    monkeypatch.setattr(sophia_blueprint, "_log_corpus", lambda *_args: None)
+    monkeypatch.setattr(sophia_blueprint, "SOPHIA_PUBLIC_CHAT", True)
+    monkeypatch.setattr(sophia_blueprint, "_PUBLIC_COOLDOWN", 0)
+    sophia_blueprint._ip_rate.clear()
+    client = _client()
+
+    response = client.post(
+        "/api/sophia",
+        json={"message": "  hello Sophia  "},
+        headers={"Origin": "https://bottube.ai"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "ok": True,
+        "reply": "reply:hello Sophia",
+        "from": "Sophia Elya",
+        "caller": "guest",
+        "generation": None,
+    }
+    assert response.headers["Access-Control-Allow-Origin"] == "https://bottube.ai"
+
+
+def test_options_and_existing_required_message_contract_remain_intact(monkeypatch):
+    client = _client()
+    preflight = client.options(
+        "/api/sophia",
+        headers={"Origin": "https://bottube.ai"},
+    )
+    assert preflight.status_code == 204
+    assert preflight.headers["Access-Control-Allow-Origin"] == "https://bottube.ai"
+
+    monkeypatch.setattr(sophia_blueprint, "_resolve_caller", lambda body: None)
+    monkeypatch.setattr(sophia_blueprint, "SOPHIA_PUBLIC_CHAT", True)
+    response = client.post("/api/sophia", json={"message": "   "})
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "message required"}


### PR DESCRIPTION
## Summary
- parse and validate the Sophia request body before caller lookup or model inference
- reject non-object JSON and non-string `agent_api_key` / `message` values with stable 400 responses
- preserve CORS preflight, public chat, authentication, and valid string-message behavior

## Verification
- `python -m pytest tests/test_sophia_input_validation.py -q` (3 passed)
- `python -m py_compile sophia_blueprint.py tests/test_sophia_input_validation.py`
- `git diff --check`

Fixes #2093