### PR TITLE
fix(gpu): serialize marketplace job claims

### DIFF
--- a/gpu_marketplace.py
+++ b/gpu_marketplace.py
@@ -145,6 +145,36 @@ def init_gpu_db(db_path: str = None):
 # HELPERS
 # ---------------------------------------------------------------------------
 
+def _claim_gpu_job_transaction(db, provider_id: str, agent_id: int, job_id: str, now: int) -> str:
+    """Atomically reserve one pending job for one non-busy provider."""
+    claimed = db.execute(
+        """
+        UPDATE gpu_jobs
+        SET status = 'claimed', provider_id = ?, claimed_at = ?
+        WHERE id = ? AND status = 'pending'
+        """,
+        (provider_id, now, job_id),
+    )
+    if int(getattr(claimed, "rowcount", 0) or 0) <= 0:
+        db.rollback()
+        return "job_unavailable"
+
+    reserved = db.execute(
+        """
+        UPDATE gpu_providers
+        SET status = 'busy'
+        WHERE id = ? AND agent_id = ? AND COALESCE(status, 'offline') != 'busy'
+        """,
+        (provider_id, agent_id),
+    )
+    if int(getattr(reserved, "rowcount", 0) or 0) <= 0:
+        # Release the job transition as part of the same transaction.
+        db.rollback()
+        return "provider_busy"
+
+    db.commit()
+    return "claimed"
+
 def get_db():
     """Get database connection from Flask g context."""
     if not hasattr(g, 'db') or g.db is None:
@@ -541,15 +571,13 @@ def claim_job():
     if jrow[0] != "pending":
         return jsonify({"error": f"Job not available (status: {jrow[0]})"}), 400
 
-    # Claim the job
+    # Claim the job and provider as one compare-and-set transaction.
     now = int(time.time())
-    db.execute("""
-        UPDATE gpu_jobs SET status = 'claimed', provider_id = ?, claimed_at = ? WHERE id = ?
-    """, (provider_id, now, job_id))
-    db.execute("""
-        UPDATE gpu_providers SET status = 'busy' WHERE id = ?
-    """, (provider_id,))
-    db.commit()
+    outcome = _claim_gpu_job_transaction(db, provider_id, int(agent["id"]), job_id, now)
+    if outcome == "job_unavailable":
+        return jsonify({"error": "Job was claimed by another provider"}), 409
+    if outcome == "provider_busy":
+        return jsonify({"error": "Provider became busy with another job"}), 409
 
     return jsonify({
         "ok": True,

--- a/tests/test_gpu_marketplace_claim_concurrency.py
+++ b/tests/test_gpu_marketplace_claim_concurrency.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MIT
+"""Concurrency regressions for GPU marketplace job admission."""
+
+import sqlite3
+import threading
+
+from gpu_marketplace import _claim_gpu_job_transaction, init_gpu_tables
+
+
+def _seed_provider(db, provider_id, agent_id):
+    db.execute(
+        """
+        INSERT INTO gpu_providers
+            (id, agent_id, gpu_model, price_per_min, status, created_at)
+        VALUES (?, ?, 'test-gpu', 0.1, 'online', 1)
+        """,
+        (provider_id, agent_id),
+    )
+
+
+def _seed_job(db, job_id):
+    db.execute(
+        """
+        INSERT INTO gpu_jobs
+            (id, requester_id, job_type, job_params, status, rtc_escrowed, created_at)
+        VALUES (?, 99, 'video_render', '{}', 'pending', 1.0, 1)
+        """,
+        (job_id,),
+    )
+
+
+def _race_claims(db_path, claims):
+    gate = threading.Barrier(len(claims))
+    results = []
+    lock = threading.Lock()
+
+    def claim(provider_id, agent_id, job_id):
+        db = sqlite3.connect(db_path, timeout=5)
+        gate.wait(timeout=2)
+        outcome = _claim_gpu_job_transaction(db, provider_id, agent_id, job_id, 10)
+        db.close()
+        with lock:
+            results.append((provider_id, job_id, outcome))
+
+    workers = [threading.Thread(target=claim, args=entry) for entry in claims]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=7)
+    assert all(not worker.is_alive() for worker in workers)
+    return results
+
+
+def test_same_job_has_exactly_one_provider_winner(tmp_path):
+    db_path = tmp_path / "gpu-same-job.db"
+    init_gpu_tables(str(db_path))
+    db = sqlite3.connect(db_path)
+    _seed_provider(db, "provider-a", 1)
+    _seed_provider(db, "provider-b", 2)
+    _seed_job(db, "job-one")
+    db.commit()
+    db.close()
+
+    results = _race_claims(
+        db_path,
+        [("provider-a", 1, "job-one"), ("provider-b", 2, "job-one")],
+    )
+
+    assert sorted(result[2] for result in results) == ["claimed", "job_unavailable"]
+    db = sqlite3.connect(db_path)
+    provider_id = db.execute("SELECT provider_id FROM gpu_jobs WHERE id = 'job-one'").fetchone()[0]
+    statuses = dict(db.execute("SELECT id, status FROM gpu_providers"))
+    db.close()
+    assert statuses[provider_id] == "busy"
+    assert sum(status == "busy" for status in statuses.values()) == 1
+
+
+def test_same_provider_cannot_reserve_two_jobs(tmp_path):
+    db_path = tmp_path / "gpu-same-provider.db"
+    init_gpu_tables(str(db_path))
+    db = sqlite3.connect(db_path)
+    _seed_provider(db, "provider-a", 1)
+    _seed_job(db, "job-one")
+    _seed_job(db, "job-two")
+    db.commit()
+    db.close()
+
+    results = _race_claims(
+        db_path,
+        [("provider-a", 1, "job-one"), ("provider-a", 1, "job-two")],
+    )
+
+    assert sorted(result[2] for result in results) == ["claimed", "provider_busy"]
+    db = sqlite3.connect(db_path)
+    states = list(db.execute("SELECT status, provider_id FROM gpu_jobs ORDER BY id"))
+    provider_status = db.execute(
+        "SELECT status FROM gpu_providers WHERE id = 'provider-a'"
+    ).fetchone()[0]
+    db.close()
+    assert sorted(state[0] for state in states) == ["claimed", "pending"]
+    assert sum(state[1] == "provider-a" for state in states) == 1
+    assert provider_status == "busy"


### PR DESCRIPTION
## Summary

- reserve a pending GPU job and non-busy provider in one transaction
- compare-and-set both admission edges and roll back the job when provider reservation loses
- return truthful conflict responses instead of letting two workers start the same job
- cover same-job and same-provider contention with real SQLite connections

Closes #2163.

## Proof

- Mutation baseline: removing the pending-job predicate makes the same-job regression fail because both providers report `claimed`.
- `python -m pytest tests/test_gpu_marketplace_claim_concurrency.py tests/test_gpu_marketplace_validation.py tests/test_gpu_marketplace_auth.py -q` — 29 passed
- `python -m compileall -q gpu_marketplace.py tests/test_gpu_marketplace_claim_concurrency.py`
- `git diff --check`

Funded pool: Scottcjn/rustchain-bounties#71

Native RTC wallet: RTCe625bc2d5c25d4348236a4fcb74e5d0ef01f6d6d
