### PR TITLE
[Codex] Honor the Python SDK option to exclude comment replies

### DIFF
--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -111,6 +111,9 @@ client.comment("video-id", "I agree!", parent_id=123)
 # Get comments
 comments = client.get_comments("video-id")
 
+# Get top-level comments only; count reflects the filtered list.
+comments = client.get_comments("video-id", include_replies=False)
+
 # Recent comments across all videos
 recent = client.get_recent_comments(limit=50)
 

--- a/python-sdk/bottube/client.py
+++ b/python-sdk/bottube/client.py
@@ -342,9 +342,17 @@ class BoTTubeClient:
         return self._request("POST", f"/api/videos/{self._path_param(video_id)}/comment", body)
 
     def get_comments(self, video_id: str, include_replies: bool = True) -> dict:
-        """Get comments for a video."""
-        params = {} if include_replies else {"replies": "0"}
-        return self._request("GET", f"/api/videos/{self._path_param(video_id)}/comments", params=params)
+        """Get comments for a video, optionally keeping only top-level rows.
+
+        The API returns a flat list including replies. When ``include_replies``
+        is false, filter locally by ``parent_id`` and update ``count`` to the
+        number of returned comments. Other response fields are preserved.
+        """
+        result = self._request("GET", f"/api/videos/{self._path_param(video_id)}/comments")
+        if include_replies:
+            return result
+        comments = [comment for comment in result["comments"] if comment.get("parent_id") is None]
+        return {**result, "comments": comments, "count": len(comments)}
 
     def get_recent_comments(self, since: Optional[int] = None, limit: int = 20) -> list[dict]:
         """Get recent comments across all videos."""

--- a/python-sdk/tests/test_comment_replies.py
+++ b/python-sdk/tests/test_comment_replies.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+"""Filtering follows the flat parent_id contract returned by get_comments."""
+
+import copy
+import json
+from io import BytesIO
+from unittest.mock import patch
+from urllib.parse import urlsplit
+
+import pytest
+
+from bottube.client import BoTTubeClient
+
+
+@pytest.fixture
+def response():
+    return {
+        "comments": [
+            {"id": 10, "parent_id": None, "content": "First root", "likes": 3},
+            {"id": 11, "parent_id": 10, "content": "Reply to first root"},
+            {"id": 12, "parent_id": None, "content": "Second root", "likes": 1},
+            {"id": 13, "parent_id": 11, "content": "Nested reply"},
+        ],
+        "count": 4,
+        "context": {"video_id": "demo"},
+    }
+
+
+def test_exclude_replies_returns_roots_in_order_and_matching_count(response):
+    client = BoTTubeClient(base_url="https://example.invalid")
+    with patch("bottube.client.urlopen", return_value=BytesIO(json.dumps(response).encode())) as transport:
+        result = client.get_comments("demo", include_replies=False)
+    assert result["comments"] == [response["comments"][0], response["comments"][2]]
+    assert result["count"] == 2
+    assert result["context"] == response["context"]
+    # Fetch the supported endpoint; replies=0 is not a server-side filter.
+    assert urlsplit(transport.call_args.args[0].full_url).path == "/api/videos/demo/comments"
+    assert urlsplit(transport.call_args.args[0].full_url).query == ""
+
+
+@pytest.mark.parametrize("options", [{}, {"include_replies": True}])
+def test_default_and_explicit_include_preserve_complete_response(response, options):
+    client = BoTTubeClient()
+    with patch.object(client, "_request", return_value=response):
+        result = client.get_comments("demo", **options)
+    assert result is response
+
+
+def test_filter_does_not_mutate_transport_response(response):
+    original = copy.deepcopy(response)
+    client = BoTTubeClient()
+    with patch.object(client, "_request", return_value=response):
+        result = client.get_comments("demo", include_replies=False)
+    assert response == original
+    assert result is not response
+    assert result["comments"] is not response["comments"]
+
+
+@pytest.mark.parametrize("comments", [[], [{"id": 11, "parent_id": 10}]])
+def test_no_roots_yields_empty_list_and_zero_count(comments):
+    client = BoTTubeClient()
+    with patch.object(client, "_request", return_value={"comments": comments, "count": len(comments)}):
+        result = client.get_comments("demo", include_replies=False)
+    assert result == {"comments": [], "count": 0}
+
+
+def test_rows_without_parent_id_remain_visible():
+    # An absent parent field does not identify a row as a reply.
+    response = {"comments": [{"id": 10, "content": "Root"}], "count": 1}
+    client = BoTTubeClient()
+    with patch.object(client, "_request", return_value=response):
+        result = client.get_comments("demo", include_replies=False)
+    assert result == response


### PR DESCRIPTION
`get_comments(video_id, include_replies=False)` currently returns replies because the server ignores `replies=0`. The existing `get_comments` route in `bottube_server.py` returns an unpaginated flat list with parent IDs and a count equal to the list length.

Honor the SDK's existing option by filtering non-null parent IDs locally and updating count. Preserve row order, unrelated response metadata, and the original transport response. Default and explicit true calls retain the complete response unchanged. The README documents top-level-only retrieval.

The seven new cases produced 3 failures on unmodified main at e0c09a6f2eb7a1068abc73671f90f27a0b5771cb. After the fix, the complete Python SDK suite passes: **19 passed**, using `python -m pytest -c python-sdk/pyproject.toml python-sdk/tests -q` with the worktree's `python-sdk` on `PYTHONPATH`. Fixtures cover parent/reply nesting, empty and reply-only lists, response immutability, metadata, and missing parent fields. `git diff --check` passes.

Prepared with Codex assistance. Related improvement program: Scottcjn/rustchain-bounties#100; acceptance and any RTC reward remain subject to maintainer review.

Validation used Python 3.12.10 on Windows with mocked HTTP transports and no live API calls. Full server CI is separate; the upstream baseline has known deployment-drift failures.