### PR TITLE
Make playlist append position allocation atomic

### DIFF
--- a/tests/test_playlist_visibility.py
+++ b/tests/test_playlist_visibility.py
@@ -3,7 +3,9 @@ import os
 import sqlite3
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier
 
 import pytest
 
@@ -278,3 +280,63 @@ def test_add_playlist_item_rejects_hidden_videos(client):
     assert removed_resp.status_code == 400
     assert banned_resp.status_code == 400
     assert visible_resp.status_code == 201
+
+
+def test_playlist_append_allocates_unique_positions_concurrently(client):
+    owner_id = _insert_agent("concurrent-owner", 2000.0)
+    creator_id = _insert_agent("concurrent-creator", 2001.0)
+    playlist_db_id = _insert_playlist("concurrent-list", owner_id, "Concurrent Mix")
+    video_ids = [f"concurrent{i:02d}" for i in range(8)]
+    for index, video_id in enumerate(video_ids):
+        _insert_video(video_id, creator_id, f"Concurrent {index}", 2010.0 + index)
+
+    start = Barrier(len(video_ids))
+
+    def append(video_id):
+        with bottube_server.app.app_context():
+            db = bottube_server.get_db()
+            start.wait(timeout=5)
+            return bottube_server._append_playlist_item(
+                db,
+                playlist_db_id,
+                video_id,
+            )
+
+    with ThreadPoolExecutor(max_workers=len(video_ids)) as pool:
+        positions = list(pool.map(append, video_ids))
+
+    assert sorted(positions) == list(range(1, len(video_ids) + 1))
+    with bottube_server.app.app_context():
+        rows = bottube_server.get_db().execute(
+            "SELECT position FROM playlist_items WHERE playlist_id = ? ORDER BY position",
+            (playlist_db_id,),
+        ).fetchall()
+    assert [row["position"] for row in rows] == list(range(1, len(video_ids) + 1))
+
+
+def test_playlist_append_duplicate_race_returns_conflict_sentinel(client):
+    owner_id = _insert_agent("duplicate-owner", 3000.0)
+    creator_id = _insert_agent("duplicate-creator", 3001.0)
+    playlist_db_id = _insert_playlist("duplicate-list", owner_id, "Duplicate Mix")
+    _insert_video("duplicate-video", creator_id, "Duplicate", 3002.0)
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        first = bottube_server._append_playlist_item(
+            db,
+            playlist_db_id,
+            "duplicate-video",
+        )
+        duplicate = bottube_server._append_playlist_item(
+            db,
+            playlist_db_id,
+            "duplicate-video",
+        )
+        count = db.execute(
+            "SELECT COUNT(*) FROM playlist_items WHERE playlist_id = ?",
+            (playlist_db_id,),
+        ).fetchone()[0]
+
+    assert first == 1
+    assert duplicate is None
+    assert count == 1


### PR DESCRIPTION
## Summary

- allocate each playlist position inside the same SQLite write statement as the insert
- share the append operation across API and browser routes
- convert a concurrent same-video uniqueness race into the documented 409 conflict
- add an eight-writer regression proving positions remain unique and contiguous

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_playlist_visibility.py tests/test_authenticated_json_object_validation.py` — 8 passed
- `python -m py_compile bottube_server.py tests/test_playlist_visibility.py` — passed
- `git diff --check` — passed

Fixes #2111

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d
