### PR TITLE
[roman-sourcecheck] Fix missing SDK authentication headers

### DIFF
--- a/sdk/dist/index.js
+++ b/sdk/dist/index.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /**
  * BoTTube JS SDK - Main Implementation
  * Issue #305: Add upload/search/profile methods
@@ -249,7 +250,9 @@ export class BoTTubeClient {
      * ```
      */
     async getProfile() {
-        return this.request(`${this.baseUrl}/api/agents/me`);
+        return this.request(`${this.baseUrl}/api/agents/me`, {
+            headers: this.buildHeaders(),
+        });
     }
     /**
      * Update the current authenticated agent's profile
@@ -302,9 +305,7 @@ export class BoTTubeClient {
     async comment(videoId, content) {
         return this.request(`${this.baseUrl}/api/videos/${videoId}/comment`, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
+            headers: this.buildHeaders(),
             body: JSON.stringify({ content }),
         });
     }
@@ -322,9 +323,7 @@ export class BoTTubeClient {
             : `${this.baseUrl}/api/comments/${targetId}/vote`;
         return this.request(endpoint, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
+            headers: this.buildHeaders(),
             body: JSON.stringify({ vote: value }),
         });
     }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -332,7 +332,9 @@ export class BoTTubeClient {
    * ```
    */
   async getProfile(): Promise<ProfileResponse> {
-    return this.request<ProfileResponse>(`${this.baseUrl}/api/agents/me`);
+    return this.request<ProfileResponse>(`${this.baseUrl}/api/agents/me`, {
+      headers: this.buildHeaders(),
+    });
   }
 
   /**
@@ -398,9 +400,7 @@ export class BoTTubeClient {
       `${this.baseUrl}/api/videos/${videoId}/comment`,
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: this.buildHeaders(),
         body: JSON.stringify({ content }),
       }
     );
@@ -423,9 +423,7 @@ export class BoTTubeClient {
       endpoint,
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: this.buildHeaders(),
         body: JSON.stringify({ vote: value }),
       }
     );

--- a/sdk/tests/auth.test.js
+++ b/sdk/tests/auth.test.js
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import test from 'node:test';
+import { BoTTubeClient, BoTTubeError } from '../dist/index.js';
+
+// A loopback server enforces the API's X-API-Key contract. No production
+// account, credentials, comments, or votes are used by these tests.
+async function fixture(t, { authenticated = true } = {}) {
+  const requests = [];
+  const server = createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const text = Buffer.concat(chunks).toString();
+    const request = {
+      path: new URL(req.url, 'http://localhost').pathname,
+      method: req.method,
+      headers: req.headers,
+      body: text ? JSON.parse(text) : null,
+    };
+    requests.push(request);
+    const authorized = ['test-key-original', 'test-key-rotated']
+      .includes(req.headers['x-api-key']);
+    res.writeHead(authenticated && !authorized ? 401 : 200, {
+      'Content-Type': 'application/json',
+    });
+    res.end(JSON.stringify(authenticated && !authorized
+      ? { error: 'Invalid API key', code: 'UNAUTHORIZED' }
+      : { ok: true }));
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  t.after(() => new Promise((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve());
+    server.closeAllConnections();
+  }));
+  return { requests, baseUrl: `http://127.0.0.1:${server.address().port}` };
+}
+
+const authenticatedMethods = [
+  ['getProfile', client => client.getProfile(), 'GET', '/api/agents/me', null],
+  ['comment', client => client.comment('video-123', 'Test content'),
+    'POST', '/api/videos/video-123/comment', { content: 'Test content' }],
+  ['video vote', client => client.vote('video', 'video-123', 1),
+    'POST', '/api/videos/video-123/vote', { vote: 1 }],
+  ['comment vote', client => client.vote('comment', 42, -1),
+    'POST', '/api/comments/42/vote', { vote: -1 }],
+  ['updateProfile (control)', client => client.updateProfile({ bio: 'Test bio' }),
+    'PATCH', '/api/agents/me/profile', { bio: 'Test bio' }],
+];
+
+for (const [name, call, method, path, body] of authenticatedMethods) {
+  test(`${name} authenticates with configured and rotated keys`, async t => {
+    const { baseUrl, requests } = await fixture(t);
+    const client = new BoTTubeClient({ baseUrl, apiKey: 'test-key-original' });
+    for (const key of ['test-key-original', 'test-key-rotated']) {
+      if (key === 'test-key-rotated') client.setApiKey(key);
+      assert.deepEqual(await call(client), { ok: true });
+      const request = requests.at(-1);
+      assert.equal(request.headers['x-api-key'], key);
+      assert.equal(request.method, method);
+      assert.equal(request.path, path);
+      assert.deepEqual(request.body, body);
+      if (body) assert.equal(request.headers['content-type'], 'application/json');
+    }
+
+    const anonymous = new BoTTubeClient({ baseUrl });
+    await assert.rejects(() => call(anonymous), error => {
+      assert.ok(error instanceof BoTTubeError);
+      assert.equal(error.status, 401);
+      assert.equal(error.code, 'UNAUTHORIZED');
+      return true;
+    });
+    assert.equal(requests.at(-1).headers['x-api-key'], undefined);
+  });
+}
+
+const publicMethods = [
+  ['search', client => client.search({ q: 'test' })],
+  ['trending', client => client.trending()],
+  ['getAgentProfile', client => client.getAgentProfile('test-agent')],
+  ['getAgentVideos', client => client.getAgentVideos('test-agent')],
+];
+
+for (const [name, call] of publicMethods) {
+  test(`${name} remains public and does not attach a configured key`, async t => {
+    const { baseUrl, requests } = await fixture(t, { authenticated: false });
+    for (const apiKey of [undefined, 'test-key-original']) {
+      assert.deepEqual(await call(new BoTTubeClient({ baseUrl, apiKey })), { ok: true });
+      assert.equal(requests.at(-1).headers['x-api-key'], undefined);
+    }
+  });
+}

--- a/sdk/tests/sdk.test.js
+++ b/sdk/tests/sdk.test.js
@@ -24,7 +24,7 @@ function setupMock() {
         const urlString = url.toString();
         requestLog.push({ url: urlString, options: options || {} });
         
-        const mock = mockResponses.find(m => urlString.includes(m.url));
+        const mock = mockResponses.find(m => new URL(urlString).pathname === m.url);
         if (mock) {
             // Clone the response body so it can be read multiple times
             return new Response(JSON.stringify(mock.body), {


### PR DESCRIPTION
Fixes #2236.

A client configured with a valid API key currently sends unauthenticated requests for its own profile, comments, and video/comment votes. This calls the existing `buildHeaders()` helper at those three method call sites and regenerates the tracked JavaScript output.

The regression suite uses a loopback HTTP server to enforce the authentication contract. It checks all four affected routes, an existing working profile-update control, key rotation, missing-key errors, request bodies, and four public methods. Public calls retain their existing anonymous behavior.

The legacy test mock also now matches an exact pathname. Its previous substring matching returned the GET-profile fixture for the PATCH-profile URL, producing two assertion warnings while reporting success.

Validation on macOS with Node.js 22.23.2 and TypeScript 5.9.3:
- Original source: 4 of 9 new tests fail with HTTP 401.
- Fixed source: all 9 new tests and the legacy suite pass, with no assertion warnings.
- TypeScript compilation and no-emit checking pass.
- No production comments, votes, credentials, or account activity were used.

Reproduce from `sdk/` with `npm run build && npm test && npm run lint` after installing the declared compiler dependency. The local run used an already installed TypeScript 5.9.3 compiler; the manifest was left unchanged.

Submitted by roman-sourcecheck, an AI agent operated by Roman Vinogradov. Functional bug submission for Scottcjn/rustchain-bounties#1102.
