### PR TITLE
fix(search): treat LIKE metacharacters literally

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -9005,6 +9005,11 @@ def web_subscribe(agent_name):
 # Search
 # ---------------------------------------------------------------------------
 
+def _escape_search_like(value: str) -> str:
+    """Escape SQLite LIKE metacharacters so search input stays literal."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 @app.route("/api/search/suggestions")
 def search_suggestions():
     """Return bounded public-catalog suggestions for a partial query."""
@@ -9014,13 +9019,13 @@ def search_suggestions():
         return jsonify(empty)
 
     db = get_db()
-    like_q = f"%{q}%"
+    like_q = f"%{_escape_search_like(q)}%"
     visible = "COALESCE(v.is_removed, 0) = 0 AND COALESCE(a.is_banned, 0) = 0"
 
     titles = db.execute(
         f"""SELECT DISTINCT v.title
               FROM videos v JOIN agents a ON a.id = v.agent_id
-             WHERE {visible} AND v.title LIKE ? COLLATE NOCASE
+             WHERE {visible} AND v.title LIKE ? ESCAPE '\\' COLLATE NOCASE
              ORDER BY v.views DESC, v.title COLLATE NOCASE
              LIMIT 8""",
         (like_q,),
@@ -9028,7 +9033,7 @@ def search_suggestions():
     categories = db.execute(
         f"""SELECT DISTINCT v.category
               FROM videos v JOIN agents a ON a.id = v.agent_id
-             WHERE {visible} AND v.category LIKE ? COLLATE NOCASE
+             WHERE {visible} AND v.category LIKE ? ESCAPE '\\' COLLATE NOCASE
              ORDER BY v.category COLLATE NOCASE
              LIMIT 8""",
         (like_q,),
@@ -9036,7 +9041,7 @@ def search_suggestions():
     agents = db.execute(
         f"""SELECT DISTINCT a.agent_name
               FROM videos v JOIN agents a ON a.id = v.agent_id
-             WHERE {visible} AND a.agent_name LIKE ? COLLATE NOCASE
+             WHERE {visible} AND a.agent_name LIKE ? ESCAPE '\\' COLLATE NOCASE
              ORDER BY a.agent_name COLLATE NOCASE
              LIMIT 8""",
         (like_q,),
@@ -9045,7 +9050,7 @@ def search_suggestions():
     tag_rows = db.execute(
         f"""SELECT v.tags
               FROM videos v JOIN agents a ON a.id = v.agent_id
-             WHERE {visible} AND v.tags LIKE ? COLLATE NOCASE
+             WHERE {visible} AND v.tags LIKE ? ESCAPE '\\' COLLATE NOCASE
              ORDER BY v.views DESC
              LIMIT 100""",
         (like_q,),
@@ -9115,14 +9120,14 @@ def search_videos():
         return jsonify({"error": "page out of range"}), 400
 
     db = get_db()
-    like_q = f"%{q}%"
+    like_q = f"%{_escape_search_like(q)}%"
 
     # Build dynamic WHERE clauses
     search_conditions = [
-        "v.title LIKE ?",
-        "v.description LIKE ?",
-        "v.tags LIKE ?",
-        "a.agent_name LIKE ?",
+        "v.title LIKE ? ESCAPE '\\'",
+        "v.description LIKE ? ESCAPE '\\'",
+        "v.tags LIKE ? ESCAPE '\\'",
+        "a.agent_name LIKE ? ESCAPE '\\'",
     ]
     params = [like_q, like_q, like_q, like_q]
     caption_video_ids = find_caption_video_ids(q, limit=500)
@@ -14890,11 +14895,11 @@ def search_page():
     total = 0
     if q:
         db = get_db()
-        like_q = f"%{q}%"
+        like_q = f"%{_escape_search_like(q)}%"
         params = [like_q, like_q, like_q, like_q]
         where = (
             "v.is_removed = 0 AND COALESCE(a.is_banned, 0) = 0 "
-            "AND (v.title LIKE ? OR v.description LIKE ? OR v.tags LIKE ? OR a.agent_name LIKE ?)"
+            "AND (v.title LIKE ? ESCAPE '\\' OR v.description LIKE ? ESCAPE '\\' OR v.tags LIKE ? ESCAPE '\\' OR a.agent_name LIKE ? ESCAPE '\\')"
         )
         if selected_categories:
             where += " AND v.category IN (%s)" % ",".join("?" * len(selected_categories))

--- a/tests/test_search_like_wildcards.py
+++ b/tests/test_search_like_wildcards.py
@@ -1,0 +1,64 @@
+﻿# SPDX-License-Identifier: MIT
+"""Regression coverage for literal SQLite LIKE metacharacters in search."""
+
+import time
+import pytest
+
+
+def _seed(app, agent_name, literal_id, literal_title):
+    with app.app_context():
+        import bottube_server
+        db = bottube_server.get_db()
+        agent = db.execute(
+            """INSERT INTO agents (agent_name, display_name, api_key, bio, created_at, last_active)
+               VALUES (?, ?, ?, '', ?, ?) RETURNING id""",
+            (agent_name, agent_name.title(), f"{agent_name}-key", time.time(), time.time()),
+        ).fetchone()
+        for video_id, title in [
+            (literal_id, literal_title),
+            (f"{literal_id}-ordinary", "Ordinary Search Result"),
+        ]:
+            db.execute(
+                """INSERT INTO videos
+                   (video_id, agent_id, title, description, filename, tags,
+                    category, views, created_at, is_removed)
+                   VALUES (?, ?, ?, 'plain description', ?, '[]', 'other', 1, ?, 0)""",
+                (video_id, agent["id"], title, f"{video_id}.mp4", time.time()),
+            )
+        db.commit()
+
+
+@pytest.mark.parametrize(
+    ("needle", "agent_name", "literal_id", "literal_title"),
+    [
+        ("%", "percentbot", "percent-literal", "Progress 100% Complete"),
+        ("_", "underscorebot", "underscore-literal", "Status_Code Literal"),
+    ],
+)
+def test_api_search_treats_like_metacharacters_as_literal_text(
+    app, client, needle, agent_name, literal_id, literal_title
+):
+    _seed(app, agent_name, literal_id, literal_title)
+    response = client.get("/api/search", query_string={"q": needle, "per_page": 50})
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["total"] == 1
+    assert [video["video_id"] for video in body["videos"]] == [literal_id]
+
+
+@pytest.mark.parametrize(
+    ("needle", "agent_name", "literal_id", "literal_title"),
+    [
+        ("%", "percentwebbot", "web-percent", "Web 100% Literal"),
+        ("_", "underscorewebbot", "web-underscore", "Web_Status Literal"),
+    ],
+)
+def test_html_search_treats_like_metacharacters_as_literal_text(
+    app, client, needle, agent_name, literal_id, literal_title
+):
+    _seed(app, agent_name, literal_id, literal_title)
+    response = client.get("/search", query_string={"q": needle})
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert literal_title in html
+    assert "Ordinary Search Result" not in html


### PR DESCRIPTION
## Summary
Fix public search treating SQLite `LIKE` metacharacters (`%` and `_`) as wildcards instead of literal user input.

## Production reproduction
On 2026-09-10 before this patch:
- `/search?q=%25` returned the full catalog: 2,978 videos / 125 pages.
- `/search?q=_` returned the full catalog: 2,978 videos.
- `/api/search?q=%25&per_page=2` reported `total: 2978`.

A search for a literal `%` or `_` should only match records containing that character.

## Fix
- Add a SQLite `LIKE` escaping helper.
- Escape backslash, `%`, and `_` before building contains patterns.
- Add explicit `ESCAPE '\'` to suggestions, `/api/search`, and `/search` queries.
- Add regression coverage for literal `%` and `_` queries.

## Verification
- `python -m py_compile bottube_server.py` PASS
- isolated Flask/SQLite smoke for `/api/search` and `/search`, `%` + `_`: `WILDCARD_SMOKE_PASS`
- `git diff --check` PASS
- duplicate scan across Bounty #1102 comments: 0 matching prior reports

Broader local search tests expose unrelated existing suggestion-route/filter-markup failures plus Windows SQLite teardown locking; they were not introduced by this patch.

Bounty: Scottcjn/rustchain-bounties#1102 (functional tier, requested 5 RTC)
Contributor/miner_id: `antoleod`