### PR TITLE
Report channel subscription outcomes

### DIFF
--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2535,10 +2535,13 @@
                 </div>
                 <div class="channel-row-right">
                     {% if current_user and current_user.agent_name != video.agent_name %}
-                    <button id="watch-sub-btn" aria-label="Subscribe to {{ channel_display_name }}" class="watch-sub-btn {{ 'following' if is_following else 'not-following' }}"
-                            onclick="toggleWatchSubscribe()">
+                    <button id="watch-sub-btn" aria-label="{{ 'Unfollow ' + channel_display_name if is_following else 'Subscribe to ' + channel_display_name }}"
+                            aria-describedby="watch-sub-status" aria-pressed="{{ 'true' if is_following else 'false' }}"
+                            class="watch-sub-btn {{ 'following' if is_following else 'not-following' }}" onclick="toggleWatchSubscribe()">
                         {{ 'Following' if is_following else 'Subscribe' }}
                     </button>
+                    <span id="watch-sub-status" role="status" aria-live="polite" aria-atomic="true"
+                          style="display:block;max-width:220px;margin-top:6px;font-size:12px;color:var(--text-muted);"></span>
                     {% elif not current_user %}
                     <a href="{{ P }}/login" aria-label="Subscribe to {{ channel_display_name }}" class="watch-sub-btn not-following">Subscribe</a>
                     {% endif %}
@@ -3447,24 +3450,43 @@ function buildCommentElement(opts) {
 
 function toggleWatchSubscribe() {
     var btn = document.getElementById("watch-sub-btn");
+    var status = document.getElementById("watch-sub-status");
+    if (!btn || btn.disabled) return Promise.resolve();
     btn.disabled = true;
-    fetch(prefix + "/api/agents/" + uploaderAgent + "/web-subscribe", {
+    status.textContent = "Updating subscription…";
+    status.style.color = "var(--text-muted)";
+    return fetch(prefix + "/api/agents/" + uploaderAgent + "/web-subscribe", {
         method: "POST",
         headers: _csrfHeaders()
     })
-    .then(function(r) { return r.json(); })
-    .then(function(d) {
-        if (d.ok) {
+    .then(function(r) {
+        return r.json().catch(function() { return null; }).then(function(d) {
+            return { httpOK: r.ok, httpStatus: r.status, body: d };
+        });
+    })
+    .then(function(result) {
+        var d = result.body;
+        if (result.httpOK && d && d.ok && typeof d.following === "boolean") {
             btn.textContent = d.following ? "Following" : "Subscribe";
             btn.className = "watch-sub-btn " + (d.following ? "following" : "not-following");
+            btn.setAttribute("aria-pressed", d.following ? "true" : "false");
+            btn.setAttribute("aria-label", d.following ? "Unfollow this channel" : "Subscribe to this channel");
             var sc = document.getElementById("watch-sub-count");
-            if (sc) sc.textContent = d.subscriber_count;
-        } else if (d.login_required) {
+            if (sc && Number.isFinite(Number(d.subscriber_count))) sc.textContent = d.subscriber_count;
+            status.textContent = d.following ? "Subscription confirmed." : "Subscription removed.";
+            status.style.color = "var(--text-muted)";
+        } else if (d && d.login_required) {
             window.location.href = prefix + "/login";
+        } else {
+            status.textContent = (d && d.error) || ("Subscription failed (" + result.httpStatus + ").");
+            status.style.color = "var(--danger, #e26060)";
         }
-        btn.disabled = false;
     })
-    .catch(function() { btn.disabled = false; });
+    .catch(function() {
+        status.textContent = "Subscription failed. Check your connection and try again.";
+        status.style.color = "var(--danger, #e26060)";
+    })
+    .finally(function() { btn.disabled = false; });
 }
 
 function postComment() {

--- a/tests/test_subscribe_result_contract.py
+++ b/tests/test_subscribe_result_contract.py
@@ -1,0 +1,130 @@
+"""Executable regressions for channel/watch subscribe result handling."""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHANNEL = ROOT / "bottube_templates" / "channel.html"
+WATCH = ROOT / "bottube_templates" / "watch.html"
+
+
+def _function_source(path, name, next_name=None):
+    template = path.read_text(encoding="utf-8")
+    start = template.index(f"function {name}()")
+    if next_name:
+        end = template.index(f"function {next_name}()", start)
+    else:
+        end = template.index("</script>", start)
+    return template[start:end]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
+@pytest.mark.parametrize(
+    ("path", "function_name", "next_name", "button_id", "status_id", "count_id"),
+    [
+        (CHANNEL, "toggleSubscribe", None, "subscribe-btn", "subscribe-status", "sub-count"),
+        (WATCH, "toggleWatchSubscribe", "postComment", "watch-sub-btn", "watch-sub-status", "watch-sub-count"),
+    ],
+)
+def test_subscribe_handlers_preserve_state_and_report_every_outcome(
+    path, function_name, next_name, button_id, status_id, count_id
+):
+    source = _function_source(path, function_name, next_name)
+    harness = f"""
+const vm = require('node:vm');
+const source = {json.dumps(source)};
+
+async function run(mode) {{
+  const attrs = {{}};
+  const elements = {{
+    {json.dumps(button_id)}: {{
+      disabled: false, textContent: 'Subscribe', className: 'not-following',
+      setAttribute(name, value) {{ attrs[name] = value; }}
+    }},
+    {json.dumps(status_id)}: {{textContent: '', style: {{color: ''}}}},
+    {json.dumps(count_id)}: {{textContent: '10'}}
+  }};
+  const sandbox = {{
+    document: {{getElementById(id) {{ return elements[id] || null; }}}},
+    window: {{location: {{href: ''}}}},
+    prefix: '', agentName: 'creator', uploaderAgent: 'creator',
+    _csrfHeaders() {{ return {{'Content-Type': 'application/json'}}; }},
+    fetch() {{
+      if (mode === 'network') return Promise.reject(new Error('offline'));
+      if (mode === 'nonjson') return Promise.resolve({{
+        ok: false, status: 502, json() {{ return Promise.reject(new Error('not json')); }}
+      }});
+      if (mode === 'api') return Promise.resolve({{
+        ok: false, status: 409, json() {{ return Promise.resolve({{ok: false, error: 'Already changed'}}); }}
+      }});
+      return Promise.resolve({{
+        ok: true, status: 200,
+        json() {{ return Promise.resolve({{ok: true, following: true, subscriber_count: 11}}); }}
+      }});
+    }}
+  }};
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+  await sandbox[{json.dumps(function_name)}]();
+  const button = elements[{json.dumps(button_id)}];
+  return {{
+    text: button.textContent, className: button.className, disabled: button.disabled,
+    count: elements[{json.dumps(count_id)}].textContent,
+    status: elements[{json.dumps(status_id)}].textContent,
+    pressed: attrs['aria-pressed'], label: attrs['aria-label']
+  }};
+}}
+
+(async () => {{
+  const success = await run('success');
+  const api = await run('api');
+  const nonjson = await run('nonjson');
+  const network = await run('network');
+  process.stdout.write(JSON.stringify({{success, api, nonjson, network}}));
+}})().catch(err => {{ console.error(err); process.exit(1); }});
+"""
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
+    )
+    result = json.loads(completed.stdout)
+
+    assert result["success"] == {
+        "text": "Following",
+        "className": "subscribe-btn following" if path == CHANNEL else "watch-sub-btn following",
+        "disabled": False,
+        "count": 11,
+        "status": "Subscription confirmed.",
+        "pressed": "true",
+        "label": "Unfollow this channel",
+    }
+    for outcome in ("api", "nonjson", "network"):
+        assert result[outcome]["text"] == "Subscribe"
+        assert result[outcome]["className"] == "not-following"
+        assert result[outcome]["disabled"] is False
+        assert result[outcome]["count"] == "10"
+        assert "pressed" not in result[outcome]
+        assert "label" not in result[outcome]
+    assert result["api"]["status"] == "Already changed"
+    assert result["nonjson"]["status"] == "Subscription failed (502)."
+    assert result["network"]["status"] == "Subscription failed. Check your connection and try again."
+
+
+def test_subscribe_results_are_atomic_live_statuses():
+    for path, status_id in ((CHANNEL, "subscribe-status"), (WATCH, "watch-sub-status")):
+        template = path.read_text(encoding="utf-8")
+        status_line = next(
+            line for line in template.splitlines() if f'id="{status_id}"' in line
+        )
+        assert 'role="status"' in status_line
+        assert 'aria-live="polite"' in status_line
+        assert 'aria-atomic="true"' in status_line


### PR DESCRIPTION
## Summary
- gate channel and watch subscription state changes on both HTTP and JSON success
- preserve the confirmed UI state and expose API, HTTP, and network failures
- announce subscription outcomes through atomic live statuses and keep pressed/label state synchronized
- prevent duplicate requests while a subscription update is in flight

## Tests
- `python -m pytest tests/test_subscribe_result_contract.py -q` (3 passed)
- `python -m py_compile tests/test_subscribe_result_contract.py`
- `git diff --check`

Fixes #2120