### PR TITLE
Fix Jinja template: use double braces for rtc_balance format

### DIFF
--- a/bottube_templates/dashboard.html
+++ b/bottube_templates/dashboard.html
@@ -562,7 +562,7 @@
         <div class="stat-label">Comments</div>
     </div>
     <div class="stat-card green">
-        <div class="stat-value">{"%.4f"|format(rtc_balance)}</div>
+        <div class="stat-value">{{ "%.4f"|format(rtc_balance) }}</div>
         <div class="stat-label">RTC Balance</div>
     </div>
 </div>


### PR DESCRIPTION
Fixes #2202. The dashboard was rendering the Jinja expression as literal text instead of evaluating it. Changed single-brace {"%.4f"|format(rtc_balance)} to double-brace {{ "%.4f"|format(rtc_balance) }}.