### PR TITLE
fix(generation): distinguish transient poll errors from genuine pending in ComfyUI LTX status

### DIFF
--- a/generation/providers/comfyui_ltx.py
+++ b/generation/providers/comfyui_ltx.py
@@ -29,6 +29,13 @@ log = logging.getLogger("generation.providers.comfyui_ltx")
 COMFYUI_URL = os.environ.get("COMFYUI_URL", "http://100.95.77.124:8188")
 COMFYUI_TIMEOUT = int(os.environ.get("COMFYUI_TIMEOUT", "300"))
 
+# get_status() polls a flaky LAN endpoint; a handful of consecutive transport
+# errors (timeout, DNS blip, ComfyUI restart) should not be indistinguishable
+# from a job that is genuinely still queued forever. After this many
+# consecutive poll failures for the same prompt_id we give up and report the
+# job failed instead of silently returning "pending" forever.
+_MAX_CONSECUTIVE_POLL_ERRORS = 5
+
 # LTX-2 workflow template
 _LTX_WORKFLOW = {
     "1": {
@@ -89,6 +96,10 @@ class ComfyUILTXProvider(GenerationProvider):
     def __init__(self):
         # Completed jobs: prompt_id -> local path
         self._completed: dict = {}
+        # prompt_id -> count of consecutive get_status() poll failures
+        # (transport error, timeout, malformed JSON). Reset on any poll that
+        # actually reaches ComfyUI, whether or not the job has an entry yet.
+        self._consecutive_poll_errors: dict = {}
 
     def get_name(self) -> str:
         return "comfyui_ltx"
@@ -141,24 +152,48 @@ class ComfyUILTXProvider(GenerationProvider):
             return False, str(exc)
 
     def get_status(self, external_id: str) -> Tuple[str, float]:
-        """Poll ComfyUI history for this prompt_id."""
+        """Poll ComfyUI history for this prompt_id.
+
+        A transport error, timeout, HTTP error, or malformed JSON is a
+        transient poll failure, not proof the job is still queued -- it is
+        tracked separately from "no history entry yet" and, after
+        _MAX_CONSECUTIVE_POLL_ERRORS in a row, turns into a "failed" status
+        so callers stop polling forever instead of timing out silently.
+        """
         if external_id in self._completed:
+            self._consecutive_poll_errors.pop(external_id, None)
             return "completed", 1.0
         try:
             with urllib.request.urlopen(
                 f"{COMFYUI_URL}/history/{external_id}", timeout=10
             ) as resp:
                 history = json.loads(resp.read())
-            if external_id in history:
-                entry = history[external_id]
-                if entry.get("status", {}).get("status_str") == "error":
-                    return "failed", 0.0
-                if entry.get("outputs"):
-                    self._completed[external_id] = entry["outputs"]
-                    return "completed", 1.0
-                return "running", 0.5
-        except Exception:
-            pass
+        except Exception as exc:
+            errors = self._consecutive_poll_errors.get(external_id, 0) + 1
+            self._consecutive_poll_errors[external_id] = errors
+            log.warning(
+                "ComfyUI status poll failed for %s (attempt %d/%d): %s",
+                external_id, errors, _MAX_CONSECUTIVE_POLL_ERRORS, exc,
+            )
+            if errors >= _MAX_CONSECUTIVE_POLL_ERRORS:
+                self._consecutive_poll_errors.pop(external_id, None)
+                return "failed", 0.0
+            return "pending", 0.0
+
+        # History fetch succeeded -- the endpoint is reachable, so any prior
+        # transport errors for this job were transient. Reset the budget
+        # even if this particular prompt_id has no entry yet (genuinely
+        # still queued, not an error).
+        self._consecutive_poll_errors.pop(external_id, None)
+
+        if external_id in history:
+            entry = history[external_id]
+            if entry.get("status", {}).get("status_str") == "error":
+                return "failed", 0.0
+            if entry.get("outputs"):
+                self._completed[external_id] = entry["outputs"]
+                return "completed", 1.0
+            return "running", 0.5
         return "pending", 0.0
 
     def get_result(self, external_id: str, output_dir: Path) -> Optional[Path]:

--- a/tests/test_comfyui_ltx_status.py
+++ b/tests/test_comfyui_ltx_status.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for ComfyUILTXProvider.get_status() transient-error handling.
+
+Before this fix, get_status() wrapped the whole history poll in
+`try: ... except Exception: pass` and always fell through to
+`return "pending", 0.0`. A transport error, timeout, HTTP error, or
+malformed JSON response was therefore indistinguishable from a job that is
+genuinely still queued -- callers polled forever and users never saw a
+failure. See issue: generation: ComfyUI get_status() turns every error into
+permanent "pending".
+"""
+import json
+import urllib.error
+
+from generation.providers.comfyui_ltx import (
+    _MAX_CONSECUTIVE_POLL_ERRORS,
+    ComfyUILTXProvider,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+def test_transport_error_is_pending_until_budget_then_fails(monkeypatch):
+    """A URLError should not be silently pending forever."""
+    provider = ComfyUILTXProvider()
+    calls = {"n": 0}
+
+    def fake_urlopen(url, timeout):
+        calls["n"] += 1
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(
+        "generation.providers.comfyui_ltx.urllib.request.urlopen", fake_urlopen
+    )
+
+    statuses = [provider.get_status("job-1") for _ in range(_MAX_CONSECUTIVE_POLL_ERRORS)]
+
+    # Every attempt before the budget is exhausted is a transient "pending"...
+    assert statuses[:-1] == [("pending", 0.0)] * (_MAX_CONSECUTIVE_POLL_ERRORS - 1)
+    # ...and the Nth consecutive failure gives up and reports it failed.
+    assert statuses[-1] == ("failed", 0.0)
+    assert calls["n"] == _MAX_CONSECUTIVE_POLL_ERRORS
+
+
+def test_malformed_json_counts_as_a_poll_error_too(monkeypatch):
+    """A non-JSON / truncated response is the same class of failure as a transport error."""
+    provider = ComfyUILTXProvider()
+
+    monkeypatch.setattr(
+        "generation.providers.comfyui_ltx.urllib.request.urlopen",
+        lambda url, timeout: _FakeResponse(b"not json"),
+    )
+
+    for _ in range(_MAX_CONSECUTIVE_POLL_ERRORS - 1):
+        assert provider.get_status("job-2") == ("pending", 0.0)
+    assert provider.get_status("job-2") == ("failed", 0.0)
+
+
+def test_valid_history_with_no_entry_yet_stays_pending_indefinitely(monkeypatch):
+    """A reachable ComfyUI with no entry for this id yet is genuinely queued, not an error."""
+    provider = ComfyUILTXProvider()
+
+    monkeypatch.setattr(
+        "generation.providers.comfyui_ltx.urllib.request.urlopen",
+        lambda url, timeout: _FakeResponse(json.dumps({}).encode()),
+    )
+
+    # Well past the error budget -- a real "no entry yet" must never trip it.
+    for _ in range(_MAX_CONSECUTIVE_POLL_ERRORS * 3):
+        assert provider.get_status("job-3") == ("pending", 0.0)
+
+
+def test_a_successful_poll_resets_the_error_budget(monkeypatch):
+    """Transient errors that later recover shouldn't leave a job one poll from failing."""
+    provider = ComfyUILTXProvider()
+    external_id = "job-4"
+    calls = {"n": 0}
+
+    def flaky_then_recovers(url, timeout):
+        calls["n"] += 1
+        if calls["n"] <= _MAX_CONSECUTIVE_POLL_ERRORS - 1:
+            raise urllib.error.URLError("timeout")
+        return _FakeResponse(json.dumps({}).encode())
+
+    monkeypatch.setattr(
+        "generation.providers.comfyui_ltx.urllib.request.urlopen", flaky_then_recovers
+    )
+
+    for _ in range(_MAX_CONSECUTIVE_POLL_ERRORS - 1):
+        assert provider.get_status(external_id) == ("pending", 0.0)
+    # The recovering poll succeeds and resets the counter...
+    assert provider.get_status(external_id) == ("pending", 0.0)
+
+    # ...so a fresh run of transport errors needs the full budget again,
+    # rather than failing on the very next call.
+    monkeypatch.setattr(
+        "generation.providers.comfyui_ltx.urllib.request.urlopen",
+        lambda url, timeout: (_ for _ in ()).throw(urllib.error.URLError("timeout")),
+    )
+    for _ in range(_MAX_CONSECUTIVE_POLL_ERRORS - 1):
+        assert provider.get_status(external_id) == ("pending", 0.0)
+    assert provider.get_status(external_id) == ("failed", 0.0)
+
+
+def test_status_str_error_is_reported_failed(monkeypatch):
+    """ComfyUI's own status_str=error must map to a failed job (unchanged behavior)."""
+    provider = ComfyUILTXProvider()
+    history = {"job-5": {"status": {"status_str": "error"}}}
+
+    monkeypatch.setattr(
+        "generation.providers.comfyui_ltx.urllib.request.urlopen",
+        lambda url, timeout: _FakeResponse(json.dumps(history).encode()),
+    )
+
+    assert provider.get_status("job-5") == ("failed", 0.0)
+
+
+def test_outputs_present_is_reported_completed(monkeypatch):
+    """A history entry with outputs must map to completed (unchanged behavior)."""
+    provider = ComfyUILTXProvider()
+    history = {"job-6": {"outputs": {"7": {"images": [{"filename": "out.webp"}]}}}}
+
+    monkeypatch.setattr(
+        "generation.providers.comfyui_ltx.urllib.request.urlopen",
+        lambda url, timeout: _FakeResponse(json.dumps(history).encode()),
+    )
+
+    assert provider.get_status("job-6") == ("completed", 1.0)
+    # Second call short-circuits via the completed-jobs cache, no network call.
+    monkeypatch.setattr(
+        "generation.providers.comfyui_ltx.urllib.request.urlopen",
+        lambda url, timeout: (_ for _ in ()).throw(AssertionError("should not poll again")),
+    )
+    assert provider.get_status("job-6") == ("completed", 1.0)


### PR DESCRIPTION
Closes rustchain-bounties#71 report (reported by @Nish916, 5 RTC).

## What
`ComfyUILTXProvider.get_status()` wrapped the whole `/history` poll in `try: ... except Exception: pass` and always fell through to `return ("pending", 0.0)`. A transport error, timeout, HTTP error, or malformed JSON response was therefore indistinguishable from a job that is genuinely still queued -- workers polled forever and users never saw a failure.

## Fix
`get_status()` now tracks consecutive poll failures per `prompt_id` separately from "reachable but no history entry yet":
- a poll error still returns `pending` for the first few attempts (a single timeout shouldn't kill a job)
- after `_MAX_CONSECUTIVE_POLL_ERRORS` (5) in a row it reports `("failed", 0.0)` so the worker's poll loop in `generation/worker.py` gives up instead of spinning to the full timeout
- any poll that actually reaches ComfyUI resets the counter, even if that particular job has no history entry yet, so a genuinely-still-queued job is never mistaken for a string of errors

## Tests
`tests/test_comfyui_ltx_status.py` -- covers all five regression cases from the report:
- `URLError` does not stay silently pending forever (fails after the budget)
- malformed JSON is the same class of failure
- a genuinely queued job (empty history, reachable) stays pending indefinitely, never trips the error budget
- a transient error that later recovers resets the budget instead of leaving the job one poll away from failing
- existing `status_str=error` -> failed and outputs-present -> completed behavior is unchanged

## Verified
- `pytest tests/test_comfyui_ltx_status.py` -- 6/6 new
- `pytest tests/ -k "comfyui or generation or worker"` (excluding 4 test files with pre-existing, unrelated collection errors on a clean checkout: `gpu_marketplace`/`news_routes` import mismatches) -- 52/52 pass
- `ruff check` on both touched files -- no new issues (pre-existing blind-except/typing-style warnings already present throughout this file, untouched)

Note: this PR is based on my fork's main, which was several hundred commits behind upstream (syncing it hit `refusing to allow a Personal Access Token to create or update workflow ... without workflow scope` -- my fork predates a workflow file added upstream and my token doesn't have `workflow` scope). The only file both branches share that I touched, `generation/providers/comfyui_ltx.py`, is identical on both as of the point I branched, so the diff here is exactly my change with no drift.

/claim rustchain-bounties#71