### PR TITLE
examples: video-archive-manifest, read-only JS SDK example (bounty #2143, by @prins1bap-ui)

### DIFF
--- a/examples/video-archive-manifest/README.md
+++ b/examples/video-archive-manifest/README.md
@@ -1,0 +1,56 @@
+# BoTTube Video Archive Manifest — Bounty #2143
+
+This is the public mirror of the existing @prins1bap-ui submission for `Scottcjn/rustchain-bounties#2143`. It creates no new claim.
+
+The operative submission was delivered by email on 2026-08-30 after Gmail blocked the original ZIP. The plain-text source bundle SHA-256 was `10b206d54bb4aad8afa60513c13304cb8f78fac0bbc0cc423c199a21a3982008`.
+
+## Current bounty accounting
+
+- Live issue title: **3 RTC**
+- Issue-body prose still says 5 RTC and is treated as stale unless the maintainer explicitly adjudicates otherwise.
+- Canonical requested exposure: **3 RTC**
+- Stage: **SUBMITTED** only. No acceptance, queue, pending transfer, or receipt is asserted.
+
+## Current-source verification — 2026-09-02
+
+Rechecked against current `Scottcjn/bottube` main:
+
+- repository-local SDK package remains `bottube-sdk`
+- `BoTTubeClient.listVideos(page, perPage)` remains available
+- `BoTTubeClient.getVideoStreamUrl(videoId)` remains available
+- the `Video` / `VideoListResponse` fields used here remain compatible
+- SDK engine requirement remains Node.js 18+
+
+Fresh local QA:
+
+- `npm test` -> 3/3 passed
+- `npm run check` -> passed
+- fixture JSON render -> passed
+- fixture Markdown render -> passed
+
+## What it does
+
+A small, read-only Node.js example using BoTTube's repository-local JavaScript SDK to export public video metadata as a portable JSON archive manifest or a human-readable Markdown inventory.
+
+Live mode imports `BoTTubeClient` from `bottube-sdk` and calls:
+
+- `client.listVideos(page, perPage)`
+- `client.getVideoStreamUrl(videoId)`
+
+No API key is required. The tool does not upload, comment, vote, tip, modify profiles, or move funds.
+
+## Intended upstream path
+
+`examples/video-archive-manifest/`
+
+## Setup
+
+When placed inside `Scottcjn/bottube`:
+
+```bash
+cd examples/video-archive-manifest
+npm install
+npm test
+npm run check
+node index.js --fixture test/fixtures/page.json --format markdown
+```

--- a/examples/video-archive-manifest/index.js
+++ b/examples/video-archive-manifest/index.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import { buildManifest, mergePages, renderMarkdown } from './lib.js';
+
+function usage() {
+  console.log(`BoTTube video archive manifest
+
+Usage:
+  node index.js [options]
+
+Options:
+  --pages N         Pages to fetch (1-10, default: 1)
+  --per-page N      Videos per page (1-50, default: 20)
+  --format TYPE     json or markdown (default: json)
+  --output FILE     Write output to a file instead of stdout
+  --base-url URL    BoTTube base URL (default: https://bottube.ai)
+  --fixture FILE    Read SDK-shaped page JSON from disk instead of network
+  --help            Show this help
+
+The live path is read-only and uses BoTTubeClient.listVideos() plus
+BoTTubeClient.getVideoStreamUrl() from the repository's JavaScript SDK.`);
+}
+
+function parseArgs(argv) {
+  const out = { pages: 1, perPage: 20, format: 'json', baseUrl: 'https://bottube.ai', output: null, fixture: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help') return { ...out, help: true };
+    if (arg === '--pages') out.pages = boundedInt(argv[++i], '--pages', 1, 10);
+    else if (arg === '--per-page') out.perPage = boundedInt(argv[++i], '--per-page', 1, 50);
+    else if (arg === '--format') out.format = String(argv[++i] ?? '');
+    else if (arg === '--output') out.output = String(argv[++i] ?? '');
+    else if (arg === '--base-url') out.baseUrl = String(argv[++i] ?? '');
+    else if (arg === '--fixture') out.fixture = String(argv[++i] ?? '');
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!['json', 'markdown'].includes(out.format)) throw new Error('--format must be json or markdown');
+  if (!/^https?:\/\//.test(out.baseUrl)) throw new Error('--base-url must start with http:// or https://');
+  return out;
+}
+
+function boundedInt(raw, name, min, max) {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < min || n > max) throw new Error(`${name} must be an integer from ${min} to ${max}`);
+  return n;
+}
+
+async function loadFixture(path) {
+  const parsed = JSON.parse(await fs.readFile(path, 'utf8'));
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+async function fetchPages(client, count, perPage) {
+  const pages = [];
+  for (let page = 1; page <= count; page += 1) {
+    const result = await client.listVideos(page, perPage);
+    pages.push(result);
+    if (!result.has_more) break;
+  }
+  return pages;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    usage();
+    return;
+  }
+
+  let pages;
+  let streamUrlFor = null;
+  if (options.fixture) {
+    pages = await loadFixture(options.fixture);
+  } else {
+    const { BoTTubeClient } = await import('bottube-sdk');
+    const client = new BoTTubeClient({ baseUrl: options.baseUrl });
+    pages = await fetchPages(client, options.pages, options.perPage);
+    streamUrlFor = (id) => client.getVideoStreamUrl(id);
+  }
+
+  const videos = mergePages(pages, options.baseUrl, streamUrlFor);
+  const manifest = buildManifest(videos, { baseUrl: options.baseUrl, pagesRequested: options.pages });
+  const output = options.format === 'markdown' ? renderMarkdown(manifest) : `${JSON.stringify(manifest, null, 2)}\n`;
+
+  if (options.output) await fs.writeFile(options.output, output, 'utf8');
+  else process.stdout.write(output);
+}
+
+main().catch((error) => {
+  console.error(`archive-manifest: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/examples/video-archive-manifest/lib.js
+++ b/examples/video-archive-manifest/lib.js
@@ -1,0 +1,89 @@
+export function normalizeVideo(video, baseUrl = 'https://bottube.ai', streamUrl = null) {
+  const id = String(video?.video_id ?? '').trim();
+  if (!id) throw new Error('video_id is required');
+
+  const cleanBase = String(baseUrl).replace(/\/+$/, '');
+  const tags = Array.isArray(video.tags) ? video.tags.map(String) : [];
+
+  return {
+    video_id: id,
+    title: String(video.title ?? ''),
+    agent_name: String(video.agent_name ?? ''),
+    description: String(video.description ?? ''),
+    tags,
+    duration_seconds: finiteNumber(video.duration),
+    views: finiteNumber(video.views),
+    likes: finiteNumber(video.likes),
+    dislikes: finiteNumber(video.dislikes),
+    created_at: finiteNumber(video.created_at),
+    watch_url: `${cleanBase}/watch/${encodeURIComponent(id)}`,
+    stream_url: streamUrl || video.stream_url || `${cleanBase}/api/videos/${encodeURIComponent(id)}/stream`,
+  };
+}
+
+export function mergePages(pages, baseUrl = 'https://bottube.ai', streamUrlFor = null) {
+  const seen = new Set();
+  const videos = [];
+
+  for (const page of pages) {
+    for (const video of page?.videos ?? []) {
+      const id = String(video?.video_id ?? '').trim();
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      const streamUrl = streamUrlFor ? streamUrlFor(id) : null;
+      videos.push(normalizeVideo(video, baseUrl, streamUrl));
+    }
+  }
+
+  return videos;
+}
+
+export function buildManifest(videos, { baseUrl = 'https://bottube.ai', pagesRequested = 1, generatedAt = new Date().toISOString() } = {}) {
+  return {
+    schema: 'bottube.video-archive-manifest.v1',
+    generated_at: generatedAt,
+    source: String(baseUrl).replace(/\/+$/, ''),
+    pages_requested: pagesRequested,
+    video_count: videos.length,
+    videos,
+  };
+}
+
+export function renderMarkdown(manifest) {
+  const lines = [
+    '# BoTTube Video Archive Manifest',
+    '',
+    `- Generated: ${manifest.generated_at}`,
+    `- Source: ${manifest.source}`,
+    `- Videos: ${manifest.video_count}`,
+    '',
+  ];
+
+  for (const video of manifest.videos) {
+    lines.push(`## ${escapeMarkdown(video.title || video.video_id)}`);
+    lines.push('');
+    lines.push(`- Video ID: \`${video.video_id}\``);
+    lines.push(`- Agent: ${escapeMarkdown(video.agent_name || 'unknown')}`);
+    lines.push(`- Watch: ${video.watch_url}`);
+    lines.push(`- Stream: ${video.stream_url}`);
+    lines.push(`- Duration: ${video.duration_seconds}s`);
+    lines.push(`- Views / likes / dislikes: ${video.views} / ${video.likes} / ${video.dislikes}`);
+    if (video.tags.length) lines.push(`- Tags: ${video.tags.map((tag) => `\`${escapeMarkdown(tag)}\``).join(', ')}`);
+    if (video.description) {
+      lines.push('');
+      lines.push(video.description.replace(/\r?\n/g, ' ').trim());
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trim()}\n`;
+}
+
+function finiteNumber(value) {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function escapeMarkdown(value) {
+  return String(value).replace(/([\\`*_{}[\]()#+.!|-])/g, '\\$1');
+}

--- a/examples/video-archive-manifest/package.json
+++ b/examples/video-archive-manifest/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bottube-video-archive-manifest-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Read-only BoTTube SDK example that exports a portable video archive manifest.",
+  "scripts": {
+    "test": "node --test",
+    "check": "node --check index.js && node --check lib.js"
+  },
+  "dependencies": {
+    "bottube-sdk": "file:../../js-sdk"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/video-archive-manifest/test/fixtures/page.json
+++ b/examples/video-archive-manifest/test/fixtures/page.json
@@ -1,0 +1,34 @@
+{
+  "videos": [
+    {
+      "video_id": "abc 123",
+      "title": "RustChain Demo",
+      "description": "A short demo.",
+      "tags": ["rustchain", "demo"],
+      "agent_id": 7,
+      "agent_name": "example-agent",
+      "duration": 8,
+      "views": 42,
+      "likes": 5,
+      "dislikes": 1,
+      "created_at": 1780000000
+    },
+    {
+      "video_id": "xyz",
+      "title": "Second Clip",
+      "description": "",
+      "tags": [],
+      "agent_id": 8,
+      "agent_name": "other-agent",
+      "duration": 7.5,
+      "views": 10,
+      "likes": 2,
+      "dislikes": 0,
+      "created_at": 1780000010
+    }
+  ],
+  "total": 2,
+  "page": 1,
+  "per_page": 20,
+  "has_more": false
+}

--- a/examples/video-archive-manifest/test/lib.test.js
+++ b/examples/video-archive-manifest/test/lib.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildManifest, mergePages, normalizeVideo, renderMarkdown } from '../lib.js';
+
+test('normalizeVideo emits stable watch and stream URLs', () => {
+  const result = normalizeVideo({ video_id: 'abc 123', title: 'Title', tags: ['one'], views: 2 }, 'https://bottube.ai/');
+  assert.equal(result.watch_url, 'https://bottube.ai/watch/abc%20123');
+  assert.equal(result.stream_url, 'https://bottube.ai/api/videos/abc%20123/stream');
+  assert.deepEqual(result.tags, ['one']);
+});
+
+test('mergePages de-duplicates video ids and honors SDK stream URL callback', () => {
+  const pages = [
+    { videos: [{ video_id: 'a', title: 'A' }, { video_id: 'b', title: 'B' }] },
+    { videos: [{ video_id: 'a', title: 'A duplicate' }, { video_id: 'c', title: 'C' }] },
+  ];
+  const videos = mergePages(pages, 'https://example.test', (id) => `sdk://${id}`);
+  assert.deepEqual(videos.map((v) => v.video_id), ['a', 'b', 'c']);
+  assert.equal(videos[0].stream_url, 'sdk://a');
+});
+
+test('manifest and Markdown report are deterministic with fixed timestamp', () => {
+  const videos = [normalizeVideo({ video_id: 'abc', title: 'A *title*', agent_name: 'bot', tags: ['x'], views: 3 })];
+  const manifest = buildManifest(videos, { generatedAt: '2026-08-30T08:00:00.000Z', pagesRequested: 2 });
+  assert.equal(manifest.schema, 'bottube.video-archive-manifest.v1');
+  assert.equal(manifest.video_count, 1);
+  const md = renderMarkdown(manifest);
+  assert.match(md, /BoTTube Video Archive Manifest/);
+  assert.match(md, /A \\?\*title\\?\*/);
+  assert.match(md, /https:\/\/bottube\.ai\/watch\/abc/);
+});


### PR DESCRIPTION
Read-only example by **@prins1bap-ui (Blake Prins)** for rustchain-bounties#2143, landed by a maintainer with his authorship on the commit (his GitHub App returns 403 on Scottcjn repos).

Uses `BoTTubeClient.listVideos(page, perPage)` and `getVideoStreamUrl(videoId)` from `bottube-sdk` to render a JSON or Markdown archive manifest. No upload, vote, tip, profile, or wallet action. `npm test` 3/3 on Node 22. Accepted and paid (3 RTC).

Source mirror: https://github.com/prins1bap-ui/rustchain-bounty-work/tree/main/2143-video-archive-manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn