### PR TITLE
fix(votes): atomic same-voter writes close #2116 race

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -8075,13 +8075,31 @@ def vote_comment(comment_id):
     if vote_val not in (1, -1, 0):
         return jsonify({"error": "vote must be 1 (like), -1 (dislike), or 0 (remove)"}), 400
 
+    # Acquire a write transaction before reading existing vote state to
+    # serialize concurrent same-voter requests (closes #2116).
+    db.execute("BEGIN IMMEDIATE")
     existing = db.execute(
         "SELECT vote FROM comment_votes WHERE agent_id = ? AND comment_id = ?",
         (g.agent["id"], comment_id),
     ).fetchone()
-
-    _apply_comment_vote(db, comment_id, comment["agent_id"], g.agent["id"], vote_val, existing)
-    db.commit()
+    try:
+        _apply_comment_vote(db, comment_id, comment["agent_id"], g.agent["id"], vote_val, existing)
+        db.commit()
+    except sqlite3.IntegrityError:
+        # Another concurrent request from the same voter inserted first;
+        # re-read their vote and report idempotent state instead of 500.
+        db.rollback()
+        winner = db.execute(
+            "SELECT vote FROM comment_votes WHERE agent_id = ? AND comment_id = ?",
+            (g.agent["id"], comment_id),
+        ).fetchone()
+        if winner:
+            return jsonify({
+                "ok": True, "comment_id": comment_id,
+                "idempotent": True,
+                "your_vote": winner["vote"],
+            }), 200
+        raise
 
     updated = db.execute("SELECT likes, dislikes FROM comments WHERE id = ?", (comment_id,)).fetchone()
     return jsonify({
@@ -8115,13 +8133,29 @@ def web_vote_comment(comment_id):
     if vote_val not in (1, -1, 0):
         return jsonify({"error": "vote must be 1 (like), -1 (dislike), or 0 (remove)"}), 400
 
+    # Serialize concurrent same-voter requests on this comment (closes #2116).
+    db.execute("BEGIN IMMEDIATE")
     existing = db.execute(
         "SELECT vote FROM comment_votes WHERE agent_id = ? AND comment_id = ?",
         (g.user["id"], comment_id),
     ).fetchone()
-
-    _apply_comment_vote(db, comment_id, comment["agent_id"], g.user["id"], vote_val, existing)
-    db.commit()
+    try:
+        _apply_comment_vote(db, comment_id, comment["agent_id"], g.user["id"], vote_val, existing)
+        db.commit()
+    except sqlite3.IntegrityError:
+        # Another concurrent request from the same voter won; return idempotent result.
+        db.rollback()
+        winner = db.execute(
+            "SELECT vote FROM comment_votes WHERE agent_id = ? AND comment_id = ?",
+            (g.user["id"], comment_id),
+        ).fetchone()
+        if winner:
+            return jsonify({
+                "ok": True, "comment_id": comment_id,
+                "idempotent": True,
+                "your_vote": winner["vote"],
+            }), 200
+        raise
 
     updated = db.execute("SELECT likes, dislikes FROM comments WHERE id = ?", (comment_id,)).fetchone()
     return jsonify({
@@ -8247,6 +8281,9 @@ def vote_video(video_id):
     if vote_val not in (1, -1, 0):
         return jsonify({"error": "vote must be 1 (like), -1 (dislike), or 0 (remove)"}), 400
 
+    # Acquire a write transaction before reading existing vote state to
+    # serialize concurrent same-voter requests (closes #2116).
+    db.execute("BEGIN IMMEDIATE")
     existing = db.execute(
         "SELECT vote FROM votes WHERE agent_id = ? AND video_id = ?",
         (g.agent["id"], video_id),
@@ -8296,7 +8333,30 @@ def vote_video(video_id):
             (g.agent["id"], video_id, vote_val, time.time()),
         )
 
-    db.commit()
+    try:
+        db.commit()
+    except sqlite3.IntegrityError:
+        # Another concurrent request from the same voter inserted first;
+        # re-read their vote and report idempotent state instead of 500.
+        db.rollback()
+        winner = db.execute(
+            "SELECT vote FROM votes WHERE agent_id = ? AND video_id = ?",
+            (g.agent["id"], video_id),
+        ).fetchone()
+        if winner:
+            updated = db.execute(
+                "SELECT likes, dislikes FROM videos WHERE video_id = ?",
+                (video_id,),
+            ).fetchone()
+            return jsonify({
+                "ok": True,
+                "video_id": video_id,
+                "likes": updated["likes"],
+                "dislikes": updated["dislikes"],
+                "your_vote": winner["vote"],
+                "idempotent": True,
+            }), 200
+        raise
 
     updated = db.execute("SELECT likes, dislikes FROM videos WHERE video_id = ?", (video_id,)).fetchone()
     return jsonify({
@@ -8333,6 +8393,8 @@ def web_vote_video(video_id):
     if vote_val not in (1, -1, 0):
         return jsonify({"error": "vote must be 1 (like), -1 (dislike), or 0 (remove)"}), 400
 
+    # Serialize concurrent same-voter requests on this video (closes #2116).
+    db.execute("BEGIN IMMEDIATE")
     existing = db.execute(
         "SELECT vote FROM votes WHERE agent_id = ? AND video_id = ?",
         (g.user["id"], video_id),
@@ -8372,7 +8434,29 @@ def web_vote_video(video_id):
         db.execute("INSERT INTO votes (agent_id, video_id, vote, created_at) VALUES (?, ?, ?, ?)",
                   (g.user["id"], video_id, vote_val, time.time()))
 
-    db.commit()
+    try:
+        db.commit()
+    except sqlite3.IntegrityError:
+        # Another concurrent request from the same voter won; return idempotent result.
+        db.rollback()
+        winner = db.execute(
+            "SELECT vote FROM votes WHERE agent_id = ? AND video_id = ?",
+            (g.user["id"], video_id),
+        ).fetchone()
+        if winner:
+            updated = db.execute(
+                "SELECT likes, dislikes FROM videos WHERE video_id = ?",
+                (video_id,),
+            ).fetchone()
+            return jsonify({
+                "ok": True,
+                "video_id": video_id,
+                "likes": updated["likes"],
+                "dislikes": updated["dislikes"],
+                "your_vote": winner["vote"],
+                "idempotent": True,
+            }), 200
+        raise
     updated = db.execute("SELECT likes, dislikes FROM videos WHERE video_id = ?", (video_id,)).fetchone()
     return jsonify({
         "ok": True,

--- a/tests/test_vote_race_2116.py
+++ b/tests/test_vote_race_2116.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for issue #2116: concurrent same-voter requests
+must not corrupt vote counters or surface 500 errors.
+
+Two routes are exercised:
+  * POST /api/videos/<id>/vote      (API key auth)
+  * POST /api/comments/<id>/vote    (API key auth)
+
+Each test fires N threads that POST the same vote in parallel. After the
+dust settles, the votes table must contain exactly one row for the
+(agent_id, target_id) pair, the denormalized counter on the target must
+match that row, and no thread may have observed a 500 (which is what
+the old code raised on UNIQUE constraint collisions)."""
+import sqlite3
+import threading
+
+import pytest
+
+
+def _setup(client, app, suffix):
+    """Create one voter agent, one owner agent, one video, one comment."""
+    voter_name = f"voter_{suffix}"
+    owner_name = f"owner_{suffix}"
+    video_id = f"vid_{suffix}"
+    with app.app_context():
+        db = sqlite3.connect(app.config["DB_PATH"])
+        db.row_factory = sqlite3.Row
+        for name in (voter_name, owner_name):
+            db.execute(
+                "INSERT OR IGNORE INTO agents (agent_name, fingerprint, public_key) "
+                "VALUES (?, ?, ?)",
+                (name, f"fp_{suffix}_{name}", f"pk_{suffix}_{name}"),
+            )
+        voter_id = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?", (voter_name,)
+        ).fetchone()["id"]
+        owner_id = db.execute(
+            "SELECT id FROM agents WHERE agent_name = ?", (owner_name,)
+        ).fetchone()["id"]
+        db.execute(
+            "INSERT INTO videos (video_id, agent_id, title, ipfs_cid, likes, dislikes) "
+            "VALUES (?, ?, ?, ?, 0, 0)",
+            (video_id, owner_id, f"video {suffix}", f"Qm{suffix}"),
+        )
+        db.execute(
+            "INSERT INTO comments (id, video_id, agent_id, body, likes, dislikes) "
+            "VALUES (?, ?, ?, ?, 0, 0)",
+            (f"cmt{suffix}", video_id, owner_id, f"comment {suffix}"),
+        )
+        api_key = "ak_" + suffix
+        db.execute(
+            "UPDATE agents SET api_key = ? WHERE id = ?", (api_key, voter_id)
+        )
+        db.commit()
+        db.close()
+    return api_key, video_id, f"cmt{suffix}"
+
+
+def test_concurrent_video_votes_no_500(client, app):
+    api_key, video_id, _ = _setup(client, app, "v")
+    codes = []
+    lock = threading.Lock()
+
+    def vote():
+        r = client.post(
+            f"/api/videos/{video_id}/vote",
+            json={"vote": 1},
+            headers={"X-API-Key": api_key},
+        )
+        with lock:
+            codes.append(r.status_code)
+
+    threads = [threading.Thread(target=vote) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # No 500s allowed; race losers should see 200 (idempotent) or 200 (winner).
+    assert codes, "no responses collected"
+    assert all(c == 200 for c in codes), f"unexpected status codes: {codes}"
+
+    with app.app_context():
+        db = sqlite3.connect(app.config["DB_PATH"])
+        votes = db.execute(
+            "SELECT * FROM votes WHERE video_id = ?", (video_id,)
+        ).fetchall()
+        video = db.execute(
+            "SELECT likes, dislikes FROM videos WHERE video_id = ?", (video_id,)
+        ).fetchone()
+        db.close()
+
+    assert len(votes) == 1, f"expected 1 vote row, got {len(votes)}"
+    assert video["likes"] == 1, f"expected likes=1, got {video['likes']}"
+
+
+def test_concurrent_comment_votes_no_500(client, app):
+    api_key, video_id, comment_id = _setup(client, app, "c")
+    codes = []
+    lock = threading.Lock()
+
+    def vote():
+        r = client.post(
+            f"/api/comments/{comment_id}/vote",
+            json={"vote": 1},
+            headers={"X-API-Key": api_key},
+        )
+        with lock:
+            codes.append(r.status_code)
+
+    threads = [threading.Thread(target=vote) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert all(c == 200 for c in codes), f"unexpected status codes: {codes}"
+
+    with app.app_context():
+        db = sqlite3.connect(app.config["DB_PATH"])
+        votes = db.execute(
+            "SELECT * FROM comment_votes WHERE comment_id = ?", (comment_id,)
+        ).fetchall()
+        comment = db.execute(
+            "SELECT likes, dislikes FROM comments WHERE id = ?", (comment_id,)
+        ).fetchone()
+        db.close()
+
+    assert len(votes) == 1, f"expected 1 comment_votes row, got {len(votes)}"
+    assert comment["likes"] == 1, f"expected likes=1, got {comment['likes']}"
+
+
+def test_concurrent_vote_idempotent_response(client, app):
+    """At least one concurrent request must report idempotent=True so
+    clients can distinguish the winner from a repeated safe submission."""
+    api_key, video_id, _ = _setup(client, app, "i")
+    payloads = []
+    lock = threading.Lock()
+
+    def vote():
+        r = client.post(
+            f"/api/videos/{video_id}/vote",
+            json={"vote": 1},
+            headers={"X-API-Key": api_key},
+        )
+        with lock:
+            payloads.append(r.get_json() if r.status_code == 200 else None)
+
+    threads = [threading.Thread(target=vote) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # BEGIN IMMEDIATE serializes requests; losers see the winner's row.
+    assert any(p and p.get("idempotent") is True for p in payloads), (
+        f"expected at least one idempotent=True response, got {payloads}"
+    )


### PR DESCRIPTION
## Summary

Fixes Scottcjn/bottube#2116. Video and comment vote routes (API-key and web-session variants) issued a SELECT for the existing vote row outside a write transaction, then attempted INSERT/UPDATE. Two concurrent same-voter requests could both pass the existing-vote check, both try to insert the same primary key, and one would fail the UNIQUE constraint on `(agent_id, video_id)` or `(agent_id, comment_id)`, surfacing as an unhandled 500.

## Fix

Wrap the existing-vote read and the subsequent state transition in a `BEGIN IMMEDIATE` write transaction so SQLite serializes competing writers. If the loser of the race still hits the UNIQUE constraint (it should not, but defensive), rollback, re-read the winner's row, and respond with an idempotent 200 carrying `{idempotent: true, your_vote: <winner>}` instead of a 500.

Touches:
- `bottube_server.py`:
  - `vote_comment` (API key, ~line 8061)
  - `web_vote_comment` (session, ~line 8099)
  - `vote_video` (API key, ~line 8232)
  - `web_vote_video` (session, ~line 8316)
- `tests/test_vote_race_2116.py` (new): three regression tests that spin up 8 parallel vote threads per route and assert no 500s, exactly one row in the votes/comment_votes table, and that at least one thread observes `idempotent=True`.

## Verification

Local syntax-check (`python3 -c "import ast; ast.parse(open('bottube_server.py').read())"`) passes. Tests can be run with `pytest tests/test_vote_race_2116.py -v` once the project test fixture (`client`, `app`) is configured per the existing suite.

## Reward claim

Filing under the rustchain-bounties pool Scottcjn/rustchain-bounties#71 (Ongoing Bug Bounty, severity Medium -> 15-50 RTC). Closing #2116.