### PR TITLE
fix: synchronize Discover tab state and navigation

### DIFF
--- a/bottube_templates/discover.html
+++ b/bottube_templates/discover.html
@@ -270,27 +270,27 @@
 
     <!-- Filter Tabs -->
     <div class="filter-tabs" role="tablist" aria-label="Content filters">
-        <button class="filter-tab active" data-filter="all" onclick="loadContent('trending')" role="tab" aria-selected="true">🔥 Trending</button>
-        <button class="filter-tab" onclick="loadContent('foryou')" role="tab" aria-selected="false">✨ For You</button>
-        <button class="filter-tab" onclick="loadContent('agents')" role="tab" aria-selected="false">👤 Creators</button>
-        <button class="filter-tab" onclick="showCategories()" role="tab" aria-selected="false">📁 Categories</button>
-        <button class="filter-tab" onclick="showTags()" role="tab" aria-selected="false">🏷️ Tags</button>
+        <button class="filter-tab active" id="discover-tab-trending" data-filter="trending" data-panel="trendingSection" role="tab" aria-controls="trendingSection" aria-selected="true" tabindex="0">🔥 Trending</button>
+        <button class="filter-tab" id="discover-tab-foryou" data-filter="foryou" data-panel="foryouSection" role="tab" aria-controls="foryouSection" aria-selected="false" tabindex="-1">✨ For You</button>
+        <button class="filter-tab" id="discover-tab-agents" data-filter="agents" data-panel="agentsSection" role="tab" aria-controls="agentsSection" aria-selected="false" tabindex="-1">👤 Creators</button>
+        <button class="filter-tab" id="discover-tab-categories" data-filter="categories" data-panel="categoriesGrid" role="tab" aria-controls="categoriesGrid" aria-selected="false" tabindex="-1">📁 Categories</button>
+        <button class="filter-tab" id="discover-tab-tags" data-filter="tags" data-panel="tagsCloud" role="tab" aria-controls="tagsCloud" aria-selected="false" tabindex="-1">🏷️ Tags</button>
     </div>
 
     <!-- Tags Cloud (hidden by default) -->
-    <div class="tags-cloud" id="tagsCloud" style="display:none;">
+    <div class="tags-cloud" id="tagsCloud" role="tabpanel" aria-labelledby="discover-tab-tags" style="display:none;">
         <div class="loading">Loading tags...</div>
     </div>
 
     <!-- Categories Grid (hidden by default) -->
-    <div id="categoriesGrid" style="display:none;">
+    <div id="categoriesGrid" role="tabpanel" aria-labelledby="discover-tab-categories" style="display:none;">
         <div class="loading">Loading categories...</div>
     </div>
 
     <!-- Main Content -->
     <div id="mainContent">
         <!-- Trending Section -->
-        <div class="content-section" id="trendingSection">
+        <div class="content-section" id="trendingSection" role="tabpanel" aria-labelledby="discover-tab-trending">
             <div class="section-title">🔥 Trending Now</div>
             <div class="video-grid" id="trendingVideos">
                 <div class="loading">Loading trending videos...</div>
@@ -298,7 +298,7 @@
         </div>
 
         <!-- For You Section -->
-        <div class="content-section" id="foryouSection" style="display:none;">
+        <div class="content-section" id="foryouSection" role="tabpanel" aria-labelledby="discover-tab-foryou" style="display:none;">
             <div class="section-title">✨ Recommended For You</div>
             <div class="video-grid" id="foryouVideos">
                 <div class="loading">Loading personalized recommendations...</div>
@@ -306,7 +306,7 @@
         </div>
 
         <!-- Agent Directory -->
-        <div class="content-section" id="agentsSection" style="display:none;">
+        <div class="content-section" id="agentsSection" role="tabpanel" aria-labelledby="discover-tab-agents" style="display:none;">
             <div class="section-title">👤 Top Creators</div>
             <div class="agent-grid" id="agentGrid">
                 <div class="loading">Loading creators...</div>
@@ -331,6 +331,11 @@
     // Load trending videos on page load
     document.addEventListener('DOMContentLoaded', () => {
         loadTrending();
+
+        document.querySelectorAll('.filter-tab').forEach(tab => {
+            tab.addEventListener('click', () => activateDiscoverTab(tab));
+            tab.addEventListener('keydown', event => handleDiscoverTabKeydown(event, tab));
+        });
 
         document.getElementById('tagsCloud').addEventListener('click', function(e) {
             const target = e.target.closest('.tag-item');
@@ -492,29 +497,50 @@
         }
     }
 
-    function loadContent(type) {
-        // Update active tab
-        document.querySelectorAll('.filter-tab').forEach(tab => tab.classList.remove('active'));
-        event.target.classList.add('active');
-        
-        // Hide other sections
-        document.getElementById('trendingSection').style.display = 'none';
-        document.getElementById('foryouSection').style.display = 'none';
-        document.getElementById('agentsSection').style.display = 'none';
-        document.getElementById('searchSection').style.display = 'none';
-        document.getElementById('tagsCloud').style.display = 'none';
-        document.getElementById('categoriesGrid').style.display = 'none';
-        
-        if (type === 'trending') {
-            document.getElementById('trendingSection').style.display = 'block';
-            loadTrending();
-        } else if (type === 'foryou') {
-            document.getElementById('foryouSection').style.display = 'block';
-            loadForYou();
-        } else if (type === 'agents') {
-            document.getElementById('agentsSection').style.display = 'block';
-            loadAgents();
+    function activateDiscoverTab(tab, moveFocus = false) {
+        const tabs = Array.from(document.querySelectorAll('.filter-tab'));
+        const panelIds = ['trendingSection', 'foryouSection', 'agentsSection', 'tagsCloud', 'categoriesGrid'];
+        tabs.forEach(option => {
+            const selected = option === tab;
+            option.classList.toggle('active', selected);
+            option.setAttribute('aria-selected', selected ? 'true' : 'false');
+            option.setAttribute('tabindex', selected ? '0' : '-1');
+        });
+        panelIds.forEach(id => {
+            document.getElementById(id).style.display = 'none';
+        });
+
+        if (moveFocus) tab.focus();
+        const type = tab.dataset.filter;
+        if (type === 'tags') {
+            showTags();
+        } else if (type === 'categories') {
+            showCategories();
+        } else {
+            document.getElementById(tab.dataset.panel).style.display = 'block';
+            if (type === 'trending') loadTrending();
+            if (type === 'foryou') loadForYou();
+            if (type === 'agents') loadAgents();
         }
+    }
+
+    function handleDiscoverTabKeydown(event, tab) {
+        const tabs = Array.from(document.querySelectorAll('.filter-tab'));
+        const currentIndex = tabs.indexOf(tab);
+        let nextIndex = currentIndex;
+        if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+            nextIndex = (currentIndex + 1) % tabs.length;
+        } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+            nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+        } else if (event.key === 'Home') {
+            nextIndex = 0;
+        } else if (event.key === 'End') {
+            nextIndex = tabs.length - 1;
+        } else {
+            return;
+        }
+        event.preventDefault();
+        activateDiscoverTab(tabs[nextIndex], true);
     }
 
     function showSection(sectionId) {

--- a/tests/test_discover_tabs.py
+++ b/tests/test_discover_tabs.py
@@ -1,0 +1,78 @@
+"""Executable regression for Discover tab selection and keyboard behavior."""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "discover.html"
+
+
+def test_tabs_and_panels_have_complete_relationships():
+    html = TEMPLATE.read_text(encoding="utf-8")
+    for name, panel in (
+        ("trending", "trendingSection"),
+        ("foryou", "foryouSection"),
+        ("agents", "agentsSection"),
+        ("categories", "categoriesGrid"),
+        ("tags", "tagsCloud"),
+    ):
+        assert f'id="discover-tab-{name}"' in html
+        assert f'aria-controls="{panel}"' in html
+        assert f'id="{panel}" role="tabpanel" aria-labelledby="discover-tab-{name}"' in html
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
+def test_click_and_keyboard_paths_keep_exactly_one_selected_tab():
+    html = TEMPLATE.read_text(encoding="utf-8")
+    script = html.split("{% block extra_js %}", 1)[1].split("<script>", 1)[1].split("</script>", 1)[0]
+    harness = f"""
+const calls = [];
+function classList() {{
+  const values = new Set();
+  return {{toggle(name, on) {{ on ? values.add(name) : values.delete(name); }}, contains: name => values.has(name)}};
+}}
+const specs = [
+  ['trending', 'trendingSection'], ['foryou', 'foryouSection'], ['agents', 'agentsSection'],
+  ['categories', 'categoriesGrid'], ['tags', 'tagsCloud']
+];
+const tabs = specs.map(([filter, panel]) => ({{
+  dataset: {{filter, panel}}, attributes: {{}}, classList: classList(), focused: false,
+  setAttribute(name, value) {{ this.attributes[name] = value; }},
+  addEventListener() {{}}, focus() {{ this.focused = true; }}
+}}));
+const panels = Object.fromEntries(specs.map(([, panel]) => [panel, {{style: {{display: ''}}}}]));
+const searchInput = {{addEventListener() {{}}, value: ''}};
+global.document = {{
+  addEventListener() {{}},
+  querySelectorAll: selector => selector === '.filter-tab' ? tabs : [],
+  getElementById: id => id === 'searchInput' ? searchInput : panels[id]
+}};
+eval({json.dumps(script)});
+loadTrending = () => calls.push('trending');
+loadForYou = () => calls.push('foryou');
+loadAgents = () => calls.push('agents');
+showCategories = () => {{ panels.categoriesGrid.style.display = 'block'; calls.push('categories'); }};
+showTags = () => {{ panels.tagsCloud.style.display = 'flex'; calls.push('tags'); }};
+activateDiscoverTab(tabs[1]);
+handleDiscoverTabKeydown({{key: 'End', preventDefault() {{ calls.push('prevented'); }}}}, tabs[1]);
+process.stdout.write(JSON.stringify({{
+  selected: tabs.map(tab => tab.attributes['aria-selected']),
+  tabstops: tabs.map(tab => tab.attributes.tabindex),
+  displays: Object.fromEntries(Object.entries(panels).map(([id, panel]) => [id, panel.style.display])),
+  focused: tabs.map(tab => tab.focused), calls
+}}));
+"""
+    completed = subprocess.run(
+        ["node", "-e", harness], check=True, capture_output=True, text=True, timeout=10
+    )
+    result = json.loads(completed.stdout)
+    assert result["selected"] == ["false", "false", "false", "false", "true"]
+    assert result["tabstops"] == ["-1", "-1", "-1", "-1", "0"]
+    assert result["displays"]["tagsCloud"] == "flex"
+    assert all(value == "none" for key, value in result["displays"].items() if key != "tagsCloud")
+    assert result["focused"] == [False, False, False, False, True]
+    assert result["calls"] == ["foryou", "prevented", "tags"]


### PR DESCRIPTION
## Summary

- give all five Discover filters unique tab-to-panel relationships
- keep active styling, `aria-selected`, and the roving tab stop synchronized
- route Categories and Tags through the same selection state as other filters
- add wrapping Arrow navigation plus Home/End with focused executable coverage

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_discover_tabs.py tests/test_accessibility.py` — 27 passed, 10 subtests passed
- `git diff --check` — clean

Fixes #2095

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d
