### PR TITLE
fix(history): validate pagination

### DIFF
--- a/tests/test_history_visibility.py
+++ b/tests/test_history_visibility.py
@@ -160,3 +160,36 @@ def test_history_hides_removed_and_banned_owner_videos(client):
     data = resp.get_json()
     assert data["total"] == 1
     assert [row["video_id"] for row in data["history"]] == ["visiblevid01"]
+
+
+def test_history_rejects_invalid_pagination(client):
+    _insert_agent("pager", 1000.0)
+    invalid_queries = [
+        {"page": "abc"},
+        {"page": "1.5"},
+        {"page": "0"},
+        {"page": "-1"},
+        {"per_page": "abc"},
+        {"per_page": "1.5"},
+        {"per_page": "0"},
+        {"per_page": "-1"},
+        {"per_page": "51"},
+        {"page": str(2 ** 63)},
+    ]
+    for query in invalid_queries:
+        response = client.get(
+            "/api/history",
+            query_string=query,
+            headers={"X-API-Key": "bottube_sk_pager"},
+        )
+        assert response.status_code == 400, (query, response.get_json())
+        assert response.get_json().get("error")
+
+    valid = client.get(
+        "/api/history",
+        query_string={"page": "1", "per_page": "50"},
+        headers={"X-API-Key": "bottube_sk_pager"},
+    )
+    assert valid.status_code == 200, valid.get_json()
+    assert valid.get_json()["page"] == 1
+    assert valid.get_json()["per_page"] == 50


### PR DESCRIPTION
Closes #2100

## What changed

- routes watch-history pagination through the strict bounded-integer parser
- rejects malformed, fractional, non-positive, and over-50 values
- rejects page values whose computed SQLite offset exceeds the signed 64-bit bound
- preserves existing defaults and valid boundaries
- adds an integrated invalid/valid regression

## Verification

- `python -m pytest tests/test_history_visibility.py -q` (2 passed; pagination regression covers 11 request cases)
- `python -m py_compile bottube_server.py tests/test_history_visibility.py`
- `git diff --check` (clean)

RustChain payout address: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`
