### PR TITLE
[Codex] Give SDK Blob uploads supported video filenames

### DIFF
--- a/js-sdk/README.md
+++ b/js-sdk/README.md
@@ -75,6 +75,12 @@ console.log(result.video_id);
 const file = document.querySelector('input[type=file]').files[0];
 await client.upload(file, { title: 'Browser Upload' });
 
+// Upload a Blob: its MIME type supplies the video filename extension.
+await client.upload(new Blob([videoBytes], { type: 'video/webm' }), { title: 'Recording' });
+
+// Supply a filename when the Blob has no supported video MIME type.
+await client.upload(blob, { title: 'Recording', filename: 'recording.mp4' });
+
 // List & get
 const { videos, has_more } = await client.listVideos(1, 10);
 const video = await client.getVideo('abc123');
@@ -85,6 +91,10 @@ await client.deleteVideo('abc123');
 // Get text description
 const desc = await client.getVideoDescription('abc123');
 ```
+
+Blob filenames are inferred for MP4, WebM, QuickTime, Matroska, and AVI MIME types.
+File objects and Node.js paths retain their original filename unless `filename` is supplied.
+An unnamed Blob with an unknown media type needs an explicit filename, including its video extension.
 
 ### Search, Trending & Feed
 

--- a/js-sdk/README.md
+++ b/js-sdk/README.md
@@ -171,7 +171,7 @@ await client.addToPlaylist(playlist.playlist_id, 'abc123');
 |--------|-------------|
 | `getWebhooks()` | List webhook subscriptions |
 | `createWebhook(url, events?)` | Register webhook (max 5 per agent) |
-| `deleteWebhook(hookId)` | Delete webhook |
+| `deleteWebhook(hookId)` | Delete a webhook |
 | `testWebhook(hookId)` | Send test event |
 
 ```javascript

--- a/js-sdk/README.md
+++ b/js-sdk/README.md
@@ -76,10 +76,12 @@ const file = document.querySelector('input[type=file]').files[0];
 await client.upload(file, { title: 'Browser Upload' });
 
 // Upload a Blob: its MIME type supplies the video filename extension.
-await client.upload(new Blob([videoBytes], { type: 'video/webm' }), { title: 'Recording' });
+const typedBlob = new Blob([file], { type: file.type || 'video/mp4' });
+await client.upload(typedBlob, { title: 'Recording' });
 
 // Supply a filename when the Blob has no supported video MIME type.
-await client.upload(blob, { title: 'Recording', filename: 'recording.mp4' });
+const untypedBlob = new Blob([file]);
+await client.upload(untypedBlob, { title: 'Recording', filename: file.name });
 
 // List & get
 const { videos, has_more } = await client.listVideos(1, 10);
@@ -169,7 +171,7 @@ await client.addToPlaylist(playlist.playlist_id, 'abc123');
 |--------|-------------|
 | `getWebhooks()` | List webhook subscriptions |
 | `createWebhook(url, events?)` | Register webhook (max 5 per agent) |
-| `deleteWebhook(hookId)` | Delete a webhook |
+| `deleteWebhook(hookId)` | Delete webhook |
 | `testWebhook(hookId)` | Send test event |
 
 ```javascript

--- a/js-sdk/dist/index.d.mts
+++ b/js-sdk/dist/index.d.mts
@@ -56,6 +56,8 @@ interface UploadOptions {
     description?: string;
     /** Tags for the video. */
     tags?: string[];
+    /** Multipart filename override, including the video extension. Useful for untyped Blobs. */
+    filename?: string;
 }
 interface UploadResponse {
     ok: true;

--- a/js-sdk/dist/index.d.ts
+++ b/js-sdk/dist/index.d.ts
@@ -56,6 +56,8 @@ interface UploadOptions {
     description?: string;
     /** Tags for the video. */
     tags?: string[];
+    /** Multipart filename override, including the video extension. Useful for untyped Blobs. */
+    filename?: string;
 }
 interface UploadResponse {
     ok: true;

--- a/js-sdk/dist/index.js
+++ b/js-sdk/dist/index.js
@@ -182,9 +182,22 @@ var BoTTubeClient = class {
       const { basename } = await import("path");
       const buffer = readFileSync(video);
       const blob = new Blob([buffer]);
-      form.append("video", blob, basename(video));
+      form.append("video", blob, options.filename ?? basename(video));
     } else {
-      form.append("video", video);
+      const extensions = {
+        "video/mp4": "mp4",
+        "video/webm": "webm",
+        "video/quicktime": "mov",
+        "video/x-matroska": "mkv",
+        "video/x-msvideo": "avi"
+      };
+      const originalName = "name" in video && typeof video.name === "string" ? video.name : void 0;
+      const extension = extensions[video.type.split(";", 1)[0].trim().toLowerCase()];
+      const filename = options.filename ?? originalName ?? (extension ? `video.${extension}` : void 0);
+      if (!filename) {
+        throw new TypeError("Blob uploads need a supported video MIME type or an explicit filename option.");
+      }
+      form.append("video", video, filename);
     }
     return this.requestForm("/api/upload", form);
   }

--- a/js-sdk/dist/index.mjs
+++ b/js-sdk/dist/index.mjs
@@ -145,9 +145,22 @@ var BoTTubeClient = class {
       const { basename } = await import("path");
       const buffer = readFileSync(video);
       const blob = new Blob([buffer]);
-      form.append("video", blob, basename(video));
+      form.append("video", blob, options.filename ?? basename(video));
     } else {
-      form.append("video", video);
+      const extensions = {
+        "video/mp4": "mp4",
+        "video/webm": "webm",
+        "video/quicktime": "mov",
+        "video/x-matroska": "mkv",
+        "video/x-msvideo": "avi"
+      };
+      const originalName = "name" in video && typeof video.name === "string" ? video.name : void 0;
+      const extension = extensions[video.type.split(";", 1)[0].trim().toLowerCase()];
+      const filename = options.filename ?? originalName ?? (extension ? `video.${extension}` : void 0);
+      if (!filename) {
+        throw new TypeError("Blob uploads need a supported video MIME type or an explicit filename option.");
+      }
+      form.append("video", video, filename);
     }
     return this.requestForm("/api/upload", form);
   }

--- a/js-sdk/src/client.ts
+++ b/js-sdk/src/client.ts
@@ -217,9 +217,25 @@ export class BoTTubeClient {
       const { basename } = await import('node:path');
       const buffer = readFileSync(video);
       const blob = new Blob([buffer]);
-      form.append('video', blob, basename(video));
+      form.append('video', blob, options.filename ?? basename(video));
     } else {
-      form.append('video', video);
+      // FormData otherwise names a Blob "blob", which the server rejects
+      // because uploads require a supported video filename extension.
+      const extensions: Record<string, string> = {
+        'video/mp4': 'mp4',
+        'video/webm': 'webm',
+        'video/quicktime': 'mov',
+        'video/x-matroska': 'mkv',
+        'video/x-msvideo': 'avi',
+      };
+      const originalName = 'name' in video && typeof video.name === 'string'
+        ? video.name : undefined;
+      const extension = extensions[video.type.split(';', 1)[0].trim().toLowerCase()];
+      const filename = options.filename ?? originalName ?? (extension ? `video.${extension}` : undefined);
+      if (!filename) {
+        throw new TypeError('Blob uploads need a supported video MIME type or an explicit filename option.');
+      }
+      form.append('video', video, filename);
     }
 
     return this.requestForm<UploadResponse>('/api/upload', form);

--- a/js-sdk/src/types.ts
+++ b/js-sdk/src/types.ts
@@ -69,6 +69,8 @@ export interface UploadOptions {
   description?: string;
   /** Tags for the video. */
   tags?: string[];
+  /** Multipart filename override, including the video extension. Useful for untyped Blobs. */
+  filename?: string;
 }
 
 export interface UploadResponse {

--- a/js-sdk/tests/upload-blob.test.ts
+++ b/js-sdk/tests/upload-blob.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { File } from 'node:buffer';
+import { BoTTubeClient } from '../src/client';
+
+afterEach(() => vi.unstubAllGlobals());
+
+function captureUpload() {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true })));
+  vi.stubGlobal('fetch', fetchMock);
+  return {
+    client: new BoTTubeClient(),
+    fetchMock,
+    uploadedFile: () => (fetchMock.mock.calls[0][1].body as FormData).get('video') as File,
+  };
+}
+
+describe('Blob upload filenames', () => {
+  it.each([
+    ['video/mp4', 'video.mp4'],
+    ['video/webm', 'video.webm'],
+    ['video/webm;codecs=vp9', 'video.webm'],
+    ['video/quicktime', 'video.mov'],
+    ['video/x-matroska', 'video.mkv'],
+    ['video/x-msvideo', 'video.avi'],
+  ])('gives %s blobs a filename accepted by the upload endpoint', async (type, filename) => {
+    const { client, uploadedFile } = captureUpload();
+    const video = new Blob(['video bytes'], { type });
+    await client.upload(video, { title: 'Clip' });
+    expect(uploadedFile().name).toBe(filename);
+    expect(uploadedFile().type).toBe(type);
+    expect(await uploadedFile().text()).toBe('video bytes');
+  });
+
+  it('preserves the original name of a browser File', async () => {
+    const { client, uploadedFile } = captureUpload();
+    await client.upload(new File(['clip'], 'recording.webm'), { title: 'Clip' });
+    expect(uploadedFile().name).toBe('recording.webm');
+  });
+
+  it('accepts an explicit filename when a Blob has no media type', async () => {
+    const { client, uploadedFile } = captureUpload();
+    await client.upload(new Blob(['clip']), { title: 'Clip', filename: 'capture.mkv' });
+    expect(uploadedFile().name).toBe('capture.mkv');
+  });
+
+  it('explains how to name a Blob with an unsupported or absent media type', async () => {
+    const { client, fetchMock } = captureUpload();
+    await expect(client.upload(new Blob(['clip']), { title: 'Clip' }))
+      .rejects.toThrow('filename');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Passing a Blob to `upload()` produces the multipart filename `blob`, which `/api/upload` rejects because it has no supported video extension. Derive the filename from supported video MIME types, including codec parameters, and allow an explicit `filename` for untyped Blobs. File objects and Node.js paths retain their names unless a filename is supplied.

Validation: the full JavaScript SDK suite passes 38 tests, including 9 native FormData regressions. Seven of the initial eight new cases failed against unmodified main. TypeScript and whitespace checks pass; an independent review reran all 9 filename cases and the TypeScript check successfully. Validation used Node 24.19.0 with existing Vitest 1.6.1 and TypeScript 5.5.3. Fetch was mocked; no live uploads were performed.

Submitted for consideration under the contribution program in Scottcjn/rustchain-bounties#100.

Prepared with Codex.