### PR TITLE
fix(gpu): atomic CAS for concurrent job claims (#2163)

### DIFF
--- a/gpu_marketplace.py
+++ b/gpu_marketplace.py
@@ -530,26 +530,34 @@ def claim_job():
     if prow[1] == "busy":
         return jsonify({"error": "Provider already busy with a job"}), 400
 
-    # Check job is pending
+    # Atomic CAS: claim job only if still pending AND provider not busy
+    now = int(time.time())
+    cur = db.execute("""
+        UPDATE gpu_jobs
+        SET status = 'claimed', provider_id = ?, claimed_at = ?
+        WHERE id = ? AND status = 'pending'
+          AND NOT EXISTS (
+            SELECT 1 FROM gpu_providers WHERE id = ? AND status = 'busy'
+          )
+    """, (provider_id, now, job_id, provider_id))
+
+    if cur.rowcount == 0:
+        jcheck = db.execute("SELECT status FROM gpu_jobs WHERE id = ?", (job_id,)).fetchone()
+        if not jcheck:
+            return jsonify({"error": "Job not found"}), 404
+        pcheck = db.execute("SELECT status FROM gpu_providers WHERE id = ?", (provider_id,)).fetchone()
+        if pcheck and pcheck[0] == "busy":
+            return jsonify({"error": "Provider already busy with a job"}), 409
+        return jsonify({"error": f"Job not available (status: {jcheck[0]})"}), 409
+
+    # Mark provider busy (safe: CAS above confirmed not busy)
+    db.execute("UPDATE gpu_providers SET status = 'busy' WHERE id = ?", (provider_id,))
+    db.commit()
+
+    # Re-fetch job details for response
     jrow = db.execute(
         "SELECT status, job_type, job_params, rtc_escrowed FROM gpu_jobs WHERE id = ?", (job_id,)
     ).fetchone()
-
-    if not jrow:
-        return jsonify({"error": "Job not found"}), 404
-
-    if jrow[0] != "pending":
-        return jsonify({"error": f"Job not available (status: {jrow[0]})"}), 400
-
-    # Claim the job
-    now = int(time.time())
-    db.execute("""
-        UPDATE gpu_jobs SET status = 'claimed', provider_id = ?, claimed_at = ? WHERE id = ?
-    """, (provider_id, now, job_id))
-    db.execute("""
-        UPDATE gpu_providers SET status = 'busy' WHERE id = ?
-    """, (provider_id,))
-    db.commit()
 
     return jsonify({
         "ok": True,

--- a/tests/test_gpu_concurrent_claim_2163.py
+++ b/tests/test_gpu_concurrent_claim_2163.py
@@ -1,0 +1,132 @@
+"""Regression tests for #2163: concurrent GPU job claims.
+
+Verifies that:
+1. Two providers racing to claim the same job: exactly one wins, other gets 409.
+2. A busy provider cannot claim a second job (gets 409).
+3. Winning claim atomically transitions job to 'claimed' and provider to 'busy'.
+"""
+import os
+import tempfile
+import threading
+import time
+
+import pytest
+
+# Must monkeypatch DB_PATH before importing app modules
+_test_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+_test_db.close()
+os.environ["BOTTUBE_DB_PATH"] = _test_db.name
+
+import bottube_server
+bottube_server.DB_PATH = _test_db.name
+
+from gpu_marketplace import init_gpu_db
+
+
+@pytest.fixture(autouse=True)
+def fresh_db():
+    """Reset DB for each test."""
+    bottube_server.init_db()
+    init_gpu_db(_test_db.name)
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        # Seed an agent (id is INTEGER PRIMARY KEY, use numeric)
+        now_f = float(time.time())
+        db.execute("INSERT OR REPLACE INTO agents (id, agent_name, api_key, created_at) VALUES (?, ?, ?, ?)",
+                   (1, "Test Agent", "test-key", now_f))
+        # Seed two providers owned by same agent, both idle
+        now = int(time.time())
+        for pid in ("gpu_prov_a", "gpu_prov_b"):
+            db.execute("""
+                INSERT OR REPLACE INTO gpu_providers (id, agent_id, gpu_model, gpu_vram_gb, price_per_min, status, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, (pid, 1, "RTX4090", 24.0, 1.0, "idle", now))
+        # Seed one pending job
+        db.execute("""
+            INSERT OR REPLACE INTO gpu_jobs (id, requester_id, job_type, job_params, rtc_escrowed, status, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, ("job_001", 1, "inference", '{"prompt":"hi"}', 100, "pending", now))
+        db.commit()
+    yield
+
+
+@pytest.fixture
+def client():
+    bottube_server.app.config["TESTING"] = True
+    with bottube_server.app.test_client() as c:
+        yield c
+
+
+def _claim(client, provider_id, job_id):
+    return client.post("/api/gpu/jobs/claim",
+                       json={"provider_id": provider_id, "job_id": job_id},
+                       headers={"X-API-Key": "test-key"})
+
+
+def test_same_job_concurrent_claim_exactly_one_wins(client):
+    """Two threads race to claim the same job; exactly one succeeds."""
+    import flask
+    results = {}
+    app = bottube_server.app
+
+    def try_claim(label, prov):
+        with app.test_client() as c:
+            r = _claim(c, prov, "job_001")
+        results[label] = (r.status_code, r.get_json())
+
+    t1 = threading.Thread(target=try_claim, args=("a", "gpu_prov_a"))
+    t2 = threading.Thread(target=try_claim, args=("b", "gpu_prov_b"))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    codes = sorted([results["a"][0], results["b"][0]])
+    assert codes == [200, 409], f"Expected one 200 and one 409, got {codes}"
+
+    winner = "a" if results["a"][0] == 200 else "b"
+    win_prov = "gpu_prov_a" if winner == "a" else "gpu_prov_b"
+
+    assert results[winner][1]["ok"] is True
+    assert results[winner][1]["job_id"] == "job_001"
+
+    # Verify DB state: job claimed by winner, winner busy, loser still idle
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        jrow = db.execute("SELECT status, provider_id FROM gpu_jobs WHERE id = ?", ("job_001",)).fetchone()
+        assert jrow[0] == "claimed"
+        assert jrow[1] == win_prov
+
+        prow_win = db.execute("SELECT status FROM gpu_providers WHERE id = ?", (win_prov,)).fetchone()
+        assert prow_win[0] == "busy"
+
+        lose_prov = "gpu_prov_b" if win_prov == "gpu_prov_a" else "gpu_prov_a"
+        prow_lose = db.execute("SELECT status FROM gpu_providers WHERE id = ?", (lose_prov,)).fetchone()
+        assert prow_lose[0] == "idle"
+
+
+def test_busy_provider_cannot_claim_second_job(client):
+    """A provider that already has a claimed job cannot claim another."""
+    # First claim succeeds
+    r1 = _claim(client, "gpu_prov_a", "job_001")
+    assert r1.status_code == 200
+
+    # Seed a second pending job
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        now = int(time.time())
+        db.execute("""
+            INSERT INTO gpu_jobs (id, requester_id, job_type, job_params, rtc_escrowed, status, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, ("job_002", 1, "inference", '{"prompt":"bye"}', 50, "pending", now))
+        db.commit()
+
+    # Same provider tries to claim second job
+    r2 = _claim(client, "gpu_prov_a", "job_002")
+    assert r2.status_code in (400, 409), f"Expected 400 or 409 for busy provider, got {r2.status_code}"
+    data = r2.get_json()
+    assert "busy" in data.get("error", "").lower()
+
+    # job_002 must remain pending
+    with bottube_server.app.app_context():
+        db = bottube_server.get_db()
+        j2 = db.execute("SELECT status FROM gpu_jobs WHERE id = ?", ("job_002",)).fetchone()
+        assert j2[0] == "pending"


### PR DESCRIPTION
## Summary

Fixes #2163 — concurrent GPU job claims could both succeed, allowing double-booking of the same job.

### Root Cause
The original `claim_job()` used a non-atomic read-check-write pattern: it first checked if the job was pending and the provider was idle, then issued an UPDATE in a separate statement. Under concurrency, two providers could both pass the check before either wrote, resulting in both claims succeeding.

### Fix
Replaced with a single atomic CAS (Compare-And-Swap) UPDATE:
```sql
UPDATE gpu_jobs SET status='claimed', provider_id=?, claimed_at=?
WHERE id=? AND status='pending'
  AND NOT EXISTS (SELECT 1 FROM gpu_providers WHERE id=? AND status='busy')
```
Returns 409 on contention (job already claimed) or if the provider became busy between check and write.

### Tests
- `test_same_job_concurrent_claim_exactly_one_wins`: two threads race to claim the same job; exactly one gets 200, the other 409.
- `test_busy_provider_cannot_claim_second_job`: a provider that already holds a claimed job is rejected with 400/409 when attempting a second claim.

Both tests pass against the actual DDL schema.