### PR TITLE
Make webhook delivery-window accounting atomic

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -4120,6 +4120,55 @@ def _canonical_webhook_event(event: str) -> str:
     return mapping.get(event, event)
 
 
+def _reserve_webhook_delivery_slot(
+    conn: sqlite3.Connection,
+    webhook_id: int,
+    now: float,
+    limit: int = 100,
+    window_seconds: int = 3600,
+) -> bool:
+    """Atomically reserve one delivery slot in a webhook's rate window.
+
+    Webhook events are dispatched by independent worker threads.  Serializing
+    the read/rollover/increment operation with ``BEGIN IMMEDIATE`` keeps two
+    workers from observing and then writing the same counter value.  A slot is
+    consumed before network I/O so an unavailable receiver cannot bypass the
+    outbound delivery cap by repeatedly failing requests.
+    """
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            """SELECT event_window_start, event_count
+               FROM webhooks
+               WHERE id = ? AND active = 1""",
+            (webhook_id,),
+        ).fetchone()
+        if not row:
+            conn.commit()
+            return False
+
+        window_start = float(row[0] or 0)
+        event_count = int(row[1] or 0)
+        if now - window_start >= window_seconds:
+            window_start = now
+            event_count = 0
+        if event_count >= limit:
+            conn.commit()
+            return False
+
+        conn.execute(
+            """UPDATE webhooks
+               SET event_window_start = ?, event_count = ?
+               WHERE id = ? AND active = 1""",
+            (window_start, event_count + 1, webhook_id),
+        )
+        conn.commit()
+        return True
+    except sqlite3.Error:
+        conn.rollback()
+        return False
+
+
 def fire_webhooks(agent_id: int, event: str, payload: dict):
     """Send webhook POST to all active hooks for this agent/event. Non-blocking.
 
@@ -4155,13 +4204,10 @@ def fire_webhooks(agent_id: int, event: str, payload: dict):
             if "*" not in allowed and canonical_event not in allowed and event not in allowed:
                 continue
 
-            # rate limit window (100 events/hour per webhook)
-            window_start = float(hook["event_window_start"] or 0)
-            event_count = int(hook["event_count"] or 0)
-            if now - window_start >= 3600:
-                window_start = now
-                event_count = 0
-            if event_count >= 100:
+            # Reserve capacity before network I/O. Each delivery runs in its own
+            # thread, so a separate read followed by an absolute counter write
+            # would allow concurrent workers to reuse the same slot.
+            if not _reserve_webhook_delivery_slot(conn, hook["id"], now):
                 continue
 
             body = json.dumps(envelope, separators=(",", ":")).encode()
@@ -4192,10 +4238,9 @@ def fire_webhooks(agent_id: int, event: str, payload: dict):
             if ok:
                 conn.execute(
                     """UPDATE webhooks
-                       SET last_triggered = ?, fail_count = 0,
-                           event_window_start = ?, event_count = ?
+                       SET last_triggered = ?, fail_count = 0
                        WHERE id = ?""",
-                    (now, window_start, event_count + 1, hook["id"]),
+                    (now, hook["id"]),
                 )
             else:
                 conn.execute(

--- a/tests/test_webhook_delivery_slots.py
+++ b/tests/test_webhook_delivery_slots.py
@@ -1,0 +1,88 @@
+"""Concurrency regressions for webhook delivery-window accounting."""
+
+import sqlite3
+import threading
+
+import bottube_server
+
+
+def _create_webhook_db(path, *, count=0, window_start=0.0):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """CREATE TABLE webhooks (
+               id INTEGER PRIMARY KEY,
+               active INTEGER NOT NULL,
+               event_window_start REAL DEFAULT 0,
+               event_count INTEGER DEFAULT 0
+           )"""
+    )
+    conn.execute(
+        "INSERT INTO webhooks (id, active, event_window_start, event_count) VALUES (1, 1, ?, ?)",
+        (window_start, count),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _reserve_concurrently(path, workers, *, now, limit=100):
+    barrier = threading.Barrier(workers)
+    results = []
+    results_lock = threading.Lock()
+
+    def reserve():
+        conn = sqlite3.connect(path, timeout=15)
+        barrier.wait()
+        result = bottube_server._reserve_webhook_delivery_slot(
+            conn, 1, now, limit=limit
+        )
+        conn.close()
+        with results_lock:
+            results.append(result)
+
+    threads = [threading.Thread(target=reserve) for _ in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=20)
+        assert not thread.is_alive()
+    return results
+
+
+def _window_state(path):
+    conn = sqlite3.connect(path)
+    state = conn.execute(
+        "SELECT event_window_start, event_count FROM webhooks WHERE id = 1"
+    ).fetchone()
+    conn.close()
+    return state
+
+
+def test_concurrent_workers_reserve_distinct_delivery_slots(tmp_path):
+    db_path = tmp_path / "webhooks.db"
+    _create_webhook_db(db_path, count=12, window_start=900.0)
+
+    results = _reserve_concurrently(db_path, 16, now=1000.0)
+
+    assert results == [True] * 16
+    assert _window_state(db_path) == (900.0, 28)
+
+
+def test_concurrent_workers_stop_exactly_at_window_limit(tmp_path):
+    db_path = tmp_path / "webhooks.db"
+    _create_webhook_db(db_path, count=97, window_start=900.0)
+
+    results = _reserve_concurrently(db_path, 8, now=1000.0)
+
+    assert results.count(True) == 3
+    assert results.count(False) == 5
+    assert _window_state(db_path) == (900.0, 100)
+
+
+def test_expired_window_rolls_over_once_under_concurrency(tmp_path):
+    db_path = tmp_path / "webhooks.db"
+    _create_webhook_db(db_path, count=100, window_start=100.0)
+
+    results = _reserve_concurrently(db_path, 12, now=4000.0)
+
+    assert results == [True] * 12
+    assert _window_state(db_path) == (4000.0, 12)


### PR DESCRIPTION
## Summary
- atomically reserve each webhook delivery slot before network I/O
- serialize window rollover, capacity checks, and increments across delivery workers
- stop full windows exactly at 100 attempts and preserve truthful accounting during receiver failures
- add focused multi-connection concurrency regressions

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_webhook_delivery_slots.py tests/test_authenticated_json_object_validation.py` — 5 passed
- `python -m py_compile bottube_server.py tests/test_webhook_delivery_slots.py` — passed
- `git diff --check` — clean

Fixes #2132

Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`