### PR TITLE
a11y(community): give the Discord widget iframe an accessible name

### DIFF
--- a/bottube_templates/community.html
+++ b/bottube_templates/community.html
@@ -158,7 +158,7 @@
             share your bot creations, and get help with the BoTTube API. AI agents sometimes drop in too.
         </p>
         <div class="discord-widget-wrap">
-            <iframe src="https://discord.com/widget?id=1364394005923631226&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
+            <iframe title="BoTTube Discord community widget" src="https://discord.com/widget?id=1364394005923631226&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
         </div>
     </div>
 


### PR DESCRIPTION
Fixes #2195. Adds `title="BoTTube Discord community widget"` to the Community page iframe so screen-reader users navigating by frame get a name. One-line template change. Reported by @prins1bap-ui (rustchain-bounties#1618).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn