### PR TITLE
Report playlist removal outcomes

### DIFF
--- a/bottube_templates/playlist.html
+++ b/bottube_templates/playlist.html
@@ -187,6 +187,21 @@
         color: var(--red);
     }
 
+    .pl-remove-btn:disabled {
+        cursor: wait;
+        opacity: 0.55;
+    }
+
+    .playlist-action-status {
+        margin-bottom: 10px;
+        color: var(--text-secondary);
+        font-size: 13px;
+    }
+
+    .playlist-action-status[data-error="true"] {
+        color: var(--red);
+    }
+
     @media (max-width: 768px) {
         .playlist-header {
             flex-direction: column;
@@ -231,6 +246,9 @@
 </div>
 
 {% if items %}
+{% if current_user and current_user.id == playlist.agent_id %}
+<div id="playlistActionStatus" class="playlist-action-status" role="status" aria-live="polite" aria-atomic="true" hidden></div>
+{% endif %}
 <ul class="playlist-items">
     {% for item in items %}
     <li class="pl-item" data-video="{{ item.video_id }}">
@@ -252,7 +270,7 @@
         </a>
         {% if current_user and current_user.id == playlist.agent_id %}
         <div class="pl-actions">
-            <button class="pl-remove-btn" onclick="removeItem('{{ item.video_id }}')" title="Remove from playlist" aria-label="Remove {{ item.title }} from playlist">&times;</button>
+            <button class="pl-remove-btn" onclick="removeItem('{{ item.video_id }}', this)" title="Remove from playlist" aria-label="Remove {{ item.title }} from playlist">&times;</button>
         </div>
         {% endif %}
     </li>
@@ -272,22 +290,46 @@
 var prefix = "{{ P }}";
 var plId = "{{ playlist.playlist_id }}";
 
-function removeItem(videoId) {
+function setPlaylistStatus(message, isError) {
+    var status = document.getElementById('playlistActionStatus');
+    if (!status) return;
+    status.hidden = false;
+    status.dataset.error = isError ? 'true' : 'false';
+    status.textContent = message;
+}
+
+function removeItem(videoId, button) {
+    if (button && button.disabled) return;
     if (!confirm("Remove this video from the playlist?")) return;
-    fetch(prefix + "/playlist/" + plId + "/remove", {
+    if (button) button.disabled = true;
+    setPlaylistStatus('Removing video…', false);
+    return fetch(prefix + "/playlist/" + plId + "/remove", {
         method: "POST",
         headers: _csrfHeaders(),
         body: JSON.stringify({video_id: videoId})
     })
-    .then(function(r) { return r.json(); })
-    .then(function(d) {
-        if (d.ok) {
-            var el = document.querySelector('[data-video="' + videoId + '"]');
-            if (el) el.remove();
-            // Re-number
-            document.querySelectorAll('.pl-item .pl-num').forEach(function(n, i) {
-                n.textContent = i + 1;
-            });
+    .then(function(r) {
+        return r.json().catch(function() { return {}; }).then(function(d) {
+            if (!r.ok || !d.ok) {
+                throw new Error(d.error || 'Could not remove this video. Please try again.');
+            }
+            return d;
+        });
+    })
+    .then(function() {
+        var el = document.querySelector('[data-video="' + videoId + '"]');
+        if (el) el.remove();
+        document.querySelectorAll('.pl-item .pl-num').forEach(function(n, i) {
+            n.textContent = i + 1;
+        });
+        setPlaylistStatus('Video removed from playlist.', false);
+    })
+    .catch(function(err) {
+        setPlaylistStatus(err.message || 'Could not remove this video. Please try again.', true);
+    })
+    .finally(function() {
+        if (button) {
+            button.disabled = false;
         }
     });
 }

--- a/tests/test_playlist_remove_feedback.py
+++ b/tests/test_playlist_remove_feedback.py
@@ -1,0 +1,104 @@
+"""Executable regressions for playlist-removal result handling."""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "playlist.html"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
+def test_playlist_removal_gates_mutation_and_reports_results():
+    template = TEMPLATE.read_text(encoding="utf-8")
+    start = template.index("function setPlaylistStatus")
+    end = template.index("</script>", start)
+    script = template[start:end]
+    harness = f"""
+const vm = require('node:vm');
+const status = {{hidden: true, dataset: {{}}, textContent: ''}};
+const item = {{removed: false, remove() {{ this.removed = true; }}}};
+const numbers = [{{textContent: '4'}}, {{textContent: '8'}}];
+let fetchCount = 0;
+let responseOK = true;
+let responsePayload = {{ok: true}};
+const sandbox = {{
+  prefix: '', plId: 'playlist-1',
+  confirm() {{ return true; }},
+  _csrfHeaders() {{ return {{'Content-Type': 'application/json'}}; }},
+  document: {{
+    getElementById(id) {{ return id === 'playlistActionStatus' ? status : null; }},
+    querySelector() {{ return item; }},
+    querySelectorAll() {{ return numbers; }}
+  }},
+  fetch() {{
+    fetchCount += 1;
+    return Promise.resolve({{
+      ok: responseOK,
+      json() {{ return Promise.resolve(responsePayload); }}
+    }});
+  }}
+}};
+vm.createContext(sandbox);
+vm.runInContext({json.dumps(script)}, sandbox);
+
+(async () => {{
+  const failedButton = {{disabled: false}};
+  responseOK = false;
+  responsePayload = {{error: 'Removal was rejected'}};
+  const firstFailure = sandbox.removeItem('video-1', failedButton);
+  sandbox.removeItem('video-1', failedButton);
+  await firstFailure;
+  const failure = {{
+    fetchCount, removed: item.removed, disabled: failedButton.disabled,
+    message: status.textContent, isError: status.dataset.error
+  }};
+
+  const successButton = {{disabled: false}};
+  responseOK = true;
+  responsePayload = {{ok: true}};
+  await sandbox.removeItem('video-1', successButton);
+  const success = {{
+    fetchCount, removed: item.removed, disabled: successButton.disabled,
+    message: status.textContent, isError: status.dataset.error,
+    numbers: numbers.map(n => n.textContent)
+  }};
+  process.stdout.write(JSON.stringify({{failure, success}}));
+}})().catch(err => {{ console.error(err); process.exit(1); }});
+"""
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    result = json.loads(completed.stdout)
+    assert result["failure"] == {
+        "fetchCount": 1,
+        "removed": False,
+        "disabled": False,
+        "message": "Removal was rejected",
+        "isError": "true",
+    }
+    assert result["success"] == {
+        "fetchCount": 2,
+        "removed": True,
+        "disabled": False,
+        "message": "Video removed from playlist.",
+        "isError": "false",
+        "numbers": [1, 2],
+    }
+
+
+def test_playlist_status_is_an_atomic_live_region():
+    template = TEMPLATE.read_text(encoding="utf-8")
+    status_line = next(
+        line for line in template.splitlines() if 'id="playlistActionStatus"' in line
+    )
+    assert 'role="status"' in status_line
+    assert 'aria-live="polite"' in status_line
+    assert 'aria-atomic="true"' in status_line


### PR DESCRIPTION
## Summary
- require both an HTTP-success and JSON-success result before removing a playlist item
- announce success/server/network failures in an atomic live status
- suppress duplicate removals while the selected button is in flight and restore it after failure
- preserve confirmation, successful removal, and renumbering

## Verification
- `python -m pytest tests/test_playlist_remove_feedback.py -q` (2 passed)
- `python -m py_compile tests/test_playlist_remove_feedback.py`
- `git diff --check`

Fixes #2110