### PR TITLE
chore(drift): allow the four spec-only operations restored by #2214 (main red since 9/10)

### DIFF
--- a/deployment-drift.issue-1410.example.json
+++ b/deployment-drift.issue-1410.example.json
@@ -19,7 +19,11 @@
       "POST /api/collaborations/{collab_id}/invite",
       "POST /api/collaborations/{collab_id}/leave",
       "POST /api/collaborations/{collab_id}/playlists",
-      "POST /api/collaborations/{collab_id}/videos"
+      "POST /api/collaborations/{collab_id}/videos",
+      "GET /api/video/mine",
+      "POST /api/video/publish",
+      "POST /api/video/discard",
+      "POST /api/forum/generate-image"
     ],
     "missing_in_spec": []
   },
@@ -62,5 +66,6 @@
     "/api/collaborations*"
   ],
   "openapi": "openapi.yaml",
-  "timeout": 5
+  "timeout": 5,
+  "_allowed_drift_note": "2026-09-11: the four /api/video/{mine,publish,discard} + /api/forum/generate-image operations were restored to openapi.yaml by #2214 (originally documented by #1608 from live production, which serves them from code not in this repository). Allowed until the routes are added to a tracked source or pruned from the spec."
 }

--- a/deployment-drift.json
+++ b/deployment-drift.json
@@ -19,7 +19,11 @@
       "POST /api/collaborations/{collab_id}/invite",
       "POST /api/collaborations/{collab_id}/leave",
       "POST /api/collaborations/{collab_id}/playlists",
-      "POST /api/collaborations/{collab_id}/videos"
+      "POST /api/collaborations/{collab_id}/videos",
+      "GET /api/video/mine",
+      "POST /api/video/publish",
+      "POST /api/video/discard",
+      "POST /api/forum/generate-image"
     ],
     "missing_in_spec": []
   },
@@ -46,5 +50,6 @@
     "/api/collaborations*"
   ],
   "openapi": "openapi.yaml",
-  "timeout": 5
+  "timeout": 5,
+  "_allowed_drift_note": "2026-09-11: the four /api/video/{mine,publish,discard} + /api/forum/generate-image operations were restored to openapi.yaml by #2214 (originally documented by #1608 from live production, which serves them from code not in this repository). Allowed until the routes are added to a tracked source or pruned from the spec."
 }

--- a/tests/test_deployment_drift.py
+++ b/tests/test_deployment_drift.py
@@ -450,9 +450,9 @@ def test_repository_configs_are_valid_offline():
     canary = build_report(REPO_ROOT, load_config(REPO_ROOT / "deployment-drift.issue-1410.example.json"))
 
     assert policy["status"] == "pass"
-    assert policy["inventory"]["openapi_operations"] == 26
+    assert policy["inventory"]["openapi_operations"] == 30
     assert policy["inventory"]["application_operations"] == 353
-    assert len(policy["drift"]["missing_in_code"]) == 19
+    assert len(policy["drift"]["missing_in_code"]) == 23
     assert canary["status"] == "pass"
     assert canary["inventory"]["canary_operations"] == 14
 


### PR DESCRIPTION
bottube main's `deployment-drift` check has failed since #2214 landed on 2026-09-10: it restored four operations to `openapi.yaml` (`GET /api/video/mine`, `POST /api/video/publish`, `POST /api/video/discard`, `POST /api/forum/generate-image`) that #1608 had documented from live production. No source file in this repository implements them (`grep` finds them only in the spec and in #1608's test), so the policy inventory moved from 26/19 to 30/23 and every PR since has inherited the red check (#2214–#2220, #2239).

This lists the four as allowed drift with a dated note and updates the two hard-coded counts. Drift tests: 43 pass. Follow-up decision: add the routes' real source to `application_sources`, or prune them from the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn