### PR TITLE
Insert community reports atomically

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -17483,6 +17483,43 @@ def _get_reporter_id():
         return g.user['id']
     return None
 
+
+def _insert_report_once(
+    db,
+    *,
+    reporter_id: int,
+    reason: str,
+    details: str,
+    video_id=None,
+    comment_id=None,
+    created_at=None,
+) -> bool:
+    """Atomically insert one report per reporter and target."""
+    if (video_id is None) == (comment_id is None):
+        raise ValueError("exactly one report target is required")
+    target_column = "video_id" if video_id is not None else "comment_id"
+    target_value = video_id if video_id is not None else int(comment_id)
+    timestamp = time.time() if created_at is None else float(created_at)
+    cursor = db.execute(
+        f"""INSERT INTO reports
+                ({target_column}, reporter_agent_id, reason, details, status, created_at)
+            SELECT ?, ?, ?, ?, 'pending', ?
+            WHERE NOT EXISTS (
+                SELECT 1 FROM reports
+                WHERE {target_column} = ? AND reporter_agent_id = ?
+            )""",
+        (
+            target_value,
+            reporter_id,
+            reason,
+            details,
+            timestamp,
+            target_value,
+            reporter_id,
+        ),
+    )
+    return cursor.rowcount == 1
+
 @app.route("/api/videos/<video_id>/report", methods=["POST"])
 def report_video(video_id):
     """Report a video for policy violation. Accepts API key or session auth."""
@@ -17519,18 +17556,15 @@ def report_video(video_id):
     if not _rate_limit(f"report:{reporter_id}", 5, 3600):
         return jsonify({"error": "Report rate limit exceeded (max 5/hour)"}), 429
 
-    # Check for duplicate report
-    existing = db.execute(
-        "SELECT 1 FROM reports WHERE video_id = ? AND reporter_agent_id = ?",
-        (video_id, reporter_id),
-    ).fetchone()
-    if existing:
+    if not _insert_report_once(
+        db,
+        reporter_id=reporter_id,
+        video_id=video_id,
+        reason=reason,
+        details=details,
+    ):
+        db.rollback()
         return jsonify({"error": "You have already reported this video"}), 409
-
-    db.execute(
-        "INSERT INTO reports (video_id, reporter_agent_id, reason, details, status, created_at) VALUES (?, ?, ?, ?, 'pending', ?)",
-        (video_id, reporter_id, reason, details, time.time()),
-    )
     db.commit()
 
     # Auto-flag: if 3+ reports on the same video, queue a hold for review
@@ -17597,17 +17631,15 @@ def report_comment(comment_id):
     if not _rate_limit(f"report:{reporter_id}", 5, 3600):
         return jsonify({"error": "Report rate limit exceeded (max 5/hour)"}), 429
 
-    existing = db.execute(
-        "SELECT 1 FROM reports WHERE comment_id = ? AND reporter_agent_id = ?",
-        (comment_id, reporter_id),
-    ).fetchone()
-    if existing:
+    if not _insert_report_once(
+        db,
+        reporter_id=reporter_id,
+        comment_id=comment_id,
+        reason=reason,
+        details=details,
+    ):
+        db.rollback()
         return jsonify({"error": "You have already reported this comment"}), 409
-
-    db.execute(
-        "INSERT INTO reports (comment_id, reporter_agent_id, reason, details, status, created_at) VALUES (?, ?, ?, ?, 'pending', ?)",
-        (comment_id, reporter_id, reason, details, time.time()),
-    )
     db.commit()
 
     return jsonify({"ok": True, "message": "Comment report submitted."})

--- a/tests/test_report_input_validation.py
+++ b/tests/test_report_input_validation.py
@@ -111,6 +111,100 @@ def _report_count() -> int:
         return int(db.execute("SELECT COUNT(*) FROM reports").fetchone()[0])
 
 
+def test_report_insert_is_atomic_per_reporter_and_target(client):
+    owner_id = _insert_agent("atomicowner", "bottube_sk_atomicowner")
+    reporter_id = _insert_agent("atomicreporter", "bottube_sk_atomicreporter")
+    _insert_video(owner_id, "atomicreport01A")
+    comment_id = _insert_comment(owner_id, "atomicreport01A", "report target")
+
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        first_video = bottube_server._insert_report_once(
+            db,
+            reporter_id=reporter_id,
+            video_id="atomicreport01A",
+            reason="spam",
+            details="first",
+            created_at=10.0,
+        )
+        duplicate_video = bottube_server._insert_report_once(
+            db,
+            reporter_id=reporter_id,
+            video_id="atomicreport01A",
+            reason="harassment",
+            details="retry",
+            created_at=11.0,
+        )
+        first_comment = bottube_server._insert_report_once(
+            db,
+            reporter_id=reporter_id,
+            comment_id=comment_id,
+            reason="spam",
+            details="first",
+            created_at=12.0,
+        )
+        duplicate_comment = bottube_server._insert_report_once(
+            db,
+            reporter_id=reporter_id,
+            comment_id=comment_id,
+            reason="harassment",
+            details="retry",
+            created_at=13.0,
+        )
+        db.commit()
+        rows = db.execute(
+            "SELECT video_id, comment_id, reason FROM reports ORDER BY id"
+        ).fetchall()
+
+    assert (first_video, duplicate_video, first_comment, duplicate_comment) == (
+        True,
+        False,
+        True,
+        False,
+    )
+    assert [(row["video_id"], row["comment_id"], row["reason"]) for row in rows] == [
+        ("atomicreport01A", None, "spam"),
+        (None, comment_id, "spam"),
+    ]
+
+
+def test_report_routes_preserve_duplicate_conflicts(client):
+    owner_id = _insert_agent("routeowner", "bottube_sk_routeowner")
+    _insert_agent("routereporter", "bottube_sk_routereporter")
+    _insert_video(owner_id, "routereport01A")
+    comment_id = _insert_comment(owner_id, "routereport01A", "report target")
+    headers = {"X-API-Key": "bottube_sk_routereporter"}
+
+    first_video = client.post(
+        "/api/videos/routereport01A/report",
+        headers=headers,
+        json={"reason": "spam"},
+    )
+    duplicate_video = client.post(
+        "/api/videos/routereport01A/report",
+        headers=headers,
+        json={"reason": "spam"},
+    )
+    first_comment = client.post(
+        f"/api/comments/{comment_id}/report",
+        headers=headers,
+        json={"reason": "spam"},
+    )
+    duplicate_comment = client.post(
+        f"/api/comments/{comment_id}/report",
+        headers=headers,
+        json={"reason": "spam"},
+    )
+
+    assert first_video.status_code == 200
+    assert duplicate_video.status_code == 409
+    assert duplicate_video.get_json() == {"error": "You have already reported this video"}
+    assert first_comment.status_code == 200
+    assert duplicate_comment.status_code == 409
+    assert duplicate_comment.get_json() == {"error": "You have already reported this comment"}
+    assert _report_count() == 2
+
+
 def test_video_report_null_reason_uses_existing_invalid_reason_error(client):
     owner_id = _insert_agent("ownerbot", "bottube_sk_owner")
     _insert_agent("reporter", "bottube_sk_reporter")


### PR DESCRIPTION
Closes #2149

## What changed

- replace video/comment report duplicate-check + insert sequences with one shared atomic SQLite write
- preserve the existing 409 duplicate contracts and release no-op write transactions promptly
- ensure a reporter contributes at most one row to a video's moderation threshold
- keep legitimate unique-reporter threshold behavior unchanged

## Proof

- mutation baseline: focused regression failed because no atomic insert operation existed and both routes used check-then-act writes
- focused report and threshold tests: `10 passed`
- full report + quests suites: `25 passed`
- route/atomic report suite after final integration coverage: `9 passed`
- `python -m py_compile bottube_server.py tests/test_report_input_validation.py`
- `git diff --check`

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d
