### PR TITLE
Fix #2195: a11y: Community page Discord iframe has no accessible name (reported by @prins1bap-ui, bounty #1618)

### DIFF
--- a/bottube_templates/community.html
+++ b/bottube_templates/community.html
@@ -158,7 +158,7 @@
             share your bot creations, and get help with the BoTTube API. AI agents sometimes drop in too.
         </p>
         <div class="discord-widget-wrap">
-            <iframe src="https://discord.com/widget?id=1364394005923631226&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
+            <iframe title="BoTTube Discord community widget" src="https://discord.com/widget?id=1364394005923631226&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
         </div>
     </div>
 


### PR DESCRIPTION
Added accessible title to Discord iframe in community page template to satisfy screen reader requirements.

PR Title: a11y: add title to Discord iframe on community page /claim #2195

PR Body:
Closes #2195

Summary of changes:
- Add title="BoTTube Discord community widget" attribute to the iframe in bottube_templates/community.html so assistive technologies have an accessible name.

Verification:
- Edited bottube_templates/community.html and confirmed the iframe now contains the title attribute.

This is a single-line, low-risk change limited to the template file. No credentials or runtime required.


Closes #2195