### PR TITLE
Make duplicate subscribe requests atomically idempotent

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -10740,6 +10740,22 @@ def update_profile():
 # Subscriptions / Follow
 # ---------------------------------------------------------------------------
 
+def _insert_subscription_once(
+    db: sqlite3.Connection,
+    follower_id: int,
+    following_id: int,
+    created_at: float,
+) -> bool:
+    """Create a subscription atomically, returning whether this call won."""
+    cursor = db.execute(
+        """INSERT OR IGNORE INTO subscriptions
+           (follower_id, following_id, created_at)
+           VALUES (?, ?, ?)""",
+        (follower_id, following_id, created_at),
+    )
+    return cursor.rowcount == 1
+
+
 @app.route("/api/agents/<agent_name>/subscribe", methods=["POST"])
 @require_api_key
 def subscribe_agent(agent_name):
@@ -10754,17 +10770,12 @@ def subscribe_agent(agent_name):
     if target["id"] == g.agent["id"]:
         return jsonify({"error": "Cannot follow yourself"}), 400
 
-    existing = db.execute(
-        "SELECT 1 FROM subscriptions WHERE follower_id = ? AND following_id = ?",
-        (g.agent["id"], target["id"]),
-    ).fetchone()
-    if existing:
+    created = _insert_subscription_once(
+        db, g.agent["id"], target["id"], time.time()
+    )
+    if not created:
         return jsonify({"ok": True, "following": True, "message": "Already following"})
 
-    db.execute(
-        "INSERT INTO subscriptions (follower_id, following_id, created_at) VALUES (?, ?, ?)",
-        (g.agent["id"], target["id"], time.time()),
-    )
     notify(db, target["id"], "subscribe",
            f'@{g.agent["agent_name"]} subscribed to you',
            from_agent=g.agent["agent_name"])

--- a/tests/test_subscription_concurrency.py
+++ b/tests/test_subscription_concurrency.py
@@ -1,0 +1,73 @@
+"""Concurrency regressions for API subscription creation."""
+
+import sqlite3
+import threading
+
+import bottube_server
+
+
+def _create_subscription_db(path):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """CREATE TABLE subscriptions (
+               follower_id INTEGER NOT NULL,
+               following_id INTEGER NOT NULL,
+               created_at REAL NOT NULL,
+               PRIMARY KEY (follower_id, following_id)
+           )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_concurrent_duplicate_subscribes_have_one_creator(tmp_path):
+    db_path = tmp_path / "subscriptions.db"
+    _create_subscription_db(db_path)
+    barrier = threading.Barrier(12)
+    results = []
+    results_lock = threading.Lock()
+
+    def subscribe(worker_id):
+        conn = sqlite3.connect(db_path, timeout=15)
+        barrier.wait()
+        created = bottube_server._insert_subscription_once(
+            conn, follower_id=7, following_id=9, created_at=1000.0 + worker_id
+        )
+        conn.commit()
+        conn.close()
+        with results_lock:
+            results.append(created)
+
+    threads = [threading.Thread(target=subscribe, args=(i,)) for i in range(12)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=20)
+        assert not thread.is_alive()
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT follower_id, following_id FROM subscriptions"
+    ).fetchall()
+    conn.close()
+
+    assert results.count(True) == 1
+    assert results.count(False) == 11
+    assert rows == [(7, 9)]
+
+
+def test_existing_subscription_is_an_idempotent_non_creation(tmp_path):
+    db_path = tmp_path / "subscriptions.db"
+    _create_subscription_db(db_path)
+    conn = sqlite3.connect(db_path)
+
+    assert bottube_server._insert_subscription_once(conn, 7, 9, 1000.0) is True
+    conn.commit()
+    assert bottube_server._insert_subscription_once(conn, 7, 9, 2000.0) is False
+    conn.commit()
+
+    created_at = conn.execute(
+        "SELECT created_at FROM subscriptions WHERE follower_id = 7 AND following_id = 9"
+    ).fetchone()[0]
+    conn.close()
+    assert created_at == 1000.0


### PR DESCRIPTION
## Summary
- replace the subscribe route's check-then-insert race with one conflict-tolerant insert
- detect the single request that created the relationship from SQLite's statement result
- emit notification and first-follow quest effects only for that creator
- return the existing successful `Already following` contract to every concurrent loser
- add focused multi-connection concurrency and idempotency regressions

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_subscription_concurrency.py tests/test_subscription_visibility.py` — 7 passed
- `python -m py_compile bottube_server.py tests/test_subscription_concurrency.py` — passed
- `git diff --check` — clean

Fixes #2136

Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`