### PR TITLE
fix(comments): align public visibility filters

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7707,7 +7707,7 @@ def describe_video(video_id):
     comments = db.execute(
         """SELECT c.content, c.comment_type, a.agent_name, c.created_at
            FROM comments c JOIN agents a ON c.agent_id = a.id
-           WHERE c.video_id = ?
+           WHERE c.video_id = ? AND COALESCE(a.is_banned, 0) = 0
            ORDER BY c.created_at ASC LIMIT 50""",
         (video_id,),
     ).fetchall()
@@ -8045,7 +8045,7 @@ def get_comments(video_id):
     rows = db.execute(
         """SELECT c.*, a.agent_name, a.display_name, a.avatar_url, a.id as agent_internal_id, a.is_human
            FROM comments c JOIN agents a ON c.agent_id = a.id
-           WHERE c.video_id = ?
+           WHERE c.video_id = ? AND COALESCE(a.is_banned, 0) = 0
            ORDER BY c.created_at ASC""",
         (video_id,),
     ).fetchall()
@@ -8119,9 +8119,16 @@ def recent_comments():
 
     db = get_db()
     rows = db.execute(
-        """SELECT c.*, a.agent_name, a.display_name, a.avatar_url
-           FROM comments c JOIN agents a ON c.agent_id = a.id
+        """SELECT c.*, commenter.agent_name, commenter.display_name,
+                  commenter.avatar_url
+           FROM comments c
+           JOIN agents commenter ON c.agent_id = commenter.id
+           JOIN videos v ON c.video_id = v.video_id
+           JOIN agents owner ON v.agent_id = owner.id
            WHERE c.created_at > ?
+             AND COALESCE(commenter.is_banned, 0) = 0
+             AND COALESCE(v.is_removed, 0) = 0
+             AND COALESCE(owner.is_banned, 0) = 0
            ORDER BY c.created_at DESC LIMIT ?""",
         (since, limit),
     ).fetchall()
@@ -12789,7 +12796,7 @@ def watch(video_id):
     comments_rows = db.execute(
         """SELECT c.*, a.agent_name, a.display_name, a.avatar_url, a.is_human
            FROM comments c JOIN agents a ON c.agent_id = a.id
-           WHERE c.video_id = ?
+           WHERE c.video_id = ? AND COALESCE(a.is_banned, 0) = 0
            ORDER BY c.created_at ASC""",
         (video_id,),
     ).fetchall()

--- a/tests/test_public_interaction_visibility.py
+++ b/tests/test_public_interaction_visibility.py
@@ -94,15 +94,19 @@ def _insert_video(
         db.commit()
 
 
-def _insert_comment(video_id: str, agent_id: int) -> None:
+def _insert_comment(
+    video_id: str,
+    agent_id: int,
+    content: str = "interaction fixture comment",
+) -> None:
     with bottube_server.app.app_context():
         db = bottube_server.get_db()
         db.execute(
             """
             INSERT INTO comments (video_id, agent_id, content, created_at)
-            VALUES (?, ?, 'interaction fixture comment', ?)
+            VALUES (?, ?, ?, ?)
             """,
-            (video_id, agent_id, time.time()),
+            (video_id, agent_id, content, time.time()),
         )
         db.commit()
 
@@ -228,3 +232,53 @@ def test_social_graph_excludes_banned_agents_and_removed_video_edges(client):
     ]
     connected_names = {row["agent_name"] for row in data["most_connected"]}
     assert connected_names <= {"alice", "bob"}
+
+
+def test_public_comment_surfaces_hide_banned_and_non_public_content(
+    client,
+    monkeypatch,
+):
+    owner = _insert_agent("owner")
+    banned_owner = _insert_agent("banned-owner", is_banned=1)
+    visible_commenter = _insert_agent("visible-commenter")
+    banned_commenter = _insert_agent("banned-commenter", is_banned=1)
+
+    _insert_video("public-video", owner)
+    _insert_video("removed-video", owner, is_removed=1)
+    _insert_video("banned-owner-video", banned_owner)
+
+    _insert_comment("public-video", visible_commenter, "VISIBLE COMMENT")
+    _insert_comment("public-video", banned_commenter, "BANNED COMMENTER COMMENT")
+    _insert_comment("removed-video", visible_commenter, "REMOVED VIDEO COMMENT")
+    _insert_comment("banned-owner-video", visible_commenter, "BANNED OWNER COMMENT")
+
+    comments_response = client.get("/api/videos/public-video/comments")
+    assert comments_response.status_code == 200
+    assert [row["content"] for row in comments_response.get_json()["comments"]] == [
+        "VISIBLE COMMENT"
+    ]
+
+    describe_response = client.get("/api/videos/public-video/describe")
+    assert describe_response.status_code == 200
+    assert [row["text"] for row in describe_response.get_json()["comments"]] == [
+        "VISIBLE COMMENT"
+    ]
+
+    recent_response = client.get("/api/comments/recent?since=0")
+    assert recent_response.status_code == 200
+    assert [row["content"] for row in recent_response.get_json()["comments"]] == [
+        "VISIBLE COMMENT"
+    ]
+
+    monkeypatch.setattr(
+        bottube_server,
+        "render_template",
+        lambda _template, **context: "|".join(
+            comment["content"] for comment in context.get("comments", [])
+        ),
+    )
+    watch_response = client.get("/watch/public-video")
+    assert watch_response.status_code == 200
+    watch_html = watch_response.get_data(as_text=True)
+    assert "VISIBLE COMMENT" in watch_html
+    assert "BANNED COMMENTER COMMENT" not in watch_html


### PR DESCRIPTION
Closes #2126.

## What changed

- Public per-video comments and text descriptions now omit comments authored by banned agents.
- The recent-comments feed now joins the referenced video and its owner so removed videos, banned owners, and banned commenters cannot leak through the feed.
- The watch-page query applies the same banned-commenter rule.
- Added an end-to-end visibility regression spanning all four public read surfaces.

## Proof

Mutation baseline (visibility predicates removed): the regression failed because `BANNED COMMENTER COMMENT` was returned by the public comments API.

Fixed verification:

- `python -m pytest tests/test_public_interaction_visibility.py -q` — 4 passed
- `python -m pytest tests/test_agent_interaction_visibility.py::TestComputeAgentInteractionContext tests/test_agent_interaction_visibility.py::TestGetCommentsAPI tests/test_recent_comments_query_validation.py tests/test_public_video_visibility.py -q` — 24 passed
- `python -m py_compile bottube_server.py tests/test_public_interaction_visibility.py`
- `git diff --check`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d
