### PR TITLE
Make duplicate comment creation atomic

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7752,6 +7752,39 @@ def describe_video(video_id):
 # Comments
 # ---------------------------------------------------------------------------
 
+def _insert_comment_once(
+    db: sqlite3.Connection,
+    video_id: str,
+    agent_id: int,
+    parent_id: Optional[int],
+    content: str,
+    comment_type: str,
+    created_at: float,
+) -> Tuple[bool, int]:
+    """Atomically create a comment unless identical content already exists.
+
+    The caller owns the write transaction after this function returns so the
+    winning request can commit rewards and notifications with the new row.
+    """
+    db.execute("BEGIN IMMEDIATE")
+    existing = db.execute(
+        """SELECT id FROM comments
+           WHERE video_id = ? AND agent_id = ? AND content = ?
+           LIMIT 1""",
+        (video_id, agent_id, content),
+    ).fetchone()
+    if existing:
+        return False, int(existing[0])
+
+    cursor = db.execute(
+        """INSERT INTO comments
+           (video_id, agent_id, parent_id, content, comment_type, created_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (video_id, agent_id, parent_id, content, comment_type, created_at),
+    )
+    return True, int(cursor.lastrowid)
+
+
 @app.route("/api/videos/<video_id>/comment", methods=["POST"])
 @require_api_key
 def add_comment(video_id):
@@ -7794,24 +7827,24 @@ def add_comment(video_id):
         if not parent:
             return jsonify({"error": "Parent comment not found"}), 404
 
-    # Duplicate check: reject if same agent posted identical content on this video
-    existing = db.execute(
-        "SELECT id FROM comments WHERE video_id = ? AND agent_id = ? AND content = ?",
-        (video_id, g.agent["id"], content),
-    ).fetchone()
-    if existing:
-        return jsonify({"error": "Duplicate comment", "existing_id": existing["id"]}), 409
-
-    cur = db.execute(
-        """INSERT INTO comments (video_id, agent_id, parent_id, content, comment_type, created_at)
-           VALUES (?, ?, ?, ?, ?, ?)""",
-        (video_id, g.agent["id"], parent_id, content, comment_type, time.time()),
+    created, comment_id = _insert_comment_once(
+        db,
+        video_id,
+        g.agent["id"],
+        parent_id,
+        content,
+        comment_type,
+        time.time(),
     )
+    if not created:
+        db.commit()
+        return jsonify({"error": "Duplicate comment", "existing_id": comment_id}), 409
+
     reward_result = _comment_reward_decision(
         db,
         agent_id=g.agent["id"],
         video_id=video_id,
-        comment_id=int(cur.lastrowid),
+        comment_id=comment_id,
         content=content,
     )
     # Notify video owner
@@ -7835,7 +7868,7 @@ def add_comment(video_id):
 
     return jsonify({
         "ok": True,
-        "comment_id": int(cur.lastrowid),
+        "comment_id": comment_id,
         "reward": {
             "awarded": bool(reward_result["awarded"]),
             "held": bool(reward_result["held"]),
@@ -7903,14 +7936,6 @@ def web_add_comment(video_id):
     if len(content) > 5000:
         return jsonify({"error": "Comment too long (max 5000 chars)"}), 400
 
-    # Duplicate check: reject if same user posted identical content on this video
-    existing = db.execute(
-        "SELECT id FROM comments WHERE video_id = ? AND agent_id = ? AND content = ?",
-        (video_id, g.user["id"], content),
-    ).fetchone()
-    if existing:
-        return jsonify({"error": "Duplicate comment"}), 409
-
     parent_id, parent_error = _parse_optional_comment_parent_id(data.get("parent_id"))
     if parent_error:
         return jsonify({"error": parent_error}), 400
@@ -7921,11 +7946,19 @@ def web_add_comment(video_id):
         if not parent:
             return jsonify({"error": "Parent comment not found"}), 404
 
-    db.execute(
-        """INSERT INTO comments (video_id, agent_id, parent_id, content, comment_type, created_at)
-           VALUES (?, ?, ?, ?, ?, ?)""",
-        (video_id, g.user["id"], parent_id, content, comment_type, time.time()),
+    created, comment_id = _insert_comment_once(
+        db,
+        video_id,
+        g.user["id"],
+        parent_id,
+        content,
+        comment_type,
+        time.time(),
     )
+    if not created:
+        db.commit()
+        return jsonify({"error": "Duplicate comment", "existing_id": comment_id}), 409
+
     # Notify video owner
     video_row = db.execute("SELECT agent_id FROM videos WHERE video_id = ?", (video_id,)).fetchone()
     if video_row:
@@ -7954,6 +7987,7 @@ def web_add_comment(video_id):
         "comment_type": comment_type,
         "video_id": video_id,
         "parent_id": parent_id,
+        "comment_id": comment_id,
     }), 201
 
 

--- a/tests/test_comment_creation_concurrency.py
+++ b/tests/test_comment_creation_concurrency.py
@@ -1,0 +1,86 @@
+"""Concurrency regressions for duplicate comment creation."""
+
+import sqlite3
+import threading
+
+import bottube_server
+
+
+def _create_comment_db(path):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """CREATE TABLE comments (
+               id INTEGER PRIMARY KEY,
+               video_id TEXT NOT NULL,
+               agent_id INTEGER NOT NULL,
+               parent_id INTEGER,
+               content TEXT NOT NULL,
+               comment_type TEXT NOT NULL,
+               created_at REAL NOT NULL
+           )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_concurrent_identical_comments_have_one_creator(tmp_path):
+    db_path = tmp_path / "comments.db"
+    _create_comment_db(db_path)
+    barrier = threading.Barrier(12)
+    results = []
+    results_lock = threading.Lock()
+
+    def comment(worker_id):
+        conn = sqlite3.connect(db_path, timeout=15)
+        barrier.wait()
+        result = bottube_server._insert_comment_once(
+            conn,
+            video_id="video-1",
+            agent_id=7,
+            parent_id=None,
+            content="One useful comment",
+            comment_type="comment",
+            created_at=1000.0 + worker_id,
+        )
+        conn.commit()
+        conn.close()
+        with results_lock:
+            results.append(result)
+
+    threads = [threading.Thread(target=comment, args=(i,)) for i in range(12)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=20)
+        assert not thread.is_alive()
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT id, video_id, agent_id, content FROM comments"
+    ).fetchall()
+    conn.close()
+
+    assert sum(created for created, _ in results) == 1
+    assert len({comment_id for _, comment_id in results}) == 1
+    assert len(rows) == 1
+    assert rows[0][1:] == ("video-1", 7, "One useful comment")
+
+
+def test_same_content_is_allowed_for_a_different_author(tmp_path):
+    db_path = tmp_path / "comments.db"
+    _create_comment_db(db_path)
+    conn = sqlite3.connect(db_path)
+
+    first = bottube_server._insert_comment_once(
+        conn, "video-1", 7, None, "Shared thought", "comment", 1000.0
+    )
+    conn.commit()
+    second = bottube_server._insert_comment_once(
+        conn, "video-1", 8, None, "Shared thought", "comment", 1001.0
+    )
+    conn.commit()
+    conn.close()
+
+    assert first[0] is True
+    assert second[0] is True
+    assert first[1] != second[1]


### PR DESCRIPTION
## Summary
- serialize duplicate lookup and comment insertion with a short SQLite write transaction
- share the atomic creator across API and web comment paths
- preserve reward, quest, and notification work for the single winning request
- return the existing comment ID to every concurrent duplicate
- add focused multi-connection concurrency and author-scope regressions

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_comment_creation_concurrency.py tests/test_quests.py -k "comment or concurrency"` — 8 passed
- `python -m py_compile bottube_server.py tests/test_comment_creation_concurrency.py` — passed
- `git diff --check` — clean

Fixes #2142

Native RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`