### PR TITLE
fix(a11y): distinguish auth switch links without color

### DIFF
--- a/bottube_templates/login.html
+++ b/bottube_templates/login.html
@@ -83,6 +83,22 @@
         color: var(--text-muted);
     }
 
+    .auth-switch a {
+        text-decoration: underline;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 0.18em;
+    }
+
+    .auth-switch a:hover {
+        text-decoration-thickness: 2px;
+    }
+
+    .auth-switch a:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 3px;
+        border-radius: 2px;
+    }
+
     .flash-msg {
         padding: 10px 16px;
         border-radius: var(--radius);

--- a/tests/test_login_auth_switch_accessibility.py
+++ b/tests/test_login_auth_switch_accessibility.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for non-color cues on auth-switch links."""
+
+import re
+from pathlib import Path
+
+
+def _login_template():
+    return (Path(__file__).resolve().parents[1] / "bottube_templates" / "login.html").read_text(encoding="utf-8")
+
+
+def test_auth_switch_links_have_persistent_non_color_cue():
+    html = _login_template()
+    rule = re.search(r"\.auth-switch\s+a\s*\{(?P<body>.*?)\}", html, re.S)
+    assert rule, "missing .auth-switch a rule"
+    assert "text-decoration: underline" in rule.group("body")
+    assert "text-underline-offset" in rule.group("body")
+
+
+def test_auth_switch_links_keep_visible_keyboard_focus():
+    html = _login_template()
+    rule = re.search(r"\.auth-switch\s+a:focus-visible\s*\{(?P<body>.*?)\}", html, re.S)
+    assert rule, "missing auth-switch focus-visible rule"
+    body = rule.group("body")
+    assert "outline:" in body
+    assert "outline-offset:" in body


### PR DESCRIPTION
## Summary
Make the inline login/signup switch links distinguishable without relying on color alone.

Fixes #2226

## Changes
- persistent underline on `.auth-switch a`
- slightly stronger underline on hover
- explicit `:focus-visible` outline for keyboard users
- static regression tests for the non-color cue and focus indicator

The selector covers both the **Sign up** link on `/login` and the **Log in** link on `/signup` while leaving button-style links unchanged.

## Verification
- `pytest -q tests/test_login_auth_switch_accessibility.py`: **2 passed**
- `git diff --check`: PASS

Submitted as an open-source learning/reputation contribution; issue discovery credit remains with @u-done.