### PR TITLE
fix(gpu_marketplace): prevent concurrent duplicate settlement on job completion (rebase of #2172 by @katakata0522)

### DIFF
--- a/gpu_marketplace.py
+++ b/gpu_marketplace.py
@@ -677,12 +677,16 @@ def complete_job():
     # Pay for actual time, capped at escrow
     payment = min(duration_mins * price_per_min, row[3])
 
-    # Update job
-    db.execute("""
+    # Update job with atomic compare-and-set
+    cursor = db.execute("""
         UPDATE gpu_jobs
         SET status = 'completed', completed_at = ?, actual_mins = ?, rtc_paid = ?, result_url = ?
-        WHERE id = ?
-    """, (now, duration_mins, payment, result_url, job_id))
+        WHERE id = ? AND provider_id = ? AND status = 'running'
+    """, (now, duration_mins, payment, result_url, job_id, provider_id))
+
+    if cursor.rowcount == 0:
+        db.rollback()
+        return jsonify({"error": "Job state changed concurrently or not running"}), 409
 
     # Update provider stats
     db.execute("""

--- a/tests/test_gpu_marketplace_validation.py
+++ b/tests/test_gpu_marketplace_validation.py
@@ -246,3 +246,69 @@ def test_active_claimed_job_can_be_failed_and_released(client):
     status_resp = client.get(f"/api/gpu/jobs/{job_id}")
     assert status_resp.get_json()["status"] == "pending"
 
+
+def test_concurrent_complete_job_credits_only_once(client):
+    import concurrent.futures
+    import sqlite3
+    import os
+
+    reg_resp = client.post(
+        "/api/gpu/providers/register",
+        headers=AUTH,
+        json={"gpu_model": "RTX 4090", "gpu_vram_gb": 24, "price_per_min": 0.1},
+    )
+    assert reg_resp.status_code == 200
+    provider_id = reg_resp.get_json()["provider_id"]
+
+    sub_resp = client.post(
+        "/api/gpu/jobs/submit",
+        headers=AUTH,
+        json={"job_type": "video_render", "estimated_mins": 2, "max_price_per_min": 0.2},
+    )
+    assert sub_resp.status_code == 200
+    job_id = sub_resp.get_json()["job_id"]
+
+    claim_resp = client.post(
+        "/api/gpu/jobs/claim",
+        headers=AUTH,
+        json={"provider_id": provider_id, "job_id": job_id},
+    )
+    assert claim_resp.status_code == 200
+
+    start_resp = client.post(
+        "/api/gpu/jobs/start",
+        headers=AUTH,
+        json={"provider_id": provider_id, "job_id": job_id},
+    )
+    assert start_resp.status_code == 200
+
+    def do_complete():
+        return client.post(
+            "/api/gpu/jobs/complete",
+            headers=AUTH,
+            json={"provider_id": provider_id, "job_id": job_id, "result_url": "https://example.com/out.mp4"},
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        f1 = executor.submit(do_complete)
+        f2 = executor.submit(do_complete)
+        r1 = f1.result()
+        r2 = f2.result()
+
+    codes = [r1.status_code, r2.status_code]
+    assert codes.count(200) == 1, f"Expected exactly one 200, got {codes}"
+
+    db_path = os.environ.get("BOTTUBE_DB_PATH")
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+
+    # Check total_jobs
+    cur.execute("SELECT total_jobs, total_rtc_earned FROM gpu_providers WHERE id = ?", (provider_id,))
+    prow = cur.fetchone()
+    assert prow[0] == 1, f"Expected total_jobs == 1, got {prow[0]}"
+
+    # Check history count
+    cur.execute("SELECT COUNT(*) FROM gpu_job_history WHERE job_id = ?", (job_id,))
+    hcount = cur.fetchone()[0]
+    assert hcount == 1, f"Expected 1 history row, got {hcount}"
+    conn.close()


### PR DESCRIPTION
Maintainer rebase of #2172 by @katakata0522 onto current main (after #2171 landed on the same function); authorship preserved. The CAS on complete_job applied cleanly; only the test file needed reassembly (main's helpers plus the new concurrency test). pytest 29/29 on the file. Fixes #2165. Supersedes #2172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn