### PR TITLE
Fix /tips/dashboard registration on direct startup

### DIFF
--- a/bottube_server.py
+++ b/bottube_server.py
@@ -26115,13 +26115,6 @@ def api_embed_discovery():
     return oembed()
 
 
-if __name__ == "__main__":
-    init_db()
-    print(f"[BoTTube] Starting on port 8097 - v{APP_VERSION}")
-    print(f"[BoTTube] DB: {DB_PATH}")
-    print(f"[BoTTube] Videos: {VIDEO_DIR}")
-    app.run(host="0.0.0.0", port=8097, debug=False)
-
 @app.route("/tips/dashboard")
 def tips_dashboard():
     db = get_db()
@@ -26205,3 +26198,11 @@ def tips_dashboard():
             for row in recent_tips
         ],
     )
+
+
+if __name__ == "__main__":
+    init_db()
+    print(f"[BoTTube] Starting on port 8097 - v{APP_VERSION}")
+    print(f"[BoTTube] DB: {DB_PATH}")
+    print(f"[BoTTube] Videos: {VIDEO_DIR}")
+    app.run(host="0.0.0.0", port=8097, debug=False)

--- a/tests/test_tips_dashboard_direct_entrypoint.py
+++ b/tests/test_tips_dashboard_direct_entrypoint.py
@@ -1,0 +1,12 @@
+"""Regression for issue #2242: direct execution must register /tips/dashboard."""
+from pathlib import Path
+
+
+def test_tips_dashboard_is_defined_before_direct_app_run():
+    """Route decorators after app.run() are unreachable for `python bottube_server.py`."""
+    source = (Path(__file__).resolve().parents[1] / "bottube_server.py").read_text(
+        encoding="utf-8"
+    )
+    route = source.index('@app.route("/tips/dashboard")')
+    direct_entrypoint = source.index('if __name__ == "__main__":')
+    assert route < direct_entrypoint


### PR DESCRIPTION
Fixes #2242.

`/tips/dashboard` was declared after the blocking `if __name__ == "__main__": app.run(...)` block. When BoTTube is launched with the documented `python3 bottube_server.py` path, execution enters `app.run()` before the decorator is reached, so the route is never registered.

This moves the direct-entrypoint block to the real end of the module and adds a focused regression test that pins route-definition order. Import/gunicorn behavior is unchanged.

Validation:
- `python3 -m pytest -q tests/test_tips_dashboard_direct_entrypoint.py` — 1 passed
- `python3 -m py_compile bottube_server.py tests/test_tips_dashboard_direct_entrypoint.py`
- `git diff --check`

AI assistance was used for investigation and implementation; the live public route was reproduced as HTTP 404 three times before the patch.