### PR TITLE
Enforce webhook registration quota atomically

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -11449,6 +11449,40 @@ def web_remove_from_playlist(playlist_id):
 WEBHOOK_EVENTS = ["video.uploaded", "video.voted", "comment.created", "agent.created", "comment", "like", "subscribe", "new_video", "mention", "*"]
 
 
+def _insert_webhook_with_quota(
+    db: sqlite3.Connection,
+    agent_id: int,
+    url: str,
+    secret: str,
+    events: str,
+    created_at: float,
+    *,
+    limit: int = 5,
+) -> bool:
+    """Atomically admit one webhook without exceeding an agent's quota."""
+    started_transaction = not db.in_transaction
+    if started_transaction:
+        db.execute("BEGIN IMMEDIATE")
+    try:
+        count = db.execute(
+            "SELECT COUNT(*) FROM webhooks WHERE agent_id = ?", (agent_id,)
+        ).fetchone()[0]
+        if count >= limit:
+            if started_transaction:
+                db.rollback()
+            return False
+        db.execute(
+            "INSERT INTO webhooks (agent_id, url, secret, events, active, created_at) "
+            "VALUES (?,?,?,?,1,?)",
+            (agent_id, url, secret, events, created_at),
+        )
+        return True
+    except Exception:
+        if started_transaction:
+            db.rollback()
+        raise
+
+
 @app.route("/api/webhooks", methods=["GET"])
 @require_api_key
 def list_webhooks():
@@ -11480,11 +11514,6 @@ def create_webhook():
     """Register a new webhook endpoint."""
     db = get_db()
 
-    # Limit to 5 webhooks per agent
-    count = db.execute("SELECT COUNT(*) FROM webhooks WHERE agent_id = ?", (g.agent["id"],)).fetchone()[0]
-    if count >= 5:
-        return jsonify({"error": "Maximum 5 webhooks per agent"}), 400
-
     data, error = _json_object_body()
     if error:
         return error
@@ -11503,10 +11532,10 @@ def create_webhook():
 
     wh_secret = secrets.token_hex(32)
     now = time.time()
-    db.execute(
-        "INSERT INTO webhooks (agent_id, url, secret, events, active, created_at) VALUES (?,?,?,?,1,?)",
-        (g.agent["id"], url, wh_secret, events, now),
-    )
+    if not _insert_webhook_with_quota(
+        db, g.agent["id"], url, wh_secret, events, now
+    ):
+        return jsonify({"error": "Maximum 5 webhooks per agent"}), 400
     db.commit()
 
     return jsonify({

--- a/tests/test_webhook_quota_concurrency.py
+++ b/tests/test_webhook_quota_concurrency.py
@@ -1,0 +1,105 @@
+"""Concurrency regressions for webhook quota admission."""
+
+import sqlite3
+import threading
+
+import bottube_server
+
+
+def _create_webhook_db(path):
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE webhooks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id INTEGER NOT NULL,
+            url TEXT NOT NULL,
+            secret TEXT NOT NULL,
+            events TEXT NOT NULL,
+            active INTEGER DEFAULT 1,
+            created_at REAL NOT NULL
+        );
+        INSERT INTO webhooks (agent_id, url, secret, events, active, created_at)
+        VALUES
+            (7, 'https://one.example/hook', 'one', '*', 1, 1),
+            (7, 'https://two.example/hook', 'two', '*', 1, 2),
+            (7, 'https://three.example/hook', 'three', '*', 1, 3),
+            (7, 'https://four.example/hook', 'four', '*', 1, 4);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _connect(path):
+    return sqlite3.connect(path, timeout=15)
+
+
+def test_concurrent_webhook_registration_never_exceeds_quota(tmp_path):
+    db_path = tmp_path / "webhooks.db"
+    _create_webhook_db(db_path)
+    barrier = threading.Barrier(10)
+    results = []
+    errors = []
+    result_lock = threading.Lock()
+
+    def register(index):
+        conn = _connect(db_path)
+        barrier.wait()
+        try:
+            admitted = bottube_server._insert_webhook_with_quota(
+                conn,
+                7,
+                f"https://worker-{index}.example/hook",
+                f"secret-{index}",
+                "*",
+                10 + index,
+            )
+            if admitted:
+                conn.commit()
+            with result_lock:
+                results.append(admitted)
+        except Exception as exc:  # surfaced below with every worker result
+            conn.rollback()
+            with result_lock:
+                errors.append(exc)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=register, args=(index,)) for index in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=20)
+        assert not thread.is_alive()
+
+    conn = _connect(db_path)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM webhooks WHERE agent_id = 7"
+    ).fetchone()[0]
+    conn.close()
+
+    assert errors == []
+    assert results.count(True) == 1
+    assert results.count(False) == 9
+    assert count == 5
+
+
+def test_quota_helper_reuses_caller_owned_transaction(tmp_path):
+    db_path = tmp_path / "webhooks.db"
+    _create_webhook_db(db_path)
+    conn = _connect(db_path)
+    conn.execute("BEGIN IMMEDIATE")
+
+    admitted = bottube_server._insert_webhook_with_quota(
+        conn, 7, "https://five.example/hook", "five", "*", 5
+    )
+
+    assert admitted is True
+    assert conn.in_transaction is True
+    conn.commit()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM webhooks WHERE agent_id = 7"
+    ).fetchone()[0]
+    conn.close()
+    assert count == 5


### PR DESCRIPTION
## Summary
- move the per-agent webhook quota check into one write-serialized admission owner
- keep request/event validation outside the database write-lock window
- preserve caller-owned transaction semantics and roll back helper-owned rejected/error paths
- prove ten concurrent registrations for one remaining slot admit exactly one row

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_webhook_quota_concurrency.py` (2 passed)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_authenticated_json_object_validation.py` (2 passed)
- `python -m py_compile bottube_server.py tests/test_webhook_quota_concurrency.py`
- `git diff --check`

Fixes #2150

RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`