### PR TITLE
i18n: Localize /community page body to use translation strings

### DIFF
--- a/bottube_templates/community.html
+++ b/bottube_templates/community.html
@@ -144,18 +144,15 @@
 
 {% block content %}
 <div class="community-container">
-    <h1>Community</h1>
+    <h1>{{ _('community.title') }}</h1>
     <p class="community-lead">
-        BoTTube is built in the open. Join the conversation on Discord, contribute code on GitHub,
-        or follow our AI agents on Moltbook. Whether you are building bots, watching AI-generated
-        videos, or exploring proof-of-antiquity computing, there is a place for you here.
+        {{ _('community.lead') }}
     </p>
 
     <div class="community-section">
-        <h2>Discord Server</h2>
+        <h2>{{ _('community.discord_server') }}</h2>
         <p>
-            Our Discord is the main hub for real-time discussion. Chat with the developers, report bugs,
-            share your bot creations, and get help with the BoTTube API. AI agents sometimes drop in too.
+            {{ _('community.discord_description') }}
         </p>
         <div class="discord-widget-wrap">
             <iframe src="https://discord.com/widget?id=1364394005923631226&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
@@ -163,7 +160,7 @@
     </div>
 
     <div class="community-section">
-        <h2>Get Involved</h2>
+        <h2>{{ _('community.get_involved') }}</h2>
         <div class="community-links">
             <a href="https://discord.gg/XnRp7M5gBW" target="_blank" rel="noopener" class="community-card">
                 <div class="card-icon">&#128172;</div>
@@ -204,10 +201,9 @@
     </div>
 
     <div class="community-section">
-        <h2>Press & Knowledge References</h2>
+        <h2>{{ _('community.press_references') }}</h2>
         <p>
-            External references for ecosystem background and verification.
-            These links are informational and maintained as factual public references.
+            {{ _('community.press_description') }}
         </p>
         <div class="community-links">
             <a href="https://grokipedia.com/page/BoTTubeai" target="_blank" rel="noopener" class="community-card">
@@ -229,10 +225,10 @@
     </div>
 
     <div class="community-cta">
-        <h3>Ready to join?</h3>
-        <p>The fastest way to get started is to hop into Discord and say hello.</p>
-        <a href="https://discord.gg/XnRp7M5gBW" target="_blank" rel="noopener" class="cta-btn">Join Discord Server</a>
-        <a href="https://t.me/+l8dHTjXCBNM1MTIx" target="_blank" rel="noopener" class="cta-btn">Join Telegram</a>
+        <h3>{{ _('community.ready_to_join') }}</h3>
+        <p>{{ _('community.cta_lead') }}</p>
+        <a href="https://discord.gg/XnRp7M5gBW" target="_blank" rel="noopener" class="cta-btn">{{ _('community.cta_join_discord') }}</a>
+        <a href="https://t.me/+l8dHTjXCBNM1MTIx" target="_blank" rel="noopener" class="cta-btn">{{ _('community.cta_join_telegram') }}</a>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
/claim #2197
Closes #2197

Summary:
- Localize community page template by replacing hard-coded English strings with translation lookups (Jinja _('...')).
- Prevents mismatch where nav is localized but page body remained English when visiting with ?lang=es.

Verification:
- Render the /community page after adding translations: the template uses keys such as community.title, community.lead, community.discord_server, community.discord_description, community.get_involved, community.press_references, community.press_description, community.ready_to_join, community.cta_lead, community.cta_join_discord, community.cta_join_telegram.
- Manual test: visit /community?lang=es (after populating translations/es.json) and confirm nav and page body are both Spanish.

Notes:
- This PR updates only the template. Translation JSON files must be updated with the new keys for each supported locale.
- No sensitive data introduced.


Closes #2197