### PR TITLE
Reject orphan WebSocket chat targets

### DIFF
--- a/tests/test_websocket_server_validation.py
+++ b/tests/test_websocket_server_validation.py
@@ -11,6 +11,7 @@ from flask import Flask
 
 def _load_websocket_server(monkeypatch):
     events = []
+    room_actions = []
 
     class FakeSocketIO:
         def on(self, _event):
@@ -25,18 +26,18 @@ def _load_websocket_server(monkeypatch):
     fake_socketio = types.SimpleNamespace(
         SocketIO=FakeSocketIO,
         emit=lambda *args, **kwargs: events.append((args, kwargs)),
-        join_room=lambda *_args, **_kwargs: None,
-        leave_room=lambda *_args, **_kwargs: None,
+        join_room=lambda *args, **kwargs: room_actions.append(("join", args, kwargs)),
+        leave_room=lambda *args, **kwargs: room_actions.append(("leave", args, kwargs)),
     )
     monkeypatch.setitem(sys.modules, "flask_socketio", fake_socketio)
     sys.modules.pop("websocket_server", None)
     module = importlib.import_module("websocket_server")
     sys.modules.pop("websocket_server", None)
-    return module, events
+    return module, events, room_actions
 
 
 def test_chat_message_rejects_non_string_message(monkeypatch):
-    websocket_server, events = _load_websocket_server(monkeypatch)
+    websocket_server, events, _room_actions = _load_websocket_server(monkeypatch)
 
     websocket_server.on_chat_message(
         {
@@ -53,7 +54,7 @@ def test_chat_message_rejects_non_string_message(monkeypatch):
 
 
 def test_chat_message_accepts_valid_string_message(monkeypatch, tmp_path):
-    websocket_server, events = _load_websocket_server(monkeypatch)
+    websocket_server, events, _room_actions = _load_websocket_server(monkeypatch)
     db_path = tmp_path / "chat.db"
     with sqlite3.connect(db_path) as db:
         db.executescript(
@@ -73,6 +74,8 @@ def test_chat_message_accepts_valid_string_message(monkeypatch, tmp_path):
                 tip_amount REAL,
                 created_at REAL
             );
+            CREATE TABLE videos (video_id TEXT PRIMARY KEY);
+            INSERT INTO videos (video_id) VALUES ('video-1');
             """
         )
 
@@ -101,7 +104,7 @@ def test_chat_message_accepts_valid_string_message(monkeypatch, tmp_path):
 
 
 def test_chat_message_rejects_non_finite_tip(monkeypatch):
-    websocket_server, events = _load_websocket_server(monkeypatch)
+    websocket_server, events, _room_actions = _load_websocket_server(monkeypatch)
     app = Flask(__name__)
     websocket_server._last_message_time.clear()
 
@@ -122,7 +125,7 @@ def test_chat_message_rejects_non_finite_tip(monkeypatch):
 
 
 def test_super_chat_rejects_zero_tip(monkeypatch):
-    websocket_server, events = _load_websocket_server(monkeypatch)
+    websocket_server, events, _room_actions = _load_websocket_server(monkeypatch)
 
     websocket_server.on_super_chat(
         {
@@ -140,7 +143,7 @@ def test_super_chat_rejects_zero_tip(monkeypatch):
 
 
 def test_mod_action_timeout_rejects_non_numeric_duration(monkeypatch):
-    websocket_server, events = _load_websocket_server(monkeypatch)
+    websocket_server, events, _room_actions = _load_websocket_server(monkeypatch)
 
     websocket_server.on_mod_action(
         {
@@ -154,3 +157,94 @@ def test_mod_action_timeout_rejects_non_numeric_duration(monkeypatch):
     assert events == [
         (("error", {"message": "duration must be a finite non-negative number"}), {})
     ]
+
+
+def _create_chat_db(db_path):
+    with sqlite3.connect(db_path) as db:
+        db.executescript(
+            """
+            CREATE TABLE videos (video_id TEXT PRIMARY KEY);
+            INSERT INTO videos (video_id) VALUES ('video-1');
+            CREATE TABLE chat_bans (
+                id TEXT,
+                video_id TEXT,
+                user_id TEXT,
+                banned_by TEXT,
+                reason TEXT,
+                expires_at REAL,
+                created_at REAL
+            );
+            CREATE TABLE chat_messages (
+                id TEXT,
+                video_id TEXT,
+                user_id TEXT,
+                username TEXT,
+                message TEXT,
+                is_super INTEGER,
+                tip_amount REAL,
+                created_at REAL
+            );
+            """
+        )
+
+
+def test_chat_message_rejects_missing_video_without_persisting(monkeypatch, tmp_path):
+    websocket_server, events, _room_actions = _load_websocket_server(monkeypatch)
+    db_path = tmp_path / "chat.db"
+    _create_chat_db(db_path)
+    app = Flask(__name__)
+    app.config["CHAT_DB_PATH"] = str(db_path)
+    websocket_server._last_message_time.clear()
+
+    with app.app_context():
+        websocket_server.on_chat_message(
+            {
+                "video_id": "ghost-video",
+                "username": "alice",
+                "user_id": "ghost-user",
+                "message": "hello",
+            }
+        )
+
+    assert events[-1] == (("error", {"message": "Video not found"}), {})
+    with sqlite3.connect(db_path) as db:
+        assert db.execute("SELECT COUNT(*) FROM chat_messages").fetchone() == (0,)
+
+
+def test_join_and_leave_reject_missing_video_without_room_action(monkeypatch, tmp_path):
+    websocket_server, events, room_actions = _load_websocket_server(monkeypatch)
+    db_path = tmp_path / "chat.db"
+    _create_chat_db(db_path)
+    app = Flask(__name__)
+    app.config["CHAT_DB_PATH"] = str(db_path)
+
+    with app.app_context():
+        websocket_server.on_join({"video_id": "ghost-video", "username": "alice"})
+        websocket_server.on_leave({"video_id": "ghost-video", "username": "alice"})
+
+    assert room_actions == []
+    assert events == [
+        (("error", {"message": "Video not found"}), {}),
+        (("error", {"message": "Video not found"}), {}),
+    ]
+
+
+def test_mod_action_rejects_missing_video_without_mutating(monkeypatch, tmp_path):
+    websocket_server, events, _room_actions = _load_websocket_server(monkeypatch)
+    db_path = tmp_path / "chat.db"
+    _create_chat_db(db_path)
+    app = Flask(__name__)
+    app.config["CHAT_DB_PATH"] = str(db_path)
+
+    with app.app_context():
+        websocket_server.on_mod_action(
+            {
+                "action": "ban",
+                "video_id": "ghost-video",
+                "target_user_id": "user-1",
+            }
+        )
+
+    assert events == [(("error", {"message": "Video not found"}), {})]
+    with sqlite3.connect(db_path) as db:
+        assert db.execute("SELECT COUNT(*) FROM chat_bans").fetchone() == (0,)

--- a/websocket_server.py
+++ b/websocket_server.py
@@ -31,6 +31,27 @@ def _get_db(app):
     return db
 
 
+def _video_exists(db, video_id):
+    """Return whether *video_id* names an existing video."""
+    if not isinstance(video_id, str) or not video_id.strip():
+        return False
+    return db.execute(
+        "SELECT 1 FROM videos WHERE video_id=? LIMIT 1", (video_id,)
+    ).fetchone() is not None
+
+
+def _require_video(app, video_id):
+    """Reject SocketIO events that target a missing video."""
+    db = _get_db(app)
+    try:
+        exists = _video_exists(db, video_id)
+    finally:
+        db.close()
+    if not exists:
+        emit("error", {"message": "Video not found"})
+    return exists
+
+
 def _coerce_flag(value):
     """Return safe 0/1 int from bool/int values or None when invalid."""
     if isinstance(value, bool):
@@ -56,8 +77,11 @@ def _coerce_non_negative_number(value, default=0.0):
 @socketio.on("join")
 def on_join(data):
     """User joins a video chat room."""
+    from flask import current_app
     room = data.get("video_id", "")
     username = data.get("username", "Anonymous")
+    if not _require_video(current_app, room):
+        return
     join_room(room)
     emit("system", {"message": f"{username} joined the chat", "type": "join"}, room=room)
 
@@ -69,8 +93,11 @@ def on_leave(data):
     Args:
         data: Parameter value.
     """
+    from flask import current_app
     room = data.get("video_id", "")
     username = data.get("username", "Anonymous")
+    if not _require_video(current_app, room):
+        return
     leave_room(room)
     emit("system", {"message": f"{username} left the chat", "type": "leave"}, room=room)
 
@@ -111,8 +138,14 @@ def on_chat_message(data):
         emit("error", {"message": "tip_amount must be a finite non-negative number"})
         return
 
-    # Check ban
+    # Reject orphan room IDs before persisting or broadcasting.
     db = _get_db(current_app)
+    if not _video_exists(db, room):
+        db.close()
+        emit("error", {"message": "Video not found"})
+        return
+
+    # Check ban
     ban = db.execute(
         "SELECT 1 FROM chat_bans WHERE video_id=? AND user_id=? AND (expires_at IS NULL OR expires_at > ?)",
         (room, user_id, now),
@@ -171,6 +204,8 @@ def on_mod_action(data):
             if duration is None:
                 emit("error", {"message": "duration must be a finite non-negative number"})
                 return
+        if not _require_video(current_app, room):
+            return
         expires = time.time() + duration if duration else None
         db = _get_db(current_app)
         db.execute(
@@ -189,10 +224,14 @@ def on_mod_action(data):
         if timeout_sec is None:
             emit("error", {"message": "duration must be a finite non-negative number"})
             return
+        if not _require_video(current_app, room):
+            return
         timeout_sec = int(timeout_sec)
         key = f"{user_id}:{room}"
         _last_message_time[key] = time.time() + timeout_sec
         emit("system", {"message": f"User timed out for {timeout_sec}s", "type": "timeout"}, room=room)
     
     elif action == "slow_mode":
+        if not _require_video(current_app, room):
+            return
         emit("system", {"message": "Slow mode enabled", "type": "slow_mode"}, room=room)


### PR DESCRIPTION
## Summary
- add a canonical target-video existence gate to Socket.IO live-chat handlers
- reject ghost video IDs before join/leave, message persistence, broadcast, or moderator mutation
- preserve validation ordering and valid realtime chat behavior

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_websocket_server_validation.py` (8 passed)
- `python -m py_compile websocket_server.py tests/test_websocket_server_validation.py`
- `git diff --check`

Fixes #2157

RTC wallet: `RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d`