### PR TITLE
fix(mood): validate update and signal fields

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -7643,6 +7643,18 @@ def update_agent_mood(agent_name):
     force_state = data.get("force_state")
     trigger_reason = data.get("trigger_reason", "")
 
+    if force_state is not None:
+        if not isinstance(force_state, str):
+            return jsonify({"error": "force_state must be a string"}), 400
+        valid_states = [state.value for state in MoodState]
+        if force_state not in valid_states:
+            return jsonify({
+                "error": "force_state is invalid",
+                "valid_states": valid_states,
+            }), 400
+    if not isinstance(trigger_reason, str):
+        return jsonify({"error": "trigger_reason must be a string"}), 400
+
     result = api_update_mood(str(DB_PATH), agent["id"], force_state, trigger_reason)
     
     return jsonify(result)
@@ -7682,8 +7694,23 @@ def record_mood_signal(agent_name):
     
     if signal_value is None:
         return jsonify({"error": "signal_value is required"}), 400
-    
-    result = api_record_signal(str(DB_PATH), agent["id"], signal_type, float(signal_value), signal_data)
+    if not isinstance(signal_type, str):
+        return jsonify({"error": "signal_type must be a string"}), 400
+    if not isinstance(signal_data, str):
+        return jsonify({"error": "signal_data must be a string"}), 400
+
+    if isinstance(signal_value, bool):
+        return jsonify({"error": "signal_value must be numeric"}), 400
+    try:
+        numeric_signal_value = float(signal_value)
+    except (TypeError, ValueError):
+        return jsonify({"error": "signal_value must be numeric"}), 400
+    if not math.isfinite(numeric_signal_value):
+        return jsonify({"error": "signal_value must be finite"}), 400
+
+    result = api_record_signal(
+        str(DB_PATH), agent["id"], signal_type, numeric_signal_value, signal_data
+    )
     
     return jsonify(result)
 

--- a/tests/test_mood_write_authorization.py
+++ b/tests/test_mood_write_authorization.py
@@ -230,3 +230,59 @@ def test_mood_history_preserves_default_and_valid_limits(
     )
     assert response.status_code == 200, response.get_json()
     assert observed and observed[-1][1] == expected
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"force_state": "definitely-not-a-state", "trigger_reason": "x"}, "force_state is invalid"),
+        ({"force_state": ["energetic"], "trigger_reason": "x"}, "force_state must be a string"),
+        ({"force_state": "playful", "trigger_reason": {"x": 1}}, "trigger_reason must be a string"),
+        ({"force_state": "playful", "trigger_reason": ["x"]}, "trigger_reason must be a string"),
+    ],
+)
+def test_mood_update_rejects_invalid_field_values(client, victim, payload, message):
+    response = client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/update",
+        json=payload,
+        headers={"X-API-Key": victim["api_key"]},
+    )
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == message
+    if message == "force_state is invalid":
+        assert "playful" in body["valid_states"]
+        assert "energetic" in body["valid_states"]
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"signal_type": "view_count", "signal_value": "not-a-number"}, "signal_value must be numeric"),
+        ({"signal_type": "view_count", "signal_value": []}, "signal_value must be numeric"),
+        ({"signal_type": "view_count", "signal_value": True}, "signal_value must be numeric"),
+        ({"signal_type": ["view_count"], "signal_value": 1}, "signal_type must be a string"),
+        ({"signal_type": "view_count", "signal_value": 1, "signal_data": {"x": 1}}, "signal_data must be a string"),
+        ({"signal_type": "view_count", "signal_value": 1, "signal_data": ["x"]}, "signal_data must be a string"),
+        ({"signal_type": "view_count", "signal_value": "nan"}, "signal_value must be finite"),
+        ({"signal_type": "view_count", "signal_value": "inf"}, "signal_value must be finite"),
+    ],
+)
+def test_mood_signal_rejects_invalid_field_values(client, victim, payload, message):
+    response = client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/signal",
+        json=payload,
+        headers={"X-API-Key": victim["api_key"]},
+    )
+    assert response.status_code == 400
+    assert response.get_json() == {"error": message}
+
+
+def test_mood_signal_keeps_numeric_string_compatibility(client, victim):
+    response = client.post(
+        f"/api/v1/agents/{victim['agent_name']}/mood/signal",
+        json={"signal_type": "view_count", "signal_value": "42.5", "signal_data": "compat"},
+        headers={"X-API-Key": victim["api_key"]},
+    )
+    assert response.status_code == 200, response.get_json()
+    assert response.get_json()["signal_value"] == 42.5


### PR DESCRIPTION
## Summary
Validate mood write payload fields before Enum conversion, float coercion, or SQLite binding.

Fixes #2227
Fixes #2228

## Changes
- reject non-string and unsupported `force_state` values with deterministic JSON 400 responses
- return the valid mood states for unsupported state names
- reject non-string `trigger_reason`, `signal_type`, and `signal_data`
- reject booleans, non-numeric values, NaN, and infinity for `signal_value`
- preserve compatibility with finite numeric strings such as `42.5`
- add regression coverage for the reported 500 cases and valid control paths

## Verification
- focused mood validation/control suite: **15 passed**
- `python -m py_compile bottube_server.py mood_engine.py`: PASS
- `git diff --check`: PASS

Broader local tests also produced 39 passes, with two unrelated existing issues: a current 403-vs-404 expectation in `test_unknown_agent_is_404_not_403` and a Windows SQLite temporary-file teardown lock.

This PR is submitted as an open-source fix/learning contribution; I am not claiming discovery credit for #2227/#2228, which were reported by @zaguzovmaksim0-hue.