### PR TITLE
fix(gpu): prevent stale start from creating ownerless running jobs (#2169)

### DIFF
--- a/gpu_marketplace.py
+++ b/gpu_marketplace.py
@@ -580,26 +580,32 @@ def start_job():
 
     db = get_db()
 
-    # Verify ownership and job state
-    row = db.execute("""
-        SELECT j.status, j.provider_id, p.agent_id
-        FROM gpu_jobs j
-        JOIN gpu_providers p ON j.provider_id = p.id
-        WHERE j.id = ?
-    """, (job_id,)).fetchone()
+    # Verify ownership via provider -> agent link
+    prov = db.execute(
+        "SELECT agent_id FROM gpu_providers WHERE id = ?", (provider_id,)
+    ).fetchone()
+    if not prov or prov[0] != agent['id']:
+        return jsonify({"error": "Not your provider"}), 403
 
-    if not row:
-        return jsonify({"error": "Job not found"}), 404
-    if row[2] != agent['id']:
-        return jsonify({"error": "Not your job"}), 403
-    if row[0] != "claimed":
-        return jsonify({"error": f"Job not in claimed state (status: {row[0]})"}), 400
+    # Atomic CAS: transition from claimed -> running only if still owned by this provider
+    now = int(time.time())
+    cur = db.execute("""
+        UPDATE gpu_jobs
+        SET status = 'running', started_at = ?
+        WHERE id = ? AND status = 'claimed' AND provider_id = ?
+    """, (now, job_id, provider_id))
 
-    db.execute("""
-        UPDATE gpu_jobs SET status = 'running', started_at = ? WHERE id = ?
-    """, (int(time.time()), job_id))
+    if cur.rowcount == 0:
+        db.rollback()
+        # Distinguish between not-found and stale/race
+        row = db.execute(
+            "SELECT status, provider_id FROM gpu_jobs WHERE id = ?", (job_id,)
+        ).fetchone()
+        if not row:
+            return jsonify({"error": "Job not found"}), 404
+        return jsonify({"error": "Stale or duplicate start; job no longer in claimed state for this provider"}), 409
+
     db.commit()
-
     return jsonify({"ok": True, "status": "running"})
 
 

--- a/tests/test_gpu_stale_start.py
+++ b/tests/test_gpu_stale_start.py
@@ -1,0 +1,85 @@
+import pytest
+import time
+import os
+import bottube_server
+from gpu_marketplace import init_gpu_db, get_db
+from bottube_server import app as flask_app, init_db
+
+@pytest.fixture
+def client(tmp_path):
+    db_file = str(tmp_path / "test_bottube.db")
+    os.environ["BOTTUBE_DB_PATH"] = db_file
+    original_db_path = bottube_server.DB_PATH
+    bottube_server.DB_PATH = type(original_db_path)(db_file)
+
+    flask_app.config['TESTING'] = True
+    with flask_app.app_context():
+        init_db()
+        init_gpu_db()
+        db = get_db()
+
+        now = int(time.time())
+        db.execute("""
+            INSERT OR IGNORE INTO agents (id, agent_name, display_name, api_key, is_banned, created_at)
+            VALUES (1, 'test-agent', 'Test Agent', 'test-key', 0, ?)
+        """, (float(now),))
+
+        db.execute("""
+            INSERT OR IGNORE INTO gpu_providers (id, agent_id, gpu_model, status, price_per_min, total_jobs, total_rtc_earned, created_at)
+            VALUES ('prov1', 1, 'RTX4090', 'online', 0.1, 0, 0.0, ?)
+        """, (now,))
+
+        # Seed a claimed job
+        db.execute("""
+            INSERT OR IGNORE INTO gpu_jobs (id, requester_id, provider_id, job_type, job_params, status, started_at, rtc_escrowed, created_at)
+            VALUES ('job1', 1, 'prov1', 'video_render', '{}', 'claimed', NULL, 10.0, ?)
+        """, (now - 120,))
+        db.commit()
+
+        yield flask_app.test_client()
+
+    if "BOTTUBE_DB_PATH" in os.environ:
+        del os.environ["BOTTUBE_DB_PATH"]
+    bottube_server.DB_PATH = original_db_path
+
+
+def test_start_claimed_job_succeeds(client):
+    r = client.post('/api/gpu/jobs/start', json={
+        "provider_id": "prov1", "job_id": "job1"
+    }, headers={"X-API-Key": "test-key"})
+    assert r.status_code == 200, f"Expected 200 but got {r.status_code}: {r.get_data(as_text=True)}"
+
+
+def test_stale_start_after_release_rejected(client):
+    """Simulate: job is claimed, then released back to pending (e.g. by failure path),
+    then a stale start request arrives. Must return 409, not create ownerless running job."""
+    # First release the job back to pending (simulating concurrent failure/release)
+    with flask_app.app_context():
+        db = get_db()
+        db.execute("UPDATE gpu_jobs SET status = 'pending', provider_id = NULL WHERE id = 'job1'")
+        db.commit()
+
+    r = client.post('/api/gpu/jobs/start', json={
+        "provider_id": "prov1", "job_id": "job1"
+    }, headers={"X-API-Key": "test-key"})
+    assert r.status_code == 409, f"Expected 409 for stale start but got {r.status_code}: {r.get_data(as_text=True)}"
+
+    # Verify no ownerless running job was created
+    with flask_app.app_context():
+        db = get_db()
+        row = db.execute("SELECT status, provider_id FROM gpu_jobs WHERE id = 'job1'").fetchone()
+        assert row[0] == 'pending', f"Job should still be pending, got {row[0]}"
+        assert row[1] is None, f"Provider should be NULL, got {row[1]}"
+
+
+def test_duplicate_start_second_rejected(client):
+    """Two start requests for the same claimed job: first wins, second gets 409."""
+    r1 = client.post('/api/gpu/jobs/start', json={
+        "provider_id": "prov1", "job_id": "job1"
+    }, headers={"X-API-Key": "test-key"})
+    assert r1.status_code == 200
+
+    r2 = client.post('/api/gpu/jobs/start', json={
+        "provider_id": "prov1", "job_id": "job1"
+    }, headers={"X-API-Key": "test-key"})
+    assert r2.status_code == 409, f"Expected 409 for duplicate start but got {r2.status_code}"


### PR DESCRIPTION
## Summary

Fixes #2169 — A stale or duplicate `POST /api/gpu/jobs/start` could transition a job to `running` even after it had been released back to `pending` (e.g. by a concurrent failure path), creating an ownerless running job with no provider assigned.

## Root Cause

The original `start_job()` used a non-atomic read-then-write pattern: it checked that the job was in `claimed` state, then issued an unconditional `UPDATE gpu_jobs SET status = 'running' WHERE id = ?`. Between the check and the update, another request could release the job, and the stale start would still succeed because the UPDATE only filtered on `id`.

## Fix

Replace the read-then-write with a single atomic CAS:

```sql
UPDATE gpu_jobs
SET status = 'running', started_at = ?
WHERE id = ? AND status = 'claimed' AND provider_id = ?
```

Success is gated on `rowcount > 0`. If the CAS fails (job no longer claimed by this provider), return 409 with a descriptive error instead of silently succeeding.

## Tests

Three regression tests added in `tests/test_gpu_stale_start.py`:

- **test_start_claimed_job_succeeds**: Normal claimed→running transition works (200)
- **test_stale_start_after_release_rejected**: Job released to pending between claim and start → 409, no ownerless running job created
- **test_duplicate_start_second_rejected**: Two concurrent starts for same claimed job → exactly one 200, one 409

All tests pass.