### PR TITLE
[Codex] Escape Python SDK multipart upload filenames

### DIFF
--- a/python-sdk/bottube/client.py
+++ b/python-sdk/bottube/client.py
@@ -69,6 +69,14 @@ class BoTTubeClient:
         """Encode one URL path segment before interpolation."""
         return quote(str(value), safe="")
 
+    @staticmethod
+    def _multipart_filename(file_path: str) -> str:
+        """Escape filename header delimiters using HTML multipart encoding."""
+        return (
+            Path(file_path).name.replace("\r", "%0D")
+            .replace("\n", "%0A").replace('"', "%22")
+        )
+
     def _request(
         self,
         method: str,
@@ -115,9 +123,10 @@ class BoTTubeClient:
 
         filename = Path(file_path).name
         mime = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+        encoded_filename = self._multipart_filename(file_path)
         body_parts.append(f"--{boundary}\r\n".encode())
         body_parts.append(
-            f'Content-Disposition: form-data; name="video"; filename="{filename}"\r\n'.encode()
+            f'Content-Disposition: form-data; name="video"; filename="{encoded_filename}"\r\n'.encode()
         )
         body_parts.append(f"Content-Type: {mime}\r\n\r\n".encode())
         with open(file_path, "rb") as f:
@@ -197,9 +206,10 @@ class BoTTubeClient:
         # Build file part header
         filename = Path(file_path).name
         mime = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+        encoded_filename = self._multipart_filename(file_path)
         file_header = (
             f"--{boundary}\r\n"
-            f'Content-Disposition: form-data; name="video"; filename="{filename}"\r\n'
+            f'Content-Disposition: form-data; name="video"; filename="{encoded_filename}"\r\n'
             f"Content-Type: {mime}\r\n\r\n"
         ).encode()
         

--- a/tests/test_python_sdk_multipart_filenames.py
+++ b/tests/test_python_sdk_multipart_filenames.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+"""Exercise SDK multipart bodies with the server's form-data parser."""
+
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from werkzeug.formparser import parse_form_data
+from werkzeug.test import EnvironBuilder
+
+from bottube.client import BoTTubeClient
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=["buffered", "streaming"])
+@pytest.mark.parametrize(
+    ("filename", "expected_filename"),
+    [
+        ("clip.mp4", "clip.mp4"),
+        ("my clip; take 2.mp4", "my clip; take 2.mp4"),
+        ("演示.mp4", "演示.mp4"),
+        ('clip"take2.mp4', 'clip"take2.mp4'),
+        ("clip\rtake2.mp4", "clip%0Dtake2.mp4"),
+        ("clip\ntake2.mp4", "clip%0Atake2.mp4"),
+        (
+            'clip"\r\nX-Extra: injected\r\n\r\ntake2.mp4',
+            'clip"%0D%0AX-Extra: injected%0D%0A%0D%0Atake2.mp4',
+        ),
+    ],
+)
+def test_upload_preserves_video_part(tmp_path, streaming, filename, expected_filename):
+    video_bytes = b"\x00\x01video\r\npayload\xff"
+    video_path = tmp_path / filename
+    video_path.write_bytes(video_bytes)
+    client = BoTTubeClient(base_url="https://example.test", api_key="test-key")
+    captured = {}
+
+    def receive(request, timeout):
+        body = request.data
+        if streaming:
+            assert not isinstance(body, (bytes, bytearray))
+            body = b"".join(body)
+            assert int(request.get_header("Content-length")) == len(body)
+        builder = EnvironBuilder(
+            method="POST",
+            input_stream=BytesIO(body),
+            content_type=request.get_header("Content-type"),
+            content_length=len(body),
+        )
+        try:
+            _, form, files = parse_form_data(builder.get_environ())
+            captured["form"] = form
+            captured["file_keys"] = list(files)
+            if "video" in files:
+                video = files["video"]
+                captured["filename"] = video.filename
+                captured["content"] = video.read()
+                captured["headers"] = video.headers
+                video.close()
+        finally:
+            builder.close()
+        return BytesIO(b'{"video_id":"uploaded"}')
+
+    with patch("bottube.client.urlopen", side_effect=receive):
+        if streaming:
+            result = client._streaming_upload(
+                "/api/upload", str(video_path), {"title": "Test clip"}, chunk_size=3
+            )
+        else:
+            result = client.upload(str(video_path), title="Test clip")
+
+    assert result == {"video_id": "uploaded"}
+    assert captured["file_keys"] == ["video"]
+    assert captured["filename"] == expected_filename
+    assert Path(captured["filename"]).suffix == ".mp4"
+    assert captured["content"] == video_bytes
+    assert captured["form"].to_dict() == {"title": "Test clip"}
+    assert "X-Extra" not in captured["headers"]


### PR DESCRIPTION
Uploading a file named `clip"take2.mp4` through the Python SDK currently sends an unescaped `Content-Disposition` filename. Werkzeug parses it as `clip`, losing the video extension; filenames containing CR/LF can remove the parsed video part entirely. Both buffered and streaming uploads interpolate the filename this way.

Add a shared HTML multipart filename encoder for CR, LF, and double quotes, and use it in both upload paths. File reads and MIME detection still use the original local path. The SDK gains no runtime dependency.

The regression tests parse the generated request bytes with Werkzeug, checking filenames, extension, file content, form fields, header isolation, and streaming content length. No production requests are made.

Validation on macOS arm64 / Python 3.14:

```text
Original implementation, new regressions: 8 failed, 6 passed
Fixed implementation, regressions + existing Python SDK tests: 26 passed
git diff --check: passed
Python compile check: passed
```

Command:

```sh
python -m pytest tests/test_python_sdk_multipart_filenames.py python-sdk/tests -q
```

The complete server and live video transcoding were not exercised. The regression covers the SDK serialization / Werkzeug parsing boundary. Special-filename fixtures require macOS/Linux filesystem support.

Related bounty: https://github.com/Scottcjn/rustchain-bounties/issues/100 (accepted improvement PR tier, listed as 10 RTC and subject to maintainer assessment). This PR does not close that ongoing bounty. No award has been approved for this fix.

AI disclosure: Codex generated the patch and tests and ran the reported local checks. The reported checks were run by the agent; no separate human test run is claimed.

Payout setup: first-time contributor Xingmingfu has no native RTC wallet yet. If this improvement is accepted under #100, please advise the supported first-time payout setup. No payout identifier is being claimed or invented.
