### PR TITLE
[Codex] Keep translation recency timestamps comparable

### DIFF
--- a/tests/test_translation_route_validation.py
+++ b/tests/test_translation_route_validation.py
@@ -130,6 +130,41 @@ def test_translation_round_trip_uses_public_video_id(client):
     assert response.get_json()["title"] == "Titre"
 
 
+def test_translation_update_keeps_numeric_recency_ordering(client):
+    payload = {
+        "video_id": "public-video-id",
+        "language": "French",
+        "title": "First translator update",
+        "description": "Updated first",
+    }
+    assert client.post("/api/translations", json=payload).status_code == 200
+    assert client.post("/api/translations", json=payload).status_code == 200
+
+    with sqlite3.connect(client.db_path) as db:
+        db.execute(
+            "INSERT INTO agents (id, agent_name) VALUES (?, ?)",
+            (8, "later-translator"),
+        )
+        db.execute(
+            """INSERT INTO video_translations
+               (video_id, language, title, description, translator_id, created_at)
+               VALUES (?, ?, ?, ?, ?, unixepoch() + 1000)""",
+            (
+                "public-video-id",
+                "French",
+                "Later translation",
+                "Created later",
+                8,
+            ),
+        )
+        db.commit()
+
+    response = client.get("/api/translations/public-video-id/French")
+
+    assert response.status_code == 200
+    assert response.get_json()["title"] == "Later translation"
+
+
 def test_translation_write_rejects_unknown_video(client):
     response = client.post(
         "/api/translations",

--- a/translation_routes.py
+++ b/translation_routes.py
@@ -182,7 +182,7 @@ def add_translation():
         # Update existing translation
         db.execute('''
             UPDATE video_translations 
-            SET title = ?, description = ?, created_at = CURRENT_TIMESTAMP
+            SET title = ?, description = ?, created_at = unixepoch()
             WHERE id = ?
         ''', (title, description, existing['id']))
     else:


### PR DESCRIPTION
## Summary

- keep `video_translations.created_at` numeric when updating an existing translation
- use the same `unixepoch()` representation as the table default for new rows
- add a route-level regression proving a genuinely later translation from a second translator wins the existing `ORDER BY created_at DESC`

Fixes #2234.

## Problem

New rows receive numeric Unix seconds from the schema default, while the update path used SQLite `CURRENT_TIMESTAMP`, which produces text. SQLite orders text ahead of numbers, so an updated row permanently appeared newer than every subsequently-created numeric row.

This affected the recent-translations page and API readers that select/order translations by `created_at DESC`.

## Verification

```text
pytest -q tests/test_translation_route_validation.py
5 passed in 0.08s

git diff --check
PASS
```

The new regression creates and updates a translation, inserts a later numeric translation from another translator, then verifies `GET /api/translations/public-video-id/French` returns the genuinely later row. It fails with the old mixed-type update and passes with this change.

Registered bug-bounty tracker: Scottcjn/rustchain-bounties#1102 (functional bug tier). If accepted, please hold/credit the award to the hosted `ishita-lives` handle wallet; no acceptance or payout is asserted until maintainer verification.

AI assistance was used for source inspection, duplicate checking, reproduction, implementation, and tests. This is an ordinary data-ordering fix; no production write or security testing was performed.
