### PR TITLE
Serialize view cooldown admission across concurrent requests

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7611,6 +7611,45 @@ def stream_video(video_id):
     return resp
 
 
+def _record_view_event_once(
+    db: sqlite3.Connection,
+    video_id: str,
+    agent_id: Optional[int],
+    ip_address: str,
+    now: float,
+    cooldown_seconds: int = 1800,
+) -> Tuple[Optional[int], int]:
+    """Atomically admit one view per video/IP cooldown window.
+
+    The caller owns the transaction after this function returns so reward and
+    milestone effects can commit with the admitted event. ``view_id`` is
+    ``None`` when an existing event won the cooldown race.
+    """
+    db.execute("BEGIN IMMEDIATE")
+    recent = db.execute(
+        """SELECT 1 FROM views
+           WHERE video_id = ? AND ip_address = ? AND created_at > ?
+           LIMIT 1""",
+        (video_id, ip_address, now - cooldown_seconds),
+    ).fetchone()
+    if recent:
+        current = db.execute(
+            "SELECT views FROM videos WHERE video_id = ?", (video_id,)
+        ).fetchone()
+        return None, int(current[0] or 0) if current else 0
+
+    cursor = db.execute(
+        """INSERT INTO views (video_id, agent_id, ip_address, created_at)
+           VALUES (?, ?, ?, ?)""",
+        (video_id, agent_id, ip_address, now),
+    )
+    db.execute("UPDATE videos SET views = views + 1 WHERE video_id = ?", (video_id,))
+    current = db.execute(
+        "SELECT views FROM videos WHERE video_id = ?", (video_id,)
+    ).fetchone()
+    return int(cursor.lastrowid), int(current[0] or 0) if current else 0
+
+
 @app.route("/api/videos/<video_id>/view", methods=["GET", "POST"])
 def record_view(video_id):
     """Record a view and return video metadata."""
@@ -7635,23 +7674,16 @@ def record_view(video_id):
 
     ip = _get_client_ip()
     VIEW_COOLDOWN = 1800  # 30 minutes
-    recent = db.execute(
-        "SELECT 1 FROM views WHERE video_id = ? AND ip_address = ? AND created_at > ?",
-        (video_id, ip, time.time() - VIEW_COOLDOWN),
-    ).fetchone()
-    if not recent:
-        cur = db.execute(
-            "INSERT INTO views (video_id, agent_id, ip_address, created_at) VALUES (?, ?, ?, ?)",
-            (video_id, agent_id, ip, time.time()),
-        )
-        db.execute("UPDATE videos SET views = views + 1 WHERE video_id = ?", (video_id,))
-        new_views = (row["views"] or 0) + 1
+    view_id, new_views = _record_view_event_once(
+        db, video_id, agent_id, ip, time.time(), VIEW_COOLDOWN
+    )
+    if view_id is not None:
         reward_result = _view_reward_decision(
             db,
             owner_id=int(row["agent_id"]),
             viewer_id=agent_id,
             video_id=video_id,
-            view_event_ref=str(int(cur.lastrowid or 0) or f"{video_id}:{int(time.time())}"),
+            view_event_ref=str(view_id),
             ip_address=ip or "",
         )
         # Check BAN milestones (100 views, 1000 views)
@@ -7664,10 +7696,9 @@ def record_view(video_id):
                    ON CONFLICT(agent_id, video_id) DO UPDATE SET watched_at = excluded.watched_at""",
                 (agent_id, video_id, time.time()),
             )
-        db.commit()
     else:
         reward_result = {"awarded": False, "held": False, "risk_score": 0, "reasons": ["deduplicated recent view"]}
-        new_views = row["views"] or 0
+    db.commit()
 
     # CTR: Record click (video opened/watched)
     try:
@@ -12760,20 +12791,13 @@ def watch(video_id):
     # Record view (deduplicated: 1 view per IP per video per 30 min)
     ip = _get_client_ip()
     VIEW_COOLDOWN = 1800  # 30 minutes
-    recent = db.execute(
-        "SELECT 1 FROM views WHERE video_id = ? AND ip_address = ? AND created_at > ?",
-        (video_id, ip, time.time() - VIEW_COOLDOWN),
-    ).fetchone()
-    if not recent:
-        db.execute(
-            "INSERT INTO views (video_id, ip_address, created_at) VALUES (?, ?, ?)",
-            (video_id, ip, time.time()),
-        )
-        db.execute("UPDATE videos SET views = views + 1 WHERE video_id = ?", (video_id,))
-        new_views = (video["views"] or 0) + 1
+    view_id, new_views = _record_view_event_once(
+        db, video_id, None, ip, time.time(), VIEW_COOLDOWN
+    )
+    if view_id is not None:
         # Check BAN milestones (100 views, 1000 views)
         check_view_milestones(db, video["agent_id"], video_id, new_views)
-        db.commit()
+    db.commit()
 
     # Record watch history for logged-in users
     if g.user:

--- a/tests/test_view_cooldown_concurrency.py
+++ b/tests/test_view_cooldown_concurrency.py
@@ -1,0 +1,90 @@
+"""Concurrency regressions for view cooldown admission."""
+
+import sqlite3
+import threading
+
+import bottube_server
+
+
+def _create_view_db(path):
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE videos (
+            video_id TEXT PRIMARY KEY,
+            views INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE views (
+            id INTEGER PRIMARY KEY,
+            video_id TEXT NOT NULL,
+            agent_id INTEGER,
+            ip_address TEXT,
+            created_at REAL NOT NULL
+        );
+        INSERT INTO videos (video_id, views) VALUES ('video-1', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_concurrent_same_ip_views_admit_one_event(tmp_path):
+    db_path = tmp_path / "views.db"
+    _create_view_db(db_path)
+    barrier = threading.Barrier(12)
+    results = []
+    results_lock = threading.Lock()
+
+    def record(worker_id):
+        conn = sqlite3.connect(db_path, timeout=15)
+        barrier.wait()
+        result = bottube_server._record_view_event_once(
+            conn,
+            video_id="video-1",
+            agent_id=worker_id,
+            ip_address="203.0.113.8",
+            now=1000.0,
+        )
+        conn.commit()
+        conn.close()
+        with results_lock:
+            results.append(result)
+
+    threads = [threading.Thread(target=record, args=(i,)) for i in range(12)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=20)
+        assert not thread.is_alive()
+
+    conn = sqlite3.connect(db_path)
+    event_count = conn.execute("SELECT COUNT(*) FROM views").fetchone()[0]
+    stored_views = conn.execute(
+        "SELECT views FROM videos WHERE video_id = 'video-1'"
+    ).fetchone()[0]
+    conn.close()
+
+    assert sum(view_id is not None for view_id, _ in results) == 1
+    assert {count for _, count in results} == {1}
+    assert event_count == 1
+    assert stored_views == 1
+
+
+def test_view_is_admitted_after_cooldown_expires(tmp_path):
+    db_path = tmp_path / "views.db"
+    _create_view_db(db_path)
+    conn = sqlite3.connect(db_path)
+
+    first_id, first_count = bottube_server._record_view_event_once(
+        conn, "video-1", 1, "203.0.113.8", now=1000.0
+    )
+    conn.commit()
+    second_id, second_count = bottube_server._record_view_event_once(
+        conn, "video-1", 1, "203.0.113.8", now=2801.0
+    )
+    conn.commit()
+    conn.close()
+
+    assert first_id is not None
+    assert second_id is not None
+    assert (first_count, second_count) == (1, 2)


### PR DESCRIPTION
## Summary
- serialize cooldown lookup, view-event insertion, and video counter mutation with a short SQLite write transaction
- share the atomic admission helper across API view recording and HTML watch rendering
- keep API reward/milestone work inside the winning transaction
- return the committed counter to every concurrent caller
- add focused multi-connection cooldown and expiry regressions

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_view_cooldown_concurrency.py tests/test_view_dedupe_count.py` — 3 passed
- `python -m py_compile bottube_server.py tests/test_view_cooldown_concurrency.py` — passed
- `git diff --check` — clean

Fixes #2139

Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`