### PR TITLE
Harden deposit bridges: stop unbacked RTC mint (Ergo) + deposit theft (wRTC)

### DIFF
--- a/ergo_bridge_blueprint.py
+++ b/ergo_bridge_blueprint.py
@@ -401,6 +401,14 @@ def ergo_deposit():
     if not tx_id:
         return jsonify({"error": "tx_id required"}), 400
 
+    # SECURITY (D1): canonicalize + strictly validate tx_id BEFORE it is used
+    # as both the on-chain lookup and the UNIQUE dedup key. Without this an
+    # alias (case variant, URL fragment, etc.) resolves to the same on-chain
+    # tx but a different dedup key -> the same deposit is minted repeatedly.
+    tx_id = tx_id.lower()
+    if len(tx_id) != 64 or any(ch not in "0123456789abcdef" for ch in tx_id):
+        return jsonify({"error": "tx_id must be 64 hexadecimal characters"}), 400
+
     # Check if already claimed
     existing = db.execute(
         "SELECT id FROM ergo_deposits WHERE tx_id = ?", (tx_id,)

--- a/wrtc_bridge.py
+++ b/wrtc_bridge.py
@@ -235,6 +235,8 @@ def verify_solana_deposit(tx_signature: str):
                 # Verify destination is our reserve wallet's ATA
                 if not _is_reserve_ata(dest_ata):
                     continue
+                if _is_reserve_ata(source_ata):
+                    continue  # D4: ignore reserve-originating/self transfers
 
                 return {
                     "tx_signature": tx_signature,
@@ -255,6 +257,8 @@ def verify_solana_deposit(tx_signature: str):
 
                 if not _is_reserve_ata(dest_ata):
                     continue
+                if _is_reserve_ata(source_ata):
+                    continue  # D4: ignore reserve-originating/self transfers
 
                 # For plain transfer, we need to verify the token account holds wRTC
                 if _verify_token_account_mint(dest_ata):
@@ -307,12 +311,14 @@ def _get_reserve_ata():
 
 
 def _is_reserve_ata(account_address: str) -> bool:
-    """Check if a token account belongs to our reserve wallet."""
+    """Check if a token account is our reserve wallet's derived ATA.
+
+    SECURITY (D2): trust ONLY the deterministic reserve ATA. The old
+    current-owner fallback let an attacker reassign a token account's owner to
+    the reserve AFTER a historical transfer into it, then claim that transfer.
+    """
     ata = _get_reserve_ata()
-    if ata and account_address == ata:
-        return True
-    # Fallback: query the account owner
-    return _check_account_owner(account_address, RESERVE_WALLET)
+    return bool(ata and account_address == ata)
 
 
 def _check_account_owner(token_account: str, expected_owner: str) -> bool:
@@ -443,6 +449,16 @@ def bridge_deposit():
         return jsonify({
             "error": f"Minimum deposit is {MIN_DEPOSIT} wRTC (got {amount})"
         }), 400
+
+    # Anti-theft (D3): the on-chain sender must match the Solana address linked
+    # to THIS account (mirrors the Ergo bridge). Without it, any authenticated
+    # user who observes a public tx signature can claim someone else's deposit.
+    _sol_row = db.execute("SELECT sol_address FROM agents WHERE id = ?", (agent["id"],)).fetchone()
+    bound_sol = ((_sol_row[0] if _sol_row else "") or "").strip()
+    if not bound_sol:
+        return jsonify({"error": "Link your Solana address to your account before depositing"}), 400
+    if info["from_address"] != bound_sol:
+        return jsonify({"error": "Transaction sender does not match the Solana address linked to your account"}), 403
 
     # Credit balance
     _award_rtc(db, agent["id"], amount, "bridge_deposit")


### PR DESCRIPTION
## Summary

Defensive audit of the **ERG** and **wRTC** deposit→mint bridges (GPT-6 Astra; **every finding source-verified** before the fix). These endpoints mint internal RTC from external crypto deposits, so a verification gap creates **unbacked RTC** (breaks the fixed-supply premise).

### Fixes
- **D1 — Ergo repeat-mint (CRITICAL).** `ergo_bridge_blueprint.py`: the client `tx_id` was used as **both** the on-chain lookup (`/transactions/{tx_id}`) **and** the `UNIQUE` dedup key, with no validation. An alias (case variant, URL fragment, etc.) resolves to the **same on-chain tx** but a **different** dedup key → the same deposit mints repeatedly. **Fix:** canonicalize + strictly validate `tx_id` to 64-hex lowercase before use, so aliases collapse to one key.
- **D3 — wRTC deposit theft (HIGH).** `wrtc_bridge.py`: `bridge_deposit` credited the authenticated caller for **any** valid `tx_signature`, with no binding to the depositor. Solana signatures are public, so anyone watching the reserve could **front-run and steal** another user's deposit. **Fix:** require the on-chain sender (`info["from_address"]`) to equal the account's linked `sol_address` — mirrors the Ergo bridge (whose comment already claimed "same rule as the Solana / Base bridges", but the check was missing here).
- **D2 — wRTC reserve-ATA spoof (HIGH).** `_is_reserve_ata` fell back to a token account's **current** owner, so an attacker could reassign an account's owner to the reserve **after** a historical transfer into it and claim that transfer. **Fix:** trust only the deterministic derived reserve ATA. (`_check_account_owner` is now unused; left in place.)
- **D4 — wRTC self-transfer credit.** Reject reserve-originating/self transfers so an internal reserve movement can't be claimed as a deposit. **Follow-up (flagged, not in this PR):** credit the reserve's **pre/post net token-balance change** from tx `meta` rather than the instruction's stated amount — that's a Solana-meta rewrite that needs live-tx tests.

### Verification / notes
- Each finding was checked against source; `ast.parse` clean on both files; **CRLF line endings preserved** (diff is 29+/5−, not a reformat).
- Reviewer note: the automated tri-brain reviewer was unavailable this session — these rest on manual source-verification; a second human review before merge is warranted given the money path.
- **Operational:** if the wRTC on-ramp is currently paused/unfunded, live exploitability is limited, but the code defects are real wherever the endpoints are reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbyXP4eiiRYEa8GsQtQPhR