### PR TITLE
fix(gpu_marketplace): prevent reopening completed jobs via fail endpoint (#2167)

### DIFF
--- a/gpu_marketplace.py
+++ b/gpu_marketplace.py
@@ -713,12 +713,20 @@ def fail_job():
     if not row or row[1] != agent['id']:
         return jsonify({"error": "Invalid job or not your job"}), 403
 
-    # Release job back to queue, mark provider available
-    db.execute("""
+    if row[0] not in ('claimed', 'running'):
+        return jsonify({"error": f"Job cannot be released in '{row[0]}' state (must be claimed or running)"}), 400
+
+    # Release job back to queue with atomic compare-and-set, mark provider available
+    cursor = db.execute("""
         UPDATE gpu_jobs
-        SET status = 'pending', provider_id = NULL, claimed_at = NULL, error_message = ?
-        WHERE id = ?
-    """, (error_msg, job_id))
+        SET status = 'pending', provider_id = NULL, claimed_at = NULL, started_at = NULL, error_message = ?
+        WHERE id = ? AND provider_id = ? AND status IN ('claimed', 'running')
+    """, (error_msg, job_id, provider_id))
+
+    if cursor.rowcount == 0:
+        db.rollback()
+        return jsonify({"error": "Job state changed concurrently or not in active state"}), 409
+
     db.execute("""
         UPDATE gpu_providers SET status = 'online' WHERE id = ?
     """, (provider_id,))

--- a/tests/test_gpu_marketplace_validation.py
+++ b/tests/test_gpu_marketplace_validation.py
@@ -135,3 +135,114 @@ def test_submit_job_non_numeric_max_price_rejected(client):
 
     assert resp.status_code == 400
     assert resp.get_json() == {"error": "Numeric value required"}
+
+def _setup_provider_and_job(client):
+    reg_resp = client.post(
+        "/api/gpu/providers/register",
+        headers=AUTH,
+        json={"gpu_model": "RTX 4090", "gpu_vram_gb": 24, "price_per_min": 0.1},
+    )
+    assert reg_resp.status_code == 200
+    provider_id = reg_resp.get_json()["provider_id"]
+
+    sub_resp = client.post(
+        "/api/gpu/jobs/submit",
+        headers=AUTH,
+        json={"job_type": "video_render", "estimated_mins": 2, "max_price_per_min": 0.2},
+    )
+    assert sub_resp.status_code == 200
+    job_id = sub_resp.get_json()["job_id"]
+
+    claim_resp = client.post(
+        "/api/gpu/jobs/claim",
+        headers=AUTH,
+        json={"provider_id": provider_id, "job_id": job_id},
+    )
+    assert claim_resp.status_code == 200
+
+    start_resp = client.post(
+        "/api/gpu/jobs/start",
+        headers=AUTH,
+        json={"provider_id": provider_id, "job_id": job_id},
+    )
+    assert start_resp.status_code == 200
+
+    return provider_id, job_id
+
+
+def test_completed_job_cannot_be_failed_or_reopened(client):
+    provider_id, job_id = _setup_provider_and_job(client)
+
+    comp_resp = client.post(
+        "/api/gpu/jobs/complete",
+        headers=AUTH,
+        json={"provider_id": provider_id, "job_id": job_id, "result_url": "https://example.com/out.mp4"},
+    )
+    assert comp_resp.status_code == 200
+    assert comp_resp.get_json()["ok"] is True
+
+    status_resp = client.get(f"/api/gpu/jobs/{job_id}")
+    assert status_resp.status_code == 200
+    assert status_resp.get_json()["status"] == "completed"
+
+    fail_resp = client.post(
+        "/api/gpu/jobs/fail",
+        headers=AUTH,
+        json={"provider_id": provider_id, "job_id": job_id, "error_message": "late failure"},
+    )
+
+    assert fail_resp.status_code in (400, 409)
+    assert fail_resp.get_json().get("ok") is not True
+
+    status_resp2 = client.get(f"/api/gpu/jobs/{job_id}")
+    assert status_resp2.get_json()["status"] == "completed"
+
+
+def test_active_running_job_can_be_failed_and_released(client):
+    provider_id, job_id = _setup_provider_and_job(client)
+
+    fail_resp = client.post(
+        "/api/gpu/jobs/fail",
+        headers=AUTH,
+        json={"provider_id": provider_id, "job_id": job_id, "error_message": "OOM error"},
+    )
+    assert fail_resp.status_code == 200
+    assert fail_resp.get_json()["ok"] is True
+
+    status_resp = client.get(f"/api/gpu/jobs/{job_id}")
+    assert status_resp.get_json()["status"] == "pending"
+
+
+def test_active_claimed_job_can_be_failed_and_released(client):
+    reg_resp = client.post(
+        "/api/gpu/providers/register",
+        headers=AUTH,
+        json={"gpu_model": "RTX 4090", "gpu_vram_gb": 24, "price_per_min": 0.1},
+    )
+    provider_id = reg_resp.get_json()["provider_id"]
+
+    sub_resp = client.post(
+        "/api/gpu/jobs/submit",
+        headers=AUTH,
+        json={"job_type": "video_render", "estimated_mins": 2, "max_price_per_min": 0.2},
+    )
+    job_id = sub_resp.get_json()["job_id"]
+
+    claim_resp = client.post(
+        "/api/gpu/jobs/claim",
+        headers=AUTH,
+        json={"provider_id": provider_id, "job_id": job_id},
+    )
+    assert claim_resp.status_code == 200
+
+    fail_resp = client.post(
+        "/api/gpu/jobs/fail",
+        headers=AUTH,
+        json={"provider_id": provider_id, "job_id": job_id, "error_message": "Driver crash"},
+    )
+    assert fail_resp.status_code == 200
+    assert fail_resp.get_json()["ok"] is True
+
+    status_resp = client.get(f"/api/gpu/jobs/{job_id}")
+    assert status_resp.get_json()["status"] == "pending"
+


### PR DESCRIPTION
## Summary
Fixes #2167.

### Problem
`POST /api/gpu/jobs/fail` previously verified only provider ownership and unconditionally executed:
```sql
UPDATE gpu_jobs SET status = 'pending', provider_id = NULL, claimed_at = NULL, error_message = ? WHERE id = ?
```
This allowed settled / completed jobs to be reopened while leaving `rtc_paid`, completion metadata, and provider earnings intact, permitting repeat claims and settlements from a single escrow record.

### Fix
1. **State Validation Guard**: Explicitly rejects `/jobs/fail` requests if the job is not in an active state (`claimed` or `running`), returning HTTP 400.
2. **Atomic Compare-and-Set**: Added `WHERE id = ? AND provider_id = ? AND status IN ('claimed', 'running')` directly into the UPDATE query.
3. **Concurrency Protection**: Evaluates `cursor.rowcount`. If 0, rolls back and returns HTTP 409 Conflict, ensuring only the winning lifecycle transition can release the provider back to `online`.
4. **Timestamp Reset**: Clears `started_at` in addition to `claimed_at` when returning the job to `pending`.
5. **Regression Tests**: Added tests in `tests/test_gpu_marketplace_validation.py` verifying:
   - Completed jobs cannot be failed or reopened (HTTP 400/409, terminal status preserved).
   - Running jobs can be failed and released back to pending.
   - Claimed jobs can be failed and released back to pending.

### Verification
All tests passing locally:
```
tests/test_gpu_marketplace_validation.py ............................ [100%]
28 passed in 0.58s
```
