### PR TITLE
fix: validate admin media backfill requests

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -20954,21 +20954,102 @@ def _uv_cache_warm():
     return True
 
 
+def _parse_admin_media_batch_request(
+    *,
+    default_limit,
+    max_limit,
+    default_concurrency=None,
+    max_concurrency=None,
+):
+    """Validate the shared request contract for media backfill operators."""
+    data, error = _json_object_body()
+    if error:
+        return None, error
+
+    def positive_int(field, default, maximum):
+        value = data.get(field, default)
+        if isinstance(value, bool) or not isinstance(value, int):
+            return None, (
+                jsonify({"ok": False, "error": f"{field} must be an integer"}),
+                400,
+            )
+        if value < 1 or value > maximum:
+            return None, (
+                jsonify({
+                    "ok": False,
+                    "error": f"{field} must be between 1 and {maximum}",
+                }),
+                400,
+            )
+        return value, None
+
+    limit, error = positive_int("limit", default_limit, max_limit)
+    if error:
+        return None, error
+
+    concurrency = None
+    if default_concurrency is not None:
+        concurrency, error = positive_int(
+            "concurrency", default_concurrency, max_concurrency,
+        )
+        if error:
+            return None, error
+
+    raw_since = data.get("since_video_id", "")
+    if raw_since is None:
+        since = ""
+    elif not isinstance(raw_since, str):
+        return None, (
+            jsonify({
+                "ok": False,
+                "error": "since_video_id must be a string or null",
+            }),
+            400,
+        )
+    else:
+        since = raw_since.strip()
+
+    return {
+        "data": data,
+        "limit": limit,
+        "concurrency": concurrency,
+        "since_video_id": since,
+    }, None
+
+
 @app.route("/admin/visual/backfill", methods=["POST"])
 def admin_visual_backfill():
     """Generate visual embeddings for videos missing them. Resumable."""
     if not _ts_admin_ok():
         return jsonify({"ok": False, "error": "unauthorized"}), 401
+    parsed, error = _parse_admin_media_batch_request(
+        default_limit=10, max_limit=50,
+    )
+    if error:
+        return error
+    data = parsed["data"]
+    limit = parsed["limit"]
+    since = parsed["since_video_id"]
+
+    targeted = data.get("video_ids")
+    if targeted is not None and not isinstance(targeted, list):
+        return jsonify({
+            "ok": False, "error": "video_ids must be an array",
+        }), 400
+    if targeted and any(
+        not isinstance(value, str)
+        or not re.fullmatch(r"[A-Za-z0-9_-]{5,32}", value)
+        for value in targeted
+    ):
+        return jsonify({
+            "ok": False,
+            "error": "video_ids must contain only valid video IDs",
+        }), 400
+
     _uv_ensure_schema()
-    data = request.get_json(silent=True) or {}
-    try:
-        limit = max(1, min(50, int(data.get("limit", 10))))
-    except Exception:
-        limit = 10
-    since = (data.get("since_video_id") or "").strip()
 
     db = get_db()
-    targeted = data.get("video_ids") or []
+    targeted = targeted or []
     if isinstance(targeted, list) and targeted:
         # Targeted mode: explicit video_ids to (re)embed. Useful for seeding
         # specific anchors or refreshing after a sprite changes.
@@ -21447,17 +21528,19 @@ def admin_embeddings_backfill():
     """Backfill embeddings for videos missing one. Resumable, batched."""
     if not _ts_admin_ok():
         return jsonify({"ok": False, "error": "unauthorized"}), 401
+    parsed, error = _parse_admin_media_batch_request(
+        default_limit=50,
+        max_limit=200,
+        default_concurrency=2,
+        max_concurrency=8,
+    )
+    if error:
+        return error
+    limit = parsed["limit"]
+    since = parsed["since_video_id"]
+    concurrency = parsed["concurrency"]
+
     _ue_ensure_schema()
-    data = request.get_json(silent=True) or {}
-    try:
-        limit = max(1, min(200, int(data.get("limit", 50))))
-    except Exception:
-        limit = 50
-    since = (data.get("since_video_id") or "").strip()
-    try:
-        concurrency = max(1, min(8, int(data.get("concurrency", 2))))
-    except Exception:
-        concurrency = 2
 
     db = get_db()
     if since:
@@ -22743,19 +22826,21 @@ def admin_renditions_backfill():
     """
     if not _ts_admin_ok():
         return jsonify({"ok": False, "error": "unauthorized"}), 401
+    parsed, error = _parse_admin_media_batch_request(
+        default_limit=20,
+        max_limit=100,
+        default_concurrency=2,
+        max_concurrency=4,
+    )
+    if error:
+        return error
+    limit = parsed["limit"]
+    concurrency = parsed["concurrency"]
+    since = parsed["since_video_id"]
+
     if not _renditions_ffmpeg_available():
         return jsonify({"ok": False, "error": "ffmpeg-vmaf not installed"}), 503
     _ensure_provenance_schema()
-    data = request.get_json(silent=True) or {}
-    try:
-        limit = max(1, min(100, int(data.get("limit", 20))))
-    except Exception:
-        limit = 20
-    try:
-        concurrency = max(1, min(4, int(data.get("concurrency", 2))))
-    except Exception:
-        concurrency = 2
-    since = (data.get("since_video_id") or "").strip()
 
     db = get_db()
     if since:

--- a/tests/test_admin_media_backfill_contract.py
+++ b/tests/test_admin_media_backfill_contract.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+"""Bounded request contracts for admin media backfill operators."""
+
+import sys
+
+import pytest
+
+
+ROUTES = (
+    "/admin/visual/backfill",
+    "/admin/embeddings/backfill",
+    "/admin/renditions/backfill",
+)
+
+
+@pytest.fixture
+def no_effects_before_validation(monkeypatch):
+    server = sys.modules["bottube_server"]
+    monkeypatch.setattr(server, "_ts_admin_ok", lambda: True)
+
+    def unexpected_effect():
+        raise AssertionError("backfill effect ran before request validation")
+
+    monkeypatch.setattr(server, "_uv_ensure_schema", unexpected_effect)
+    monkeypatch.setattr(server, "_ue_ensure_schema", unexpected_effect)
+    monkeypatch.setattr(server, "_ensure_provenance_schema", unexpected_effect)
+    monkeypatch.setattr(server, "_renditions_ffmpeg_available", unexpected_effect)
+
+
+def test_backfills_reject_non_object_json_before_effects(
+    client, no_effects_before_validation,
+):
+    for route in ROUTES:
+        for payload in ([], True, "batch"):
+            response = client.post(route, json=payload)
+
+            assert response.status_code == 400
+            assert "object" in response.get_json()["error"]
+
+
+def test_backfills_reject_invalid_fields_before_effects(
+    client, no_effects_before_validation,
+):
+    cases = (
+        ("/admin/visual/backfill", {"limit": "10"}),
+        ("/admin/visual/backfill", {"limit": 0}),
+        ("/admin/visual/backfill", {"limit": 51}),
+        ("/admin/visual/backfill", {"since_video_id": 7}),
+        ("/admin/visual/backfill", {"video_ids": "video_1"}),
+        ("/admin/visual/backfill", {"video_ids": ["bad id"]}),
+        ("/admin/embeddings/backfill", {"limit": 201}),
+        ("/admin/embeddings/backfill", {"concurrency": True}),
+        ("/admin/embeddings/backfill", {"concurrency": 9}),
+        ("/admin/renditions/backfill", {"limit": 101}),
+        ("/admin/renditions/backfill", {"concurrency": 0}),
+        ("/admin/renditions/backfill", {"since_video_id": []}),
+    )
+    for route, payload in cases:
+        response = client.post(route, json=payload)
+
+        assert response.status_code == 400
+        assert response.get_json()["error"]
+
+
+def test_shared_parser_preserves_defaults_and_valid_boundaries(app):
+    cases = (
+        ({}, (20, 2, "")),
+        (
+            {"limit": 1, "concurrency": 1, "since_video_id": None},
+            (1, 1, ""),
+        ),
+        (
+            {"limit": 100, "concurrency": 4, "since_video_id": " video_7 "},
+            (100, 4, "video_7"),
+        ),
+    )
+    server = sys.modules["bottube_server"]
+    for payload, expected in cases:
+        with app.test_request_context(json=payload):
+            parsed, error = server._parse_admin_media_batch_request(
+                default_limit=20,
+                max_limit=100,
+                default_concurrency=2,
+                max_concurrency=4,
+            )
+
+        assert error is None
+        assert (
+            parsed["limit"],
+            parsed["concurrency"],
+            parsed["since_video_id"],
+        ) == expected


### PR DESCRIPTION
## Summary

- add one strict JSON-object request contract shared by all three admin media backfill operators
- reject booleans, strings, out-of-range batch limits/concurrency, malformed cursors, and invalid targeted video IDs before schema, database, or ffmpeg effects
- preserve documented defaults and valid boundary values while replacing silent coercion/clamping with actionable 400 responses

## Verification

- `python -m pytest tests/test_admin_media_backfill_contract.py -q --disable-warnings --maxfail=1` (3 passed; 24 contract cases)
- `python -m py_compile bottube_server.py tests/test_admin_media_backfill_contract.py`
- `git diff --check`

Closes #2112
