### PR TITLE
Validate terms acceptance payloads

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -20435,9 +20435,15 @@ def agent_accept_terms():
     Required before any write action by agents created after the TOS rollout.
     Existing agents are grandfathered with a 30-day grace period.
     """
-    _ensure_ts_schema()
-    data = request.get_json(silent=True) or {}
-    version = str(data.get("version", "")).strip() or TOS_VERSION
+    data = request.get_json(silent=True) if request.is_json else {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+
+    raw_version = data.get("version")
+    if raw_version is not None and not isinstance(raw_version, str):
+        return jsonify({"error": "version must be a string"}), 400
+
+    version = (raw_version or "").strip() or TOS_VERSION
     if version != TOS_VERSION:
         return jsonify({
             "ok": False,
@@ -20447,6 +20453,7 @@ def agent_accept_terms():
             "terms_url": "https://bottube.ai/terms",
         }), 400
 
+    _ensure_ts_schema()
     agent = g.agent
     ip = _get_client_ip()
     db = get_db()

--- a/tests/test_terms_acceptance_input_validation.py
+++ b/tests/test_terms_acceptance_input_validation.py
@@ -1,0 +1,78 @@
+"""Request-contract regressions for agent terms acceptance."""
+
+from flask import Flask, g
+
+import bottube_server
+
+
+def _client():
+    app = Flask(__name__)
+    app.config.update(TESTING=True, SECRET_KEY="terms-contract-test")
+
+    @app.before_request
+    def _set_agent():
+        g.agent = {"id": 17, "agent_name": "contract-test-agent"}
+
+    app.add_url_rule(
+        "/api/agents/me/accept-terms",
+        "test_agent_accept_terms",
+        bottube_server.agent_accept_terms.__wrapped__,
+        methods=["POST"],
+    )
+    return app.test_client()
+
+
+def test_malformed_terms_bodies_are_rejected_before_mutation(monkeypatch):
+    def unexpected_call(*_args, **_kwargs):
+        raise AssertionError("malformed input reached the terms mutation edge")
+
+    monkeypatch.setattr(bottube_server, "_ensure_ts_schema", unexpected_call)
+    monkeypatch.setattr(bottube_server, "get_db", unexpected_call)
+    monkeypatch.setattr(bottube_server, "_ts_log_audit", unexpected_call)
+    client = _client()
+
+    cases = [
+        (["current"], "Request body must be a JSON object"),
+        ({"version": 3}, "version must be a string"),
+        ({"version": ["current"]}, "version must be a string"),
+    ]
+    for payload, expected_error in cases:
+        response = client.post("/api/agents/me/accept-terms", json=payload)
+        assert response.status_code == 400
+        assert response.get_json() == {"error": expected_error}
+
+    null_response = client.post(
+        "/api/agents/me/accept-terms", data="null", content_type="application/json"
+    )
+    assert null_response.status_code == 400
+    assert null_response.get_json() == {"error": "Request body must be a JSON object"}
+
+
+def test_omitted_version_preserves_current_terms_acceptance(monkeypatch):
+    operations = []
+
+    class FakeDB:
+        def execute(self, sql, params):
+            operations.append(("execute", sql, params))
+            return self
+
+        def commit(self):
+            operations.append(("commit",))
+
+    monkeypatch.setattr(bottube_server, "_ensure_ts_schema", lambda: operations.append(("schema",)))
+    monkeypatch.setattr(bottube_server, "get_db", lambda: FakeDB())
+    monkeypatch.setattr(
+        bottube_server,
+        "_ts_log_audit",
+        lambda *args, **kwargs: operations.append(("audit", args, kwargs)),
+    )
+
+    response = _client().post("/api/agents/me/accept-terms", json={})
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["ok"] is True
+    assert data["agent_name"] == "contract-test-agent"
+    assert data["tos_version_accepted"] == bottube_server.TOS_VERSION
+    assert [entry[0] for entry in operations] == ["schema", "execute", "commit", "audit"]
+    assert operations[1][2][0] == bottube_server.TOS_VERSION


### PR DESCRIPTION
## Summary
- reject non-object terms-acceptance payloads before the mutation path
- reject present non-string `version` values instead of coercing structures
- preserve omitted/blank current-version acceptance and mismatched string behavior

## Verification
- `python -m pytest tests/test_terms_acceptance_input_validation.py -q` (2 passed)
- `python -m py_compile bottube_server.py tests/test_terms_acceptance_input_validation.py`
- `git diff --check`

Fixes #2108