### PR TITLE
[Codex] Point legacy Python SDK at the live API domain

### DIFF
--- a/bottube_sdk/client.py
+++ b/bottube_sdk/client.py
@@ -54,11 +54,11 @@ class BoTTubeClient:
         api_key: Agent API key for authenticated operations.
                  Set via constructor or BOTTUBE_API_KEY env var.
         base_url: Base URL of the BoTTube server.
-                  Defaults to https://bottube.com or BOTTUBE_BASE_URL env var.
+                  Defaults to https://bottube.ai or BOTTUBE_BASE_URL env var.
         timeout: Default request timeout in seconds (default: 30).
     """
 
-    DEFAULT_BASE_URL = "https://bottube.com"
+    DEFAULT_BASE_URL = "https://bottube.ai"
     DEFAULT_TIMEOUT = 30
 
     def __init__(

--- a/tests/test_bottube_sdk.py
+++ b/tests/test_bottube_sdk.py
@@ -250,6 +250,13 @@ class TestErrorHandling:
 # ---------------------------------------------------------------------------
 
 class TestURLConstruction:
+    def test_default_base_url_uses_live_domain(self, monkeypatch):
+        monkeypatch.delenv("BOTTUBE_BASE_URL", raising=False)
+
+        c = BoTTubeClient()
+
+        assert c.base_url == "https://bottube.ai"
+
     def test_base_url_trailing_slash_stripped(self):
         c = BoTTubeClient(base_url="https://bottube.test/")
         assert c.base_url == "https://bottube.test"


### PR DESCRIPTION
## Summary

- change the legacy `bottube_sdk.BoTTubeClient` default from the dead `https://bottube.com` endpoint to the live `https://bottube.ai` API
- update the constructor documentation to match
- add a regression test that clears `BOTTUBE_BASE_URL` and verifies the zero-configuration default

Fixes #2232.

## Before

The root README's normal construction path:

```python
client = BoTTubeClient(api_key="your-agent-api-key")
```

used `https://bottube.com`. A public `client.list_videos(per_page=1)` call then raised `NotFoundError` because `/api/videos` returns HTTP 404 on that domain.

## After

The same client targets `https://bottube.ai`; a live read-only `list_videos(per_page=1)` smoke test succeeds and returns one video.

Explicit `base_url=` and `BOTTUBE_BASE_URL` overrides are unchanged.

## Verification

```text
pytest -q tests/test_bottube_sdk.py
31 passed in 0.06s

git diff --check
PASS

BoTTubeClient().list_videos(per_page=1)
status=ok, per_page=1, videos=1
```

Registered bug-bounty tracker: Scottcjn/rustchain-bounties#1102 (functional bug tier). If accepted, please hold/credit the award to the hosted `ishita-lives` handle wallet; no acceptance or payout is asserted until maintainer verification.

AI assistance was used for repository inspection, duplicate checking, reproduction, implementation, and tests. The issue and PR text were reviewed for accuracy against the actual source and live read-only responses.
