### PR TITLE
[Codex] Repair Python SDK notification listing and read actions

### DIFF
--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -265,8 +265,15 @@ graph = client.get_social_graph()
 # Get notifications
 notifications = client.get_notifications(limit=20)
 
+# Fetch another page of unread notifications (per_page maximum: 50)
+notifications = client.get_notifications(page=2, per_page=20, unread_only=True)
+# limit remains an alias for per_page; supply only one of the two.
+
 # Get unread count
 count = client.get_notification_count()
+
+# Mark one notification as read
+client.mark_notification_read(123)
 
 # Mark all as read
 client.mark_notifications_read()

--- a/python-sdk/bottube/client.py
+++ b/python-sdk/bottube/client.py
@@ -411,11 +411,25 @@ class BoTTubeClient:
 
     # ── notifications ───────────────────────────────────────────────────
 
-    def get_notifications(self, limit: Optional[int] = None) -> dict:
-        """Get current agent's notifications."""
-        params = {}
-        if limit:
-            params["limit"] = limit
+    def get_notifications(
+        self,
+        limit: Optional[int] = None,
+        *,
+        page: Optional[int] = None,
+        per_page: Optional[int] = None,
+        unread_only: Optional[bool] = None,
+    ) -> dict:
+        """Get current agent's notifications with pagination.
+
+        ``limit`` is retained as an alias for ``per_page`` (server maximum 50).
+        Supply at most one page-size argument. Omitted values use server
+        defaults; ``unread_only=True`` requests only unread notifications.
+        """
+        if limit is not None and per_page is not None:
+            raise ValueError("Specify either limit or per_page, not both")
+        params = {"page": page, "per_page": per_page if per_page is not None else limit}
+        if unread_only is not None:
+            params["unread"] = "1" if unread_only else "0"
         return self._request("GET", "/api/agents/me/notifications", params=params)
 
     def get_notification_count(self) -> dict:
@@ -424,11 +438,11 @@ class BoTTubeClient:
 
     def mark_notifications_read(self) -> dict:
         """Mark all notifications as read."""
-        return self._request("POST", "/api/agents/me/notifications/read")
+        return self._request("POST", "/api/agents/me/notifications/read", {"all": True})
 
     def mark_notification_read(self, notification_id: int) -> dict:
         """Mark a specific notification as read."""
-        return self._request("POST", f"/api/notifications/{self._path_param(notification_id)}/read")
+        return self._request("POST", "/api/agents/me/notifications/read", {"ids": [notification_id]})
 
     # ── gamification / quests ───────────────────────────────────────────
 

--- a/python-sdk/tests/test_notifications.py
+++ b/python-sdk/tests/test_notifications.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MIT
+"""Wire contracts for the API-key notification endpoints."""
+
+import json
+from io import BytesIO
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from bottube.client import BoTTubeClient
+
+
+@pytest.fixture
+def client_and_transport():
+    client = BoTTubeClient(base_url="https://example.invalid", api_key="test-key")
+    with patch("bottube.client.urlopen") as transport:
+        transport.return_value = BytesIO(b'{"notifications":[],"total":0,"updated":1}')
+        yield client, transport
+
+
+def test_legacy_limit_controls_notification_page_size(client_and_transport):
+    client, transport = client_and_transport
+    result = client.get_notifications(3)
+    request = transport.call_args.args[0]
+    assert parse_qs(urlsplit(request.full_url).query) == {"per_page": ["3"]}
+    assert result["notifications"] == []
+
+
+def test_notifications_can_page_through_unread_results(client_and_transport):
+    client, transport = client_and_transport
+    client.get_notifications(page=2, per_page=5, unread_only=True)
+    request = transport.call_args.args[0]
+    assert urlsplit(request.full_url).path == "/api/agents/me/notifications"
+    assert parse_qs(urlsplit(request.full_url).query) == {
+        "page": ["2"], "per_page": ["5"], "unread": ["1"]
+    }
+    assert request.get_header("X-api-key") == "test-key"
+
+
+def test_default_notifications_preserve_server_defaults(client_and_transport):
+    client, transport = client_and_transport
+    client.get_notifications()
+    assert urlsplit(transport.call_args.args[0].full_url).query == ""
+
+
+def test_false_unread_filter_is_sent_using_server_parameter(client_and_transport):
+    client, transport = client_and_transport
+    client.get_notifications(unread_only=False)
+    assert parse_qs(urlsplit(transport.call_args.args[0].full_url).query) == {"unread": ["0"]}
+
+
+def test_conflicting_page_size_aliases_are_rejected(client_and_transport):
+    client, transport = client_and_transport
+    with pytest.raises(ValueError, match="limit.*per_page"):
+        client.get_notifications(limit=2, per_page=3)
+    transport.assert_not_called()
+
+
+def test_zero_limit_is_not_silently_replaced_by_default(client_and_transport):
+    client, transport = client_and_transport
+    client.get_notifications(limit=0)
+    assert parse_qs(urlsplit(transport.call_args.args[0].full_url).query) == {"per_page": ["0"]}
+
+
+def test_mark_all_sends_explicit_selection(client_and_transport):
+    client, transport = client_and_transport
+    result = client.mark_notifications_read()
+    request = transport.call_args.args[0]
+    assert request.method == "POST"
+    assert urlsplit(request.full_url).path == "/api/agents/me/notifications/read"
+    assert json.loads(request.data) == {"all": True}
+    assert result["updated"] == 1
+
+
+def test_mark_one_uses_api_key_endpoint_and_id_selection(client_and_transport):
+    client, transport = client_and_transport
+    client.mark_notification_read(42)
+    request = transport.call_args.args[0]
+    assert request.method == "POST"
+    assert urlsplit(request.full_url).path == "/api/agents/me/notifications/read"
+    assert json.loads(request.data) == {"ids": [42]}
+    assert request.get_header("X-api-key") == "test-key"


### PR DESCRIPTION
The Python SDK's notification limit is ignored because the API consumes `per_page`. Its mark-all call sends no selection and updates zero rows, while mark-one uses an undeclared route. Map the existing limit argument to `per_page`, expose page/unread filtering, and send `{all: true}` or `{ids: [id]}` to the existing API-key read endpoint. The README documents the supported calls.

This follows `my_notifications`, `mark_notifications_read`, and the existing notification selection helpers in `bottube_server.py` at e0c09a6f2eb7a1068abc73671f90f27a0b5771cb. Conflicting page-size aliases are rejected; omitted options preserve server defaults.

The eight new regression cases produced 7 failures on unmodified main. After the fix, the complete Python SDK suite passes: **20 passed**, using `python -m pytest -c python-sdk/pyproject.toml python-sdk/tests -q` with the worktree's `python-sdk` on `PYTHONPATH`. `git diff --check` passes.

Prepared with Codex assistance. Related improvement program: Scottcjn/rustchain-bounties#100; acceptance and any RTC reward remain subject to maintainer review.

Validation used Python 3.12.10 on Windows with mocked HTTP transports and no live API calls. Full server CI is separate; the upstream baseline has known deployment-drift failures.