### PR TITLE
Validate anchor detail chain responses

### DIFF
--- a/bottube_templates/anchor_detail.html
+++ b/bottube_templates/anchor_detail.html
@@ -94,7 +94,7 @@
   <div class="ad-meta" id="chain-panel" style="background:rgba(74,210,122,0.06);border-color:rgba(74,210,122,0.4);">
     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
       <strong style="color:#4ad27a;">On-chain data (live)</strong>
-      <span id="chain-status" style="font-size:11px;color:var(--text-secondary);">fetching…</span>
+      <span id="chain-status" role="status" aria-live="polite" aria-atomic="true" style="font-size:11px;color:var(--text-secondary);">fetching…</span>
     </div>
     <div id="chain-rows" style="display:none;">
       <div class="row"><span class="key">R4 (raw)</span><span class="val" id="chain-r4-raw">—</span></div>
@@ -112,16 +112,31 @@
       var tx = "{{ batch.tx_hash }}";
       var claimedRoot = "{{ batch.manifest_hash }}";
       fetch("{{ P }}/api/anchors/" + tx + "/chain", { credentials: "omit" })
-        .then(function (r) { return r.json(); })
-        .then(function (j) {
+        .then(function (r) {
+          return r.json().catch(function () { return null; }).then(function (j) {
+            return { httpOK: r.ok, status: r.status, body: j };
+          });
+        })
+        .then(function (result) {
           var status = document.getElementById("chain-status");
           var rows = document.getElementById("chain-rows");
+          var j = result.body;
+          if (!result.httpOK) {
+            status.textContent = "chain request failed (" + result.status + ")";
+            status.style.color = "#e26060";
+            return;
+          }
           if (!j || !j.ok) {
             status.textContent = "chain unreachable: " + ((j && j.error) || "unknown");
             status.style.color = "#e26060";
             return;
           }
-          var match = j.r4_merkle_root && j.r4_merkle_root === claimedRoot;
+          if (typeof j.r4_merkle_root !== "string" || !j.r4_merkle_root.trim()) {
+            status.textContent = "chain response incomplete";
+            status.style.color = "#e26060";
+            return;
+          }
+          var match = j.r4_merkle_root === claimedRoot;
           status.textContent = match ? "✓ root matches bottube's claim" : "✗ MISMATCH";
           status.style.color = match ? "#4ad27a" : "#e26060";
           rows.style.display = "block";
@@ -130,10 +145,11 @@
           var matchEl = document.getElementById("chain-match");
           matchEl.textContent = match ? "matches byte-for-byte ✓" : "DIFFERS — investigate ✗";
           matchEl.style.color = match ? "#4ad27a" : "#e26060";
-          document.getElementById("chain-confs").textContent = j.num_confirmations;
+          document.getElementById("chain-confs").textContent = Number.isFinite(Number(j.num_confirmations)) ? j.num_confirmations : "—";
           document.getElementById("chain-incl").textContent = j.inclusion_height || "pending";
-          document.getElementById("chain-value").textContent = (j.anchor_value_nanoerg / 1e9).toFixed(6) + " ERG";
-          document.getElementById("chain-tree").textContent = (j.ergo_tree_short || "—") + "…";
+          var anchorValue = Number(j.anchor_value_nanoerg);
+          document.getElementById("chain-value").textContent = Number.isFinite(anchorValue) ? (anchorValue / 1e9).toFixed(6) + " ERG" : "—";
+          document.getElementById("chain-tree").textContent = j.ergo_tree_short ? j.ergo_tree_short + "…" : "—";
         })
         .catch(function (e) {
           var status = document.getElementById("chain-status");

--- a/tests/test_anchor_detail_chain_contract.py
+++ b/tests/test_anchor_detail_chain_contract.py
@@ -1,0 +1,96 @@
+"""Executable regressions for anchor-detail chain response handling."""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "anchor_detail.html"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
+def test_anchor_verdict_requires_http_success_and_complete_root():
+    template = TEMPLATE.read_text(encoding="utf-8")
+    start = template.index("(function () {")
+    end = template.index("</script>", start)
+    script = template[start:end].replace("{{ batch.manifest_hash }}", "root-abc")
+    harness = f"""
+const vm = require('node:vm');
+const source = {json.dumps(script)};
+
+async function run(httpOK, httpStatus, payload) {{
+  const ids = ['chain-status', 'chain-rows', 'chain-r4-raw', 'chain-r4-merkle',
+    'chain-match', 'chain-confs', 'chain-incl', 'chain-value', 'chain-tree'];
+  const elements = Object.fromEntries(ids.map(id => [id, {{textContent: '', style: {{display: id === 'chain-rows' ? 'none' : ''}}}}]));
+  const sandbox = {{
+    document: {{getElementById(id) {{ return elements[id]; }}}},
+    fetch() {{
+      return Promise.resolve({{
+        ok: httpOK, status: httpStatus,
+        json() {{ return Promise.resolve(payload); }}
+      }});
+    }}
+  }};
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setImmediate(resolve));
+  return {{
+    status: elements['chain-status'].textContent,
+    rows: elements['chain-rows'].style.display,
+    confirmations: elements['chain-confs'].textContent,
+    value: elements['chain-value'].textContent,
+    tree: elements['chain-tree'].textContent
+  }};
+}}
+
+(async () => {{
+  const incomplete = await run(true, 200, {{ok: true}});
+  const failed = await run(false, 503, {{ok: true, r4_merkle_root: 'root-abc'}});
+  const complete = await run(true, 200, {{
+    ok: true,
+    r4_merkle_root: 'root-abc',
+    num_confirmations: 7,
+    anchor_value_nanoerg: 1250000000
+  }});
+  process.stdout.write(JSON.stringify({{incomplete, failed, complete}}));
+}})().catch(err => {{ console.error(err); process.exit(1); }});
+"""
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
+    )
+    result = json.loads(completed.stdout)
+    assert result["incomplete"] == {
+        "status": "chain response incomplete",
+        "rows": "none",
+        "confirmations": "",
+        "value": "",
+        "tree": "",
+    }
+    assert result["failed"]["status"] == "chain request failed (503)"
+    assert result["failed"]["rows"] == "none"
+    assert result["complete"] == {
+        "status": "✓ root matches bottube's claim",
+        "rows": "block",
+        "confirmations": 7,
+        "value": "1.250000 ERG",
+        "tree": "—",
+    }
+
+
+def test_chain_verdict_is_an_atomic_live_status():
+    template = TEMPLATE.read_text(encoding="utf-8")
+    status_line = next(
+        line for line in template.splitlines() if 'id="chain-status"' in line
+    )
+    assert 'role="status"' in status_line
+    assert 'aria-live="polite"' in status_line
+    assert 'aria-atomic="true"' in status_line


### PR DESCRIPTION
## Summary
- require a successful chain HTTP response before rendering an anchor verdict
- refuse to label incomplete payloads as a root mismatch
- render optional on-chain values defensively and announce the verdict through an atomic live status

## Tests
- `python -m pytest tests/test_anchor_detail_chain_contract.py -q`
- `git diff --check`

Fixes #2115