### PR TITLE
[Codex] Make Python SDK search and trending options effective

### DIFF
--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -73,9 +73,16 @@ video = client.get_video("video-id")
 
 # Search
 results = client.search("query")
+# Fetch another page (per_page maximum: 50)
+results = client.search("query", page=2, per_page=10)
+# The existing limit argument is an alias for per_page; do not supply both.
 
 # Trending
 trending = client.get_trending(limit=10, timeframe="day")
+# timeframe accepts day/week/month; use days for a custom 1-90 day window.
+trending = client.get_trending(days=14, category="science-tech")
+# Or use an absolute creation timestamp, without timeframe/days.
+trending = client.get_trending(since=1710000000)
 
 # Feed
 feed = client.get_feed(page=1, per_page=20, since=1710000000)

--- a/python-sdk/bottube/client.py
+++ b/python-sdk/bottube/client.py
@@ -295,16 +295,54 @@ class BoTTubeClient:
         """Get the direct stream URL for a video."""
         return f"{self.base_url}/api/videos/{self._path_param(video_id)}/stream"
 
-    def search(self, query: str, limit: Optional[int] = None) -> dict:
-        """Search videos by query string."""
-        params = {"q": query}
-        if limit:
-            params["limit"] = limit
+    def search(
+        self,
+        query: str,
+        limit: Optional[int] = None,
+        *,
+        page: Optional[int] = None,
+        per_page: Optional[int] = None,
+    ) -> dict:
+        """Search videos with pagination.
+
+        ``limit`` is an alias for ``per_page`` (server maximum 50). Supply
+        at most one page-size argument; omitted values use server defaults.
+        """
+        if limit is not None and per_page is not None:
+            raise ValueError("Specify either limit or per_page, not both")
+        params = {
+            "q": query,
+            "page": page,
+            "per_page": per_page if per_page is not None else limit,
+        }
         return self._request("GET", "/api/search", params=params)
 
-    def get_trending(self, limit: Optional[int] = None, timeframe: Optional[str] = None) -> dict:
-        """Get trending videos."""
-        return self._request("GET", "/api/trending", params={"limit": limit, "timeframe": timeframe})
+    def get_trending(
+        self,
+        limit: Optional[int] = None,
+        timeframe: Optional[str] = None,
+        *,
+        days: Optional[int] = None,
+        since: Optional[Union[int, float]] = None,
+        category: Optional[str] = None,
+    ) -> dict:
+        """Get trending videos with an optional activity window and category.
+
+        ``timeframe`` accepts ``day``, ``week``, or ``month`` as aliases for
+        1, 7, or 30 days. Alternatively supply ``days`` (1-90), or ``since``
+        (a Unix timestamp). Supply only one window; omit all for the server's
+        default. The server validates numeric ranges.
+        """
+        if sum(value is not None for value in (timeframe, days, since)) > 1:
+            raise ValueError("Specify only one of timeframe, days, or since")
+        if timeframe is not None:
+            windows = {"day": 1, "week": 7, "month": 30}
+            if timeframe not in windows:
+                raise ValueError("timeframe must be day, week, or month")
+            days = windows[timeframe]
+        return self._request("GET", "/api/trending", params={
+            "limit": limit, "days": days, "since": since, "category": category,
+        })
 
     def get_feed(
         self,

--- a/python-sdk/tests/test_catalog_queries.py
+++ b/python-sdk/tests/test_catalog_queries.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+"""Search and trending options must reach parameters the server consumes."""
+
+from io import BytesIO
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from bottube.client import BoTTubeClient
+
+
+@pytest.fixture
+def client_and_transport():
+    client = BoTTubeClient(base_url="https://example.invalid")
+    with patch("bottube.client.urlopen") as transport:
+        transport.return_value = BytesIO(b'{"videos":[],"total":0}')
+        yield client, transport
+
+
+def query(transport):
+    return parse_qs(urlsplit(transport.call_args.args[0].full_url).query)
+
+
+def test_search_legacy_limit_uses_server_page_size(client_and_transport):
+    client, transport = client_and_transport
+    result = client.search("cats & dogs / café", 3)
+    assert query(transport) == {"q": ["cats & dogs / café"], "per_page": ["3"]}
+    assert result == {"videos": [], "total": 0}
+
+
+def test_search_can_request_later_result_pages(client_and_transport):
+    client, transport = client_and_transport
+    client.search("robots", page=2, per_page=4)
+    assert query(transport) == {"q": ["robots"], "page": ["2"], "per_page": ["4"]}
+
+
+def test_search_default_leaves_pagination_to_server(client_and_transport):
+    client, transport = client_and_transport
+    client.search("robots")
+    assert query(transport) == {"q": ["robots"]}
+
+
+def test_search_rejects_ambiguous_page_sizes(client_and_transport):
+    client, transport = client_and_transport
+    with pytest.raises(ValueError, match="limit.*per_page"):
+        client.search("robots", limit=3, per_page=4)
+    transport.assert_not_called()
+
+
+def test_zero_search_limit_reaches_server_validation(client_and_transport):
+    client, transport = client_and_transport
+    client.search("robots", limit=0)
+    assert query(transport) == {"q": ["robots"], "per_page": ["0"]}
+
+
+@pytest.mark.parametrize("timeframe,days", [("day", "1"), ("week", "7"), ("month", "30")])
+def test_trending_timeframes_translate_to_days(client_and_transport, timeframe, days):
+    client, transport = client_and_transport
+    client.get_trending(10, timeframe)
+    assert query(transport) == {"limit": ["10"], "days": [days]}
+
+
+def test_trending_accepts_day_window_and_category(client_and_transport):
+    client, transport = client_and_transport
+    client.get_trending(days=14, category="science-tech")
+    assert query(transport) == {"days": ["14"], "category": ["science-tech"]}
+
+
+def test_trending_since_zero_is_preserved(client_and_transport):
+    client, transport = client_and_transport
+    client.get_trending(since=0)
+    assert query(transport) == {"since": ["0"]}
+
+
+@pytest.mark.parametrize("options", [
+    {"days": 2, "since": 123},
+    {"timeframe": "week", "days": 2},
+    {"timeframe": "week", "since": 123},
+])
+def test_trending_rejects_conflicting_windows(client_and_transport, options):
+    client, transport = client_and_transport
+    with pytest.raises(ValueError, match="one of timeframe, days, or since"):
+        client.get_trending(**options)
+    transport.assert_not_called()
+
+
+def test_unknown_timeframe_is_not_silently_ignored(client_and_transport):
+    client, transport = client_and_transport
+    with pytest.raises(ValueError, match="day.*week.*month"):
+        client.get_trending(timeframe="forever")
+    transport.assert_not_called()
+
+
+def test_default_trending_preserves_server_defaults(client_and_transport):
+    client, transport = client_and_transport
+    client.get_trending()
+    assert query(transport) == {}


### PR DESCRIPTION
`search(query, limit=3)` currently sends an ignored `limit` parameter, and `get_trending(timeframe="week")` sends an ignored `timeframe`. The server's `search_videos` route consumes page/per_page; `trending` consumes days/since/category.

Preserve `limit` as a search page-size alias and expose pagination. Map day/week/month timeframes to 1/7/30 days, expose the server's custom day window, absolute timestamp, and category options, and reject conflicting windows or unknown timeframe strings. Numeric ranges remain validated by the server. The README includes working examples.

The 15 new cases produced 13 failures on unmodified main at e0c09a6f2eb7a1068abc73671f90f27a0b5771cb. After the fix, the complete Python SDK suite passes: **27 passed**, using `python -m pytest -c python-sdk/pyproject.toml python-sdk/tests -q` with the worktree's `python-sdk` on `PYTHONPATH`. Coverage includes URL encoding, omitted defaults, zero values, legacy arguments, and ambiguous options. `git diff --check` passes.

Prepared with Codex assistance. Related improvement program: Scottcjn/rustchain-bounties#100; acceptance and any RTC reward remain subject to maintainer review.

Validation used Python 3.12.10 on Windows with mocked HTTP transports and no live API calls. Full server CI is separate; the upstream baseline has known deployment-drift failures.