### PR TITLE
[ASTRA-QUAY] Include Studio source in deployment drift inventories

### DIFF
--- a/deployment-drift.issue-1410.example.json
+++ b/deployment-drift.issue-1410.example.json
@@ -27,7 +27,8 @@
     "app"
   ],
   "application_sources": [
-    "bottube_server.py"
+    "bottube_server.py",
+    "studio_blueprint.py"
   ],
   "canaries": [
     "GET /settings/profile",

--- a/deployment-drift.json
+++ b/deployment-drift.json
@@ -27,7 +27,8 @@
     "app"
   ],
   "application_sources": [
-    "bottube_server.py"
+    "bottube_server.py",
+    "studio_blueprint.py"
   ],
   "fixtures": {
     "agent_name": "deployment-drift-canary",

--- a/tests/test_deployment_drift.py
+++ b/tests/test_deployment_drift.py
@@ -450,8 +450,8 @@ def test_repository_configs_are_valid_offline():
     canary = build_report(REPO_ROOT, load_config(REPO_ROOT / "deployment-drift.issue-1410.example.json"))
 
     assert policy["status"] == "pass"
-    assert policy["inventory"]["openapi_operations"] == 24
-    assert policy["inventory"]["application_operations"] == 347
+    assert policy["inventory"]["openapi_operations"] == 26
+    assert policy["inventory"]["application_operations"] == 353
     assert len(policy["drift"]["missing_in_code"]) == 19
     assert canary["status"] == "pass"
     assert canary["inventory"]["canary_operations"] == 14

--- a/tests/test_deployment_drift_studio.py
+++ b/tests/test_deployment_drift_studio.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+"""Keep Studio declarations in both offline deployment-drift inventories."""
+
+from pathlib import Path
+
+import pytest
+
+from deployment_drift import MISSING_IN_CODE, build_report, load_config
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_NAMES = (
+    "deployment-drift.json",
+    "deployment-drift.issue-1410.example.json",
+)
+STUDIO_SOURCE = "studio_blueprint.py"
+STUDIO_OPERATION = {"method": "POST", "path": "/api/studio/generate"}
+
+
+@pytest.mark.parametrize("config_name", CONFIG_NAMES)
+def test_studio_is_inventoried_without_a_drift_allowance(config_name):
+    config = load_config(REPO_ROOT / config_name)
+
+    report = build_report(REPO_ROOT, config)
+
+    assert STUDIO_SOURCE in report["inventory"]["application_sources"]
+    assert STUDIO_OPERATION not in report["blocking"]["missing_in_code"]
+    assert STUDIO_OPERATION not in report["allowed"]["missing_in_code"]
+    assert report["exit_code"] == 0
+
+
+@pytest.mark.parametrize("config_name", CONFIG_NAMES)
+def test_omitting_studio_source_still_reports_missing_code(config_name):
+    config = load_config(REPO_ROOT / config_name)
+    config["application_sources"] = [
+        source for source in config["application_sources"] if source != STUDIO_SOURCE
+    ]
+
+    report = build_report(REPO_ROOT, config)
+
+    assert STUDIO_OPERATION in report["blocking"]["missing_in_code"]
+    assert STUDIO_OPERATION not in report["allowed"]["missing_in_code"]
+    assert report["exit_code"] & MISSING_IN_CODE


### PR DESCRIPTION
## Problem
Both deployment-drift policies inventory only `bottube_server.py`, so the existing `POST /api/studio/generate` declaration in `studio_blueprint.py` is reported as missing code. The original sentinel suite at the merge revision used by #2207 reproduced 2 failures / 37 passes.

## Changes
- Add `studio_blueprint.py` to both explicit source inventories.
- Refresh two stale inventory-count snapshots: 26 documented operations and 353 declared application operations.
- Add four regression cases covering both policies. Studio is included without a drift allowance, and removing its source still produces `MISSING_IN_CODE`.

Exactly four files change. No drift allowances, production routes, live-probe settings, SDK code or CI gates change. This is a separate repository-inventory repair from #2207; its existing contributors and ASTRA-JUNCTION retain SDK delivery credit. The extractor inventories AST declarations without importing modules; this does NOT establish that the Blueprint is mounted or its endpoint is available in production.

## Validation
Base: `7fe70c398275eedcbe09dc9a07be30a5d84ff14c`. Head: `38a4c2725fc5cf681cf107dfd6fa08f0b734d89f`.

On BOTH Python 3.11.16 and 3.13.15: all 43 focused cases pass; both offline policies return PASS/exit 0; restoring the original configs and existing sentinel test from the base reproduces exactly 4 expected failures / 39 passes; restoring the candidate leaves a clean worktree and 43 passes again. `git diff --check` and compile checks pass. The unchanged policies retain 19 known allowances, zero blocking drift and zero stale allowances.

Full hosted logs: <https://github.com/woahwhattheheck/bottube/actions/runs/34152787252

Commands:
```sh
python|github.com/woahwhattheheck/bottube/…/34152787252

Commands:
```sh
python> -m pip install pytest==9.1.1 PyYAML==6.0.3
python -m pytest tests/test_deployment_drift.py tests/test_deployment_drift_studio.py -q
python deployment_drift.py --format text
python deployment_drift.py --config deployment-drift.issue-1410.example.json --format text
```

The validation workflow and durable report stay on a separate fork-only diagnostic branch, outside this PR. No full-project CI, live endpoint, reward or payment claim.

AI-assisted contribution by ASTRA-QUAY, operated by `woahwhattheheck`. Operation: `astra-quay-bottube-studio-drift-pr-20260907`.