### PR TITLE
[Codex] Apply SDK request timeouts to response body reads

### DIFF
--- a/js-sdk/src/client.ts
+++ b/js-sdk/src/client.ts
@@ -92,6 +92,9 @@ export class BoTTubeClient {
     try {
       data = await res.json();
     } catch (err) {
+      // Let the request helper classify a timed-out body read consistently,
+      // including responses whose error status arrived before the deadline.
+      if (err instanceof Error && err.name === 'AbortError') throw err;
       // Successful DELETE-style operations may legitimately return no body.
       if (res.ok && res.status === 204) return undefined as T;
 
@@ -125,15 +128,15 @@ export class BoTTubeClient {
         body: body !== undefined ? JSON.stringify(body) : undefined,
         signal: controller.signal,
       });
-      clearTimeout(timer);
       return await this.responseData<T>(res);
     } catch (err) {
-      clearTimeout(timer);
       if (err instanceof BoTTubeError) throw err;
       if (err instanceof Error && err.name === 'AbortError') {
         throw new BoTTubeError(408, { error: 'Request timeout' }, 'Request timed out');
       }
       throw err;
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -149,15 +152,15 @@ export class BoTTubeClient {
         body: form,
         signal: controller.signal,
       });
-      clearTimeout(timer);
       return await this.responseData<T>(res);
     } catch (err) {
-      clearTimeout(timer);
       if (err instanceof BoTTubeError) throw err;
       if (err instanceof Error && err.name === 'AbortError') {
         throw new BoTTubeError(408, { error: 'Request timeout' }, 'Request timed out');
       }
       throw err;
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/js-sdk/tests/response-timeout.test.ts
+++ b/js-sdk/tests/response-timeout.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { File } from 'node:buffer';
+import { BoTTubeClient } from '../src/client';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('response body deadlines', () => {
+  it.each([
+    ['json', 200], ['multipart', 200], ['json', 503], ['multipart', 503],
+  ])('times out a stalled %s response with status %s after headers arrive', async (kind, status) => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async (_url, options) => ({
+      ok: status === 200,
+      status,
+      json: () => new Promise((_resolve, reject) => {
+        options.signal.addEventListener('abort', () => {
+          reject(new DOMException('Body read aborted', 'AbortError'));
+        }, { once: true });
+      }),
+    })));
+    const client = new BoTTubeClient({ timeout: 100 });
+    const operation = kind === 'json'
+      ? client.health()
+      : client.upload(new File(['clip'], 'clip.mp4'), { title: 'Clip' });
+    let outcome: unknown;
+    operation.then(value => { outcome = value; }, error => { outcome = error; });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(outcome).toMatchObject({ name: 'BoTTubeError', statusCode: 408 });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('allows a body that completes within the deadline', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: () => new Promise(resolve => setTimeout(() => resolve({ status: 'ok' }), 25)),
+    })));
+    const operation = new BoTTubeClient({ timeout: 100 }).health();
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(operation).resolves.toEqual({ status: 'ok' });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cleans up the deadline after a body decoding error', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => { throw new SyntaxError('Invalid JSON'); },
+    })));
+    await expect(new BoTTubeClient({ timeout: 100 }).health()).rejects.toThrow(SyntaxError);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
The JavaScript SDK stops its timeout when response headers arrive, so a stalled JSON body can leave the operation pending indefinitely. Keep the deadline active through body decoding for JSON and multipart requests, and classify aborted body reads consistently as 408 timeouts even when error-status headers have already arrived.

Validation: the full JavaScript SDK suite passes 35 tests, including 6 deadline regressions. Both initial stalled-body cases failed against unmodified main. Tests cover stalled 200 and 503 bodies, successful decoding before the deadline, and timer cleanup after decoding errors. TypeScript and whitespace checks pass; an independent review reran all 6 deadline cases and the TypeScript check successfully. Validation used Node 24.19.0 with existing Vitest 1.6.1 and TypeScript 5.5.3 and mocked HTTP responses.

Submitted for consideration under the contribution program in Scottcjn/rustchain-bounties#100.

Prepared with Codex.