### PR TITLE
Reject orphan live-chat video targets

### DIFF
--- a/chat_handlers.py
+++ b/chat_handlers.py
@@ -4,7 +4,7 @@ BoTTube Live Chat - Flask Blueprint
 Real-time chat for video playback, premieres, super chat, and moderation.
 Uses Flask + Flask-SocketIO, SQLite via get_db(), session/g.user patterns.
 """
-from flask import Blueprint, render_template, request, jsonify, g, session
+from flask import Blueprint, abort, render_template, request, jsonify, g, session
 import math
 import sqlite3
 import time
@@ -94,12 +94,25 @@ def _coerce_non_negative_number(value, field_name):
     return value
 
 
+def _chat_video_exists(db, video_id):
+    """Return whether a chat target refers to an existing video."""
+    return db.execute(
+        "SELECT 1 FROM videos WHERE video_id = ? LIMIT 1", (video_id,)
+    ).fetchone() is not None
+
+
+def _missing_chat_video_response():
+    return jsonify({"error": "Video not found"}), 404
+
+
 # ── Routes ──────────────────────────────────────────────────────
 @chat_bp.route("/chat/<video_id>")
 def chat_page(video_id):
     """Render the live-chat sidebar/page for a video."""
     db = get_db()
     init_chat_tables(db)
+    if not _chat_video_exists(db, video_id):
+        abort(404)
     username = session.get("username", "Anonymous")
     is_mod = session.get("is_mod", False)
     return render_template(
@@ -115,6 +128,8 @@ def chat_history(video_id):
     """Return recent chat messages (last 100)."""
     db = get_db()
     init_chat_tables(db)
+    if not _chat_video_exists(db, video_id):
+        return _missing_chat_video_response()
     rows = db.execute(
         "SELECT * FROM chat_messages WHERE video_id = ? ORDER BY created_at DESC LIMIT 100",
         (video_id,),
@@ -127,6 +142,8 @@ def send_message(video_id):
     """REST fallback for sending a chat message (non-WebSocket clients)."""
     db = get_db()
     init_chat_tables(db)
+    if not _chat_video_exists(db, video_id):
+        return _missing_chat_video_response()
     data, error = _json_object_body()
     if error:
         return error
@@ -171,6 +188,8 @@ def ban_user(video_id):
         return error
     db = get_db()
     init_chat_tables(db)
+    if not _chat_video_exists(db, video_id):
+        return _missing_chat_video_response()
     duration = data.get("duration")  # seconds, None = permanent
     if duration is not None:
         duration = _coerce_non_negative_number(duration, "duration")
@@ -192,6 +211,8 @@ def chat_settings(video_id):
     """Get or update chat settings (slow mode, sub-only, premiere)."""
     db = get_db()
     init_chat_tables(db)
+    if not _chat_video_exists(db, video_id):
+        return _missing_chat_video_response()
     if request.method == "POST":
         if not session.get("is_mod"):
             return jsonify({"error": "Moderator only"}), 403

--- a/tests/test_chat_handlers_validation.py
+++ b/tests/test_chat_handlers_validation.py
@@ -34,6 +34,9 @@ def chat_client(tmp_path):
         db.row_factory = sqlite3.Row
         g.db = db
         chat_handlers.init_chat_tables(db)
+        db.execute("CREATE TABLE videos (video_id TEXT PRIMARY KEY)")
+        db.execute("INSERT INTO videos (video_id) VALUES ('video-1')")
+        db.commit()
 
     client = app.test_client()
     client.db_path = db_path
@@ -98,3 +101,39 @@ def test_settings_reject_non_boolean_like_flags(chat_client):
 
     assert resp.status_code == 400
     assert resp.get_json() == {"error": "slow_mode, sub_only, and premiere must be 0/1 or boolean"}
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        ("get", "/api/chat/ghost/history", None),
+        ("post", "/api/chat/ghost/send", {"message": "orphan"}),
+        ("get", "/api/chat/ghost/settings", None),
+    ],
+)
+def test_chat_routes_reject_nonexistent_video(chat_client, method, path, payload):
+    resp = getattr(chat_client, method)(path, json=payload)
+
+    assert resp.status_code == 404
+    assert resp.get_json() == {"error": "Video not found"}
+    assert _chat_message_count(chat_client.db_path) == 0
+
+
+def test_moderator_routes_do_not_create_orphan_chat_state(chat_client):
+    with chat_client.session_transaction() as sess:
+        sess["is_mod"] = True
+        sess["username"] = "mod"
+
+    ban = chat_client.post(
+        "/api/chat/ghost/ban", json={"user_id": "user-1"}
+    )
+    settings = chat_client.post(
+        "/api/chat/ghost/settings",
+        json={"slow_mode": 1, "sub_only": 0, "premiere": 0},
+    )
+
+    assert ban.status_code == 404
+    assert settings.status_code == 404
+    with sqlite3.connect(chat_client.db_path) as db:
+        assert db.execute("SELECT COUNT(*) FROM chat_bans").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM chat_settings").fetchone()[0] == 0


### PR DESCRIPTION
## Summary
- add one canonical target-video existence gate for live-chat surfaces
- reject ghost video IDs before page/history rendering or message persistence
- prevent moderators from creating orphan ban and settings rows
- preserve valid live-chat send and validation behavior

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_chat_handlers_validation.py` (9 passed)
- `python -m py_compile chat_handlers.py tests/test_chat_handlers_validation.py`
- `git diff --check`

Fixes #2154

RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`