### PR TITLE
[Aming9303] Fix dashboard RTC balance rendering

### DIFF
--- a/bottube_templates/dashboard.html
+++ b/bottube_templates/dashboard.html
@@ -562,7 +562,7 @@
         <div class="stat-label">Comments</div>
     </div>
     <div class="stat-card green">
-        <div class="stat-value">{"%.4f"|format(rtc_balance)}</div>
+        <div class="stat-value">{{ "%.4f"|format(rtc_balance) }}</div>
         <div class="stat-label">RTC Balance</div>
     </div>
 </div>

--- a/tests/test_dashboard_rtc_balance_template.py
+++ b/tests/test_dashboard_rtc_balance_template.py
@@ -1,0 +1,22 @@
+import re
+from pathlib import Path
+
+from jinja2 import Template
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "bottube_templates" / "dashboard.html"
+
+
+def test_dashboard_renders_rtc_balance_instead_of_template_source():
+    html = TEMPLATE.read_text(encoding="utf-8")
+    match = re.search(
+        r'<div class="stat-card green">(.*?)<div class="stat-label">RTC Balance</div>',
+        html,
+        re.DOTALL,
+    )
+
+    assert match, "expected the RTC Balance stat card in dashboard.html"
+    rendered = Template(match.group(1)).render(rtc_balance=12.34567)
+
+    assert "12.3457" in rendered
+    assert "format(rtc_balance)" not in rendered


### PR DESCRIPTION
## Summary

- restore the missing Jinja output delimiters around the dashboard RTC balance
- add a focused rendering regression that checks four-decimal output and rejects leaked template source

Fixes #2202.
Refs Scottcjn/rustchain-bounties#71 (low-severity UI bug).

## Verification

```text
python -c "import runpy; ns=runpy.run_path(r'tests/test_dashboard_rtc_balance_template.py'); ns['test_dashboard_renders_rtc_balance_instead_of_template_source']()"
dashboard RTC template regression: passed

python -m py_compile tests/test_dashboard_rtc_balance_template.py
passed

git diff --check
passed
```

The local interpreter does not have pytest installed, so I did not claim a full pytest run. The focused test function was executed directly against Jinja2.

Native RTC wallet: `RTCc8cdaa67b90f9b06987135b8b65ab037bfb603a9`

No reward or payment is claimed unless the maintainer accepts it.