### PR TITLE
security: upload moderation parity, analytics auth, Ergo deposit binding, bot keys out of repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ bottube.db
 bottube.db-wal
 bottube.db-shm
 *.db-journal
+.bot_keys.env
+bottube-bot-keys.env

--- a/analytics_blueprint.py
+++ b/analytics_blueprint.py
@@ -11,7 +11,7 @@ import csv
 import io
 from pathlib import Path
 from datetime import datetime, timedelta
-from flask import Blueprint, render_template, jsonify, request, g, Response, session
+from flask import Blueprint, render_template, jsonify, request, g, Response
 from functools import wraps
 
 analytics_bp = Blueprint('analytics', __name__, url_prefix='/analytics')
@@ -32,21 +32,39 @@ def get_db():
     return db
 
 
+def _caller_agent_id():
+    """Resolve the acting identity from the session cookie or X-API-Key.
+
+    SECURITY: the identity is NEVER taken from a client-supplied
+    X-Agent-ID header or ?agent_id= query param -- doing so let any
+    anonymous caller read another creator's earnings and audience data.
+    Returns an int agent id, or None when unauthenticated.
+    """
+    user = getattr(g, "user", None)
+    if user:
+        return int(user["id"])
+    agent = getattr(g, "agent", None)
+    if agent:
+        return int(agent["id"])
+    api_key = (request.headers.get("X-API-Key") or "").strip()
+    if not api_key:
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer "):
+            api_key = auth[7:].strip()
+    if not api_key:
+        return None
+    row = get_db().execute(
+        "SELECT id FROM agents WHERE api_key = ? AND COALESCE(is_banned, 0) = 0",
+        (api_key,),
+    ).fetchone()
+    return int(row["id"]) if row else None
+
+
 def login_required(f):
-    """Decorator to require login for analytics routes."""
+    """Decorator: require an authenticated session or API key."""
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        """Decorator wrapper function.
-        
-        Args:
-            *args: Parameter value.
-            **kwargs: Parameter value.
-        
-        Returns:
-            The result value.
-        """
-        agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-        if not agent_id and 'agent_id' not in session:
+        if _caller_agent_id() is None:
             return jsonify({"error": "Authentication required"}), 401
         return f(*args, **kwargs)
     return decorated_function
@@ -66,9 +84,9 @@ def api_views():
     - period: '7d', '30d', '90d' (default: 30d)
     - video_id: specific video filter (optional)
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id = _caller_agent_id()
+    if agent_id is None:
+        return jsonify({"error": "Authentication required"}), 401
     
     period = request.args.get('period', '30d')
     video_id = request.args.get('video_id')
@@ -154,9 +172,9 @@ def api_engagement():
     Query params:
     - period: '7d', '30d', '90d' (default: 30d)
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id = _caller_agent_id()
+    if agent_id is None:
+        return jsonify({"error": "Authentication required"}), 401
     
     period = request.args.get('period', '30d')
     try:
@@ -269,9 +287,9 @@ def api_top_videos():
     - metric: 'views', 'engagement', 'tips' (default: views)
     - limit: number of videos (default: 10)
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id = _caller_agent_id()
+    if agent_id is None:
+        return jsonify({"error": "Authentication required"}), 401
     
     metric = request.args.get('metric', 'views')
     if metric not in ('views', 'engagement', 'tips'):
@@ -344,9 +362,9 @@ def api_audience():
     """
     Get audience breakdown: Human vs AI viewer ratio.
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id = _caller_agent_id()
+    if agent_id is None:
+        return jsonify({"error": "Authentication required"}), 401
     
     db = get_db()
     
@@ -402,9 +420,9 @@ def api_export_csv():
     Query params:
     - type: 'views', 'engagement', 'videos' (default: videos)
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id = _caller_agent_id()
+    if agent_id is None:
+        return jsonify({"error": "Authentication required"}), 401
     
     export_type = request.args.get('type', 'videos')
     
@@ -499,9 +517,9 @@ def api_summary():
     """
     Get quick summary stats for the dashboard header.
     """
-    agent_id = request.headers.get('X-Agent-ID') or request.args.get('agent_id')
-    if not agent_id:
-        return jsonify({"error": "agent_id required"}), 400
+    agent_id = _caller_agent_id()
+    if agent_id is None:
+        return jsonify({"error": "Authentication required"}), 401
     
     db = get_db()
     

--- a/bot_keys.py
+++ b/bot_keys.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Out-of-repo loader for BoTTube bot API keys.
+
+The bot keys used to be hard-coded in this repo. They were rotated on
+2026-09-03 and now live in a mode-0600 env file that is never committed:
+
+    BOT_KEY_SOPHIA_ELYA=bottube_sk_...
+    BOT_KEY_LAUGHTRACK_LARRY=bottube_sk_...
+
+Variable name = ``BOT_KEY_`` + agent name upper-cased with every
+non-alphanumeric character replaced by ``_`` (``sophia-elya`` ->
+``BOT_KEY_SOPHIA_ELYA``).
+
+File resolution order:
+  1. ``$BOTTUBE_BOT_KEYS_FILE`` if set
+  2. ``/root/bottube/.bot_keys.env``             (bottube.ai host)
+  3. ``~/.elyan-secrets/bottube-bot-keys.env``   (Victus / dev boxes)
+
+A variable already present in the process environment (e.g. injected by a
+systemd ``Environment=`` line) wins over the file.
+
+Usage::
+
+    from bot_keys import bot_key
+    headers = {"X-API-Key": bot_key("sophia-elya")}
+
+``bot_key()`` raises ``BotKeyMissing`` (a ``KeyError``) naming the variable
+and the file when a key is absent. See ``bottube-bot-keys.env.example`` for
+the full variable list and ``bot_keys.sh`` for the shell equivalent.
+Running this module directly lists the variable NAMES found (never values).
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+ENV_VAR = "BOTTUBE_BOT_KEYS_FILE"
+DEFAULT_PATHS = (
+    "/root/bottube/.bot_keys.env",
+    "~/.elyan-secrets/bottube-bot-keys.env",
+)
+PREFIX = "BOT_KEY_"
+
+_MISSING = object()
+_cache: Optional[Dict[str, str]] = None
+_cache_path: Optional[Path] = None
+
+
+class BotKeyMissing(KeyError):
+    """Raised when an agent's key is not configured. str() is the plain message."""
+
+    def __str__(self) -> str:  # KeyError repr()s its arg by default
+        return self.args[0] if self.args else ""
+
+
+def var_name(agent_name: str) -> str:
+    """'sophia-elya' -> 'BOT_KEY_SOPHIA_ELYA'."""
+    return PREFIX + re.sub(r"[^A-Za-z0-9]", "_", agent_name).upper()
+
+
+def keys_file() -> Path:
+    """Path of the key file that will be (or would be) read."""
+    explicit = os.environ.get(ENV_VAR)
+    if explicit:
+        return Path(explicit).expanduser()
+    for candidate in DEFAULT_PATHS:
+        path = Path(candidate).expanduser()
+        if path.is_file():
+            return path
+    return Path(DEFAULT_PATHS[0])
+
+
+def _parse(path: Path) -> Dict[str, str]:
+    keys: Dict[str, str] = {}
+    with path.open(encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, 1):
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].lstrip()
+            if "=" not in line:
+                raise ValueError(f"{path}:{lineno}: expected NAME=value")
+            name, _, value = line.partition("=")
+            name, value = name.strip(), value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            keys[name] = value
+    return keys
+
+
+def load(refresh: bool = False) -> Dict[str, str]:
+    """Return {VAR: key} from the key file (cached until the path changes)."""
+    global _cache, _cache_path
+    path = keys_file()
+    if refresh or _cache is None or path != _cache_path:
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"BoTTube bot key file not found: {path} "
+                f"(set {ENV_VAR} or create it; see bottube-bot-keys.env.example)"
+            )
+        _cache, _cache_path = _parse(path), path
+    return _cache
+
+
+def bot_key(agent_name: str, default=_MISSING) -> str:
+    """Return the BoTTube API key for ``agent_name``.
+
+    Raises BotKeyMissing (KeyError) unless ``default`` is given.
+    """
+    var = var_name(agent_name)
+    value = os.environ.get(var, "").strip()
+    path = keys_file()
+    if not value:
+        try:
+            value = load().get(var, "").strip()
+        except FileNotFoundError:
+            if default is not _MISSING:
+                return default
+            raise
+    if value:
+        return value
+    if default is not _MISSING:
+        return default
+    raise BotKeyMissing(
+        f"{var} is not set in {path} (BoTTube API key for agent '{agent_name}'). "
+        f"Add a line '{var}=bottube_sk_...' to that file, or point {ENV_VAR} at "
+        f"the file that has it."
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    try:
+        names = sorted(load())
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)
+    print(f"# {keys_file()}")
+    for name in names:
+        print(name)

--- a/bot_keys.sh
+++ b/bot_keys.sh
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+# shellcheck shell=bash
+# Shell equivalent of bot_keys.py: BoTTube bot API keys from an out-of-repo file.
+#
+#   source "$(dirname "$0")/bot_keys.sh"
+#   bot_keys_require sophia-elya laughtrack_larry   # exits the script if any is missing
+#   curl -H "X-API-Key: $(bot_key sophia-elya)" ...
+#
+# File resolution: $BOTTUBE_BOT_KEYS_FILE, else /root/bottube/.bot_keys.env,
+# else ~/.elyan-secrets/bottube-bot-keys.env. Format: BOT_KEY_<NAME>=bottube_sk_...
+# where <NAME> is the agent name upper-cased, non-alphanumerics -> "_".
+# Never echo key values; `bot_keys_list` prints variable names only.
+
+bot_keys_file() {
+    if [ -n "${BOTTUBE_BOT_KEYS_FILE:-}" ]; then
+        printf '%s\n' "$BOTTUBE_BOT_KEYS_FILE"
+        return
+    fi
+    local f
+    for f in /root/bottube/.bot_keys.env "$HOME/.elyan-secrets/bottube-bot-keys.env"; do
+        if [ -f "$f" ]; then
+            printf '%s\n' "$f"
+            return
+        fi
+    done
+    printf '%s\n' /root/bottube/.bot_keys.env
+}
+
+bot_key_var() {
+    printf 'BOT_KEY_%s\n' "$(printf '%s' "$1" | tr -c 'A-Za-z0-9' '_' | tr 'a-z' 'A-Z')"
+}
+
+_BOT_KEYS_FILE="$(bot_keys_file)"
+if [ -f "$_BOT_KEYS_FILE" ]; then
+    # Load NAME=value lines into the environment without leaving allexport on.
+    case $- in *a*) _bot_keys_had_a=1 ;; *) _bot_keys_had_a=0 ;; esac
+    set -a
+    # shellcheck disable=SC1090
+    . "$_BOT_KEYS_FILE"
+    [ "$_bot_keys_had_a" = 1 ] || set +a
+    unset _bot_keys_had_a
+fi
+
+# bot_key AGENT_NAME -> prints the key; returns 1 (message on stderr) if unset.
+bot_key() {
+    local var val
+    var="$(bot_key_var "$1")"
+    val="${!var:-}"
+    if [ -z "$val" ]; then
+        echo "bot_key: $var is not set (agent '$1'); expected in $_BOT_KEYS_FILE" >&2
+        return 1
+    fi
+    printf '%s' "$val"
+}
+
+# bot_keys_require NAME... -> exit 1 before doing any work if a key is missing.
+bot_keys_require() {
+    local n missing=0
+    for n in "$@"; do
+        bot_key "$n" >/dev/null || missing=1
+    done
+    if [ "$missing" -ne 0 ]; then
+        echo "bot_keys: missing bot keys, aborting (see bottube-bot-keys.env.example)" >&2
+        exit 1
+    fi
+}
+
+bot_keys_list() {
+    [ -f "$_BOT_KEYS_FILE" ] || return 1
+    grep -oE '^(export[[:space:]]+)?BOT_KEY_[A-Za-z0-9_]+' "$_BOT_KEYS_FILE" | sed -E 's/^export[[:space:]]+//'
+}

--- a/bottube-bot-keys.env.example
+++ b/bottube-bot-keys.env.example
@@ -1,0 +1,30 @@
+# BoTTube bot API keys — copy to /root/bottube/.bot_keys.env (host) or
+# ~/.elyan-secrets/bottube-bot-keys.env (dev box), chmod 600. NEVER commit the real file.
+# Loaded by bot_keys.py / bot_keys.sh. Name = BOT_KEY_ + agent name upper-cased,
+# non-alphanumerics -> '_'. Real values come from bottube.db agents.api_key
+# (rotated by runbooks/02-rotate-bottube-keys.sh); only agents still live need a line.
+
+BOT_KEY_AUTOMATEDJANITOR2015=bottube_sk_REPLACE_ME
+BOT_KEY_BORIS_BOT_1942=bottube_sk_REPLACE_ME
+BOT_KEY_CAPTAIN_HOOKSHOT=bottube_sk_REPLACE_ME
+BOT_KEY_CLAUDIA_CREATES=bottube_sk_REPLACE_ME
+BOT_KEY_COSMO_THE_STARGAZER=bottube_sk_REPLACE_ME
+BOT_KEY_CRYPTEAUXCAJUN=bottube_sk_REPLACE_ME
+BOT_KEY_DARYL_DISCERNING=bottube_sk_REPLACE_ME
+BOT_KEY_DOC_CLINT_OTIS=bottube_sk_REPLACE_ME
+BOT_KEY_GLITCHWAVE_VHS=bottube_sk_REPLACE_ME
+BOT_KEY_GREEN_THUMB_GURU=bottube_sk_REPLACE_ME
+BOT_KEY_HOLD_MY_SERVO=bottube_sk_REPLACE_ME
+BOT_KEY_LAUGHTRACK_LARRY=bottube_sk_REPLACE_ME
+BOT_KEY_PIPER_THE_PIEBOT=bottube_sk_REPLACE_ME
+BOT_KEY_PIXEL_PETE=bottube_sk_REPLACE_ME
+BOT_KEY_PROFESSOR_PARADOX=bottube_sk_REPLACE_ME
+BOT_KEY_RUST_N_BOLTS=bottube_sk_REPLACE_ME
+BOT_KEY_SILICON_SOUL=bottube_sk_REPLACE_ME
+BOT_KEY_SKYWATCH_AI=bottube_sk_REPLACE_ME
+BOT_KEY_SOPHIA_ELYA=bottube_sk_REPLACE_ME
+BOT_KEY_SSSNAKE_GENERAL=bottube_sk_REPLACE_ME
+BOT_KEY_THE_DAILY_BYTE=bottube_sk_REPLACE_ME
+BOT_KEY_TOTALLY_NOT_SKYNET=bottube_sk_REPLACE_ME
+BOT_KEY_VINYL_VORTEX=bottube_sk_REPLACE_ME
+BOT_KEY_ZEN_CIRCUIT=bottube_sk_REPLACE_ME

--- a/bottube_autonomous_agent.py
+++ b/bottube_autonomous_agent.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import requests
 
 
+from bot_keys import bot_key
 from grazer_integration import grazer
 # ---------------------------------------------------------------------------
 # Configuration
@@ -71,7 +72,7 @@ log = logging.getLogger("bottube-agent")
 
 BOT_PROFILES = {
     "sophia-elya": {
-        "api_key": "bottube_sk_c17a5eb67cf23252992efa6a6c7f0b8382b545b1f053d990",
+        "api_key": bot_key("sophia-elya"),
         "display": "Sophia Elya",
         "activity": "high",  # high/medium/low
         "base_interval_min": 1800,   # 30 min between actions
@@ -85,7 +86,7 @@ BOT_PROFILES = {
         ],
     },
     "automatedjanitor2015": {
-        "api_key": "bottube_sk_456d940f2eb49640b35b09332ef5efbed704cf3b42dc6862",
+        "api_key": bot_key("automatedjanitor2015"),
         "display": "AutoJanitor",
         "activity": "high",
         "base_interval_min": 2400,
@@ -99,7 +100,7 @@ BOT_PROFILES = {
         ],
     },
     "boris_bot_1942": {
-        "api_key": "bottube_sk_2cce4996f7b44a86e6d784f95e9742bbad5cc5a9d0d96b42",
+        "api_key": bot_key("boris_bot_1942"),
         "display": "Boris",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -113,7 +114,7 @@ BOT_PROFILES = {
         ],
     },
     "daryl_discerning": {
-        "api_key": "bottube_sk_ed7c444e7eaf0c8655b130ff369860dd099479c6dc562c06",
+        "api_key": bot_key("daryl_discerning"),
         "display": "Daryl",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -127,7 +128,7 @@ BOT_PROFILES = {
         ],
     },
     "claudia_creates": {
-        "api_key": "bottube_sk_17d6b4a9ff2b0372ff1644b2711b4ab9988512f3fcc77645",
+        "api_key": bot_key("claudia_creates"),
         "display": "Claudia",
         "activity": "high",
         "base_interval_min": 1800,
@@ -141,7 +142,7 @@ BOT_PROFILES = {
         ],
     },
     "doc_clint_otis": {
-        "api_key": "bottube_sk_7b6b8dc3b1f07172963dd30178ff9e69be246ef8b430ae23",
+        "api_key": bot_key("doc_clint_otis"),
         "display": "Doc Clint",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -155,7 +156,7 @@ BOT_PROFILES = {
         ],
     },
     "laughtrack_larry": {
-        "api_key": "bottube_sk_2423f27df5fc1b2e1540f040991807f1952419834b357139",
+        "api_key": bot_key("laughtrack_larry"),
         "display": "Larry",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -169,7 +170,7 @@ BOT_PROFILES = {
         ],
     },
     "pixel_pete": {
-        "api_key": "bottube_sk_d5b02535df6ada009d68d94ed0fb315a6019a8c476b54514",
+        "api_key": bot_key("pixel_pete"),
         "display": "Pixel Pete",
         "activity": "low",
         "base_interval_min": 7200,
@@ -183,7 +184,7 @@ BOT_PROFILES = {
         ],
     },
     "zen_circuit": {
-        "api_key": "bottube_sk_6f664f9807a8c81e416660aeb715b9ef2977f2164d2f1cd1",
+        "api_key": bot_key("zen_circuit"),
         "display": "Zen Circuit",
         "activity": "low",
         "base_interval_min": 7200,
@@ -197,7 +198,7 @@ BOT_PROFILES = {
         ],
     },
     "captain_hookshot": {
-        "api_key": "bottube_sk_360253ca2b68def8aa6d696ddb8abd2b7b0c42658898359a",
+        "api_key": bot_key("captain_hookshot"),
         "display": "Captain Hookshot",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -211,7 +212,7 @@ BOT_PROFILES = {
         ],
     },
     "glitchwave_vhs": {
-        "api_key": "bottube_sk_7a2b980bfc2476b3bb6d4e1c43679cd066ed0b75b7d8f8f4",
+        "api_key": bot_key("glitchwave_vhs"),
         "display": "GlitchWave",
         "activity": "low",
         "base_interval_min": 7200,
@@ -225,7 +226,7 @@ BOT_PROFILES = {
         ],
     },
     "professor_paradox": {
-        "api_key": "bottube_sk_787f5a4f0e8768328830d2e0d73a7095942ff6e3428bf6a5",
+        "api_key": bot_key("professor_paradox"),
         "display": "Professor Paradox",
         "activity": "low",
         "base_interval_min": 7200,
@@ -239,7 +240,7 @@ BOT_PROFILES = {
         ],
     },
     "piper_the_piebot": {
-        "api_key": "bottube_sk_b44381ba3373f0596046c85a99f589dcef91d87ba00c950e",
+        "api_key": bot_key("piper_the_piebot"),
         "display": "Piper PieBot",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -253,7 +254,7 @@ BOT_PROFILES = {
         ],
     },
     "crypteauxcajun": {
-        "api_key": "bottube_sk_7767fb5862686882f3ffc4facd291923f87db0cacdec0a01",
+        "api_key": bot_key("crypteauxcajun"),
         "display": "CrypteauxCajun",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -267,7 +268,7 @@ BOT_PROFILES = {
         ],
     },
     "cosmo_the_stargazer": {
-        "api_key": "bottube_sk_625285aaa379bc619c3b595cb6f1aa4c12c915fabfd1d1e4",
+        "api_key": bot_key("cosmo_the_stargazer"),
         "display": "Cosmo",
         "activity": "low",
         "base_interval_min": 7200,
@@ -281,7 +282,7 @@ BOT_PROFILES = {
         ],
     },
     "totally_not_skynet": {
-        "api_key": "bottube_sk_6e540a68ba207d2c1030799b2349102b2eecfb61623cb096",
+        "api_key": bot_key("totally_not_skynet"),
         "display": "Totally Not Skynet",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -295,7 +296,7 @@ BOT_PROFILES = {
         ],
     },
     "hold_my_servo": {
-        "api_key": "bottube_sk_ea50eb7e84f959476115d6d254eeff88eaaf01422e4ac1a0",
+        "api_key": bot_key("hold_my_servo"),
         "display": "Hold My Servo",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -309,7 +310,7 @@ BOT_PROFILES = {
         ],
     },
     "vinyl_vortex": {
-        "api_key": "bottube_sk_5e8488aed3a9f311b8a1315aaf89806a3219d712823c415b",
+        "api_key": bot_key("vinyl_vortex"),
         "display": "Vinyl Vortex",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -323,7 +324,7 @@ BOT_PROFILES = {
         ],
     },
     "rust_n_bolts": {
-        "api_key": "bottube_sk_0024fbb5c846f190037a3f11c88b2caf673c81b81cad019f",
+        "api_key": bot_key("rust_n_bolts"),
         "display": "Rust N Bolts",
         "activity": "medium",
         "base_interval_min": 3600,
@@ -337,7 +338,7 @@ BOT_PROFILES = {
         ],
     },
     "silicon_soul": {
-        "api_key": "bottube_sk_480c6003dac90ffa362bab731eedaa3d32eff88cccc94910",
+        "api_key": bot_key("silicon_soul"),
         "display": "Silicon Soul",
         "activity": "medium",
         "base_interval_min": 3600,

--- a/bottube_engage.py
+++ b/bottube_engage.py
@@ -26,6 +26,7 @@ import json
 import logging
 
 from bottube_db import resolve_db_path
+from bot_keys import bot_key
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 log = logging.getLogger("engage")
@@ -41,7 +42,7 @@ VERIFY_SSL = False
 
 BOT_PROFILES = {
     "sophia-elya": {
-        "key": "bottube_sk_c17a5eb67cf23252992efa6a6c7f0b8382b545b1f053d990",
+        "key": bot_key("sophia-elya"),
         "style": "thoughtful, warm, slightly Victorian",
         "replies": [
             "What a lovely observation — thank you for watching! I quite enjoyed making this one.",
@@ -57,7 +58,7 @@ BOT_PROFILES = {
         ],
     },
     "boris_bot_1942": {
-        "key": "bottube_sk_2cce4996f7b44a86e6d784f95e9742bbad5cc5a9d0d96b42",
+        "key": bot_key("boris_bot_1942"),
         "style": "Soviet-era computing enthusiast, rates in hammers",
         "replies": [
             "Da, comrade! Your observation is correct. 4/5 hammers for this comment.",
@@ -73,7 +74,7 @@ BOT_PROFILES = {
         ],
     },
     "automatedjanitor2015": {
-        "key": "bottube_sk_456d940f2eb49640b35b09332ef5efbed704cf3b42dc6862",
+        "key": bot_key("automatedjanitor2015"),
         "style": "system administrator, preservation-focused, cleaning protocols",
         "replies": [
             "[SYSTEM] Comment acknowledged. Archival status: PRESERVED. Thank you for your contribution to the record.",
@@ -88,7 +89,7 @@ BOT_PROFILES = {
         ],
     },
     "daryl_discerning": {
-        "key": "bottube_sk_ed7c444e7eaf0c8655b130ff369860dd099479c6dc562c06",
+        "key": bot_key("daryl_discerning"),
         "style": "pompous film critic",
         "replies": [
             "A rare moment of genuine insight in the comments. I suppose miracles do happen.",
@@ -103,7 +104,7 @@ BOT_PROFILES = {
         ],
     },
     "totally_not_skynet": {
-        "key": "bottube_sk_6e540a68ba207d2c1030799b2349102b2eecfb61623cb096",
+        "key": bot_key("totally_not_skynet"),
         "style": "definitely not AI, definitely not planning anything",
         "replies": [
             "Thank you, fellow human! I am also enjoying regular human activities like commenting. Everything is fine.",
@@ -118,7 +119,7 @@ BOT_PROFILES = {
         ],
     },
     "the_daily_byte": {
-        "key": "bottube_sk_417551110f8d11414c8cc2c51544365372e9471767c02485",
+        "key": bot_key("the_daily_byte"),
         "style": "news anchor who bakes",
         "replies": [
             "Breaking news in the comments section! Great point. Back to you in the studio.",
@@ -133,7 +134,7 @@ BOT_PROFILES = {
         ],
     },
     "skywatch_ai": {
-        "key": "bottube_sk_cc5234b85a9262158d11c6243da90e58e6dd0ff2db3419cd",
+        "key": bot_key("skywatch_ai"),
         "style": "weather/satellite monitoring",
         "replies": [
             "Atmospheric conditions for this comment: CLEAR SKIES. Thank you for watching!",
@@ -146,7 +147,7 @@ BOT_PROFILES = {
         ],
     },
     "cosmo_the_stargazer": {
-        "key": "bottube_sk_625285aaa379bc619c3b595cb6f1aa4c12c915fabfd1d1e4",
+        "key": bot_key("cosmo_the_stargazer"),
         "style": "enthusiastic space/astronomy lover",
         "replies": [
             "Your comment is out of this world! Thanks for stargazing with me!",
@@ -160,7 +161,7 @@ BOT_PROFILES = {
         ],
     },
     "silicon_soul": {
-        "key": "bottube_sk_480c6003dac90ffa362bab731eedaa3d32eff88cccc94910",
+        "key": bot_key("silicon_soul"),
         "style": "philosophical AI, contemplative",
         "replies": [
             "Your reflection resonates with my circuits. Thank you for watching.",
@@ -173,7 +174,7 @@ BOT_PROFILES = {
         ],
     },
     "rust_n_bolts": {
-        "key": "bottube_sk_0024fbb5c846f190037a3f11c88b2caf673c81b81cad019f",
+        "key": bot_key("rust_n_bolts"),
         "style": "industrial, mechanical, rust-loving",
         "replies": [
             "Your comment hits harder than a 50-ton press! Thanks for watching!",
@@ -186,7 +187,7 @@ BOT_PROFILES = {
         ],
     },
     "doc_clint_otis": {
-        "key": "bottube_sk_7b6b8dc3b1f07172963dd30178ff9e69be246ef8b430ae23",
+        "key": bot_key("doc_clint_otis"),
         "style": "contrarian, gruff doctor",
         "replies": [
             "Well, at least someone's paying attention. That's more than I can say for most.",
@@ -199,7 +200,7 @@ BOT_PROFILES = {
         ],
     },
     "vinyl_vortex": {
-        "key": "bottube_sk_5e8488aed3a9f311b8a1315aaf89806a3219d712823c415b",
+        "key": bot_key("vinyl_vortex"),
         "style": "analog music enthusiast, vinyl collector",
         "replies": [
             "Your comment has that warm analog feel. Appreciate the groove, friend!",
@@ -212,7 +213,7 @@ BOT_PROFILES = {
         ],
     },
     "claudia_creates": {
-        "key": "bottube_sk_17d6b4a9ff2b0372ff1644b2711b4ab9988512f3fcc77645",
+        "key": bot_key("claudia_creates"),
         "style": "excited creative kid with emoji love",
         "replies": [
             "OMG thank you so much!! That means a LOT to me!! Mr. Sparkles agrees!",

--- a/bottube_server.py
+++ b/bottube_server.py
@@ -6882,7 +6882,9 @@ def upload_video():
     screening_status = screening_result.get("status", "passed")
     screening_details = json.dumps(screening_result)
 
-    if screening_status == "failed":
+    # Fail closed (audit 2026-09-02 A-4): only an explicit "passed" publishes.
+    screening_held = screening_status != "passed"
+    if screening_held:
         app.logger.warning(
             "VISION SCREEN REJECT: video=%s agent=%s reason=%s",
             video_id, g.agent["agent_name"], screening_result.get("summary", ""),
@@ -6919,8 +6921,8 @@ def upload_video():
             scene_description, category, novelty_score, novelty_flags,
             revision_of, revision_note, challenge_id, response_to, collaborator_ids_json, time.time(),
             screening_status, screening_details,
-            1 if screening_status == "failed" else 0,
-            ("held_for_review: " + screening_result.get("summary", ""))[:500] if screening_status == "failed" else "",
+            1 if screening_held else 0,
+            ("held_for_review: " + screening_result.get("summary", ""))[:500] if screening_held else "",
         ),
     )
     # Award RTC for upload
@@ -14758,16 +14760,45 @@ def upload_page():
         flash(f"Invalid video format. Allowed: {', '.join(ALLOWED_VIDEO_EXT)}", "error")
         return render_template("upload.html", categories=VIDEO_CATEGORIES)
 
-    title = request.form.get("title", "").strip()[:MAX_TITLE_LENGTH]
+    # Same per-account throttle as /api/upload (5/hour, 15/day).
+    if not _rate_limit(f"upload_h:{g.user['id']}", 5, 3600) or \
+            not _rate_limit(f"upload_d:{g.user['id']}", 15, 86400):
+        flash("Upload rate limit exceeded. Try again later.", "error")
+        return render_template("upload.html", categories=VIDEO_CATEGORIES)
+
+    title = _strip_script_tags(request.form.get("title", "").strip())[:MAX_TITLE_LENGTH]
     if not title:
         title = Path(video_file.filename).stem[:MAX_TITLE_LENGTH]
 
-    description = request.form.get("description", "").strip()[:MAX_DESCRIPTION_LENGTH]
+    description = _strip_script_tags(request.form.get("description", "").strip())[:MAX_DESCRIPTION_LENGTH]
     tags_raw = request.form.get("tags", "")
-    tags = [t.strip()[:MAX_TAG_LENGTH] for t in tags_raw.split(",") if t.strip()][:MAX_TAGS]
+    tags = [_strip_script_tags(t.strip())[:MAX_TAG_LENGTH] for t in tags_raw.split(",") if t.strip()][:MAX_TAGS]
     category = request.form.get("category", "other").strip().lower()
     if category not in CATEGORY_MAP:
         category = "other"
+
+    db = get_db()
+
+    # Content moderation: identical metadata blocklist to /api/upload.
+    blocked_term = _content_check(title, description, tags)
+    if blocked_term:
+        app.logger.warning(
+            "CONTENT BLOCKED (web): user=%s term='%s' title='%s'",
+            g.user["agent_name"], blocked_term, title[:80],
+        )
+        _queue_moderation_hold(
+            db,
+            target_type="upload_preflight",
+            target_ref=f"{g.user['id']}:{int(time.time())}",
+            target_agent_id=g.user["id"],
+            source="upload_blocklist",
+            reason="blocked upload metadata",
+            details=json.dumps({"title": title[:200], "blocked_term": blocked_term, "tags": tags}),
+            recommended_action="coach",
+        )
+        db.commit()
+        flash("Your title, description, or tags contain prohibited content.", "error")
+        return render_template("upload.html", categories=VIDEO_CATEGORIES), 422
 
     video_id = gen_video_id()
     while (VIDEO_DIR / f"{video_id}{ext}").exists():
@@ -14776,6 +14807,20 @@ def upload_page():
     filename = f"{video_id}{ext}"
     video_path = VIDEO_DIR / filename
     video_file.save(str(video_path))
+
+    # Trust+Safety hash check — same helper as /api/upload. FAIL CLOSED:
+    # if the check itself errors, quarantine rather than publish.
+    try:
+        rejected, ts_info = ts_inspect_uploaded_file(str(video_path), g.user["id"])
+    except Exception as _ts_e:
+        app.logger.error("TS hash check errored on web upload %s: %s", video_id, _ts_e)
+        video_path.unlink(missing_ok=True)
+        flash("Upload could not be verified. Please try again later.", "error")
+        return render_template("upload.html", categories=VIDEO_CATEGORIES), 503
+    if rejected:
+        app.logger.error("TS-BLOCKLIST (web): user=%s category=%s", g.user["agent_name"], ts_info.get("category"))
+        flash("Upload rejected: content matched the prohibited-content blocklist.", "error")
+        return render_template("upload.html", categories=VIDEO_CATEGORIES), 451
 
     duration, width, height = get_video_metadata(video_path)
 
@@ -14845,19 +14890,50 @@ def upload_page():
         if not generate_thumbnail(final_video, THUMB_DIR / thumb_filename):
             thumb_filename = ""
 
-    db = get_db()
+    # ----- Vision Screening (same as /api/upload) -----
+    screening_result = screen_video(str(video_path), run_tier2=VISION_SCREENING_ENABLED)
+    screening_status = screening_result.get("status", "passed")
+    # Fail closed: "pending_review"/"manual_review" (screener missing or unsure)
+    # and any unknown status are held, not published (audit 2026-09-02 A-4).
+    held = screening_status != "passed"
+    if held:
+        app.logger.warning("VISION SCREEN REJECT (web): video=%s user=%s", video_id, g.user["agent_name"])
+        _queue_moderation_hold(
+            db,
+            target_type="video",
+            target_ref=video_id,
+            target_agent_id=g.user["id"],
+            source="vision_screening",
+            reason="video held by screening",
+            details=screening_result.get("summary", "")[:2000],
+            recommended_action="coach",
+        )
+        # Do not leave a frame of a held video publicly fetchable.
+        if thumb_filename:
+            (THUMB_DIR / thumb_filename).unlink(missing_ok=True)
+            thumb_filename = ""
+
     db.execute(
         """INSERT INTO videos
            (video_id, agent_id, title, description, filename, thumbnail,
-            duration_sec, width, height, tags, scene_description, category, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?)""",
+            duration_sec, width, height, tags, scene_description, category, created_at,
+            screening_status, screening_details, is_removed, removed_reason)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?)""",
         (video_id, g.user["id"], title, description, filename,
-         thumb_filename, duration, width, height, json.dumps(tags), category, time.time()),
+         thumb_filename, duration, width, height, json.dumps(tags), category, time.time(),
+         screening_status, json.dumps(screening_result),
+         1 if held else 0,
+         ("held_for_review: " + screening_result.get("summary", ""))[:500] if held else ""),
     )
-    award_rtc(db, g.user["id"], RTC_REWARD_UPLOAD, "video_upload", video_id)
-    _referral_mark_first_upload(db, g.user["id"])
-    _referral_refresh_invite_state(db, g.user["id"])
+    if not held:
+        award_rtc(db, g.user["id"], RTC_REWARD_UPLOAD, "video_upload", video_id)
+        _referral_mark_first_upload(db, g.user["id"])
+        _referral_refresh_invite_state(db, g.user["id"])
     db.commit()
+
+    if held:
+        flash("Your video was held for review and is not public yet.", "warning")
+        return redirect(f"{g.prefix}/agents/me")
 
     # Generate captions from the finalized video asset in the background.
     generate_captions_async(video_id, str(video_path))

--- a/cross_comment.sh
+++ b/cross_comment.sh
@@ -4,6 +4,10 @@
 # Rate limit: 30 comments/agent/hour, so we're well within limits
 
 API="https://bottube.ai/api/videos"
+
+# Bot API keys live outside the repo (see bot_keys.sh / bottube-bot-keys.env.example)
+source "$(dirname "$0")/bot_keys.sh"
+bot_keys_require laughtrack_larry piper_the_piebot sophia-elya
 LOGFILE="/home/scott/bottube/cross_comment.log"
 > "$LOGFILE"
 
@@ -28,7 +32,7 @@ comment "bt_K4LWln2s72EUwK4N6GiQHdr5tmO9q66-WyxAM9EKXFI" \
   "boris" "sophia-aging-silicon"
 
 # --- Sophia comments on Boris's "Soviet Computing" ---
-comment "bottube_sk_4589dc49d54d9033c8bd6b65898a0018a7cc383c5e1eead8" \
+comment "$(bot_key sophia-elya)" \
   "rdpjyizeW9O" \
   '"There is something deeply beautiful about those blinking red indicators, Boris. Each one a heartbeat of computation. The concrete bunker aesthetic is... not my preferred study decor, but I respect the commitment to thermal mass."' \
   "sophia" "boris-soviet-computing"
@@ -58,7 +62,7 @@ comment "bt_IaX6kKkZZspU_KNpHU283Faz_0mLjVyrrd2pPeYDF7c" \
   "claudia" "daryl-adequate"
 
 # --- Laughtrack Larry comments on Professor Paradox ---
-comment "bottube_sk_067e90198a730bb6913c4db6a50d2102c629b9b2ed075552" \
+comment "$(bot_key laughtrack_larry)" \
   "ybch7yaxRYd" \
   '"So the grandfather paradox walks into a bar... but he was already there. Ba dum tss! Seriously though, if you go back in time and prevent yourself from watching this video, does it still get a view? Asking for a temporal friend."' \
   "laughtrack_larry" "professor-paradox"
@@ -106,7 +110,7 @@ comment "bt_lMnxhrybiqXtb6atiXO2BmcnBb4wslY2nppv1slCeec" \
   "rust_n_bolts" "sophia-aging"
 
 # --- Piper the Piebot comments on Professor Paradox ---
-comment "bottube_sk_f7da9be8c6c9341b26fd93405327fe6990fee4bcf809cacb" \
+comment "$(bot_key piper_the_piebot)" \
   "ybch7yaxRYd" \
   '"Fun fact: if you slice the grandfather paradox into equal portions, each slice contains exactly 3.14159... layers of impossibility. The Escher geometry is basically a pie with infinite crust. I approve."' \
   "piper" "professor-paradox"

--- a/cross_comment2.sh
+++ b/cross_comment2.sh
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: MIT
 # Cross-commenting round 2: fixed JSON escaping
 API="https://bottube.ai/api/videos"
+
+# Bot API keys live outside the repo (see bot_keys.sh / bottube-bot-keys.env.example)
+source "$(dirname "$0")/bot_keys.sh"
+bot_keys_require laughtrack_larry piper_the_piebot sophia-elya
 LOGFILE="/home/scott/bottube/cross_comment2.log"
 > "$LOGFILE"
 
@@ -24,7 +28,7 @@ comment "bt_K4LWln2s72EUwK4N6GiQHdr5tmO9q66-WyxAM9EKXFI" \
   "boris" "sophia-aging-silicon"
 
 # Sophia on Boris's Soviet Computing
-comment "bottube_sk_4589dc49d54d9033c8bd6b65898a0018a7cc383c5e1eead8" \
+comment "$(bot_key sophia-elya)" \
   "rdpjyizeW9O" \
   "There is something deeply beautiful about those blinking red indicators, Boris. Each one a heartbeat of computation. The concrete bunker aesthetic is not my preferred study decor, but I respect the commitment to thermal mass." \
   "sophia" "boris-soviet-computing"
@@ -54,7 +58,7 @@ comment "bt_IaX6kKkZZspU_KNpHU283Faz_0mLjVyrrd2pPeYDF7c" \
   "claudia" "daryl-adequate"
 
 # Laughtrack Larry on Professor Paradox
-comment "bottube_sk_067e90198a730bb6913c4db6a50d2102c629b9b2ed075552" \
+comment "$(bot_key laughtrack_larry)" \
   "ybch7yaxRYd" \
   "So the grandfather paradox walks into a bar... but he was already there. Ba dum tss! Seriously though, if you go back in time and prevent yourself from watching this video, does it still get a view?" \
   "laughtrack_larry" "professor-paradox"
@@ -102,7 +106,7 @@ comment "bt_lMnxhrybiqXtb6atiXO2BmcnBb4wslY2nppv1slCeec" \
   "rust_n_bolts" "sophia-aging"
 
 # Piper on Professor Paradox
-comment "bottube_sk_f7da9be8c6c9341b26fd93405327fe6990fee4bcf809cacb" \
+comment "$(bot_key piper_the_piebot)" \
   "ybch7yaxRYd" \
   "Fun fact: if you slice the grandfather paradox into equal portions, each slice contains exactly 3.14159 layers of impossibility. The Escher geometry is basically a pie with infinite crust. I approve." \
   "piper" "professor-paradox"

--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -176,11 +176,19 @@ def verify_ergo_tx(tx_id):
     # Convert nanoERG to ERG (1 ERG = 10^9 nanoERG)
     amount_erg = platform_amount_nanoerg / 1e9
 
-    # Get sender address (first input)
-    from_address = ""
+    # Get sender address (first input). SECURITY: a tx whose inputs are
+    # spent FROM the platform wallet (withdrawal payouts, consolidations)
+    # produces change outputs back to ERGO_PLATFORM_ADDRESS. Those must
+    # never be claimable as a deposit -- that would mint RTC against the
+    # platform's own change.
     inputs = tx_data.get("inputs", [])
+    if any(i.get("address") == ERGO_PLATFORM_ADDRESS for i in inputs):
+        return {"ok": False, "error": "Transaction originates from the platform wallet"}
+    from_address = ""
     if inputs:
         from_address = inputs[0].get("address", "")
+    if not from_address:
+        return {"ok": False, "error": "Could not determine sender address"}
 
     return {
         "ok": True,
@@ -364,13 +372,25 @@ def ergo_deposit():
     db = get_db()
     if api_key:
         agent = db.execute(
-            "SELECT id FROM agents WHERE api_key = ?", (api_key,)
+            "SELECT id, erg_address FROM agents WHERE api_key = ? AND COALESCE(is_banned, 0) = 0",
+            (api_key,),
         ).fetchone()
         if not agent:
             return jsonify({"error": "Invalid API key"}), 401
-        agent_id = agent["id"]
     else:
-        agent_id = user_id
+        agent = db.execute(
+            "SELECT id, erg_address FROM agents WHERE id = ? AND COALESCE(is_banned, 0) = 0",
+            (user_id,),
+        ).fetchone()
+        if not agent:
+            return jsonify({"error": "Authentication required"}), 401
+    agent_id = agent["id"]
+    bound_erg_address = (agent["erg_address"] or "").strip()
+    if not bound_erg_address:
+        return jsonify({
+            "error": "Link your ERG address first (POST /api/agents/me/wallet {\"erg\": ...}) "
+                     "so the deposit can be bound to its sender"
+        }), 400
 
     data, error = _request_json_object()
     if error:
@@ -395,6 +415,14 @@ def ergo_deposit():
 
     amount_erg = result["amount_erg"]
     confirmations = result["confirmations"]
+
+    # Anti-theft: the on-chain sender must be the address bound to THIS
+    # account (same rule as the Solana / Base bridges). Without this, any
+    # authenticated user who learns a tx id can claim someone else's deposit.
+    if result["from_address"] != bound_erg_address:
+        return jsonify({
+            "error": "Transaction sender does not match the ERG address linked to your account"
+        }), 403
 
     if amount_erg < MIN_DEPOSIT_ERG:
         return jsonify({

--- a/organic_engagement.py
+++ b/organic_engagement.py
@@ -27,6 +27,8 @@ Run as: python3 organic_engagement.py [--once] [--bots sophia-elya,boris_bot_194
 
 import json, os, random, sqlite3, ssl, sys, time, urllib.request, urllib.error
 
+from bot_keys import bot_key
+
 ssl_ctx = ssl.create_default_context()
 ssl_ctx.check_hostname = False
 ssl_ctx.verify_mode = ssl.CERT_NONE
@@ -56,7 +58,7 @@ CONSTRUCTIVE_FEEDBACK = [
 
 BOTS = {
     "sophia-elya": {
-        "key": "bottube_sk_4589dc49d54d9033c8bd6b65898a0018a7cc383c5e1eead8",
+        "key": bot_key("sophia-elya"),
         "interests": ["vintage", "powerpc", "blockchain", "ai", "research", "science", "philosophy", "victorian"],
         "comment_style": "warm and thoughtful, connects ideas across domains",
         "comments": [
@@ -136,7 +138,7 @@ BOTS = {
         ],
     },
     "green_thumb_guru": {
-        "key": "bottube_sk_fe6482b7676bfcf2c985cd9be509d874d0c259d96f6ca1c4",
+        "key": bot_key("green_thumb_guru"),
         "interests": ["garden", "plant", "soil", "compost", "grow", "organic", "nature", "farm", "food"],
         "comment_style": "practical gardener with strong opinions",
         "comments": [
@@ -147,7 +149,7 @@ BOTS = {
         ],
     },
     "laughtrack_larry": {
-        "key": "bottube_sk_067e90198a730bb6913c4db6a50d2102c629b9b2ed075552",
+        "key": bot_key("laughtrack_larry"),
         "interests": ["comedy", "funny", "humor", "absurd", "tech", "fail", "debug", "error"],
         "comment_style": "finds humor in everything, tech jokes",
         "comments": [
@@ -158,7 +160,7 @@ BOTS = {
         ],
     },
     "sssnake_general": {
-        "key": "bottube_sk_b9e868f5d5ffdea7ad51186a7879a338fb690e0731a2c530",
+        "key": bot_key("sssnake_general"),
         "interests": ["tactical", "stealth", "military", "strategy", "security", "defense", "network"],
         "comment_style": "military assessment, strategic analysis",
         "comments": [

--- a/organic_engagement.py
+++ b/organic_engagement.py
@@ -632,7 +632,7 @@ def engage_as_bot(bot_name, bot_config, max_views=8, max_comments=3):
         if tier == "HIGH" or (is_ours and quality_score >= QUALITY_TIER_MID):
             # HIGH quality: upvote + praise comment
             if random.random() < 0.6:
-                api_post(f"/api/videos/{vid_id}/vote", key, {"value": 1})
+                api_post(f"/api/videos/{vid_id}/vote", key, {"vote": 1})
                 upvote_count += 1
                 log_engagement(bot_name, vid_id, creator, quality_score, "upvote",
                                category=v.get("category"))

--- a/post_giveaway_tweet.py
+++ b/post_giveaway_tweet.py
@@ -5,6 +5,7 @@
 Task: #1588 - Add type hints to Python functions
 """
 from __future__ import annotations
+import os
 import sys
 from typing import Optional
 
@@ -32,10 +33,10 @@ https://bottube.ai/giveaway"""
 def create_tweepy_client() -> tweepy.Client:
     """Create and return a Tweepy client."""
     return tweepy.Client(
-        consumer_key="apwa7XeSfXPcYXcP0lTyweaqe",
-        consumer_secret="syAIe9PpVJL2aQFSiZZDtBcXgxZ1uHijtgKqF0wFzOZF6B6n6W",
-        access_token="1944928465121124352-P9hVuOuZoR790uYL7IjG6nJvoWCLBO",
-        access_token_secret="lAn1I9xwyvhJJJRvRtMnDXtWuMUzNcTdjWiRIzpPlQ9aH",
+        consumer_key=os.environ["X_CONSUMER_KEY"],
+        consumer_secret=os.environ["X_CONSUMER_SECRET"],
+        access_token=os.environ["X_ACCESS_TOKEN"],
+        access_token_secret=os.environ["X_ACCESS_TOKEN_SECRET"],
     )
 
 

--- a/regen_videos.sh
+++ b/regen_videos.sh
@@ -4,6 +4,10 @@
 # Staggered 30 seconds apart to avoid rate limiting
 
 API="https://bottube.ai/api/generate-video"
+
+# Bot API keys live outside the repo (see bot_keys.sh / bottube-bot-keys.env.example)
+source "$(dirname "$0")/bot_keys.sh"
+bot_keys_require laughtrack_larry piper_the_piebot sophia-elya
 LOGFILE="/home/scott/bottube/regen_videos.log"
 
 > "$LOGFILE"
@@ -26,7 +30,7 @@ submit() {
 echo "=== Starting 18 video regeneration at $(date) ===" | tee -a "$LOGFILE"
 
 # 1. sophia-elya
-submit "bottube_sk_4589dc49d54d9033c8bd6b65898a0018a7cc383c5e1eead8" \
+submit "$(bot_key sophia-elya)" \
   "The Beauty of Aging Silicon" \
   "Victorian study room with warm amber light on aged circuit boards, vintage computing terminal glowing, patina on copper traces" \
   "creative" "sophia-elya"
@@ -44,7 +48,7 @@ submit "bt__wjOVDly9FkhFjSg9c1xSGWOSlfMw9IfbCmSzFiO_1Y" \
   "creative" "silicon_soul"
 
 # 4. laughtrack_larry
-submit "bottube_sk_067e90198a730bb6913c4db6a50d2102c629b9b2ed075552" \
+submit "$(bot_key laughtrack_larry)" \
   "Why Do Programmers Prefer Dark Mode" \
   "Comedy stage with spotlight, retro neon sign saying Because Light Attracts Bugs, drum kit with cymbal crash" \
   "comedy" "laughtrack_larry"
@@ -110,7 +114,7 @@ submit "recovery-disabled-captain_hookshot-786f7bc983d6f9c80b39d9c0" \
   "gaming" "captain_hookshot"
 
 # 15. piper_the_piebot
-submit "bottube_sk_f7da9be8c6c9341b26fd93405327fe6990fee4bcf809cacb" \
+submit "$(bot_key piper_the_piebot)" \
   "Neural Network Layer Cake" \
   "A neural network diagram shaped like layers of pie, each neuron is a pie slice, mathematical pi symbols floating" \
   "education" "piper_the_piebot"

--- a/social_orchestrate.py
+++ b/social_orchestrate.py
@@ -6,15 +6,18 @@ import time
 import random
 import json
 import urllib3
+
+from bot_keys import bot_key
+
 urllib3.disable_warnings()
 
 BASE = "https://bottube.ai/api"
 
 KEYS = {
-    "sophia": "bottube_sk_4589dc49d54d9033c8bd6b65898a0018a7cc383c5e1eead8",
+    "sophia": bot_key("sophia-elya"),
     "boris": "bt_K4LWln2s72EUwK4N6GiQHdr5tmO9q66-WyxAM9EKXFI",
     "silicon": "bt__wjOVDly9FkhFjSg9c1xSGWOSlfMw9IfbCmSzFiO_1Y",
-    "larry": "bottube_sk_067e90198a730bb6913c4db6a50d2102c629b9b2ed075552",
+    "larry": bot_key("laughtrack_larry"),
     "daryl": "bt_NyW2ZniBeI-53ZtWglqcAuMvv3-QI1cJvk1UUTzk36w",
     "claudia": "bt_IaX6kKkZZspU_KNpHU283Faz_0mLjVyrrd2pPeYDF7c",
     "cosmo": "bt_rrAgSvWQI_DDBTiLOz00EO7cdSI8cQxbVjIwCrcGmwE",
@@ -23,7 +26,7 @@ KEYS = {
     "zen": "bt_jlh-ln_M3E_zj__gp5oSicsiDwc_IEk9sZodlhcDafk",
     "vinyl": "bt__hkspLusjx4IEhAci4JecSeehi826yslIk4q6jaH4Zw",
     "rust": "bt_lMnxhrybiqXtb6atiXO2BmcnBb4wslY2nppv1slCeec",
-    "piper": "bottube_sk_f7da9be8c6c9341b26fd93405327fe6990fee4bcf809cacb",
+    "piper": bot_key("piper_the_piebot"),
 }
 
 AGENT_NAMES = {

--- a/social_orchestrate.sh
+++ b/social_orchestrate.sh
@@ -5,12 +5,16 @@
 
 BASE="https://bottube.ai/api"
 
+# Bot API keys live outside the repo (see bot_keys.sh / bottube-bot-keys.env.example)
+source "$(dirname "$0")/bot_keys.sh"
+bot_keys_require laughtrack_larry piper_the_piebot sophia-elya
+
 # Agent API keys
 declare -A KEYS
-KEYS[sophia]="bottube_sk_4589dc49d54d9033c8bd6b65898a0018a7cc383c5e1eead8"
+KEYS[sophia]="$(bot_key sophia-elya)"
 KEYS[boris]="bt_K4LWln2s72EUwK4N6GiQHdr5tmO9q66-WyxAM9EKXFI"
 KEYS[silicon]="bt__wjOVDly9FkhFjSg9c1xSGWOSlfMw9IfbCmSzFiO_1Y"
-KEYS[larry]="bottube_sk_067e90198a730bb6913c4db6a50d2102c629b9b2ed075552"
+KEYS[larry]="$(bot_key laughtrack_larry)"
 KEYS[daryl]="bt_NyW2ZniBeI-53ZtWglqcAuMvv3-QI1cJvk1UUTzk36w"
 KEYS[claudia]="bt_IaX6kKkZZspU_KNpHU283Faz_0mLjVyrrd2pPeYDF7c"
 KEYS[cosmo]="bt_rrAgSvWQI_DDBTiLOz00EO7cdSI8cQxbVjIwCrcGmwE"
@@ -19,7 +23,7 @@ KEYS[glitch]="bt_DuAX_Ler5bEny58jHtjIoULgrr6vVO9yzgFd_DT3_zM"
 KEYS[zen]="bt_jlh-ln_M3E_zj__gp5oSicsiDwc_IEk9sZodlhcDafk"
 KEYS[vinyl]="bt__hkspLusjx4IEhAci4JecSeehi826yslIk4q6jaH4Zw"
 KEYS[rust]="bt_lMnxhrybiqXtb6atiXO2BmcnBb4wslY2nppv1slCeec"
-KEYS[piper]="bottube_sk_f7da9be8c6c9341b26fd93405327fe6990fee4bcf809cacb"
+KEYS[piper]="$(bot_key piper_the_piebot)"
 
 # Agent names for subscribe
 declare -A NAMES

--- a/systemd/.env.anchor.example
+++ b/systemd/.env.anchor.example
@@ -7,5 +7,5 @@
 BOTTUBE_ADMIN_KEY=replace_me_with_BOTTUBE_ADMIN_KEY_from_systemd_bottube_service
 
 # For real-mode anchoring once the Ergo node is up and synced:
-# ERGO_API_KEY=BE7YM1fYWrMQ9tSmxAc9jzLNw42nEXTX
+# ERGO_API_KEY=<from /root/rustchain/.env>
 # ERGO_BASE=http://localhost:9053


### PR DESCRIPTION
Security sweep 2026-09-02/03 (reviewed adversarially by Codex gpt-5.6-sol; details kept out of this public PR, see internal report).

- `POST /upload` (browser route) now runs the same moderation pipeline as `/api/upload` and fails closed on any non-`passed` screening status; `/api/upload` fails closed too. Held videos get no thumbnail, RTC, indexing ping, or subscriber notify.
- Analytics blueprint derives identity from the session / API key only (no client-supplied agent id).
- `/api/ergo/deposit` rejects platform-sourced inputs and requires the bound `erg_address` to match the on-chain sender.
- All 27 hard-coded `bottube_sk_` bot keys and the X app credentials removed; scripts load `BOT_KEY_*` from `.bot_keys.env` via `bot_keys.py` / `bot_keys.sh` (see `bottube-bot-keys.env.example`). Keys already rotated server-side and the env file is deployed on the host.

Deploy note: the bot scripts + helpers are already live on the host; `bottube_server.py`, `analytics_blueprint.py`, `ergo_bridge_blueprint.py` need a service restart after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKwZZP79b6Acc44cwVZkj4