### PR TITLE
Bound Studio job polling failures

### DIFF
--- a/bottube_templates/studio.html
+++ b/bottube_templates/studio.html
@@ -124,7 +124,7 @@
     <button class="gen" id="i2v-btn" onclick="stGenerate('i2v')">Animate Image · <span class="btnc-i2v">5</span> RTC</button>
   </div>
 
-  <div class="st-status" id="st-status"></div>
+  <div class="st-status" id="st-status" role="status" aria-live="polite" aria-atomic="true"></div>
   <div class="st-result" id="st-result"></div>
 
   <div class="st-foot">
@@ -256,12 +256,54 @@
 
   function poll(url) {
     var tries = 0;
+    var consecutiveFailures = 0;
+    var pollInFlight = false;
+    var finished = false;
+    var maxFailures = 3;
+
+    function finish(message) {
+      if (finished) return;
+      finished = true;
+      clearInterval(iv);
+      setBusy(false);
+      if (message) say(message);
+    }
+
+    function recordFailure(detail) {
+      if (finished) return;
+      consecutiveFailures++;
+      if (consecutiveFailures >= maxFailures) {
+        finish("Job status is unavailable after " + maxFailures + " attempts. Your generation may still be running; check your channel before starting another charge.");
+        return;
+      }
+      say("Job status temporarily unavailable (" + detail + "; retry " + consecutiveFailures + "/" + maxFailures + ").");
+    }
+
     var iv = setInterval(function(){
+      if (finished || pollInFlight) return Promise.resolve();
+      if (tries >= 120) {
+        finish("Still working — check your channel shortly.");
+        return Promise.resolve();
+      }
       tries++;
-      fetch(url, { credentials: "same-origin" }).then(function(r){ return r.json(); }).then(function(d){
+      pollInFlight = true;
+      return fetch(url, { credentials: "same-origin" }).then(function(r){
+        return r.json().catch(function(){ return null; }).then(function(d){
+          return { httpOK: r.ok, status: r.status, body: d };
+        });
+      }).then(function(result){
+        if (!result.httpOK) {
+          recordFailure("HTTP " + result.status);
+          return;
+        }
+        var d = result.body;
+        if (!d || typeof d !== "object" || Array.isArray(d)) {
+          recordFailure("invalid response");
+          return;
+        }
+        consecutiveFailures = 0;
         if (d.model_url) {
-          clearInterval(iv); setBusy(false);
-          say("🧊 Done! Charged successfully.");
+          finish("🧊 Done! Charged successfully.");
           resultEl.innerHTML =
             '<model-viewer src="' + d.model_url + '" camera-controls auto-rotate ' +
             'style="width:100%;height:360px;background:#111;border-radius:8px;" ' +
@@ -269,17 +311,18 @@
             '<div style="margin-top:8px"><a href="' + d.model_url + '" download>Download GLB →</a>' +
             ((d.formats && d.formats.length) ? ' · formats: ' + d.formats.join(", ") : "") + '</div>';
         } else if (d.status === "completed" || d.video_id) {
-          clearInterval(iv); setBusy(false);
           var watch = d.watch_url || (d.video_id ? ("/watch/" + d.video_id) : null);
-          say(watch ? ("🎬 Done! <a href='" + watch + "'>Watch your video →</a>") : "🎬 Done — check your channel.");
+          finish(watch ? ("🎬 Done! <a href='" + watch + "'>Watch your video →</a>") : "🎬 Done — check your channel.");
         } else if (d.status === "failed" || d.error) {
-          clearInterval(iv); setBusy(false);
-          say("Generation failed: " + (d.error || "unknown") + ". (RTC for failed jobs is refunded.)");
+          finish("Generation failed: " + (d.error || "unknown") + ". (RTC for failed jobs is refunded.)");
         } else {
           say("Generating… (" + (d.status || "working") + ")");
         }
-      }).catch(function(){ /* keep polling */ });
-      if (tries > 120) { clearInterval(iv); setBusy(false); say("Still working — check your channel shortly."); }
+      }).catch(function(){
+        recordFailure("network error");
+      }).finally(function(){
+        pollInFlight = false;
+      });
     }, 3000);
   }
 })();

--- a/tests/test_studio_poll_contract.py
+++ b/tests/test_studio_poll_contract.py
@@ -1,0 +1,129 @@
+"""Executable regressions for Studio asynchronous job polling."""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "studio.html"
+
+
+def _poll_source():
+    template = TEMPLATE.read_text(encoding="utf-8")
+    start = template.index("function poll(url)")
+    marker = "\n  }\n})();"
+    end = template.index(marker, start) + len("\n  }")
+    return template[start:end]
+
+
+def _run_node(payload):
+    source = _poll_source()
+    harness = f"""
+const vm = require('node:vm');
+const outcomes = {json.dumps(payload)};
+const messages = [];
+const busy = [];
+let cleared = false;
+
+const sandbox = {{
+  resultEl: {{innerHTML: ''}},
+  say(message) {{ messages.push(message); }},
+  setBusy(value) {{ busy.push(value); }},
+  setInterval(callback) {{ sandbox._tick = callback; return 42; }},
+  clearInterval(id) {{ if (id !== 42) throw new Error('wrong interval'); cleared = true; }},
+  fetch() {{
+    const outcome = outcomes.shift();
+    if (!outcome) throw new Error('unexpected poll');
+    if (outcome.kind === 'network') return Promise.reject(new Error('offline'));
+    return Promise.resolve({{
+      ok: outcome.ok,
+      status: outcome.status,
+      json() {{
+        if (outcome.kind === 'nonjson') return Promise.reject(new Error('not json'));
+        return Promise.resolve(outcome.body);
+      }}
+    }});
+  }}
+}};
+vm.createContext(sandbox);
+vm.runInContext({json.dumps(source)}, sandbox);
+sandbox.poll('/jobs/one');
+
+(async () => {{
+  const snapshots = [];
+  while (outcomes.length) {{
+    await sandbox._tick();
+    snapshots.push({{
+      message: messages[messages.length - 1] || '',
+      cleared,
+      busy: busy.slice(),
+      result: sandbox.resultEl.innerHTML
+    }});
+  }}
+  process.stdout.write(JSON.stringify({{snapshots, messages, busy, cleared}}));
+}})().catch(err => {{ console.error(err); process.exit(1); }});
+"""
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
+    )
+    return json.loads(completed.stdout)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
+def test_poll_recovers_then_stops_after_three_new_consecutive_failures():
+    result = _run_node(
+        [
+            {"kind": "nonjson", "ok": False, "status": 503},
+            {"kind": "json", "ok": True, "status": 200, "body": {"status": "queued"}},
+            {"kind": "network"},
+            {"kind": "json", "ok": True, "status": 200, "body": []},
+            {"kind": "json", "ok": False, "status": 502, "body": {"error": "gateway"}},
+        ]
+    )
+    snapshots = result["snapshots"]
+    assert snapshots[0]["message"] == "Job status temporarily unavailable (HTTP 503; retry 1/3)."
+    assert snapshots[0]["cleared"] is False
+    assert snapshots[1]["message"] == "Generating… (queued)"
+    assert snapshots[2]["message"] == "Job status temporarily unavailable (network error; retry 1/3)."
+    assert snapshots[3]["message"] == "Job status temporarily unavailable (invalid response; retry 2/3)."
+    assert snapshots[4]["message"] == (
+        "Job status is unavailable after 3 attempts. Your generation may still be running; "
+        "check your channel before starting another charge."
+    )
+    assert snapshots[4]["cleared"] is True
+    assert snapshots[4]["busy"] == [False]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
+def test_poll_finishes_a_valid_completed_video_response():
+    result = _run_node(
+        [
+            {
+                "kind": "json",
+                "ok": True,
+                "status": 200,
+                "body": {"status": "completed", "video_id": "vid123"},
+            }
+        ]
+    )
+    assert result["cleared"] is True
+    assert result["busy"] == [False]
+    assert result["messages"] == ["🎬 Done! <a href='/watch/vid123'>Watch your video →</a>"]
+
+
+def test_studio_status_is_an_atomic_live_region():
+    template = TEMPLATE.read_text(encoding="utf-8")
+    status_line = next(
+        line for line in template.splitlines() if 'id="st-status"' in line
+    )
+    assert 'role="status"' in status_line
+    assert 'aria-live="polite"' in status_line
+    assert 'aria-atomic="true"' in status_line


### PR DESCRIPTION
## Summary
- reject failed HTTP and malformed/non-object Studio job responses instead of treating them as healthy progress
- expose bounded transient retry state and stop after three consecutive failures
- reset the failure budget after a valid job response and suppress overlapping poll requests
- restore generation controls on terminal, timeout, and retry-exhaustion outcomes
- announce Studio job status through an atomic live region

## Tests
- `python -m pytest tests/test_studio_poll_contract.py -q` (3 passed)
- `python -m py_compile tests/test_studio_poll_contract.py`
- `git diff --check`

Fixes #2125