### PR TITLE
fix(a11y): name the iframe the embed generators hand out

### DIFF
--- a/bottube_templates/embed_guide.html
+++ b/bottube_templates/embed_guide.html
@@ -359,7 +359,13 @@ function setVideo(videoId, btn) {
     iframe.title = "BoTTube video preview: " + btn.textContent.trim();
     document.getElementById("embed-demo").style.display = "block";
 
-    var codeText = '&lt;iframe src="https://bottube.ai/embed/' + videoId + '" width="560" height="315" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;';
+    // The snippet is what a reader copies onto their own site, so its iframe
+    // carries an accessible name (WCAG 4.1.2) exactly as the watch page's
+    // generator does. A fixed name rather than the picked video's: this block
+    // is rendered as HTML entities and decoded again on copy, so a name taken
+    // from the page would have to survive two decodes to stay escaped, and
+    // the reader is expected to swap VIDEO_ID and the title for their own.
+    var codeText = '&lt;iframe src="https://bottube.ai/embed/' + videoId + '" title="BoTTube video" width="560" height="315" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;';
     document.getElementById("embed-code-text").innerHTML = codeText;
     document.getElementById("embed-code-output").style.display = "block";
 }

--- a/bottube_templates/watch.html
+++ b/bottube_templates/watch.html
@@ -2935,6 +2935,7 @@
 <script>
 var myVote = {{ user_vote|default(0) }};
 var videoId = "{{ video.video_id }}";
+var videoTitle = {{ (video.title or "") | tojson }};
 var prefix = "{{ P }}";
 var uploaderAgent = "{{ video.agent_name }}";
 
@@ -3687,12 +3688,33 @@ function toggleEmbedPanel() {
     }
 }
 
+// The snippet below is copied onto other people's sites, so its iframe needs
+// an accessible name of its own (WCAG 4.1.2): a screen reader announces frames
+// by name, and an unnamed one gives the reader nothing to decide on before
+// entering it. The name carries the video title where there is one, because a
+// page embedding several BoTTube videos would otherwise present a row of
+// frames that all announce identically.
+function escapeEmbedAttribute(value) {
+    return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+function embedFrameTitle() {
+    var title = (typeof videoTitle === "string" ? videoTitle : "").trim();
+    return title ? "BoTTube video: " + title : "BoTTube video";
+}
+
 function updateEmbedCode() {
     var size = document.getElementById("embed-size").value;
     var parts = size.split("x");
     var w = parts[0], h = parts[1];
     var style = w === "100%" ? ' style="width:100%;max-width:853px;"' : '';
-    var code = '<iframe src="https://bottube.ai/embed/' + videoId + '" width="' + w + '" height="' + h + '" frameborder="0" allowfullscreen' + style + '></iframe>';
+    var title = escapeEmbedAttribute(embedFrameTitle());
+    var code = '<iframe src="https://bottube.ai/embed/' + videoId + '" title="' + title + '" width="' + w + '" height="' + h + '" frameborder="0" allowfullscreen' + style + '></iframe>';
     document.getElementById("embed-code").value = code;
 }
 

--- a/tests/js/embed_snippet_title.test.cjs
+++ b/tests/js/embed_snippet_title.test.cjs
@@ -1,0 +1,92 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// The watch page's embed generator, run for real (#2251). The snippet it
+// produces is copied onto other people's sites, so its iframe needs an
+// accessible name of its own: a screen reader announces frames by name, and an
+// unnamed one gives the reader nothing to decide on before entering it.
+const template = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'bottube_templates', 'watch.html'),
+  'utf8'
+);
+const start = template.indexOf('function escapeEmbedAttribute');
+const end = template.indexOf('function copyEmbedCode', start);
+assert.ok(start >= 0 && end > start, 'the embed generator is present');
+
+function harness(size) {
+  const embedCode = { value: '' };
+  const sandbox = {
+    videoId: 'GAdSoP9G9Q2',
+    videoTitle: '',
+    document: {
+      getElementById(id) {
+        return { 'embed-size': { value: size }, 'embed-code': embedCode }[id];
+      },
+    },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(template.slice(start, end), sandbox);
+  return { sandbox, embedCode };
+}
+
+// A plain title becomes the frame's name, so several BoTTube embeds on one
+// page announce as different frames rather than as a row of identical ones.
+{
+  const { sandbox, embedCode } = harness('853x480');
+  sandbox.videoTitle = 'How agents learn';
+  sandbox.updateEmbedCode();
+  assert.equal(
+    embedCode.value,
+    '<iframe src="https://bottube.ai/embed/GAdSoP9G9Q2" title="BoTTube video: How agents learn"'
+      + ' width="853" height="480" frameborder="0" allowfullscreen></iframe>'
+  );
+}
+
+// A title is free text. Unescaped, a quote in it would close the attribute and
+// the copied snippet would carry whatever followed as markup.
+{
+  const { sandbox, embedCode } = harness('853x480');
+  sandbox.videoTitle = 'He said "hi" & <b>bold</b>';
+  sandbox.updateEmbedCode();
+  assert.match(
+    embedCode.value,
+    /title="BoTTube video: He said &quot;hi&quot; &amp; &lt;b&gt;bold&lt;\/b&gt;"/
+  );
+  assert.ok(!embedCode.value.includes('<b>'), 'the title must not reach the snippet as markup');
+}
+
+{
+  const { sandbox, embedCode } = harness('853x480');
+  sandbox.videoTitle = "'single' quotes";
+  sandbox.updateEmbedCode();
+  assert.match(embedCode.value, /title="BoTTube video: &#39;single&#39; quotes"/);
+}
+
+// No title, whitespace, or a missing variable still names the frame.
+for (const absent of ['', '   ', undefined, null]) {
+  const { sandbox, embedCode } = harness('853x480');
+  sandbox.videoTitle = absent;
+  sandbox.updateEmbedCode();
+  assert.match(
+    embedCode.value,
+    /title="BoTTube video"/,
+    `a video title of ${JSON.stringify(absent)} must still produce a named frame`
+  );
+}
+
+// The responsive size keeps its inline style, and the name sits before it.
+{
+  const { sandbox, embedCode } = harness('100%x480');
+  sandbox.videoTitle = 'Responsive';
+  sandbox.updateEmbedCode();
+  assert.equal(
+    embedCode.value,
+    '<iframe src="https://bottube.ai/embed/GAdSoP9G9Q2" title="BoTTube video: Responsive"'
+      + ' width="100%" height="480" frameborder="0" allowfullscreen'
+      + ' style="width:100%;max-width:853px;"></iframe>'
+  );
+}
+
+console.log('embed snippet title: ok');

--- a/tests/test_embed_snippet_title_runtime.py
+++ b/tests/test_embed_snippet_title_runtime.py
@@ -1,0 +1,22 @@
+"""Execute the browser-neutral embed-snippet naming regression (#2251)."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_embed_snippet_names_the_iframe_it_generates():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript runtime regression")
+
+    result = subprocess.run(
+        [node, str(Path(__file__).parent / "js" / "embed_snippet_title.test.cjs")],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_watch_template_accessibility.py
+++ b/tests/test_watch_template_accessibility.py
@@ -17,3 +17,33 @@ def test_watch_template_does_not_duplicate_main_landmark():
     assert 'role="main"' not in html
     assert 'href="#main-content"' not in html
     assert 'id="watch-layout" role="region" aria-label="Video page"' in html
+
+
+def test_watch_template_embed_snippet_names_its_iframe():
+    """The copyable embed snippet must carry an accessible name (#2251).
+
+    The generator's output lands on other people's sites, so its iframe needs
+    a name of its own: a screen reader announces frames by name, and an
+    unnamed one gives the reader nothing to decide on before entering it. The
+    name carries the video title because a page embedding several BoTTube
+    videos would otherwise present frames that all announce identically, and
+    it is escaped because a title is free text that would otherwise close the
+    attribute.
+    """
+    template = Path(__file__).resolve().parents[1] / "bottube_templates" / "watch.html"
+    html = template.read_text(encoding="utf-8")
+
+    assert 'var videoTitle = {{ (video.title or "") | tojson }};' in html, (
+        "the embed generator has no title to work from; `tojson` is what keeps "
+        "a quote or a backslash in the title from breaking the script"
+    )
+    assert "function escapeEmbedAttribute(value)" in html
+    for replacement in ("&amp;", "&lt;", "&gt;", "&quot;", "&#39;"):
+        assert replacement in html, f"escapeEmbedAttribute does not encode {replacement}"
+    assert 'return title ? "BoTTube video: " + title : "BoTTube video";' in html, (
+        "a video with no title must still produce a named frame"
+    )
+    assert (
+        '\'<iframe src="https://bottube.ai/embed/\' + videoId + \'" title="\' + title + \'"'
+        in html
+    ), "the generated snippet does not name the frame"


### PR DESCRIPTION
## What

The watch page's **Embed code** field generated an iframe with no accessible name, and that snippet is what a creator copies onto their own site, so the unnamed frame travels with it. A screen reader announces frames by name; an unnamed one gives the reader nothing to decide on before entering it.

Fixes #2251.

## How

`updateEmbedCode()` now names the frame with the video's title, escaped for an HTML attribute, and falls back to a plain `BoTTube video` when there is no title:

```
<iframe src="https://bottube.ai/embed/GAdSoP9G9Q2" title="BoTTube video: How agents learn" width="853" height="480" frameborder="0" allowfullscreen></iframe>
```

The title rather than a fixed string, because a page embedding several BoTTube videos would otherwise present a row of frames that all announce identically, which is exactly the case where a name stops helping.

Two escaping layers, because a title is free text:

- it reaches the script through Jinja's `tojson`, so a quote, a backslash or a `</script>` in it cannot break the page;
- `escapeEmbedAttribute()` then keeps it inside the attribute, so `He said "hi" & <b>bold</b>` becomes `&quot;hi&quot; &amp; &lt;b&gt;` in the snippet rather than closing the attribute.

**The embed guide had the same gap** and gets a fixed `title="BoTTube video"`. That block is rendered as HTML entities and decoded again by `copyCode`, so a name taken from the page would have to survive two decodes to stay escaped, and a reader of that page is swapping the id and the title for their own anyway. Noted in a comment there.

The `/badges` verification preview and the `/embed-guide` live preview are already named, so with these two the copyable surfaces are covered.

## Evidence

`tests/js/embed_snippet_title.test.cjs` runs the real generator out of the template through `vm`, the same pattern as `embed_preview_selection.test.cjs`, with `tests/test_embed_snippet_title_runtime.py` as its pytest wrapper:

| input | asserted |
|---|---|
| `How agents learn` | exact snippet, name included |
| `He said "hi" & <b>bold</b>` | escaped in the attribute, and `<b>` never reaches the snippet as markup |
| `'single' quotes` | `&#39;` in the attribute |
| `""`, `"   "`, `undefined`, `null` | still named `BoTTube video` |
| size `100%x480` | responsive inline style preserved, name before it |

`tests/test_watch_template_accessibility.py` gains a template-level check so the `tojson` hand-off and the escape function cannot quietly disappear.

```
pytest tests/test_embed_snippet_title_runtime.py tests/test_watch_template_accessibility.py tests/test_embed_preview_selection_runtime.py
# 4 passed
```

Negative controls: dropping the `title` from the snippet fails the exact-shape cases, and dropping `escapeEmbedAttribute` fails with the title closing its own attribute:

```
'<iframe src="…" title="BoTTube video: He said "hi" & <b>bold</b>" width="853" …>'
```

I also checked Jinja's `tojson` against the inputs that matter, so the hand-off is not an assumption: `He said "hi"` → `"He said \"hi\""`, `</script><script>` → `"</script><script>"`, a missing title → `""`.
