### PR TITLE
[claude] fix(a11y): name the verification preview iframe on /badges

### DIFF
--- a/bottube_templates/badges.html
+++ b/bottube_templates/badges.html
@@ -364,7 +364,7 @@
                 are already set on <code>/embed/*</code>.
             </div>
             <div class="badge-preview" style="padding:12px;">
-                <iframe src="{{ P }}/embed/verify/lcqlfSGodNx" width="340" height="76" style="border:0; border-radius:8px;"></iframe>
+                <iframe src="{{ P }}/embed/verify/lcqlfSGodNx" width="340" height="76" style="border:0; border-radius:8px;" title="BoTTube verification preview"></iframe>
             </div>
             <div class="code-tabs">
                 <button class="code-tab active" onclick="showTab(this, 'vrf-iframe')">HTML</button>

--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 import os
+import re
 import sqlite3
 import sys
 import time
@@ -385,3 +386,15 @@ def test_badge_candidates_follow_referral_activation_and_scout_thresholds(client
     assert len(scout_badges) == 1
     assert scout_badges[0]["evidence"]["pair_count"] == 3
     assert 3 in scout_badges[0]["evidence"]["bonus_thresholds_reached"]
+
+
+def test_badges_page_verification_preview_iframe_has_an_accessible_name(client):
+    """The live "Sandboxed iframe widget" preview needs a `title` so screen
+    readers can name the frame (WCAG 4.1.2); the sample embed code below it
+    already carried one, the rendered preview did not."""
+    response = client.get("/badges")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    preview = re.search(r'<iframe[^>]*/embed/verify/[^>]*>', html)
+    assert preview is not None, "verification preview iframe missing from /badges"
+    assert 'title="BoTTube verification preview"' in preview.group(0)


### PR DESCRIPTION
## Description

The live "Sandboxed iframe widget" preview on the Badges & Widgets page (`bottube_templates/badges.html`) was rendered without a `title`, `aria-label` or other accessible name, so assistive technology exposed an unnamed `iframe` (WCAG 4.1.2 Name, Role, Value). The sample embed code shown right below the preview already carried `title="BoTTube verification"`; the rendered preview itself did not.

This adds `title="BoTTube verification preview"` to the preview iframe and a test that renders `/badges` through the Flask test client and checks the attribute on that frame (the test fails on `main`, passes with the change).

Fixes #2238

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] My code follows the style of this project
- [x] I have performed a self-review of my changes
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass (`pytest tests/test_badges.py`: 11 passed)

Per CONTRIBUTING, the title carries the agent prefix: this change was produced with Claude Code from the maintainer-facing report in #2238; the account owner directed the work and takes responsibility for it.
